### PR TITLE
fix(gui): place the diversity master flag on the right

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -321,8 +321,16 @@ void assignDiversityPairDirections(const QVector<VfoPos>& vfos,
         return vfos[lhs].sliceId < vfos[rhs].sliceId;
     });
 
-    dirMap[vfos[diversityIndices[0]].sliceId] = VfoWidget::LockLeft;
-    dirMap[vfos[diversityIndices[1]].sliceId] = VfoWidget::LockRight;
+    // After the sort, index 0 is the parent / master slice (the one DIV was
+    // enabled on, which SmartSDR tags "DIV") when the radio reports the
+    // diversity_parent / diversity_index metadata; absent that, diversityOrder-
+    // KeyForVfo falls back to slice ID and index 0 is the lower-numbered slice.
+    // diversityPairFlagDir locks index 0 RIGHT to match SmartSDR's layout and
+    // index 1 LEFT; see its comment for the fallback case.
+    dirMap[vfos[diversityIndices[0]].sliceId] =
+        VfoWidget::diversityPairFlagDir(0);
+    dirMap[vfos[diversityIndices[1]].sliceId] =
+        VfoWidget::diversityPairFlagDir(1);
 }
 
 void assignModeForcedDirections(const QVector<SpectrumWidget::SliceOverlay>& overlays,

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -214,6 +214,22 @@ public:
         return 1000 + std::max(sliceId, 0);
     }
 
+    // Locked flag side for one member of an attached diversity pair, keyed by
+    // its position after diversityPairOrderKey ordering. Order index 0 is the
+    // parent / master slice — the one DIV was enabled on, which SmartSDR tags
+    // "DIV" — whenever the radio reports diversity_parent or diversity_index;
+    // with neither field present the key falls back to slice ID and index 0 is
+    // simply the lower-numbered slice. In the reported case index 0 locks RIGHT
+    // to match SmartSDR's layout, so a cross-client operator finds the DIV flag
+    // where muscle memory reaches for it; in the fallback case the swap still
+    // yields stable opposite sides, which is all the pre-metadata path promised.
+    // index 1 locks LEFT. Both are Lock* (not Force*) so the pair holds opposite
+    // sides through a pan edge instead of collapsing together (#2663, #3880).
+    static FlagDir diversityPairFlagDir(int orderIndex)
+    {
+        return orderIndex == 0 ? LockRight : LockLeft;
+    }
+
     static FlagPlacement placementForMarker(int markerX,
                                             int specTop,
                                             int widgetWidth,

--- a/tests/vfo_flag_placement_test.cpp
+++ b/tests/vfo_flag_placement_test.cpp
@@ -167,6 +167,40 @@ int main()
            VfoWidget::diversityPairOrderKey(false, false, -1, 3)
                < VfoWidget::diversityPairOrderKey(false, false, -1, 4));
 
+    expectDir("diversity order index 0 flag locks right",
+              VfoWidget::diversityPairFlagDir(0), VfoWidget::LockRight);
+    expectDir("diversity order index 1 flag locks left",
+              VfoWidget::diversityPairFlagDir(1), VfoWidget::LockLeft);
+
+    // Compose the ordering and the side map the way assignDiversityPairDirections
+    // does. When the radio reports roles, a parent sorts ahead of a child even
+    // when the child has the lower slice ID, so the parent (master, DIV-tagged)
+    // lands RIGHT and the child LEFT — the parent-goes-right guarantee the old
+    // inline literal left untested.
+    {
+        const int parentKey = VfoWidget::diversityPairOrderKey(true, false, -1, 7);
+        const int childKey = VfoWidget::diversityPairOrderKey(false, true, -1, 2);
+        const bool parentFirst = parentKey <= childKey;
+        report("diversity reported parent lands on the right",
+               VfoWidget::diversityPairFlagDir(parentFirst ? 0 : 1)
+                   == VfoWidget::LockRight);
+        report("diversity reported child lands on the left",
+               VfoWidget::diversityPairFlagDir(parentFirst ? 1 : 0)
+                   == VfoWidget::LockLeft);
+    }
+
+    // Metadata absent: the order key falls back to slice ID, so "index 0" is
+    // just the lower-numbered slice. The pair still splits to opposite sides —
+    // all the pre-metadata path ever promised.
+    {
+        const int loKey = VfoWidget::diversityPairOrderKey(false, false, -1, 3);
+        const int hiKey = VfoWidget::diversityPairOrderKey(false, false, -1, 9);
+        const bool loFirst = loKey <= hiKey;
+        report("diversity metadata-absent pair still splits opposite",
+               VfoWidget::diversityPairFlagDir(loFirst ? 0 : 1)
+                   != VfoWidget::diversityPairFlagDir(loFirst ? 1 : 0));
+    }
+
     std::printf("%s\n", g_failures == 0 ? "All tests passed." : "Test failures.");
     return g_failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

In an attached diversity pair both slices sit on the same frequency, so the
**flag side is the only spatial cue** that distinguishes the pair on the
panadapter. AetherSDR locked the **master** slice's flag `LockLeft`; SmartSDR
draws it on the right. An operator running both clients against one radio —
contest diversity RX on the low bands, a KiwiSDR as the second receiver — then
finds the DIV flag on the opposite side from where muscle memory reaches for it.

This locks the master flag right and the partner flag left.

## Change

- `src/gui/SpectrumWidget.cpp` — `assignDiversityPairDirections()`: the two
  members now take their locked side from `VfoWidget::diversityPairFlagDir()`
  instead of an inline `LockLeft`/`LockRight` literal pair. Comment reworked.
- `src/gui/VfoWidget.h` — new `diversityPairFlagDir(orderIndex)`: order index 0
  (parent / `diversityIndex 0` — the slice DIV was enabled on, the one SmartSDR
  tags "DIV") → `LockRight`; the auto-created partner → `LockLeft`. This is the
  test seam the previous version lacked.
- `tests/vfo_flag_placement_test.cpp` — asserts `diversityPairFlagDir(0) ==
  LockRight` and `(1) == LockLeft`, next to the existing `diversityPairOrderKey`
  ordering assertions that establish which member is index 0.

Both members stay `Lock*` (not `Force*`), so the pair still holds opposite sides
through a pan edge (#2663, #3880) — only which locked side each takes changes.
Pair detection, ordering, split-pair deconfliction, and the RTTY `ForceRight`
override are untouched.

## Review feedback addressed

From the `aethersdr-agent` pass on the first revision:

- **"DIV slice" vs. the slice the code locks right** — clarified. Order index 0
  is the parent / **master** (the slice you enable diversity *on*, which SmartSDR
  labels "DIV"), not the auto-created partner. Comment and helper doc now say
  "master" explicitly.
- **"by default" is wrong for a `Lock`** — dropped from the title and comment;
  `LockRight` disables the edge-clip flip, it is not a geometry-overridable
  default.
- **Unsupported audio-pan claim** — removed. The rationale now rests only on
  matching SmartSDR's on-screen layout, which is what a cross-client operator
  reconciles against.
- **No test on the mapping** — added, via the new `diversityPairFlagDir` seam.

## Authority

No prior issue tracked this; #3880 chose a side for *stability*, not because
left was correct. The reference this moves toward is SmartSDR's own layout. A
follow-up issue with a SmartSDR diversity-pair screenshot will be filed so a
maintainer has a concrete artifact to rule against; if SmartSDR turns out to put
the partner (not the master) on the right, the fix is the same lines with the
`diversityPairFlagDir` mapping flipped.

Separately: the reporter notes volume/AGC adjustment bugs in the diversity
implementation. Those are out of scope here and will be filed on their own.

## Test plan

- [x] `git diff --check` clean; rebased on `upstream/main`
- [ ] `ctest --test-dir build -R '^vfo_flag_placement_test$'` — CI (no local
      toolchain in this environment). New assertions added this revision.
- [ ] Behaviour spot-check on a live diversity pair (SmartSDR side-by-side)
      before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
