### PR TITLE
fix(msix): preserve production release versions

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -42,7 +42,7 @@ jobs:
             -Repository $env:STORE_REPOSITORY -RunNumber $env:STORE_RUN_NUMBER `
             -RequestFlight ($env:STORE_REQUESTED_FLIGHT -eq 'true') `
             -ProductId $env:AETHERSDR_STORE_PRODUCT_ID -FlightId $env:AETHERSDR_STORE_FLIGHT_ID
-          foreach ($name in @('releaseArtifacts', 'productionDraft', 'publishFlight')) {
+          foreach ($name in @('releaseArtifacts', 'productionDraft', 'publishFlight', 'storeEligible')) {
             "$name=$($plan.$name.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
           }
           "AETHERSDR_MSIX_VERSION=$($plan.msixVersion)" >> $env:GITHUB_ENV
@@ -384,6 +384,7 @@ jobs:
       # users depend on.  When MSIX matures we can promote it back into
       # the hard-required artifact set.
       - name: Create MSIX package
+        if: steps.store-plan.outputs.storeEligible == 'true'
         continue-on-error: true
         env:
           AETHERSDR_MSIX_IDENTITY_NAME: ${{ vars.AETHERSDR_MSIX_IDENTITY_NAME }}
@@ -415,7 +416,7 @@ jobs:
           Write-Host "Required symbols present; $symbolCount PDBs staged."
 
       - name: Verify Store symbol package topology
-        if: hashFiles('AetherSDR-*.appxsym') != ''
+        if: steps.store-plan.outputs.storeEligible == 'true' && hashFiles('AetherSDR-*.appxsym') != ''
         run: |
           $appxSym = @(Get-ChildItem -File -Filter "AetherSDR-*.appxsym")
           $msixUpload = @(Get-ChildItem -File -Filter "AetherSDR-*.msixupload")

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -46,6 +46,11 @@ jobs:
             "$name=$($plan.$name.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
           }
           "AETHERSDR_MSIX_VERSION=$($plan.msixVersion)" >> $env:GITHUB_ENV
+          if (-not $plan.storeEligible) {
+            # A plain Write-Warning stays inside this step's collapsed log; the
+            # annotation puts the reason on the run summary where it is seen.
+            Write-Host "::warning title=Store package skipped::$($plan.storeSkipReason)"
+          }
           Write-Host "Store package version: $($plan.msixVersion)"
 
       # pwsh, not Windows PowerShell: the suite is developed and verified on
@@ -416,7 +421,7 @@ jobs:
           Write-Host "Required symbols present; $symbolCount PDBs staged."
 
       - name: Verify Store symbol package topology
-        if: steps.store-plan.outputs.storeEligible == 'true' && hashFiles('AetherSDR-*.appxsym') != ''
+        if: hashFiles('AetherSDR-*.appxsym') != ''
         run: |
           $appxSym = @(Get-ChildItem -File -Filter "AetherSDR-*.appxsym")
           $msixUpload = @(Get-ChildItem -File -Filter "AetherSDR-*.msixupload")

--- a/docs/WINDOWS-STORE-MSIX.md
+++ b/docs/WINDOWS-STORE-MSIX.md
@@ -335,26 +335,31 @@ secrets + one variable in GitHub.
 ### Version discipline
 
 Microsoft Store [reserves the fourth version component for its own use](https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/msix/app-package-requirements);
-submitted packages must end in `.0`. The Windows Installer workflow uses
-`YY.M.<workflow run number>.0` for **both production and flight MSIX packages**.
-For example, run 203 builds `26.9.203.0`; the next production run 204 builds
-`26.9.204.0`, which outranks the flight. The first two components come from
-`project(AetherSDR VERSION ...)`; the app's CalVer, portable ZIP, Inno installer,
-and release tags keep their existing versioning.
+submitted packages must end in `.0`.
 
-Use the current or a later CalVer year/month when submitting a ref. Selecting
-an older source series can produce a lower Store version. Before the first
-upload with this scheme, compare it with the highest package already submitted
-in Partner Center. The shared workflow counter must be greater than that
-package's third component within the same year/month. Do not reset the counter
-or move publication to another workflow without checking this ordering.
-Rerunning the same workflow run reuses its version; dispatch a new run when a
-new version is required. Run numbers outside `1..65535` fail before building
-instead of wrapping or emitting an invalid package.
+Production tag pushes use the source release version: `26.9.2` becomes
+`26.9.2.0`, independent of the workflow run number and flight configuration.
+The tag must exactly match `project(AetherSDR VERSION ...)`. Three-component
+versions and explicit zero fourth components are supported; a nonzero CalVer
+hotfix revision is refused until an explicit Store version policy is selected.
+The planner must not silently replace a release patch or discard a hotfix.
 
-Local `create-msix.ps1` builds still default to the normalized source version.
+Development builds, including manual flights, retain `YY.M.<workflow run
+number>.0`. Their run number must fit `1..65535`; that limit does not apply to
+production because production does not use it. Rerunning a development workflow
+reuses its version.
+
+**Flight upgrade ordering is separate from production naming.** A flight such
+as `26.9.205.0` is higher than production `26.9.2.0`; do not assume the next
+production release supersedes it for flight users. Before another flight,
+select a version strategy against the highest package accepted in Partner
+Center. This production correction does not redesign flight numbering or reset
+any accepted Store version.
+
+Local `create-msix.ps1` builds also default to the normalized source version.
 With `-CreateUpload`, a nonzero fourth component is rejected before staging
-files; pass a suitable `-Version YY.M.BUILD.0` for a CalVer hotfix upload.
+files. The app's CalVer, portable ZIP, Inno installer and release tags are
+unchanged by MSIX packaging.
 
 ### Promoting to fully automatic later
 
@@ -404,9 +409,9 @@ that the pinned CLI accepts `--flightId` on `publish`. A wrong option name
 fails the step loudly rather than publishing anywhere, but budget for it —
 along with credentials and certification — on the first attempt.
 
-The flight uses the shared MSIX sequence described under **Version discipline**
-above. This also changes production MSIX version numbers; production remains a
-draft and its certification requires maintainer action.
+The flight uses the development MSIX sequence described under **Version discipline**
+above. Production uses its source release version, remains a draft, and requires
+maintainer action for certification.
 
 The socket-free regression suite is `tests/windows_store_policy_test.ps1`:
 

--- a/docs/WINDOWS-STORE-MSIX.md
+++ b/docs/WINDOWS-STORE-MSIX.md
@@ -340,21 +340,28 @@ submitted packages must end in `.0`.
 Production tag pushes use the source release version: `26.9.2` becomes
 `26.9.2.0`, independent of the workflow run number and flight configuration.
 The tag must exactly match `project(AetherSDR VERSION ...)`. Three-component
-versions and explicit zero fourth components are supported; a nonzero CalVer
-hotfix revision is refused until an explicit Store version policy is selected.
-The planner must not silently replace a release patch or discard a hotfix.
+versions and explicit zero fourth components are supported. A nonzero CalVer
+hotfix revision, unsupported Store patch, or mismatched/suffixed tag yields a
+plan with `storeEligible = false`, an empty MSIX version and an explanatory
+warning. MSIX creation, Store symbol-package validation and production Store
+submission are skipped; the portable ZIP, Inno installer, debug-symbol artifact
+and GitHub release attachment remain enabled. The planner must not silently
+replace a release patch or discard a hotfix.
+
+Before uploading a production package, compare its version with the highest
+production package accepted in Partner Center. Restoring release-based numbering
+must not be treated as permission to downgrade an already accepted package.
 
 Development builds, including manual flights, retain `YY.M.<workflow run
 number>.0`. Their run number must fit `1..65535`; that limit does not apply to
 production because production does not use it. Rerunning a development workflow
 reuses its version.
 
-**Flight upgrade ordering is separate from production naming.** A flight such
-as `26.9.205.0` is higher than production `26.9.2.0`; do not assume the next
-production release supersedes it for flight users. Before another flight,
-select a version strategy against the highest package accepted in Partner
-Center. This production correction does not redesign flight numbering or reset
-any accepted Store version.
+**Developer flights intentionally rank ahead of production.** A flight such
+as `26.9.205.0` is higher than production `26.9.2.0`, allowing developers to
+receive the flight. That separation is intentional; the next production patch
+does not necessarily supersede it for flight users. This production correction
+does not redesign flight numbering or reset any accepted Store version.
 
 Local `create-msix.ps1` builds also default to the normalized source version.
 With `-CreateUpload`, a nonzero fourth component is rejected before staging

--- a/docs/WINDOWS-STORE-MSIX.md
+++ b/docs/WINDOWS-STORE-MSIX.md
@@ -339,18 +339,19 @@ submitted packages must end in `.0`.
 
 Production tag pushes use the source release version: `26.9.2` becomes
 `26.9.2.0`, independent of the workflow run number and flight configuration.
-The tag must exactly match `project(AetherSDR VERSION ...)`. Three-component
-versions and explicit zero fourth components are supported. A nonzero CalVer
+The tag must name the same version as `project(AetherSDR VERSION ...)`;
+`v26.9.2` and `v26.9.2.0` both match a `26.9.2` source. A nonzero CalVer
 hotfix revision, unsupported Store patch, or mismatched/suffixed tag yields a
-plan with `storeEligible = false`, an empty MSIX version and an explanatory
-warning. MSIX creation, Store symbol-package validation and production Store
-submission are skipped; the portable ZIP, Inno installer, debug-symbol artifact
-and GitHub release attachment remain enabled. The planner must not silently
-replace a release patch or discard a hotfix.
+plan with `storeEligible = false`, an empty MSIX version and a run annotation
+explaining why. MSIX creation, Store symbol-package validation and production
+Store submission are skipped; the portable ZIP, Inno installer, debug-symbol
+artifact and GitHub release attachment remain enabled. The planner never
+substitutes another version for a release it cannot package.
 
 Before uploading a production package, compare its version with the highest
-production package accepted in Partner Center. Restoring release-based numbering
-must not be treated as permission to downgrade an already accepted package.
+production package accepted in Partner Center; Partner Center rejects a lower
+version, and a package accepted under the earlier run-counter scheme outranks
+every release-based version in the same month.
 
 Development builds, including manual flights, retain `YY.M.<workflow run
 number>.0`. Their run number must fit `1..65535`; that limit does not apply to
@@ -358,15 +359,16 @@ production because production does not use it. Rerunning a development workflow
 reuses its version.
 
 **Developer flights intentionally rank ahead of production.** A flight such
-as `26.9.205.0` is higher than production `26.9.2.0`, allowing developers to
-receive the flight. That separation is intentional; the next production patch
-does not necessarily supersede it for flight users. This production correction
-does not redesign flight numbering or reset any accepted Store version.
+as `26.9.205.0` is higher than production `26.9.2.0`, so flight users keep
+receiving flights; the next production patch does not supersede a flight for
+them. Flight numbering is independent of production versioning.
 
 Local `create-msix.ps1` builds also default to the normalized source version.
 With `-CreateUpload`, a nonzero fourth component is rejected before staging
-files. The app's CalVer, portable ZIP, Inno installer and release tags are
-unchanged by MSIX packaging.
+files; a CalVer hotfix is not Store-published by the workflow, so to upload one
+by hand pass an explicit `-Version YY.M.BUILD.0` that is higher than the last
+accepted package. The app's CalVer, portable ZIP, Inno installer and release
+tags are unchanged by MSIX packaging.
 
 ### Promoting to fully automatic later
 

--- a/packaging/windows/get-store-build-plan.ps1
+++ b/packaging/windows/get-store-build-plan.ps1
@@ -1,6 +1,6 @@
 # Resolve the Windows Installer workflow's publication policy without network
-# access. Both Store channels share the workflow run counter so production can
-# supersede flights while Microsoft's reserved fourth component stays zero.
+# access. Production uses the source release version; development packages use
+# the workflow run counter. Microsoft's reserved fourth component stays zero.
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)][string]$EventName,
@@ -14,18 +14,6 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-
-# This step runs on every Windows Installer run, so a bare range-validation
-# failure here would take the whole workflow down — portable ZIP and Inno
-# installer included — with a message that says nothing about why. Name the
-# cause and the fix instead: MSIX version components are 16-bit, so the shared
-# workflow run counter cannot exceed 65535.
-if ($RunNumber -lt 1 -or $RunNumber -gt 65535) {
-    throw ("RunNumber $RunNumber is outside the MSIX component range 1..65535. " +
-        "The Windows Installer run counter has passed Microsoft's 16-bit package " +
-        "version limit; see the Version discipline section of " +
-        "docs/WINDOWS-STORE-MSIX.md before changing or resetting the counter.")
-}
 
 $upstream = $Repository -eq 'aethersdr/AetherSDR'
 $release = $upstream -and $EventName -eq 'push' -and $Ref.StartsWith('refs/tags/v')
@@ -51,9 +39,28 @@ if ($sourceVersion.Major -lt 1 -or $sourceVersion.Major -gt 65535 -or $sourceVer
     throw "The source version's first two MSIX components must fit in 16 bits, with a nonzero first component."
 }
 
+# Release tags must describe the same version as the application. Never let a
+# flight's run counter or configured ID rewrite a production package version.
+if ($release) {
+    if ($sourceVersion.Build -lt 0 -or $sourceVersion.Build -gt 65535 -or $sourceVersion.Revision -gt 0) {
+        throw "Production Store versions require a three-component source version (or a zero fourth component), with patch in 0..65535. Nonzero CalVer hotfix revisions need an explicit Store version policy."
+    }
+    $tagVersion = $Ref.Substring('refs/tags/v'.Length)
+    if ($tagVersion -ne $match.Matches[0].Groups[1].Value) {
+        throw "Release tag version '$tagVersion' does not match the source version. Bump CMakeLists.txt before tagging."
+    }
+    $msixVersion = "$($sourceVersion.Major).$($sourceVersion.Minor).$($sourceVersion.Build).0"
+}
+else {
+    if ($RunNumber -lt 1 -or $RunNumber -gt 65535) {
+        throw "RunNumber $RunNumber is outside the development MSIX component range 1..65535. See docs/WINDOWS-STORE-MSIX.md before changing or resetting flight numbering."
+    }
+    $msixVersion = "$($sourceVersion.Major).$($sourceVersion.Minor).$RunNumber.0"
+}
+
 [pscustomobject]@{
     releaseArtifacts = $release
     productionDraft = $release -and -not [string]::IsNullOrWhiteSpace($ProductId)
     publishFlight = $flight
-    msixVersion = "$($sourceVersion.Major).$($sourceVersion.Minor).$RunNumber.0"
+    msixVersion = $msixVersion
 }

--- a/packaging/windows/get-store-build-plan.ps1
+++ b/packaging/windows/get-store-build-plan.ps1
@@ -41,15 +41,24 @@ if ($sourceVersion.Major -lt 1 -or $sourceVersion.Major -gt 65535 -or $sourceVer
 
 # Release tags must describe the same version as the application. Never let a
 # flight's run counter or configured ID rewrite a production package version.
+$storeEligible = $true
+$storeSkipReason = ''
+$msixVersion = ''
 if ($release) {
-    if ($sourceVersion.Build -lt 0 -or $sourceVersion.Build -gt 65535 -or $sourceVersion.Revision -gt 0) {
-        throw "Production Store versions require a three-component source version (or a zero fourth component), with patch in 0..65535. Nonzero CalVer hotfix revisions need an explicit Store version policy."
-    }
     $tagVersion = $Ref.Substring('refs/tags/v'.Length)
-    if ($tagVersion -ne $match.Matches[0].Groups[1].Value) {
-        throw "Release tag version '$tagVersion' does not match the source version. Bump CMakeLists.txt before tagging."
+    if ($sourceVersion.Build -lt 0 -or $sourceVersion.Build -gt 65535 -or $sourceVersion.Revision -gt 0) {
+        $storeSkipReason = "Production Store versions require a three-component source version (or a zero fourth component), with patch in 0..65535. Nonzero CalVer hotfix revisions need an explicit Store version policy."
     }
-    $msixVersion = "$($sourceVersion.Major).$($sourceVersion.Minor).$($sourceVersion.Build).0"
+    elseif ($tagVersion -ne $match.Matches[0].Groups[1].Value) {
+        $storeSkipReason = "Release tag version '$tagVersion' does not match the source version. Bump CMakeLists.txt before tagging."
+    }
+    if ($storeSkipReason) {
+        $storeEligible = $false
+        Write-Warning "Skipping MSIX and Store submission: $storeSkipReason Portable ZIP and Inno installer remain enabled."
+    }
+    else {
+        $msixVersion = "$($sourceVersion.Major).$($sourceVersion.Minor).$($sourceVersion.Build).0"
+    }
 }
 else {
     if ($RunNumber -lt 1 -or $RunNumber -gt 65535) {
@@ -60,7 +69,9 @@ else {
 
 [pscustomobject]@{
     releaseArtifacts = $release
-    productionDraft = $release -and -not [string]::IsNullOrWhiteSpace($ProductId)
+    productionDraft = $release -and $storeEligible -and -not [string]::IsNullOrWhiteSpace($ProductId)
     publishFlight = $flight
+    storeEligible = $storeEligible
+    storeSkipReason = $storeSkipReason
     msixVersion = $msixVersion
 }

--- a/packaging/windows/get-store-build-plan.ps1
+++ b/packaging/windows/get-store-build-plan.ps1
@@ -35,6 +35,16 @@ if (-not $match) {
     throw "Could not read the AetherSDR version from $ProjectFile."
 }
 $sourceVersion = [version]$match.Matches[0].Groups[1].Value
+
+# Compare versions by value, not spelling: "26.9.2" and "26.9.2.0" name the
+# same release. System.Version treats a missing component as -1, so pad first.
+function Get-NormalizedVersion([string]$Text) {
+    $parsed = $Text -as [version]
+    if ($null -eq $parsed) { return $null }
+    $build = if ($parsed.Build -lt 0) { 0 } else { $parsed.Build }
+    $revision = if ($parsed.Revision -lt 0) { 0 } else { $parsed.Revision }
+    return [version]::new($parsed.Major, $parsed.Minor, $build, $revision)
+}
 if ($sourceVersion.Major -lt 1 -or $sourceVersion.Major -gt 65535 -or $sourceVersion.Minor -gt 65535) {
     throw "The source version's first two MSIX components must fit in 16 bits, with a nonzero first component."
 }
@@ -49,8 +59,8 @@ if ($release) {
     if ($sourceVersion.Build -lt 0 -or $sourceVersion.Build -gt 65535 -or $sourceVersion.Revision -gt 0) {
         $storeSkipReason = "Production Store versions require a three-component source version (or a zero fourth component), with patch in 0..65535. Nonzero CalVer hotfix revisions need an explicit Store version policy."
     }
-    elseif ($tagVersion -ne $match.Matches[0].Groups[1].Value) {
-        $storeSkipReason = "Release tag version '$tagVersion' does not match the source version. Bump CMakeLists.txt before tagging."
+    elseif ((Get-NormalizedVersion $tagVersion) -ne (Get-NormalizedVersion $sourceVersion.ToString())) {
+        $storeSkipReason = "Release tag version '$tagVersion' does not match the source version $sourceVersion. Bump CMakeLists.txt before tagging."
     }
     if ($storeSkipReason) {
         $storeEligible = $false
@@ -62,7 +72,7 @@ if ($release) {
 }
 else {
     if ($RunNumber -lt 1 -or $RunNumber -gt 65535) {
-        throw "RunNumber $RunNumber is outside the development MSIX component range 1..65535. See docs/WINDOWS-STORE-MSIX.md before changing or resetting flight numbering."
+        throw "RunNumber $RunNumber is outside the development MSIX component range 1..65535. See docs/WINDOWS-STORE-MSIX.md before changing or resetting development numbering."
     }
     $msixVersion = "$($sourceVersion.Major).$($sourceVersion.Minor).$RunNumber.0"
 }

--- a/tests/windows_store_policy_test.ps1
+++ b/tests/windows_store_policy_test.ps1
@@ -44,7 +44,8 @@ try {
                 Assert-True ($plan.releaseArtifacts -eq $releaseExpected) "Release routing: $eventName $ref $requested"
                 Assert-True ($plan.productionDraft -eq $releaseExpected) "Production routing: $eventName $ref $requested"
                 Assert-True ($plan.publishFlight -eq ($eventName -eq 'workflow_dispatch' -and $requested)) 'Flight routing'
-                Assert-True ($plan.msixVersion -eq '26.9.203.0') 'Store version must reserve revision zero'
+                $expectedVersion = if ($releaseExpected) { '26.9.1.0' } else { '26.9.203.0' }
+                Assert-True ($plan.msixVersion -eq $expectedVersion) "Version routing: $eventName $ref $requested"
             }
         }
     }
@@ -63,19 +64,36 @@ try {
     $inputs.EventName = 'workflow_dispatch'
     Assert-Throws { & $planScript @inputs -RequestFlight $true } 'require workflow_dispatch'
     $inputs.Repository = 'aethersdr/AetherSDR'
-    $flightVersion = [version](& $planScript @inputs -RequestFlight $true).msixVersion
-    $inputs.RunNumber = 204; $inputs.EventName = 'push'
-    Set-Content -LiteralPath $project -Value 'project(AetherSDR VERSION 26.9.2.1 LANGUAGES CXX)'
-    $productionVersion = [version](& $planScript @inputs).msixVersion
-    Assert-True ($productionVersion -gt $flightVersion) 'Next production must outrank a flight'
-    Assert-True ($productionVersion.Revision -eq 0) 'CalVer hotfix must not occupy Store revision'
+    Assert-True ((& $planScript @inputs -RequestFlight $true).msixVersion -eq '26.9.203.0') 'Flight keeps development numbering'
+    $inputs.EventName = 'push'; $inputs.Ref = 'refs/tags/v26.9.2'
+    Set-Content -LiteralPath $project -Value 'project(AetherSDR VERSION 26.9.2 LANGUAGES CXX)'
+    foreach ($run in @(1, 205, 65535, 65536)) {
+        $inputs.RunNumber = $run
+        foreach ($flightId in @('', 'FLIGHT')) {
+            $inputs.FlightId = $flightId
+            $plan = & $planScript @inputs
+            Assert-True ($plan.msixVersion -eq '26.9.2.0') 'Production version must ignore run number and flight ID'
+            Assert-True ($plan.productionDraft -and -not $plan.publishFlight) 'Production remains draft-only'
+        }
+    }
+    $inputs.Ref = 'refs/tags/v26.9.1'
+    Assert-Throws { & $planScript @inputs } 'does not match the source version'
+    foreach ($invalidVersion in @('26.9.2.1', '26.9.65536', '26.9')) {
+        Set-Content -LiteralPath $project -Value "project(AetherSDR VERSION $invalidVersion LANGUAGES CXX)"
+        $inputs.Ref = "refs/tags/v$invalidVersion"
+        Assert-Throws { & $planScript @inputs } 'Production Store versions require'
+    }
+    $inputs.Ref = 'refs/tags/v26.9.2.0'
+    Set-Content -LiteralPath $project -Value 'project(AetherSDR VERSION 26.9.2.0 LANGUAGES CXX)'
+    Assert-True ((& $planScript @inputs).msixVersion -eq '26.9.2.0') 'Explicit zero revision stays unchanged'
+    $inputs.EventName = 'workflow_dispatch'; $inputs.FlightId = 'FLIGHT'
     foreach ($valid in @(1, 65535)) {
         $inputs.RunNumber = $valid
-        Assert-True (([version](& $planScript @inputs).msixVersion).Build -eq $valid) 'Run number boundary'
+        Assert-True (([version](& $planScript @inputs -RequestFlight $true).msixVersion).Build -eq $valid) 'Development run number boundary'
     }
     foreach ($invalid in @(0, -1, 65536)) {
         $inputs.RunNumber = $invalid
-        Assert-Throws { & $planScript @inputs } 'MSIX component range 1\.\.65535'
+        Assert-Throws { & $planScript @inputs -RequestFlight $true } 'MSIX component range 1\.\.65535'
     }
     $inputs.RunNumber = 204
     Set-Content -LiteralPath $project -Value 'project(AetherSDR VERSION invalid)'

--- a/tests/windows_store_policy_test.ps1
+++ b/tests/windows_store_policy_test.ps1
@@ -45,6 +45,7 @@ try {
                 Assert-True ($plan.productionDraft -eq $releaseExpected) "Production routing: $eventName $ref $requested"
                 Assert-True ($plan.publishFlight -eq ($eventName -eq 'workflow_dispatch' -and $requested)) 'Flight routing'
                 $expectedVersion = if ($releaseExpected) { '26.9.1.0' } else { '26.9.203.0' }
+                Assert-True ($plan.storeEligible) 'Supported production and development plans stay Store eligible'
                 Assert-True ($plan.msixVersion -eq $expectedVersion) "Version routing: $eventName $ref $requested"
             }
         }
@@ -73,15 +74,27 @@ try {
             $inputs.FlightId = $flightId
             $plan = & $planScript @inputs
             Assert-True ($plan.msixVersion -eq '26.9.2.0') 'Production version must ignore run number and flight ID'
+            Assert-True ($plan.storeEligible -and $plan.storeSkipReason -eq '') 'Supported production release is Store eligible'
             Assert-True ($plan.productionDraft -and -not $plan.publishFlight) 'Production remains draft-only'
         }
     }
-    $inputs.Ref = 'refs/tags/v26.9.1'
-    Assert-Throws { & $planScript @inputs } 'does not match the source version'
+    # Store-ineligible releases must still reach the ZIP/EXE attachment path.
+    foreach ($tag in @('v26.9.1', 'v26.9.2-beta', 'v26.9.2a')) {
+        $inputs.Ref = "refs/tags/$tag"
+        $plan = & $planScript @inputs
+        Assert-True ($plan.releaseArtifacts) 'Mismatched/suffixed tag keeps release artifacts enabled'
+        Assert-True (-not $plan.storeEligible -and -not $plan.productionDraft -and -not $plan.publishFlight) 'Mismatched/suffixed tag skips only Store paths'
+        Assert-True ($plan.msixVersion -eq '') 'Ineligible release must not invent a Store version'
+        Assert-True ($plan.storeSkipReason -match 'does not match') 'Tag mismatch explains Store skip'
+    }
     foreach ($invalidVersion in @('26.9.2.1', '26.9.65536', '26.9')) {
         Set-Content -LiteralPath $project -Value "project(AetherSDR VERSION $invalidVersion LANGUAGES CXX)"
         $inputs.Ref = "refs/tags/v$invalidVersion"
-        Assert-Throws { & $planScript @inputs } 'Production Store versions require'
+        $plan = & $planScript @inputs
+        Assert-True ($plan.releaseArtifacts) 'Unsupported Store version keeps ZIP/EXE enabled'
+        Assert-True (-not $plan.storeEligible -and -not $plan.productionDraft -and -not $plan.publishFlight) 'Unsupported Store version skips Store paths'
+        Assert-True ($plan.msixVersion -eq '') 'Unsupported Store version has no fallback numbering'
+        Assert-True ($plan.storeSkipReason -match 'Production Store versions require') 'Unsupported Store version explains skip'
     }
     $inputs.Ref = 'refs/tags/v26.9.2.0'
     Set-Content -LiteralPath $project -Value 'project(AetherSDR VERSION 26.9.2.0 LANGUAGES CXX)'

--- a/tests/windows_store_policy_test.ps1
+++ b/tests/windows_store_policy_test.ps1
@@ -68,18 +68,26 @@ try {
     Assert-True ((& $planScript @inputs -RequestFlight $true).msixVersion -eq '26.9.203.0') 'Flight keeps development numbering'
     $inputs.EventName = 'push'; $inputs.Ref = 'refs/tags/v26.9.2'
     Set-Content -LiteralPath $project -Value 'project(AetherSDR VERSION 26.9.2 LANGUAGES CXX)'
-    foreach ($run in @(1, 205, 65535, 65536)) {
+    # 65536 is out of range for development numbering; production must not
+    # read the run number at all. The configured flight ID is likewise inert.
+    $inputs.FlightId = 'FLIGHT'
+    foreach ($run in @(205, 65536)) {
         $inputs.RunNumber = $run
-        foreach ($flightId in @('', 'FLIGHT')) {
-            $inputs.FlightId = $flightId
-            $plan = & $planScript @inputs
-            Assert-True ($plan.msixVersion -eq '26.9.2.0') 'Production version must ignore run number and flight ID'
-            Assert-True ($plan.storeEligible -and $plan.storeSkipReason -eq '') 'Supported production release is Store eligible'
-            Assert-True ($plan.productionDraft -and -not $plan.publishFlight) 'Production remains draft-only'
-        }
+        $plan = & $planScript @inputs
+        Assert-True ($plan.msixVersion -eq '26.9.2.0') 'Production version must ignore run number and flight ID'
+        Assert-True ($plan.storeEligible -and $plan.storeSkipReason -eq '') 'Supported production release is Store eligible'
+        Assert-True ($plan.productionDraft -and -not $plan.publishFlight) 'Production remains draft-only'
     }
+    $inputs.RunNumber = 205
+    # Tag and source are compared by version value, not spelling.
+    $inputs.Ref = 'refs/tags/v26.9.2.0'
+    Assert-True ((& $planScript @inputs).msixVersion -eq '26.9.2.0') 'Explicit-zero tag matches a three-component source'
+    Set-Content -LiteralPath $project -Value 'project(AetherSDR VERSION 26.9.2.0 LANGUAGES CXX)'
+    $inputs.Ref = 'refs/tags/v26.9.2'
+    Assert-True ((& $planScript @inputs).msixVersion -eq '26.9.2.0') 'Three-component tag matches an explicit-zero source'
+    Set-Content -LiteralPath $project -Value 'project(AetherSDR VERSION 26.9.2 LANGUAGES CXX)'
     # Store-ineligible releases must still reach the ZIP/EXE attachment path.
-    foreach ($tag in @('v26.9.1', 'v26.9.2-beta', 'v26.9.2a')) {
+    foreach ($tag in @('v26.9.1', 'v26.9.2-beta', 'v26.9.2a', 'v26.9.2.1', 'v')) {
         $inputs.Ref = "refs/tags/$tag"
         $plan = & $planScript @inputs
         Assert-True ($plan.releaseArtifacts) 'Mismatched/suffixed tag keeps release artifacts enabled'
@@ -99,6 +107,14 @@ try {
     $inputs.Ref = 'refs/tags/v26.9.2.0'
     Set-Content -LiteralPath $project -Value 'project(AetherSDR VERSION 26.9.2.0 LANGUAGES CXX)'
     Assert-True ((& $planScript @inputs).msixVersion -eq '26.9.2.0') 'Explicit zero revision stays unchanged'
+
+    # The workflow, not the planner, applies storeEligible: it must export the
+    # flag and gate MSIX creation on it, or an ineligible release would fall
+    # through to create-msix.ps1's project-version default.
+    $workflow = Get-Content -Raw (Join-Path $RepositoryRoot '.github/workflows/windows-installer.yml')
+    Assert-True ($workflow -match "@\('releaseArtifacts', 'productionDraft', 'publishFlight', 'storeEligible'\)") 'Workflow exports storeEligible'
+    Assert-True ($workflow -match "- name: Create MSIX package\s+if: steps\.store-plan\.outputs\.storeEligible == 'true'") 'Workflow gates MSIX creation on storeEligible'
+    Assert-True ($workflow -match 'storeSkipReason') 'Workflow surfaces the Store skip reason'
     $inputs.EventName = 'workflow_dispatch'; $inputs.FlightId = 'FLIGHT'
     foreach ($valid in @(1, 65535)) {
         $inputs.RunNumber = $valid


### PR DESCRIPTION
The v26.9.2 production release generated `26.9.205.0` because #5346 applied the Windows workflow run counter to both production and development MSIX versions. Production tag pushes now normalize the CMake release version instead: `26.9.2` produces `26.9.2.0`, independent of run number or flight configuration.

Store-ineligible release versions no longer abort Windows delivery. A nonzero hotfix revision, unsupported Store patch, or mismatched/suffixed tag returns `storeEligible = false`, an empty MSIX version and an explanatory warning. The workflow skips MSIX creation, Store symbol-package validation and production Store submission while retaining portable ZIP, Inno installer, debug-symbol artifacts and GitHub release attachment. Supported releases retain their existing symbol packaging and draft-only submission behavior.

Developer flights intentionally keep higher run-based versions (`26.9.<run>.0`), as requested by the operator. Their separate CLI issue and live certification proof remain outside this production fix. Documentation restores the instruction to compare production versions with the highest accepted Partner Center package before upload.

Validation on the updated changes:
- PowerShell 7.6.5 on macOS ARM64: all 140 socket-free Store policy assertions pass (review follow-up f2bfee5a trimmed an inert loop and added tag-spelling and workflow-gate cases). Publisher calls use an in-process substitute; no Store authentication or network calls occur.
- Executed the actual planning step extracted from the workflow YAML with normal, hotfix, suffixed and mismatched tag inputs. Every case retains `releaseArtifacts=true`; only the normal release enables `storeEligible` and `productionDraft`. Checked the parsed workflow gates preserve ZIP, EXE and symbol delivery.
- Five independent mutations fail: restoring either release-path throw, disabling all release artifacts for ineligible Store versions, enabling an ineligible Store submission, and restoring production run-counter numbering. Restored code passes all assertions.
- actionlint 1.7.12, strict test-registration and whitespace checks pass. No test registration or frozen CI gate changes.
- No application compile, Windows SDK packaging or live Store ingestion was run for this code change. The automation bridge cannot exercise packaging policy. Hosted PR CI is separate; it does not execute the tag-triggered Windows Installer workflow.

The Windows release workflow change requires maintainer CODEOWNERS review. The already-repackaged 26.9.2.0 artifact is separate release recovery work.

Generated with OpenAI Codex (GPT-6 Astra)

