### PR TITLE
feat(core): add shared-capture RF admission policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -757,6 +757,7 @@ set(CORE_SOURCES
     src/core/AudioDeviceNegotiator.cpp
     src/core/AudioOutputRouter.cpp
     src/core/AetherDspModePolicy.cpp
+    src/core/SharedCapturePolicy.cpp
     src/core/AudioEngine.cpp
     src/core/TxCaptureBuffer.cpp
     src/core/TxMicChannelNormalizer.cpp

--- a/docs/shared-capture-policy.md
+++ b/docs/shared-capture-policy.md
@@ -91,7 +91,7 @@ ownership and publication remain the integration layer's responsibility.
 Center domains and returned centers must use the same adapter-declared
 representation. The adapter must document whether readback is logical library
 state or a measured hardware quantity. In
-[Osmocom librtlsdr v2.0.2](https://github.com/osmocom/rtl-sdr/blob/v2.0.2/src/librtlsdr.c#L836-L863)
+[Osmocom librtlsdr v2.0.2](https://github.com/osmocom/rtl-sdr/blob/v2.0.2/src/librtlsdr.c#L884-L913)
 and [RTL-SDR Blog commit aed0ea19](https://github.com/rtlsdrblog/rtl-sdr-blog/blob/aed0ea19f3a273370a13c9009b96313c75d54c7b/src/librtlsdr.c#L887-L936),
 `rtlsdr_get_center_freq()` returns the cached requested frequency stored after
 successful tuning; it does not measure the achieved PLL frequency. Verify other

--- a/docs/shared-capture-policy.md
+++ b/docs/shared-capture-policy.md
@@ -1,0 +1,114 @@
+# Shared capture policy foundation
+
+`src/core/SharedCapturePolicy.{h,cpp}` implements the pure RF admission and
+restore policy from approved RTL RFC #5468. It is compiled into `aethercore`
+and exercised directly by `shared_capture_policy_test`. No backend invokes it
+yet. It does not change USB, DSP, audio, viewport, UI, settings or slice lifecycle.
+
+## Descriptor contract
+
+All frequency and rate fields use finite `double` Hz with magnitude at most
+2^40 Hz. This numerical ceiling is not a tuner range or usable-bandwidth claim.
+Occupied RF must be nonnegative and remain below that ceiling. Empty/inverted
+filters, negative guards, zero achieved rate and unresolved numerical intervals
+are refused. No mode defaults, filter presets or measured margins are inferred.
+
+A slice's complete occupied interval is:
+
+```
+[carrier + translation + filterLow - guardLow,
+ carrier + translation + filterHigh + guardHigh]
+```
+
+The adapter supplies the signed carrier/BFO translation so both filter edges
+refer to RF in the same coordinate system. Filter edges may be asymmetric or
+on one side of the carrier. `occupiedInterval` validates geometry and a
+nonnegative stable ID; the set operations also validate the caller's slot bound.
+
+A capture descriptor carries one endpoint ID, a target generation, its center,
+achieved sample rate and independently supplied left/right usable extents.
+Extents are nonnegative, not both zero, and each must fit within half the achieved
+rate. One-sided usable intervals are supported. Usable bandwidth is separate
+from nominal rate and viewport. A legal capture may include unused negative RF;
+that does not disqualify positive occupied RF inside it.
+
+`ReceiverLimits` separates addressable slots from concurrent capacity. The caller
+must supply `slotCount` matching its published `maxSlices`/addressable range;
+valid IDs are `[0, slotCount)`. `capacity` may be lower because fewer resources
+are available, but cannot exceed `slotCount` or bypass a smaller architectural
+limit. Slot count is positive; zero capacity is valid. The 4096-entry/slot and
+256-domain ceilings only bound validation work and allocations; they do not
+advertise supported receiver counts. Architecture limits require integrated
+measurement in later RFC phases.
+
+Hardware center domains are an explicit union of inclusive intervals with
+independent grids. They may be disjoint, overlapping or supplied in any order.
+The representable hardware request at grid index `n` is
+`std::fma(n, stepHz, gridOriginHz)`. The adapter must describe its actual tuning
+quantization this way; the helper does not infer it from a nominal sample rate.
+Indices are exact integers bounded to +/-2^52. A domain must contain a realizable
+point and its step must be at least the greatest double spacing at its upper
+edge/origin. Unresolvable grids fail validation instead of hanging or rounding
+onto unrelated centers.
+
+Arithmetic uses IEEE round-to-nearest double operations. TwoSum residuals round
+occupied edges outward and usable capture edges inward. There is no tolerance
+that widens acceptance and no fixed fractional-Hz lattice. Conservative rounding
+can refuse a mathematically fitting fringe that cannot be represented safely.
+The helper must not be compiled with unsafe floating-point reassociation or
+fast-math. Ordinary decimal rates, guards and measured margins are accepted.
+
+## Selection and readback
+
+`selectCenter` receives the complete desired receiver set. It validates every
+entry and the caller's limits before returning a proposal. From occupied
+intervals `[L_i,H_i]` and usable extents `U_L,U_R`, the continuous center bound is:
+
+```
+max(H_i - U_R) <= center <= min(L_i + U_L)
+```
+
+It intersects that bound with each legal hardware domain, examines neighboring
+grid points around the current center and feasible endpoints, then checks full
+containment at the actual returned double center. It preserves a legal current
+center, otherwise chooses the nearest realizable center; exact ties choose lower
+Hz regardless of domain order. Distance residuals distinguish close candidates
+whose large distances would otherwise round to the same double.
+
+All add/tune/filter/guard/mode-translation/rate proposals use this same operation
+with their full desired set and proposed achieved capture descriptor. No input
+is mutated; one invalid or impossible entry refuses the whole proposal. Removing
+entries preserves the center when still legal.
+
+A selection is a proposal, not confirmed hardware state. `validateReadback`
+requires coherent proposed and actual endpoint IDs and target generations, checks
+both descriptors and the entire desired set, and validates actual center/rate/
+usable margins. Actual values may differ if the full set still fits. The caller
+assigns the target generation for a reconfiguration and assembles one coherent
+readback with that generation. Hardware transactions, rollback, asynchronous
+ownership and publication remain the integration layer's responsibility.
+
+## Fixed-capture restore
+
+`restoreFixedCapture` validates the actual established capture and all input
+entries before returning a complete plan. It never recenters or changes capture
+bandwidth. Among valid individually fitting entries it accepts ascending stable
+IDs up to capacity, preserving every field and ID. All occurrences of duplicated
+nonnegative IDs are rejected, including otherwise-invalid occurrences, so input
+order cannot choose a winner. Other per-entry reasons distinguish invalid IDs,
+numeric/interval failures, outside-capture intervals and capacity refusal.
+Rejections carry the original input index and ID in original input order.
+A global descriptor/limits/collection failure returns no partial plan.
+
+Saved slice descriptors contain only RF configuration and stable slot IDs, no
+session capture identity or generation. Consequently reconnecting into a new
+capture generation does not invalidate remembered configuration. Future lifecycle
+code owns slot occupant generations; future persistence code owns parsing,
+logging each refusal and atomically applying/persisting accepted state. If no
+slice is accepted, the caller retains the session's valid initial state.
+
+The focused test has no sockets, settings, hardware, Qt event loop or DSP. It
+uses explicit RF edges, exhaustive small integer hardware-center enumeration,
+nextafter boundary cases and malformed bounded input. Live RTL integration,
+measured margins, architecture capacity, RF reception and GUI convergence remain
+later gates.

--- a/docs/shared-capture-policy.md
+++ b/docs/shared-capture-policy.md
@@ -88,6 +88,16 @@ assigns the target generation for a reconfiguration and assembles one coherent
 readback with that generation. Hardware transactions, rollback, asynchronous
 ownership and publication remain the integration layer's responsibility.
 
+Center domains and returned centers must use the same adapter-declared
+representation. The adapter must document whether readback is logical library
+state or a measured hardware quantity. In
+[Osmocom librtlsdr v2.0.2](https://github.com/osmocom/rtl-sdr/blob/v2.0.2/src/librtlsdr.c#L836-L863)
+and [RTL-SDR Blog commit aed0ea19](https://github.com/rtlsdrblog/rtl-sdr-blog/blob/aed0ea19f3a273370a13c9009b96313c75d54c7b/src/librtlsdr.c#L887-L936),
+`rtlsdr_get_center_freq()` returns the cached requested frequency stored after
+successful tuning; it does not measure the achieved PLL frequency. Verify other
+library versions or forks before relying on that behavior. This policy's
+validation does not establish physical RF accuracy, which needs hardware evidence.
+
 ## Fixed-capture restore
 
 `restoreFixedCapture` validates the actual established capture and all input

--- a/src/core/SharedCapturePolicy.cpp
+++ b/src/core/SharedCapturePolicy.cpp
@@ -1,0 +1,407 @@
+#include "SharedCapturePolicy.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <map>
+#include <set>
+
+namespace AetherSDR::SharedCapturePolicy {
+namespace {
+constexpr double kMaxIndex = 4503599627370496.0; // 2^52, exact integer double.
+constexpr double kInfinity = std::numeric_limits<double>::infinity();
+
+bool validNumber(double value)
+{
+    return std::isfinite(value) && std::abs(value) <= kMaxMagnitudeHz;
+}
+
+// TwoSum's residual tells which way IEEE round-to-nearest moved the sum.
+// Bound every input before arithmetic; no overflow, epsilon or wider long-double
+// assumption (MSVC long double is double). Never compile this with fast-math.
+double directedSum(double left, double right, bool upward)
+{
+    const double sum = left + right;
+    const double rightPart = sum - left;
+    const double residual = (left - (sum - rightPart)) + (right - rightPart);
+    if ((upward && residual > 0) || (!upward && residual < 0)) {
+        return std::nextafter(sum, upward ? kInfinity : -kInfinity);
+    }
+    return sum;
+}
+
+// Keep the residual when comparing distances, too: at a very distant current
+// center, two distinct nearby candidates can have the same rounded distance.
+struct Distance {
+    double value;
+    double residual;
+};
+
+Distance distanceFrom(double center, double current)
+{
+    const double value = center - current;
+    const double rightPart = value - center;
+    const double residual = (center - (value - rightPart)) + (-current - rightPart);
+    return value < 0 ? Distance{-value, -residual} : Distance{value, residual};
+}
+
+bool closer(const Distance& left, const Distance& right)
+{
+    return left.value < right.value
+        || (left.value == right.value && left.residual < right.residual);
+}
+
+Error captureInterval(const CaptureDescriptor& capture, Interval& interval)
+{
+    if (capture.captureId == 0 || capture.generation == 0) {
+        return Error::InvalidIdentity;
+    }
+    if (!validNumber(capture.centerHz) || !validNumber(capture.achievedSampleRateHz)
+        || !validNumber(capture.usableLeftHz) || !validNumber(capture.usableRightHz)) {
+        return Error::InvalidNumber;
+    }
+    if (capture.centerHz < 0 || capture.achievedSampleRateHz <= 0
+        || capture.usableLeftHz < 0 || capture.usableRightHz < 0
+        || 2 * capture.usableLeftHz > capture.achievedSampleRateHz
+        || 2 * capture.usableRightHz > capture.achievedSampleRateHz) {
+        return Error::InvalidInterval;
+    }
+    // Inward capture edges cannot promise an unrepresentable sliver of RF.
+    interval = {directedSum(capture.centerHz, -capture.usableLeftHz, true),
+                directedSum(capture.centerHz, capture.usableRightHz, false)};
+    if (interval.lowHz >= interval.highHz) {
+        return Error::InvalidInterval;
+    }
+    return Error::None;
+}
+
+Error sliceInterval(const SliceDescriptor& slice, Interval& interval)
+{
+    if (slice.stableId < 0) {
+        return Error::InvalidIdentity;
+    }
+    for (const double value : {slice.carrierHz, slice.filterLowHz, slice.filterHighHz,
+                              slice.translationHz, slice.guardLowHz, slice.guardHighHz}) {
+        if (!validNumber(value)) {
+            return Error::InvalidNumber;
+        }
+    }
+    if (slice.carrierHz < 0 || slice.filterLowHz >= slice.filterHighHz
+        || slice.guardLowHz < 0 || slice.guardHighHz < 0) {
+        return Error::InvalidInterval;
+    }
+    const double lowCarrier = directedSum(slice.carrierHz, slice.translationHz, false);
+    const double highCarrier = directedSum(slice.carrierHz, slice.translationHz, true);
+    interval = {
+        directedSum(directedSum(lowCarrier, slice.filterLowHz, false), -slice.guardLowHz, false),
+        directedSum(directedSum(highCarrier, slice.filterHighHz, true), slice.guardHighHz, true)};
+    if (interval.lowHz < 0 || interval.highHz > kMaxMagnitudeHz
+        || interval.lowHz >= interval.highHz) {
+        return Error::InvalidInterval;
+    }
+    return Error::None;
+}
+
+// Enumerate bounded neighboring integer grid indices around a target. Division
+// may round at an endpoint; neighbors are checked using the returned fma value.
+// Valid domains keep indices <= 2^52 and step >= their largest ULP, so two
+// neighbors cover quotient rounding and a center rounded onto an endpoint.
+template <typename Visitor>
+void gridNeighbors(const CenterDomain& domain, double target, Visitor visit)
+{
+    const double index = std::floor((target - domain.gridOriginHz) / domain.stepHz);
+    for (int offset = -2; offset <= 2; ++offset) {
+        const double candidateIndex = index + offset;
+        if (std::abs(candidateIndex) <= kMaxIndex) {
+            const double center = std::fma(candidateIndex, domain.stepHz, domain.gridOriginHz);
+            if (center >= domain.minimumHz && center <= domain.maximumHz) {
+                visit(center);
+            }
+        }
+    }
+}
+
+Error validateDomains(std::span<const CenterDomain> domains)
+{
+    if (domains.empty() || domains.size() > kMaxDomains) {
+        return Error::InvalidDomains;
+    }
+    for (const CenterDomain& domain : domains) {
+        for (const double value : {domain.minimumHz, domain.maximumHz, domain.gridOriginHz, domain.stepHz}) {
+            if (!validNumber(value)) {
+                return Error::InvalidNumber;
+            }
+        }
+        if (domain.minimumHz < 0 || domain.maximumHz < domain.minimumHz
+            || domain.gridOriginHz < 0 || domain.stepHz <= 0) {
+            return Error::InvalidDomains;
+        }
+        const double magnitude = std::max(domain.maximumHz, domain.gridOriginHz);
+        const double resolution = std::nextafter(magnitude, kInfinity) - magnitude;
+        const double first = (domain.minimumHz - domain.gridOriginHz) / domain.stepHz;
+        const double last = (domain.maximumHz - domain.gridOriginHz) / domain.stepHz;
+        if (domain.stepHz < resolution || !std::isfinite(first) || !std::isfinite(last)
+            || std::abs(first) > kMaxIndex || std::abs(last) > kMaxIndex) {
+            return Error::InvalidDomains;
+        }
+        bool any = false;
+        gridNeighbors(domain, domain.minimumHz, [&any](double) { any = true; });
+        if (!any) {
+            return Error::InvalidDomains;
+        }
+    }
+    return Error::None;
+}
+
+bool legalCenter(double center, std::span<const CenterDomain> domains)
+{
+    for (const CenterDomain& domain : domains) {
+        if (center < domain.minimumHz || center > domain.maximumHz) {
+            continue;
+        }
+        bool matches = false;
+        gridNeighbors(domain, center, [center, &matches](double candidate) {
+            matches = matches || center == candidate;
+        });
+        if (matches) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool contains(const Interval& capture, const Interval& slice)
+{
+    return slice.lowHz >= capture.lowHz && slice.highHz <= capture.highHz;
+}
+
+Error validateLimits(ReceiverLimits limits)
+{
+    if (limits.slotCount == 0 || limits.slotCount > kMaxEntries || limits.capacity > limits.slotCount) {
+        return Error::InvalidCapacity;
+    }
+    return Error::None;
+}
+
+Error desiredIntervals(std::span<const SliceDescriptor> desired, ReceiverLimits limits,
+                       std::vector<Interval>& result)
+{
+    if (desired.size() > kMaxEntries) {
+        return Error::TooManyEntries;
+    }
+    if (desired.size() > limits.capacity) {
+        return Error::CapacityExceeded;
+    }
+    std::set<std::int32_t> ids;
+    for (const SliceDescriptor& slice : desired) {
+        Interval interval;
+        const Error error = sliceInterval(slice, interval);
+        if (error != Error::None) {
+            return error;
+        }
+        if (static_cast<std::size_t>(slice.stableId) >= limits.slotCount) {
+            return Error::InvalidIdentity;
+        }
+        if (!ids.insert(slice.stableId).second) {
+            return Error::DuplicateId;
+        }
+        result.push_back(interval);
+    }
+    return Error::None;
+}
+
+Error fixedCapture(const CaptureDescriptor& descriptor, std::span<const CenterDomain> domains,
+                   Interval& interval)
+{
+    Error error = captureInterval(descriptor, interval);
+    if (error != Error::None) {
+        return error;
+    }
+    error = validateDomains(domains);
+    if (error != Error::None) {
+        return error;
+    }
+    if (!legalCenter(descriptor.centerHz, domains)) {
+        return Error::NoLegalCenter;
+    }
+    return Error::None;
+}
+} // namespace
+
+IntervalResult occupiedInterval(const SliceDescriptor& slice)
+{
+    Interval interval;
+    const Error error = sliceInterval(slice, interval);
+    if (error != Error::None) {
+        return {error, std::nullopt};
+    }
+    return {Error::None, interval};
+}
+
+SelectionResult selectCenter(const CaptureDescriptor& capture,
+    std::span<const SliceDescriptor> desired, std::span<const CenterDomain> domains,
+    ReceiverLimits limits)
+{
+    if (validateLimits(limits) != Error::None) {
+        return {Error::InvalidCapacity, std::nullopt};
+    }
+    Interval currentInterval;
+    Error error = captureInterval(capture, currentInterval);
+    if (error != Error::None) {
+        return {error, std::nullopt};
+    }
+    error = validateDomains(domains);
+    if (error != Error::None) {
+        return {error, std::nullopt};
+    }
+    std::vector<Interval> intervals;
+    error = desiredIntervals(desired, limits, intervals);
+    if (error != Error::None) {
+        return {error, std::nullopt};
+    }
+    double low = 0;
+    double high = kMaxMagnitudeHz;
+    for (const Interval& interval : intervals) {
+        low = std::max(low, directedSum(interval.highHz, -capture.usableRightHz, true));
+        high = std::min(high, directedSum(interval.lowHz, capture.usableLeftHz, false));
+    }
+    std::optional<double> best;
+    Distance bestDistance{kInfinity, 0};
+    for (const CenterDomain& domain : domains) {
+        const double first = std::max(low, domain.minimumHz);
+        const double last = std::min(high, domain.maximumHz);
+        if (first > last) {
+            continue;
+        }
+        const auto consider = [&](double center) {
+            if (center < first || center > last) {
+                return;
+            }
+            CaptureDescriptor candidate = capture;
+            candidate.centerHz = center;
+            Interval candidateInterval;
+            if (captureInterval(candidate, candidateInterval) != Error::None) {
+                return;
+            }
+            for (const Interval& interval : intervals) {
+                if (!contains(candidateInterval, interval)) {
+                    return;
+                }
+            }
+            const Distance distance = distanceFrom(center, capture.centerHz);
+            const bool sameDistance = distance.value == bestDistance.value
+                && distance.residual == bestDistance.residual;
+            if (!best || closer(distance, bestDistance) || (sameDistance && center < *best)) {
+                best = center;
+                bestDistance = distance;
+            }
+        };
+        gridNeighbors(domain, std::clamp(capture.centerHz, first, last), consider);
+        gridNeighbors(domain, first, consider);
+        gridNeighbors(domain, last, consider);
+    }
+    if (!best) {
+        return {Error::NoLegalCenter, std::nullopt};
+    }
+    CaptureDescriptor proposed = capture;
+    proposed.centerHz = *best;
+    // Acceptance is only a proposal. Validate the quantized center before return.
+    error = validateReadback(proposed, proposed, desired, domains, limits);
+    if (error != Error::None) {
+        return {error, std::nullopt};
+    }
+    return {Error::None, proposed};
+}
+
+Error validateReadback(const CaptureDescriptor& proposed, const CaptureDescriptor& actual,
+    std::span<const SliceDescriptor> desired, std::span<const CenterDomain> domains,
+    ReceiverLimits limits)
+{
+    if (validateLimits(limits) != Error::None) {
+        return Error::InvalidCapacity;
+    }
+    Interval proposalInterval, actualInterval;
+    Error error = fixedCapture(proposed, domains, proposalInterval);
+    if (error != Error::None) {
+        return error;
+    }
+    error = fixedCapture(actual, domains, actualInterval);
+    if (error != Error::None) {
+        return error;
+    }
+    if (actual.captureId != proposed.captureId) {
+        return Error::CaptureMismatch;
+    }
+    if (actual.generation != proposed.generation) {
+        return Error::GenerationMismatch;
+    }
+    std::vector<Interval> intervals;
+    error = desiredIntervals(desired, limits, intervals);
+    if (error != Error::None) {
+        return error;
+    }
+    for (const Interval& interval : intervals) {
+        if (!contains(proposalInterval, interval) || !contains(actualInterval, interval)) {
+            return Error::OutsideCapture;
+        }
+    }
+    return Error::None;
+}
+
+RestoreResult restoreFixedCapture(const CaptureDescriptor& actual,
+    std::span<const SliceDescriptor> saved, std::span<const CenterDomain> domains,
+    ReceiverLimits limits)
+{
+    if (validateLimits(limits) != Error::None) {
+        return {Error::InvalidCapacity, {}, {}};
+    }
+    if (saved.size() > kMaxEntries) {
+        return {Error::TooManyEntries, {}, {}};
+    }
+    Interval capture;
+    const Error error = fixedCapture(actual, domains, capture);
+    if (error != Error::None) {
+        return {error, {}, {}};
+    }
+    std::map<std::int32_t, std::size_t> counts;
+    for (const SliceDescriptor& slice : saved) {
+        ++counts[slice.stableId];
+    }
+    std::vector<Error> reasons(saved.size(), Error::None);
+    std::vector<std::size_t> fitting;
+    for (std::size_t i = 0; i < saved.size(); ++i) {
+        const SliceDescriptor& slice = saved[i];
+        Interval interval;
+        reasons[i] = sliceInterval(slice, interval);
+        if (slice.stableId >= 0 && static_cast<std::size_t>(slice.stableId) >= limits.slotCount) {
+            reasons[i] = Error::InvalidIdentity;
+        }
+        if (slice.stableId >= 0 && counts[slice.stableId] > 1) {
+            reasons[i] = Error::DuplicateId;
+        }
+        if (reasons[i] == Error::None && !contains(capture, interval)) {
+            reasons[i] = Error::OutsideCapture;
+        }
+        if (reasons[i] == Error::None) {
+            fitting.push_back(i);
+        }
+    }
+    std::sort(fitting.begin(), fitting.end(), [saved](std::size_t left, std::size_t right) {
+        return saved[left].stableId < saved[right].stableId;
+    });
+    RestoreResult result;
+    for (const std::size_t index : fitting) {
+        if (result.accepted.size() < limits.capacity) {
+            result.accepted.push_back(saved[index]);
+        } else {
+            reasons[index] = Error::CapacityExceeded;
+        }
+    }
+    for (std::size_t i = 0; i < saved.size(); ++i) {
+        if (reasons[i] != Error::None) {
+            result.rejected.push_back({i, saved[i].stableId, reasons[i]});
+        }
+    }
+    return result;
+}
+} // namespace AetherSDR::SharedCapturePolicy

--- a/src/core/SharedCapturePolicy.cpp
+++ b/src/core/SharedCapturePolicy.cpp
@@ -305,7 +305,8 @@ SelectionResult selectCenter(const CaptureDescriptor& capture,
     }
     CaptureDescriptor proposed = capture;
     proposed.centerHz = *best;
-    // Acceptance is only a proposal. Validate the quantized center before return.
+    // Acceptance is only a proposal. Re-validate as defense in depth after
+    // candidate range and containment checks.
     error = validateReadback(proposed, proposed, desired, domains, limits);
     if (error != Error::None) {
         return {error, std::nullopt};

--- a/src/core/SharedCapturePolicy.h
+++ b/src/core/SharedCapturePolicy.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <vector>
+
+namespace AetherSDR::SharedCapturePolicy {
+
+// Representation/resource ceilings, not hardware bandwidth or receiver limits.
+// Finite double-Hz input; RF intervals are rounded conservatively outward.
+inline constexpr double kMaxMagnitudeHz = 1099511627776.0; // 2^40
+inline constexpr std::size_t kMaxEntries = 4096;
+inline constexpr std::size_t kMaxDomains = 256;
+
+enum class Error {
+    None, InvalidNumber, InvalidInterval, InvalidIdentity, DuplicateId,
+    TooManyEntries, InvalidCapacity, InvalidDomains, CaptureMismatch,
+    GenerationMismatch, OutsideCapture, NoLegalCenter, CapacityExceeded
+};
+
+struct CaptureDescriptor {
+    std::uint64_t captureId = 0; // Session endpoint identity, not persistent USB identity.
+    std::uint64_t generation = 0; // Coherent center/rate/usable readback generation.
+    double centerHz = 0;
+    double achievedSampleRateHz = 0;
+    double usableLeftHz = 0; // Nonnegative extents; each <= achieved rate / 2.
+    double usableRightHz = 0;
+    bool operator==(const CaptureDescriptor&) const = default;
+};
+
+struct SliceDescriptor {
+    std::int32_t stableId = -1; // Stable UI slot, never a vector index or DSP channel.
+    double carrierHz = 0;
+    double filterLowHz = 0;
+    double filterHighHz = 0;
+    // RF = carrier + translation + filter offset. Adapter supplies the signed
+    // carrier/BFO translation; this helper invents no mode presets or CW pitch.
+    double translationHz = 0;
+    double guardLowHz = 0;
+    double guardHighHz = 0;
+    bool operator==(const SliceDescriptor&) const = default;
+};
+
+struct CenterDomain {
+    double minimumHz = 0;
+    double maximumHz = 0; // Inclusive; a single realizable point is allowed.
+    double gridOriginHz = 0;
+    double stepHz = 0; // Realizable centers are fma(integer, step, origin).
+    // Exact integer indices are bounded to +/-2^52; step must resolve across
+    // this domain. These are numeric guards, not hardware tuning limits.
+};
+
+struct ReceiverLimits {
+    // Must match the caller's published maxSlices/addressable range.
+    std::size_t slotCount = 0; // Valid stable IDs are [0, slotCount).
+    std::size_t capacity = 0; // Available receivers, may be less than slotCount.
+};
+
+struct Interval {
+    double lowHz = 0;
+    double highHz = 0;
+};
+
+struct IntervalResult {
+    Error error = Error::None;
+    std::optional<Interval> interval;
+};
+
+struct SelectionResult {
+    Error error = Error::None;
+    std::optional<CaptureDescriptor> capture; // Proposal only; needs actual readback.
+};
+
+struct RestoreRejection {
+    std::size_t inputIndex = 0;
+    std::int32_t stableId = -1;
+    Error reason = Error::None;
+};
+
+struct RestoreResult {
+    Error error = Error::None; // Global error => no accepted/rejected partial plan.
+    std::vector<SliceDescriptor> accepted; // Ascending stable ID, unchanged values.
+    std::vector<RestoreRejection> rejected; // Original input order.
+};
+
+[[nodiscard]] IntervalResult occupiedInterval(const SliceDescriptor& slice);
+// The complete desired set is atomic: malformed or impossible => no proposal.
+// Keep a legal current center; otherwise nearest grid point, lower Hz on ties.
+[[nodiscard]] SelectionResult selectCenter(const CaptureDescriptor& capture,
+    std::span<const SliceDescriptor> desired, std::span<const CenterDomain> domains,
+    ReceiverLimits limits);
+// Actual center/rate/margins may differ from the proposal if the complete set
+// still fits. Identity and generation must match. Does not perform a transaction.
+[[nodiscard]] Error validateReadback(const CaptureDescriptor& proposed,
+    const CaptureDescriptor& actual, std::span<const SliceDescriptor> desired,
+    std::span<const CenterDomain> domains, ReceiverLimits limits);
+// Fixed actual capture: no retune, bandwidth change, truncation, or renumbering.
+// All occurrences of a duplicated ID are rejected, regardless of validity/order.
+// Capacity zero is valid. If accepted is empty the caller retains initial state.
+[[nodiscard]] RestoreResult restoreFixedCapture(const CaptureDescriptor& actual,
+    std::span<const SliceDescriptor> saved, std::span<const CenterDomain> domains,
+    ReceiverLimits limits);
+
+} // namespace AetherSDR::SharedCapturePolicy

--- a/tests/shared_capture_policy_test.cpp
+++ b/tests/shared_capture_policy_test.cpp
@@ -372,6 +372,14 @@ void malformedInputs()
         check(selectCenter(good, one, domain).error == Error::InvalidDomains,
               "invalid, empty-grid, unresolved or overflowing-index domain rejected");
     }
+    // The capture and slice otherwise fit; small indices leave the resolution
+    // guard as the reason to reject this grid's colliding center values.
+    constexpr double kLargeGridOriginHz = 549755813888.0; // 2^39; ULP is 2^-13.
+    const std::array<CenterDomain, 1> unresolvedGrid{{
+        {kLargeGridOriginHz, kLargeGridOriginHz + 1, kLargeGridOriginHz, 1e-5}}};
+    const std::array<SliceDescriptor, 1> highSlice{{slice(0, kLargeGridOriginHz)}};
+    check(selectCenter(capture(kLargeGridOriginHz), highSlice, unresolvedGrid).error == Error::InvalidDomains,
+          "sub-ULP center step rejected even when grid indices are bounded");
     const std::array<SliceDescriptor, 2> duplicate{{one[0], one[0]}};
     check(selectCenter(good, duplicate, kDomains).error == Error::DuplicateId, "duplicate desired slots refuse whole request");
     const std::vector<SliceDescriptor> oversized(kMaxEntries + 1, one[0]);

--- a/tests/shared_capture_policy_test.cpp
+++ b/tests/shared_capture_policy_test.cpp
@@ -1,0 +1,452 @@
+#include "core/SharedCapturePolicy.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <vector>
+
+using namespace AetherSDR::SharedCapturePolicy;
+
+namespace {
+int g_failures = 0;
+int g_checks = 0;
+void check(bool condition, const char* message)
+{
+    ++g_checks;
+    if (!condition) {
+        ++g_failures;
+        std::fprintf(stderr, "FAIL: %s\n", message);
+    }
+}
+
+CaptureDescriptor capture(double center = 1000, double left = 100, double right = 100)
+{
+    return {7, 3, center, 1000, left, right};
+}
+
+SliceDescriptor slice(std::int32_t id, double carrier, double low = -10, double high = 10)
+{
+    return {id, carrier, low, high, 0, 0, 0};
+}
+
+constexpr ReceiverLimits kLimits{kMaxEntries, kMaxEntries};
+
+const std::array<CenterDomain, 1> kDomains{{{100, 2000, 0, 1}}};
+
+SelectionResult selectCenter(const CaptureDescriptor& current, std::span<const SliceDescriptor> desired,
+                             std::span<const CenterDomain> domains)
+{
+    return AetherSDR::SharedCapturePolicy::selectCenter(current, desired, domains, kLimits);
+}
+
+Error validateReadback(const CaptureDescriptor& proposed, const CaptureDescriptor& actual,
+                      std::span<const SliceDescriptor> desired, std::span<const CenterDomain> domains)
+{
+    return AetherSDR::SharedCapturePolicy::validateReadback(proposed, actual, desired, domains, kLimits);
+}
+
+RestoreResult restoreFixedCapture(const CaptureDescriptor& actual, std::span<const SliceDescriptor> saved,
+                                 std::span<const CenterDomain> domains, std::size_t capacity)
+{
+    return AetherSDR::SharedCapturePolicy::restoreFixedCapture(actual, saved, domains, {kMaxEntries, capacity});
+}
+
+void expectCenter(const SelectionResult& result, double expected, const char* message)
+{
+    check(result.error == Error::None && result.capture && result.capture->centerHz == expected, message);
+}
+
+// Independent containment against explicit RF edges: no policy formula duplicated.
+void expectContains(const SelectionResult& result, double low, double high)
+{
+    check(result.capture && result.capture->centerHz - result.capture->usableLeftHz <= low
+          && result.capture->centerHz + result.capture->usableRightHz >= high,
+          "selected capture contains independently specified RF interval");
+}
+
+void geometryAndWholeSet()
+{
+    SliceDescriptor translated = slice(0, 1000, -30, 10);
+    translated.translationHz = 20;
+    translated.guardLowHz = 5;
+    translated.guardHighHz = 7;
+    const IntervalResult occupied = occupiedInterval(translated);
+    check(occupied.error == Error::None && occupied.interval
+          && occupied.interval->lowHz == 985 && occupied.interval->highHz == 1037,
+          "asymmetric filter plus signed BFO translation and two guards produce [985,1037]");
+    translated.translationHz = -20;
+    const IntervalResult reversed = occupiedInterval(translated);
+    check(reversed.interval && reversed.interval->lowHz == 945 && reversed.interval->highHz == 997,
+          "negative carrier/BFO translation has explicit RF sign");
+
+    const CaptureDescriptor current = capture(1000, 80, 120); // [920,1120]
+    const std::array<SliceDescriptor, 2> edgeSlices{{slice(9, 930), slice(2, 1110)}};
+    const SelectionResult fixed = selectCenter(current, edgeSlices, kDomains);
+    expectCenter(fixed, 1000, "two opposite-edge receivers fit full asymmetric capture exactly");
+    expectContains(fixed, 920, 1120);
+    const auto savedInputs = edgeSlices;
+    const CaptureDescriptor savedCapture = current;
+
+    std::array<SliceDescriptor, 2> moved = edgeSlices;
+    moved[0].carrierHz = 970;
+    moved[1].carrierHz = 1130;
+    const SelectionResult recentered = selectCenter(current, moved, kDomains);
+    expectCenter(recentered, 1020, "recenter chooses nearest fit for complete desired set");
+    expectContains(recentered, 960, 1140);
+    check(moved[0].carrierHz == 970 && moved[1].carrierHz == 1130,
+          "successful selection preserves absolute sibling frequencies");
+
+    moved = edgeSlices;
+    moved[1].carrierHz += 1;
+    const SelectionResult impossible = selectCenter(current, moved, kDomains);
+    check(impossible.error == Error::NoLegalCenter && !impossible.capture,
+          "one-Hz whole-set excess refuses atomically");
+    check(current == savedCapture && edgeSlices == savedInputs && moved[1].carrierHz == 1111,
+          "refusal leaves inputs and prior valid state unchanged");
+
+    moved = edgeSlices;
+    moved[1].guardHighHz = 1;
+    check(selectCenter(current, moved, kDomains).error == Error::NoLegalCenter,
+          "transition guard widening participates in whole-set fit");
+    moved = edgeSlices;
+    moved[1].filterHighHz = 11;
+    check(selectCenter(current, moved, kDomains).error == Error::NoLegalCenter,
+          "mode/filter widening participates in whole-set fit");
+    CaptureDescriptor shrink = current;
+    shrink.achievedSampleRateHz = 200;
+    shrink.usableLeftHz = 80;
+    shrink.usableRightHz = 100;
+    check(selectCenter(shrink, edgeSlices, kDomains).error == Error::NoLegalCenter,
+          "proposed achieved-rate shrink validates all existing receivers");
+    expectCenter(selectCenter(current, std::span(edgeSlices).first(1), kDomains), 1000,
+                 "removing a receiver preserves a legal center");
+    expectCenter(selectCenter(current, {}, kDomains), 1000,
+                 "removing all receivers preserves a legal center");
+}
+
+void gridsAndDomains()
+{
+    const std::array<SliceDescriptor, 1> desired{{slice(0, 1065, -40, 40)}}; // [1025,1105]
+    const std::array<CenterDomain, 1> grid{{{100, 2000, 0, 10}}};
+    expectCenter(selectCenter(capture(1000, 50, 50), desired, grid), 1060,
+                 "rounding 1055 to outside point 1050 still finds legal 1060");
+    expectContains(selectCenter(capture(1000, 50, 50), desired, grid), 1025, 1105);
+    const std::array<SliceDescriptor, 1> noGrid{{slice(0, 1060, -49, 49)}}; // centers [1059,1061]
+    const std::array<CenterDomain, 1> offsetGrid{{{100, 2000, 5, 10}}};
+    check(selectCenter(capture(1000, 50, 50), noGrid, offsetGrid).error == Error::NoLegalCenter,
+          "continuous feasible interval with no realizable center refuses");
+
+    const std::array<CenterDomain, 2> bands{{{900, 980, 0, 10}, {1020, 1100, 0, 10}}};
+    const std::array<SliceDescriptor, 1> narrow{{slice(0, 1000)}};
+    expectCenter(selectCenter(capture(), narrow, bands), 980,
+                 "disjoint hardware bands do not bridge gap; lower-Hz tie wins");
+    auto reversedBands = bands;
+    std::reverse(reversedBands.begin(), reversedBands.end());
+    expectCenter(selectCenter(capture(), narrow, reversedBands), 980,
+                 "domain input order does not change tie outcome");
+    expectCenter(selectCenter(capture(1020), narrow, bands), 1020,
+                 "existing legal grid center beats recentering");
+    const std::array<CenterDomain, 1> negativeIndex{{{900, 1100, 2000, 10}}};
+    expectCenter(selectCenter(capture(1005), narrow, negativeIndex), 1000,
+                 "negative grid indices and halfway tie are mathematical, not truncating");
+    const std::array<CenterDomain, 1> point{{{1000, 1000, 0, 1}}};
+    expectCenter(selectCenter(capture(), narrow, point), 1000,
+                 "single realizable hardware center is a valid domain");
+
+    CaptureDescriptor far = capture(kMaxMagnitudeHz / 2, 0.125, 0.125);
+    const double next = std::nextafter(1.0, 2.0);
+    const std::array<CenterDomain, 1> tiny{{{1, next, 1, next - 1}}};
+    expectCenter(selectCenter(far, {}, tiny), next,
+                 "nearest comparison retains residual when large distances round equal");
+
+    // Exhaustive small integer domain oracle enumerates hardware points directly,
+    // never computes the policy's intersection formula or quantization quotient.
+    const std::array<CenterDomain, 2> oracleBands{{{80, 98, 0, 3}, {103, 130, 1, 4}}};
+    for (int current = 90; current <= 112; current += 2) {
+        for (int station = 85; station <= 125; station += 5) {
+            const CaptureDescriptor proposed = capture(current, 11, 15);
+            const std::array<SliceDescriptor, 2> receivers{{slice(7, 100, -2, 3), slice(3, station, -3, 4)}};
+            std::optional<int> expected;
+            for (int center = 80; center <= 130; ++center) {
+                const bool legal = (center <= 98 && center % 3 == 0)
+                    || (center >= 103 && (center - 1) % 4 == 0);
+                if (!legal || center - 11 > 98 || center + 15 < 103
+                    || center - 11 > station - 3 || center + 15 < station + 4) {
+                    continue;
+                }
+                if (!expected || std::abs(center - current) < std::abs(*expected - current)) {
+                    expected = center;
+                }
+            }
+            const SelectionResult actual = selectCenter(proposed, receivers, oracleBands);
+            check(expected ? actual.capture && actual.capture->centerHz == *expected
+                           : actual.error == Error::NoLegalCenter && !actual.capture,
+                  "enumerated hardware-center oracle agrees across desired sets");
+        }
+    }
+}
+
+void slotBoundsAndUnusedCapture()
+{
+    const std::array<CenterDomain, 1> lowBand{{{100, 100, 0, 1}}};
+    const std::array<SliceDescriptor, 1> desired{{slice(0, 100)}};
+    const CaptureDescriptor low = capture(100, 400, 400);
+    expectCenter(selectCenter(low, desired, lowBand), 100,
+                 "unused negative capture interval does not veto legal positive RF slice");
+    check(validateReadback(low, low, desired, lowBand) == Error::None,
+          "actual capture may extend below zero when requested RF is valid");
+    const std::array<CenterDomain, 1> fineGrid{{{1, 2, 0, 1e-5}}};
+    expectCenter(selectCenter(capture(1e12, 1, 1), {}, fineGrid), 2,
+                 "rounded distance ties cannot select 1.99998 over nearer 2");
+
+    const std::array<SliceDescriptor, 1> positive{{slice(0, 1000, 0, 10)}};
+    expectCenter(selectCenter(capture(1000, 0, 100), positive, kDomains), 1000,
+                 "positive-only measured usable interval is valid");
+    const std::array<SliceDescriptor, 1> negative{{slice(0, 1000, -10, 0)}};
+    expectCenter(selectCenter(capture(1000, 100, 0), negative, kDomains), 1000,
+                 "negative-only measured usable interval is valid");
+
+    const ReceiverLimits limited{4, 2};
+    const std::array<SliceDescriptor, 3> receivers{{slice(1, 1000), slice(3, 1000), slice(2, 1000)}};
+    check(AetherSDR::SharedCapturePolicy::selectCenter(capture(), receivers, kDomains, limited).error
+          == Error::CapacityExceeded, "whole desired set respects caller concurrent capacity");
+    const std::array<SliceDescriptor, 1> invalidSlot{{slice(std::numeric_limits<std::int32_t>::max(), 1000)}};
+    check(AetherSDR::SharedCapturePolicy::selectCenter(capture(), invalidSlot, kDomains, limited).error
+          == Error::InvalidIdentity, "positive but out-of-range desired stable ID rejected");
+    const RestoreResult invalid = AetherSDR::SharedCapturePolicy::restoreFixedCapture(
+        capture(), invalidSlot, kDomains, limited);
+    check(invalid.error == Error::None && invalid.accepted.empty() && invalid.rejected.size() == 1
+          && invalid.rejected[0].reason == Error::InvalidIdentity,
+          "positive but out-of-range saved stable ID rejected without renumbering");
+    const RestoreResult sparse = AetherSDR::SharedCapturePolicy::restoreFixedCapture(
+        capture(), receivers, kDomains, limited);
+    check(sparse.accepted.size() == 2 && sparse.accepted[0].stableId == 1 && sparse.accepted[1].stableId == 2,
+          "capacity reduction preserves stable slots within explicit slot bounds");
+    for (const ReceiverLimits invalidLimits : {ReceiverLimits{0, 0}, {4, 5}, {kMaxEntries + 1, 1}}) {
+        check(AetherSDR::SharedCapturePolicy::selectCenter(capture(), {}, kDomains, invalidLimits).error
+              == Error::InvalidCapacity, "invalid public receiver limits rejected");
+        check(AetherSDR::SharedCapturePolicy::restoreFixedCapture(capture(), {}, kDomains, invalidLimits).error
+              == Error::InvalidCapacity, "invalid restore slot limits rejected");
+    }
+}
+
+void readbackAndPrecision()
+{
+    const std::array<SliceDescriptor, 2> edges{{slice(0, 920), slice(1, 1080)}}; // [910,1090]
+    const CaptureDescriptor proposed = capture();
+    check(validateReadback(proposed, proposed, edges, kDomains) == Error::None,
+          "coherent achieved readback validates");
+    CaptureDescriptor actual = proposed;
+    actual.centerHz = 1005;
+    actual.achievedSampleRateHz = 220;
+    actual.usableLeftHz = 95;
+    actual.usableRightHz = 85;
+    check(validateReadback(proposed, actual, edges, kDomains) == Error::None,
+          "different actual center/rate/asymmetric margins accepted if complete set fits");
+    actual.centerHz = 1006;
+    check(validateReadback(proposed, actual, edges, kDomains) == Error::OutsideCapture,
+          "actual center mismatch that loses left edge fails");
+    actual = proposed;
+    actual.achievedSampleRateHz = 160;
+    actual.usableLeftHz = 80;
+    actual.usableRightHz = 80;
+    check(validateReadback(proposed, actual, edges, kDomains) == Error::OutsideCapture,
+          "actual achieved-rate shrink cannot publish false acceptance");
+    actual = proposed;
+    ++actual.generation;
+    check(validateReadback(proposed, actual, edges, kDomains) == Error::GenerationMismatch,
+          "mixed readback generation rejected");
+    actual = proposed;
+    ++actual.captureId;
+    check(validateReadback(proposed, actual, edges, kDomains) == Error::CaptureMismatch,
+          "different capture endpoint readback rejected");
+    actual = proposed;
+    actual.centerHz = 1000.5;
+    check(validateReadback(proposed, actual, edges, kDomains) == Error::NoLegalCenter,
+          "off-grid actual readback rejected");
+
+    const std::array<CenterDomain, 1> point{{{1000, 1000, 0, 1}}};
+    std::array<SliceDescriptor, 1> exact{{slice(0, 1000, -100, 100)}};
+    expectCenter(selectCenter(proposed, exact, point), 1000, "exact edge is accepted without epsilon");
+    exact[0].filterHighHz = std::nextafter(100.0, 101.0);
+    check(selectCenter(proposed, exact, point).error == Error::NoLegalCenter,
+          "nextafter over edge cannot disappear in carrier addition");
+    exact[0] = slice(0, 1000, std::nextafter(-100.0, -101.0), 100);
+    check(selectCenter(proposed, exact, point).error == Error::NoLegalCenter,
+          "nextafter below left edge cannot disappear in carrier addition");
+    exact[0] = slice(0, 1000, -100, std::nextafter(100.0, 99.0));
+    expectCenter(selectCenter(proposed, exact, point), 1000, "nextafter inward is conservatively accepted");
+
+    CaptureDescriptor decimal = capture(1000, 0.45 * 333.3, 0.43 * 333.3);
+    decimal.achievedSampleRateHz = 333.3;
+    const std::array<SliceDescriptor, 1> fractional{{slice(0, 1000.1, -10.2, 10.3)}};
+    expectCenter(selectCenter(decimal, fractional, kDomains), 1000,
+                 "ordinary decimal achieved rate and measured margins need no invented lattice");
+    const std::array<CenterDomain, 1> decimalGrid{{{999, 1001, 1000, 0.1}}};
+    CaptureDescriptor decimalCurrent = capture(std::fma(3.0, 0.1, 1000.0));
+    expectCenter(selectCenter(decimalCurrent, fractional, decimalGrid), decimalCurrent.centerHz,
+                 "correctly rounded decimal tuning grid preserves current center");
+    CaptureDescriptor unresolvable = capture(kMaxMagnitudeHz, 1e-10, 1e-10);
+    check(selectCenter(unresolvable, {}, kDomains).error == Error::InvalidInterval,
+          "usable span erased by floating precision fails closed");
+}
+
+void malformedInputs()
+{
+    const CaptureDescriptor good = capture();
+    const std::array<SliceDescriptor, 1> one{{slice(0, 1000)}};
+    const std::array<double, 4> badNumbers{{std::numeric_limits<double>::quiet_NaN(),
+        std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::infinity(),
+        std::numeric_limits<double>::max()}};
+    for (const double value : badNumbers) {
+        for (double SliceDescriptor::*field : {&SliceDescriptor::carrierHz, &SliceDescriptor::filterLowHz,
+             &SliceDescriptor::filterHighHz, &SliceDescriptor::translationHz,
+             &SliceDescriptor::guardLowHz, &SliceDescriptor::guardHighHz}) {
+            auto malformed = one;
+            malformed[0].*field = value;
+            const SelectionResult result = selectCenter(good, malformed, kDomains);
+            check(result.error == Error::InvalidNumber && !result.capture,
+                  "every public slice numeric field rejects nonfinite/overflow magnitude");
+        }
+        for (double CaptureDescriptor::*field : {&CaptureDescriptor::centerHz,
+             &CaptureDescriptor::achievedSampleRateHz, &CaptureDescriptor::usableLeftHz,
+             &CaptureDescriptor::usableRightHz}) {
+            CaptureDescriptor malformed = good;
+            malformed.*field = value;
+            check(selectCenter(malformed, one, kDomains).error == Error::InvalidNumber,
+                  "every public capture numeric field rejects nonfinite/overflow magnitude");
+        }
+        for (double CenterDomain::*field : {&CenterDomain::minimumHz, &CenterDomain::maximumHz,
+             &CenterDomain::gridOriginHz, &CenterDomain::stepHz}) {
+            auto malformed = kDomains;
+            malformed[0].*field = value;
+            check(selectCenter(good, one, malformed).error == Error::InvalidNumber,
+                  "every public hardware-domain numeric field rejects nonfinite/overflow magnitude");
+        }
+    }
+    for (const SliceDescriptor& invalid : {slice(-1, 1000), slice(0, -1), slice(0, 1000, 10, 10),
+                                         slice(0, 1000, 11, 10)}) {
+        check(occupiedInterval(invalid).error != Error::None, "invalid slot/carrier/empty/inverted passband rejected");
+    }
+    SliceDescriptor invalid = one[0];
+    invalid.guardLowHz = -1;
+    check(occupiedInterval(invalid).error == Error::InvalidInterval, "negative left guard rejected");
+    invalid = one[0];
+    invalid.guardHighHz = -1;
+    check(occupiedInterval(invalid).error == Error::InvalidInterval, "negative right guard rejected");
+    invalid = slice(0, kMaxMagnitudeHz, -1, 1);
+    invalid.translationHz = kMaxMagnitudeHz;
+    check(occupiedInterval(invalid).error == Error::InvalidInterval, "bounded operands cannot overflow RF result");
+    invalid = slice(0, 1, -2, 1);
+    check(occupiedInterval(invalid).error == Error::InvalidInterval, "negative occupied RF rejected");
+    CaptureDescriptor bad = good;
+    bad.captureId = 0;
+    check(selectCenter(bad, one, kDomains).error == Error::InvalidIdentity, "zero capture identity rejected");
+    bad = good;
+    bad.generation = 0;
+    check(selectCenter(bad, one, kDomains).error == Error::InvalidIdentity, "zero readback generation rejected");
+    for (const double rate : {0.0, -1.0, 199.0}) {
+        bad = good;
+        bad.achievedSampleRateHz = rate;
+        check(selectCenter(bad, one, kDomains).error == Error::InvalidInterval,
+              "achieved rate must be positive and contain both usable extents within Nyquist");
+    }
+    bad = good;
+    bad.usableLeftHz = 0;
+    bad.usableRightHz = 0;
+    check(selectCenter(bad, one, kDomains).error == Error::InvalidInterval, "empty whole usable interval rejected");
+    const double denormal = std::numeric_limits<double>::denorm_min();
+    bad = capture(0, 2 * denormal, 0);
+    bad.achievedSampleRateHz = 3 * denormal;
+    check(selectCenter(bad, {}, kDomains).error == Error::InvalidInterval,
+          "subnormal rate cannot round half-rate upward and admit excess usable extent");
+    bad = good;
+    bad.usableRightHz = -1;
+    check(selectCenter(bad, one, kDomains).error == Error::InvalidInterval, "negative usable right extent rejected");
+    check(selectCenter(good, one, {}).error == Error::InvalidDomains, "empty center domains rejected");
+    for (const CenterDomain& invalidDomain : {CenterDomain{1000, 999, 0, 1}, {1, 2, 0, 0},
+             {1, 2, 0, -1}, {1000, 1000, 0, 3}, {1, 2, 0, 1e-300}, {-1, 2, 0, 1}, {1, 2, -1, 1}}) {
+        const std::array<CenterDomain, 1> domain{{invalidDomain}};
+        check(selectCenter(good, one, domain).error == Error::InvalidDomains,
+              "invalid, empty-grid, unresolved or overflowing-index domain rejected");
+    }
+    const std::array<SliceDescriptor, 2> duplicate{{one[0], one[0]}};
+    check(selectCenter(good, duplicate, kDomains).error == Error::DuplicateId, "duplicate desired slots refuse whole request");
+    const std::vector<SliceDescriptor> oversized(kMaxEntries + 1, one[0]);
+    check(selectCenter(good, oversized, kDomains).error == Error::TooManyEntries,
+          "desired collection size bounded before iteration");
+    const std::vector<CenterDomain> tooManyDomains(kMaxDomains + 1, kDomains[0]);
+    check(selectCenter(good, one, tooManyDomains).error == Error::InvalidDomains,
+          "hardware-domain collection bounded before iteration");
+}
+
+void restorePlan()
+{
+    const CaptureDescriptor current = capture();
+    std::vector<SliceDescriptor> saved{slice(8, 1020), slice(2, 1000), slice(7, 1400),
+        slice(4, 1010), slice(4, 990), slice(-1, 1000), slice(1, 980), slice(6, 1030)};
+    saved[4].guardLowHz = -1; // Invalid duplicate still invalidates both ID-4 rows.
+    saved[7].filterHighHz = std::numeric_limits<double>::infinity();
+    const RestoreResult result = restoreFixedCapture(current, saved, kDomains, 2);
+    check(result.error == Error::None && result.accepted.size() == 2
+          && result.accepted[0] == saved[6] && result.accepted[1] == saved[1],
+          "restore keeps fitting ascending stable IDs 1,2 without renumbering");
+    const std::array<std::size_t, 6> indices{{0, 2, 3, 4, 5, 7}};
+    const std::array<Error, 6> reasons{{Error::CapacityExceeded, Error::OutsideCapture,
+        Error::DuplicateId, Error::DuplicateId, Error::InvalidIdentity, Error::InvalidNumber}};
+    check(result.rejected.size() == reasons.size(), "every refused restore row has explicit reason");
+    for (std::size_t i = 0; i < std::min(reasons.size(), result.rejected.size()); ++i) {
+        check(result.rejected[i].inputIndex == indices[i] && result.rejected[i].reason == reasons[i],
+              "restore rejection is indexed to original input and deterministic");
+    }
+    std::reverse(saved.begin(), saved.end());
+    const RestoreResult reordered = restoreFixedCapture(current, saved, kDomains, 2);
+    check(reordered.accepted == result.accepted, "restore survivor set independent of input order");
+    const RestoreResult zero = restoreFixedCapture(current, saved, kDomains, 0);
+    check(zero.error == Error::None && zero.accepted.empty() && zero.rejected.size() == saved.size(),
+          "validated zero capacity rejects every row without partial application");
+    const RestoreResult invalidCapacity = restoreFixedCapture(current, saved, kDomains, kMaxEntries + 1);
+    check(invalidCapacity.error == Error::InvalidCapacity && invalidCapacity.accepted.empty()
+          && invalidCapacity.rejected.empty(), "invalid capacity gives no partial restore plan");
+    const std::vector<SliceDescriptor> oversized(kMaxEntries + 1, slice(0, 1000));
+    check(restoreFixedCapture(current, oversized, kDomains, 2).error == Error::TooManyEntries,
+          "restore parser collection ceiling enforced");
+    const std::array<SliceDescriptor, 1> far{{slice(0, 1500)}};
+    const RestoreResult refused = restoreFixedCapture(current, far, kDomains, 1);
+    check(refused.accepted.empty() && refused.rejected.size() == 1
+          && refused.rejected[0].reason == Error::OutsideCapture && current.centerHz == 1000,
+          "restore never silently recenters even when one remembered receiver could be retuned into view");
+    CaptureDescriptor reconnected = current;
+    reconnected.captureId = 9;
+    reconnected.generation = 80;
+    check(restoreFixedCapture(reconnected, saved, kDomains, 2).accepted == result.accepted,
+          "stored RF configuration is independent of old session identity/generation");
+    CaptureDescriptor invalidCapture = current;
+    invalidCapture.centerHz = 1000.5;
+    const RestoreResult noPlan = restoreFixedCapture(invalidCapture, saved, kDomains, 2);
+    check(noPlan.error == Error::NoLegalCenter && noPlan.accepted.empty() && noPlan.rejected.empty(),
+          "invalid actual capture rejects global restore before any partial plan");
+    std::vector<SliceDescriptor> bounded;
+    for (std::size_t i = 0; i < kMaxEntries; ++i) {
+        bounded.push_back(slice(static_cast<std::int32_t>(kMaxEntries - i - 1), 1000));
+    }
+    const RestoreResult maximum = restoreFixedCapture(current, bounded, kDomains, kMaxEntries);
+    check(maximum.error == Error::None && maximum.accepted.size() == kMaxEntries
+          && maximum.accepted.front().stableId == 0 && maximum.accepted.back().stableId == 4095,
+          "parser ceiling is inclusive and does not hardcode a small architecture RX count");
+}
+} // namespace
+
+int main()
+{
+    geometryAndWholeSet();
+    gridsAndDomains();
+    slotBoundsAndUnusedCapture();
+    readbackAndPrecision();
+    malformedInputs();
+    restorePlan();
+    std::fprintf(stderr, "shared_capture_policy_test: %d checks, %d failures\n", g_checks, g_failures);
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -66,6 +66,15 @@ unset(_aether_stray_targets)
 unset(_aether_stray_registrations)
 
 
+# Pure shared-capture geometry policy: no sockets, settings, DSP or hardware.
+add_executable(shared_capture_policy_test
+    tests/shared_capture_policy_test.cpp
+    src/core/SharedCapturePolicy.cpp
+)
+target_include_directories(shared_capture_policy_test PRIVATE src)
+set_target_properties(shared_capture_policy_test PROPERTIES AUTOMOC OFF)
+add_test(NAME shared_capture_policy_test COMMAND shared_capture_policy_test)
+
 # ── AetherD control protocol tests ───────────────────────────────────────────
 # AetherD control protocol v1: transport-neutral envelope validation and
 # fail-closed structural limits. QtCore only; no daemon/socket/model dependency.


### PR DESCRIPTION
## Summary

RTL RFC #5468 requires every receiver's complete guarded RF passband to fit the shared capture before tuning, filter/mode changes or sample-rate changes are accepted. Add a pure `SharedCapturePolicy` helper that selects the nearest legal quantized tuner center, validates coherent readback and produces a deterministic restore plan within the current capture.

The helper validates asymmetric filter/usable margins, signed carrier/BFO translation, transition guards, disjoint hardware domains, bounded numeric inputs, stable slot IDs and caller-supplied receiver capacity. It keeps an already legal center, refuses an impossible desired set atomically, and restores fitting entries in ascending stable-ID order without recentering or renumbering. Conservative floating-point arithmetic rejects unrepresentable boundary fringes rather than widening acceptance with a tolerance.

This is F2 of #5468 and is independent of P01 #5471. The helper compiles into the static `aethercore` library; the registered test compiles that same implementation. No live backend calls it yet. USB/DSP/audio/viewport/UI/persistence integration and supported receiver counts remain later RFC phases. The new contract is documented in `docs/shared-capture-policy.md`. This PR does not close the umbrella RFC.

## Review follow-up

An additional regression rejects a center grid whose 1e-5 Hz step is smaller than the double spacing at 2^39 Hz while its grid indices remain within the independent index bound. The capture and slice otherwise fit. Disabling only the resolution guard makes this new check fail, closing the reported mutation-coverage gap. The final readback validation remains, with its defense-in-depth purpose made explicit.

The contract now distinguishes adapter-declared logical readback from measured physical RF frequency. In [Osmocom librtlsdr v2.0.2](https://github.com/osmocom/rtl-sdr/blob/v2.0.2/src/librtlsdr.c#L884-L913) and [RTL-SDR Blog commit aed0ea19](https://github.com/rtlsdrblog/rtl-sdr-blog/blob/aed0ea19f3a273370a13c9009b96313c75d54c7b/src/librtlsdr.c#L887-L936), `rtlsdr_get_center_freq()` returns the cached requested frequency stored by successful tuning; it does not measure achieved PLL frequency. Other versions and forks need verification. Actual readback must still satisfy the declared domains and complete-set containment checks.

## Constitution principles honored

Principle VII — invalid numeric descriptors, impossible intervals, malformed identities, oversized collections and incoherent readback fail at the policy boundary. Principle II — a selection is only a proposal; the integration layer must validate coherent capture state before publication. Logical library readback does not establish physical RF accuracy.

## Validation

- Follow-up on macOS ARM64, Apple clang 21.0.0, standalone C++20 `-O2`: **260 checks, 0 failures**. The test is socket-free and requires no Qt event loop, hardware, DSP or settings.
- Follow-up mutation in a temporary source copy: disabling only `stepHz < resolution` produces **260 checks, 1 failure**, specifically the new unresolved-grid assertion. Production guards remain unchanged.
- `git diff --check` passes for the follow-up.
- Prior reviewed head `5cd78ad10bf3ce86c404cddf7c2aea9b4215c844`: Linux normal engine policy object and registered CTest built with GCC 16.2.1; all 259 then-existing assertions passed. The independent rational oracle matched all 2,000 cases, upper-transition-guard and generation mutations failed as expected, and the exact restored source passed. Strict engine-boundary, test-registration, frozen CI-gate and touchpoint checks passed on that head. Those are recorded prior-head results, not a new Linux run of this follow-up.
- Linux follow-up: normal engine policy object and registered CTest rebuilt; **260 checks pass**. Removing only the resolution guard compiled and failed the new assertion. Exact source restoration, rebuild and final CTest pass. Strict engine-boundary, registration, frozen CI gate, touchpoint manifest and whitespace checks pass.
- Signed follow-up head `bec2815c605442864fc425133ddd887cb200680d`; full source matches validation base `e60c3bea2ac8e5b762be9a3c6f52aa1bab8fb9ad` plus six-file digest `b2237190f1a875addf40557d39d9e5e8c01fcc171906908861a1c51ac46c4cf5`. All seven PR checks passed on this follow-up head.

- Review follow-up `beb054c384c9bb1334c68ab6ecb8bc8ec96ebd93` corrects only the Osmocom source anchor; implementation and tests are unchanged. Independent review of `bec2815c` merged with main `f0ed969b` passed all 260 checks in native macOS ARM64 optimized and ASan/UBSan builds. Grid-resolution, upper-guard, generation and restore-capacity mutations all failed as expected. Engine-boundary, registration, frozen CI-gate, touchpoint and whitespace checks passed. See the live Checks tab for the documentation follow-up status.

No live-radio or performance claim is made for this unintegrated policy. The test is registered in the default graph without expanding the frozen per-PR allow-list. No dependencies, threads, settings owner, socket-owning test, UI controls or CHANGELOG entry are added. Full application behavior, physical RF accuracy and supported receiver capacity remain integration gates.

---

73, Ozy **K6OZY**  · GPT-6 Astra-Ultra

