### PR TITLE
Harden NASA and NWS map retries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -997,6 +997,7 @@ set(GUI_SOURCES
     src/gui/map/CityLightsItem.cpp
     src/gui/map/CityLightsSource.cpp
     src/gui/map/MapDisplayWidget.cpp
+    src/gui/map/MapProviderNetworkAccessManager.cpp
     src/gui/map/GlobeMapView.cpp
     src/gui/map/MapView.cpp
     src/gui/map/MapMarkerBatchItem.cpp

--- a/docs/map-provider-retries.md
+++ b/docs/map-provider-retries.md
@@ -1,0 +1,25 @@
+# Map provider retry protection
+
+NASA GIBS and NWS imagery each have a process-wide cooldown, shared by flat
+and globe views and by reopened dialogs. HTTP errors (including 429 and 503)
+and transport failures pause new requests to that provider for at least
+60 seconds. Repeated failed recovery attempts increase the delay to 2, 4, 8,
+and 15 minutes, with up to 6 seconds of positive jitter. A valid longer
+`Retry-After` delay, in seconds or HTTP-date form, takes precedence.
+
+While cooling down, request attempts receive a local asynchronous failure;
+no HTTP request is sent. Existing decoded imagery and playback frames remain
+usable. At expiry only one recovery request is admitted. Its uncached success releases
+the cooldown; cancellation releases the probe without counting as another
+failure. Old in-flight successes cannot erase a more recent failure. Local
+cooldown responses do not extend the deadline. Switching projections, panning,
+and reopening the map cannot bypass this shared gate.
+
+These controls follow the [NWS appropriate-use guidance](https://www.weather.gov/abusive-user-block)
+for one-minute outage retries. NASA also publishes
+[GIBS download guidance](https://nasa-gibs.github.io/gibs-api-docs/map-library-usage/).
+They reduce retry storms; they are not a guarantee against IP blocking or an
+aggregate limit across multiple app processes, machines, or users sharing a
+public IP. Cooldowns are in memory and reset on process restart. Normal
+successful-request caching and concurrency limits remain unchanged; other
+providers (including OSM and KiwiSDR) are unaffected.

--- a/docs/map-provider-retries.md
+++ b/docs/map-provider-retries.md
@@ -5,13 +5,21 @@ and globe views and by reopened dialogs. HTTP errors (including 429 and 503)
 and transport failures pause new requests to that provider for at least
 60 seconds. Repeated failed recovery attempts increase the delay to 2, 4, 8,
 and 15 minutes, with up to 6 seconds of positive jitter. A valid longer
-`Retry-After` delay, in seconds or HTTP-date form, takes precedence.
+`Retry-After` delay, in seconds or HTTP-date form, takes precedence up to a
+one-day cap (including overflowing numeric values). City-light and radar-history
+retry timers wait 66 seconds, covering the initial cooldown's full jitter range.
+Live-tile readiness uses a separate short retry clock that panning cannot reset;
+the shared network gate still enforces the provider cooldown.
 
-While cooling down, request attempts receive a local asynchronous failure;
-no HTTP request is sent. Existing decoded imagery and playback frames remain
-usable. At expiry only one recovery request is admitted. Its uncached success releases
-the cooldown; cancellation releases the probe without counting as another
-failure. Old in-flight successes cannot erase a more recent failure. Local
+While cooling down, cache-eligible requests may read the HTTP disk cache in
+cache-only mode; misses receive a local failure and never start HTTP. Explicit
+network-only requests receive a local cooldown error. Local denials do not evict
+cached city-light images; invalid image payloads still do. Existing decoded
+imagery and playback frames remain usable. At expiry only one recovery request
+is admitted. Its uncached success releases the cooldown; cancellation releases
+the probe without counting as another failure. Old in-flight successes cannot erase a more recent failure. Late
+failures can extend the deadline using their server's bounded `Retry-After`,
+but simultaneous failures within a cooldown do not multiply the backoff. Local
 cooldown responses do not extend the deadline. Switching projections, panning,
 and reopening the map cannot bypass this shared gate.
 

--- a/docs/psk-reporter-city-lights.md
+++ b/docs/psk-reporter-city-lights.md
@@ -51,10 +51,10 @@ reuse when the map is reopened.
   geographic surface normal; no lights are projected onto the far hemisphere.
 - Download limit: 16 MiB, 15-second timeout, one active HTTP request. PNG
   dimensions are checked before decoding. Failures retain the previous image
-  and retry no sooner than one minute after a failure. The dedicated HTTP disk cache is bounded to
-  64 MiB and follows response cache headers. CPU image work uses the existing
-  Qt global worker pool, with at most one twilight-mask job plus a coalesced
-  follow-up.
+  and retry after 66 seconds (or later while the provider cooldown remains).
+  The dedicated HTTP disk cache is bounded to 64 MiB and follows response cache
+  headers. CPU image work uses the existing Qt global worker pool, with at most
+  one twilight-mask job plus a coalesced follow-up.
 
 References:
 - [GIBS available visualizations](https://nasa-gibs.github.io/gibs-api-docs/available-visualizations/)

--- a/docs/psk-reporter-city-lights.md
+++ b/docs/psk-reporter-city-lights.md
@@ -51,7 +51,7 @@ reuse when the map is reopened.
   geographic surface normal; no lights are projected onto the far hemisphere.
 - Download limit: 16 MiB, 15-second timeout, one active HTTP request. PNG
   dimensions are checked before decoding. Failures retain the previous image
-  and retry after 30 seconds. The dedicated HTTP disk cache is bounded to
+  and retry no sooner than one minute after a failure. The dedicated HTTP disk cache is bounded to
   64 MiB and follows response cache headers. CPU image work uses the existing
   Qt global worker pool, with at most one twilight-mask job plus a coalesced
   follow-up.
@@ -81,3 +81,6 @@ grayscale NASA lights; increasing it adds a warm-white to golden tint without
 changing opacity. It does not represent measured lamp color. The globe applies
 warmth as a shader uniform without uploading a new image; the flat map applies
 the same channel scaling in its CPU image worker.
+
+See [map provider retry protection](map-provider-retries.md) for shared NASA/NWS
+cooldowns, `Retry-After` handling, recovery probes, and the limits of this protection.

--- a/docs/psk-reporter-weather-radar.md
+++ b/docs/psk-reporter-weather-radar.md
@@ -44,3 +44,6 @@ Focused regression coverage lives in the weather_radar source, placement,
 wrap-render, loading, and texture tests. Loading tests inject replies without
 opening sockets or contacting NOAA. Native GPU cases require explicit opt-in;
 an offscreen skip is not native rendering verification.
+
+See [map provider retry protection](map-provider-retries.md) for shared NASA/NWS
+cooldowns, `Retry-After` handling, recovery probes, and the limits of this protection.

--- a/src/gui/map/CityLightsSource.cpp
+++ b/src/gui/map/CityLightsSource.cpp
@@ -1,4 +1,5 @@
 #include "CityLightsSource.h"
+#include "MapProviderNetworkAccessManager.h"
 #include "SolarTerminator.h"
 
 #include <array>
@@ -23,7 +24,7 @@ constexpr double kNativePixelMetres = kRadarWorldWidth / 65536.0;
 }
 
 CityLightsSource::CityLightsSource(QObject* parent, QNetworkAccessManager* network)
-    : QObject(parent), m_network(network != nullptr ? network : new QNetworkAccessManager(this))
+    : QObject(parent), m_network(network != nullptr ? network : new MapProviderNetworkAccessManager(this))
 {
     if (network == nullptr) {
         auto* cache = new QNetworkDiskCache(m_network);
@@ -296,7 +297,7 @@ void CityLightsSource::requestImage()
                     m_network->cache()->remove(imageUrl(requested));
                 }
                 emit statusChanged(tr("City lights unavailable — retrying"));
-                m_debounce.start(30000);
+                m_debounce.start(60000);
                 return;
             }
             m_loaded = requested;

--- a/src/gui/map/CityLightsSource.cpp
+++ b/src/gui/map/CityLightsSource.cpp
@@ -34,6 +34,8 @@ CityLightsSource::CityLightsSource(QObject* parent, QNetworkAccessManager* netwo
         m_network->setCache(cache);
     }
     m_debounce.setSingleShot(true);
+    // Coarse timers may fire early and miss the provider cooldown plus jitter.
+    m_debounce.setTimerType(Qt::PreciseTimer);
     connect(&m_debounce, &QTimer::timeout, this, &CityLightsSource::requestImage);
     m_clock.setInterval(60 * 1000);
     connect(&m_clock, &QTimer::timeout, this, &CityLightsSource::renderImage);
@@ -284,7 +286,7 @@ void CityLightsSource::requestImage()
         m_reply = nullptr;
         auto* watcher = new QFutureWatcher<QImage>(this);
         connect(watcher, &QFutureWatcher<QImage>::finished, this,
-                [this, watcher, requested, generation] {
+                [this, watcher, requested, generation, valid] {
             const QImage image = watcher->result();
             watcher->deleteLater();
             if (generation != m_generation || !m_enabled) {
@@ -293,11 +295,12 @@ void CityLightsSource::requestImage()
             if (image.isNull()) {
                 // A provider can return an XML error with HTTP 200. Do not
                 // replay that cached error on every retry for this viewport.
-                if (m_network->cache() != nullptr) {
+                // Transport errors and local denials contain no image to judge.
+                if (valid && m_network->cache() != nullptr) {
                     m_network->cache()->remove(imageUrl(requested));
                 }
                 emit statusChanged(tr("City lights unavailable — retrying"));
-                m_debounce.start(60000);
+                m_debounce.start(MapProviderRetryPolicy::kConsumerRetryMs);
                 return;
             }
             m_loaded = requested;

--- a/src/gui/map/MapDisplayWidget.cpp
+++ b/src/gui/map/MapDisplayWidget.cpp
@@ -1,4 +1,5 @@
 #include "MapDisplayWidget.h"
+#include "MapProviderNetworkAccessManager.h"
 #include "CityLightsSource.h"
 #include "GlobeMapView.h"
 #include "WeatherRadarPlaybackTimeline.h"
@@ -139,7 +140,7 @@ MapDisplayWidget::MapDisplayWidget(QWidget* parent)
     m_weatherRadarRebufferTimer->setInterval(350);
     connect(m_weatherRadarRebufferTimer, &QTimer::timeout,
             this, &MapDisplayWidget::rebufferWeatherRadarPlayback);
-    m_weatherRadarNetwork = new QNetworkAccessManager(this);
+    m_weatherRadarNetwork = new MapProviderNetworkAccessManager(this);
     m_weatherRadarNetwork->setTransferTimeout(kTimelineTimeoutMs);
     m_weatherRadarLoadingLabel = new QLabel(this);
     m_weatherRadarLoadingLabel->setObjectName(QStringLiteral("pskReporterWeatherRadarLoading"));
@@ -512,7 +513,7 @@ void MapDisplayWidget::retryWeatherRadarHistory()
     emit weatherRadarTimelineLoadingChanged(false);
     m_weatherRadarTimelineCache.clear();
     m_weatherRadarTimelineCachedAt = {};
-    m_weatherRadarRebufferTimer->start(5000);
+    m_weatherRadarRebufferTimer->start(60000);
     updateWeatherRadarLoadingStatus();
 }
 
@@ -1144,7 +1145,7 @@ void MapDisplayWidget::finishWeatherRadarDownloadBatch()
         // No timeline/cadence reset on a zoom. Failed detail keeps that frame's
         // older image; retry only the missing upgrades after a bounded delay.
         if (!m_weatherRadarDownloadFailed.isEmpty()) {
-            m_weatherRadarRebufferTimer->start(5000);
+            m_weatherRadarRebufferTimer->start(60000);
         }
         if (m_weatherRadarPlayableFrameCount != m_weatherRadarFrames.size()
             || std::any_of(m_weatherRadarFrames.cbegin(), m_weatherRadarFrames.cend(),
@@ -1312,7 +1313,7 @@ void MapDisplayWidget::applyFinalizedWeatherRadarBuffering()
     }
     m_weatherRadarBufferFinalizationPending = false;
     if (!m_weatherRadarRetryFrames.isEmpty()) {
-        m_weatherRadarRebufferTimer->start(5000);
+        m_weatherRadarRebufferTimer->start(60000);
     }
     if (m_weatherRadarFrames.size() < 2) {
         resetWeatherRadarAnimation(true);

--- a/src/gui/map/MapDisplayWidget.cpp
+++ b/src/gui/map/MapDisplayWidget.cpp
@@ -136,6 +136,8 @@ MapDisplayWidget::MapDisplayWidget(QWidget* parent)
     connect(m_weatherRadarPlaybackTimer, &QTimer::timeout,
             this, &MapDisplayWidget::updateWeatherRadarPlayback);
     m_weatherRadarRebufferTimer = new QTimer(this);
+    // Recovery must not fire early inside the provider cooldown plus jitter.
+    m_weatherRadarRebufferTimer->setTimerType(Qt::PreciseTimer);
     m_weatherRadarRebufferTimer->setSingleShot(true);
     m_weatherRadarRebufferTimer->setInterval(350);
     connect(m_weatherRadarRebufferTimer, &QTimer::timeout,
@@ -513,7 +515,7 @@ void MapDisplayWidget::retryWeatherRadarHistory()
     emit weatherRadarTimelineLoadingChanged(false);
     m_weatherRadarTimelineCache.clear();
     m_weatherRadarTimelineCachedAt = {};
-    m_weatherRadarRebufferTimer->start(60000);
+    m_weatherRadarRebufferTimer->start(MapProviderRetryPolicy::kConsumerRetryMs);
     updateWeatherRadarLoadingStatus();
 }
 
@@ -1145,7 +1147,7 @@ void MapDisplayWidget::finishWeatherRadarDownloadBatch()
         // No timeline/cadence reset on a zoom. Failed detail keeps that frame's
         // older image; retry only the missing upgrades after a bounded delay.
         if (!m_weatherRadarDownloadFailed.isEmpty()) {
-            m_weatherRadarRebufferTimer->start(60000);
+            m_weatherRadarRebufferTimer->start(MapProviderRetryPolicy::kConsumerRetryMs);
         }
         if (m_weatherRadarPlayableFrameCount != m_weatherRadarFrames.size()
             || std::any_of(m_weatherRadarFrames.cbegin(), m_weatherRadarFrames.cend(),
@@ -1313,7 +1315,7 @@ void MapDisplayWidget::applyFinalizedWeatherRadarBuffering()
     }
     m_weatherRadarBufferFinalizationPending = false;
     if (!m_weatherRadarRetryFrames.isEmpty()) {
-        m_weatherRadarRebufferTimer->start(60000);
+        m_weatherRadarRebufferTimer->start(MapProviderRetryPolicy::kConsumerRetryMs);
     }
     if (m_weatherRadarFrames.size() < 2) {
         resetWeatherRadarAnimation(true);

--- a/src/gui/map/MapProviderNetworkAccessManager.cpp
+++ b/src/gui/map/MapProviderNetworkAccessManager.cpp
@@ -1,0 +1,212 @@
+#include "MapProviderNetworkAccessManager.h"
+
+#include <QMutexLocker>
+#include <QLocale>
+#include <QTimeZone>
+#include <QNetworkReply>
+#include <QRandomGenerator>
+#include <QTimer>
+
+#include <algorithm>
+#include <limits>
+
+namespace AetherSDR {
+namespace {
+constexpr qint64 kMinimumRetryMs = 60000;
+constexpr qint64 kMaximumBackoffMs = 15 * 60000;
+// Saturation prevents hostile Retry-After values overflowing arithmetic.
+// Do not cap a valid server cooldown at our shorter exponential-backoff cap.
+constexpr qint64 kMaximumDelayMs = std::numeric_limits<qint64>::max() / 4;
+
+class CooldownReply final : public QNetworkReply {
+public:
+    CooldownReply(const QNetworkRequest& request, QNetworkAccessManager::Operation operation,
+                  qint64 delayMs, QObject* parent) : QNetworkReply(parent)
+    {
+        setRequest(request);
+        setUrl(request.url());
+        setOperation(operation);
+        setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 503);
+        setRawHeader("Retry-After", QByteArray::number((delayMs + 999) / 1000));
+        open(QIODevice::ReadOnly | QIODevice::Unbuffered);
+        QTimer::singleShot(0, this, [this] {
+            finish(QNetworkReply::TemporaryNetworkFailureError,
+                   tr("Map provider cooling down; cached imagery remains available"));
+        });
+    }
+    void abort() override { finish(OperationCanceledError, tr("Canceled")); }
+protected:
+    qint64 readData(char*, qint64) override { return -1; }
+private:
+    void finish(NetworkError error, const QString& message)
+    {
+        if (isFinished()) {
+            return;
+        }
+        setError(error, message);
+        setFinished(true);
+        emit errorOccurred(error);
+        emit finished();
+    }
+};
+
+std::shared_ptr<MapProviderRetryPolicy> sharedPolicy()
+{
+    static const auto policy = std::make_shared<MapProviderRetryPolicy>();
+    return policy;
+}
+}
+
+MapProviderRetryPolicy::MapProviderRetryPolicy(std::function<qint64()> clock)
+    : m_clock(std::move(clock))
+{
+    m_elapsed.start();
+}
+
+qint64 MapProviderRetryPolicy::now() const
+{
+    return m_clock ? m_clock() : m_elapsed.elapsed();
+}
+
+QString MapProviderRetryPolicy::provider(const QUrl& url)
+{
+    const QString host = url.host().toLower();
+    if (host == QLatin1String("gibs.earthdata.nasa.gov")
+        || host == QLatin1String("gibs-a.earthdata.nasa.gov")
+        || host == QLatin1String("gibs-b.earthdata.nasa.gov")
+        || host == QLatin1String("gibs-c.earthdata.nasa.gov")) {
+        return QStringLiteral("nasa-gibs");
+    }
+    if (host == QLatin1String("mapservices.weather.noaa.gov")) {
+        return QStringLiteral("nws-imagery");
+    }
+    return {};
+}
+
+qint64 MapProviderRetryPolicy::retryAfterMs(const QByteArray& value, const QDateTime& now)
+{
+    const QByteArray text = value.trimmed();
+    if (text.isEmpty()) {
+        return 0;
+    }
+    if (std::all_of(text.cbegin(), text.cend(), [](char c) { return c >= '0' && c <= '9'; })) {
+        bool ok = false;
+        const qulonglong seconds = text.toULongLong(&ok);
+        if (!ok || seconds > qulonglong(kMaximumDelayMs / 1000)) {
+            return kMaximumDelayMs;
+        }
+        return qint64(seconds) * 1000;
+    }
+    // HTTP uses IMF-fixdate (literal GMT); Qt's RFC2822 parser expects a
+    // numeric offset on some versions. Parse the wire format in English/UTC.
+    QDateTime date = QLocale::c().toDateTime(QString::fromLatin1(text),
+                                           QStringLiteral("ddd, dd MMM yyyy HH:mm:ss 'GMT'"));
+    if (date.isValid()) {
+        date.setTimeZone(QTimeZone::UTC);
+    } else {
+        date = QDateTime::fromString(QString::fromLatin1(text), Qt::RFC2822Date);
+    }
+    return date.isValid() ? std::clamp(now.msecsTo(date), qint64(0), kMaximumDelayMs) : 0;
+}
+
+MapProviderRetryPolicy::Admission MapProviderRetryPolicy::admit(const QUrl& url)
+{
+    const QString key = provider(url);
+    if (key.isEmpty()) {
+        return {};
+    }
+    QMutexLocker lock(&m_mutex);
+    State& state = m_states[key];
+    const qint64 remaining = state.until - now();
+    if (remaining > 0) {
+        return {remaining, state.generation, false};
+    }
+    if (state.probeInFlight) {
+        return {kMinimumRetryMs, state.generation, false};
+    }
+    const bool probe = state.failures != 0;
+    state.probeInFlight = probe;
+    return {0, state.generation, probe};
+}
+
+void MapProviderRetryPolicy::complete(const QUrl& url, Admission admission,
+    bool failed, bool canceled, const QByteArray& retryAfter, const QDateTime& wallNow)
+{
+    const QString key = provider(url);
+    if (key.isEmpty()) {
+        return;
+    }
+    QMutexLocker lock(&m_mutex);
+    State& state = m_states[key];
+    const qint64 time = now();
+    if (admission.probe && admission.generation == state.generation) {
+        state.probeInFlight = false;
+    }
+    if (canceled) {
+        return; // Panning, disabling or closing is not a provider failure.
+    }
+    if (!failed) {
+        if (admission.generation == state.generation && time >= state.until) {
+            state.failures = 0;
+        }
+        return; // An older in-flight success cannot erase a newer failure.
+    }
+    if (time >= state.until) {
+        state.failures = std::min(state.failures + 1, 5U);
+        ++state.generation;
+        state.probeInFlight = false; // A newer failure invalidates any older probe.
+        const qint64 backoff = std::min(kMaximumBackoffMs,
+            kMinimumRetryMs * (qint64(1) << (state.failures - 1)));
+        // Positive jitter never undercuts NWS's one-minute outage guidance.
+        const qint64 jitter = QRandomGenerator::global()->bounded(6001);
+        state.until = time + backoff + jitter;
+    }
+    state.until = std::max(state.until, time + retryAfterMs(retryAfter, wallNow));
+}
+
+MapProviderNetworkAccessManager::MapProviderNetworkAccessManager(QObject* parent,
+    std::shared_ptr<MapProviderRetryPolicy> policy)
+    : QNetworkAccessManager(parent), m_policy(policy ? std::move(policy) : sharedPolicy())
+{
+}
+
+QNetworkReply* MapProviderNetworkAccessManager::sendRequest(Operation operation,
+    const QNetworkRequest& request, QIODevice* outgoingData)
+{
+    return QNetworkAccessManager::createRequest(operation, request, outgoingData);
+}
+
+QNetworkReply* MapProviderNetworkAccessManager::createRequest(Operation operation,
+    const QNetworkRequest& request, QIODevice* outgoingData)
+{
+    if (operation != GetOperation || MapProviderRetryPolicy::provider(request.url()).isEmpty()) {
+        return sendRequest(operation, request, outgoingData);
+    }
+    const MapProviderRetryPolicy::Admission admission = m_policy->admit(request.url());
+    if (admission.delayMs > 0) {
+        return new CooldownReply(request, operation, admission.delayMs, this);
+    }
+    QNetworkReply* reply = sendRequest(operation, request, outgoingData);
+    const auto policy = m_policy;
+    const QUrl url = request.url();
+    const auto completed = std::make_shared<bool>(false);
+    connect(reply, &QNetworkReply::finished, reply, [reply, policy, url, admission, completed] {
+        *completed = true;
+        const bool canceled = reply->error() == QNetworkReply::OperationCanceledError;
+        const bool failed = reply->error() != QNetworkReply::NoError
+            || reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() >= 400;
+        // A disk-cache hit is not evidence that the remote service recovered.
+        const bool cachedSuccess = !failed
+            && reply->attribute(QNetworkRequest::SourceIsFromCacheAttribute).toBool();
+        policy->complete(url, admission, failed, canceled || cachedSuccess,
+                         reply->rawHeader("Retry-After"));
+    });
+    connect(reply, &QObject::destroyed, [policy, url, admission, completed] {
+        if (!*completed) {
+            policy->complete(url, admission, false, true);
+        }
+    });
+    return reply;
+}
+
+} // namespace AetherSDR

--- a/src/gui/map/MapProviderNetworkAccessManager.cpp
+++ b/src/gui/map/MapProviderNetworkAccessManager.cpp
@@ -1,6 +1,8 @@
 #include "MapProviderNetworkAccessManager.h"
 
 #include <QMutexLocker>
+#include <QCoreApplication>
+#include <QAbstractNetworkCache>
 #include <QLocale>
 #include <QTimeZone>
 #include <QNetworkReply>
@@ -8,15 +10,13 @@
 #include <QTimer>
 
 #include <algorithm>
-#include <limits>
 
 namespace AetherSDR {
 namespace {
 constexpr qint64 kMinimumRetryMs = 60000;
 constexpr qint64 kMaximumBackoffMs = 15 * 60000;
-// Saturation prevents hostile Retry-After values overflowing arithmetic.
-// Do not cap a valid server cooldown at our shorter exponential-backoff cap.
-constexpr qint64 kMaximumDelayMs = std::numeric_limits<qint64>::max() / 4;
+// Bound malformed server values while allowing longer-than-backoff cooldowns.
+constexpr qint64 kMaximumDelayMs = 24 * 60 * 60000;
 
 class CooldownReply final : public QNetworkReply {
 public:
@@ -31,10 +31,15 @@ public:
         open(QIODevice::ReadOnly | QIODevice::Unbuffered);
         QTimer::singleShot(0, this, [this] {
             finish(QNetworkReply::TemporaryNetworkFailureError,
-                   tr("Map provider cooling down; cached imagery remains available"));
+                   QCoreApplication::translate("MapProviderNetworkAccessManager",
+                       "Map provider cooling down; cached imagery remains available"));
         });
     }
-    void abort() override { finish(OperationCanceledError, tr("Canceled")); }
+    void abort() override
+    {
+        finish(OperationCanceledError,
+               QCoreApplication::translate("MapProviderNetworkAccessManager", "Canceled"));
+    }
 protected:
     qint64 readData(char*, qint64) override { return -1; }
 private:
@@ -161,6 +166,8 @@ void MapProviderRetryPolicy::complete(const QUrl& url, Admission admission,
         const qint64 jitter = QRandomGenerator::global()->bounded(6001);
         state.until = time + backoff + jitter;
     }
+    // Even an older failed request may carry a newer server deadline. Honor it
+    // conservatively (within the one-day cap); only successes are generation-gated.
     state.until = std::max(state.until, time + retryAfterMs(retryAfter, wallNow));
 }
 
@@ -184,6 +191,17 @@ QNetworkReply* MapProviderNetworkAccessManager::createRequest(Operation operatio
     }
     const MapProviderRetryPolicy::Admission admission = m_policy->admit(request.url());
     if (admission.delayMs > 0) {
+        const int control = request.attribute(QNetworkRequest::CacheLoadControlAttribute,
+                                              QNetworkRequest::PreferNetwork).toInt();
+        if (cache() != nullptr && control != QNetworkRequest::AlwaysNetwork
+            && cache()->metaData(request.url()).isValid()) {
+            // PreferCache can go to the wire on a miss. AlwaysCache cannot,
+            // even if the entry disappears between this lookup and Qt's read.
+            QNetworkRequest cached(request);
+            cached.setAttribute(QNetworkRequest::CacheLoadControlAttribute,
+                                QNetworkRequest::AlwaysCache);
+            return sendRequest(operation, cached, outgoingData);
+        }
         return new CooldownReply(request, operation, admission.delayMs, this);
     }
     QNetworkReply* reply = sendRequest(operation, request, outgoingData);

--- a/src/gui/map/MapProviderNetworkAccessManager.h
+++ b/src/gui/map/MapProviderNetworkAccessManager.h
@@ -15,6 +15,8 @@ namespace AetherSDR {
 // sockets or timers: tests inject monotonic time instead of waiting minutes.
 class MapProviderRetryPolicy {
 public:
+    // Consumer timers must cover the initial cooldown including positive jitter.
+    static constexpr int kConsumerRetryMs = 66000;
     struct Admission {
         qint64 delayMs{0};
         quint64 generation{0};

--- a/src/gui/map/MapProviderNetworkAccessManager.h
+++ b/src/gui/map/MapProviderNetworkAccessManager.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <QDateTime>
+#include <QElapsedTimer>
+#include <QHash>
+#include <QMutex>
+#include <QNetworkAccessManager>
+
+#include <functional>
+#include <memory>
+
+namespace AetherSDR {
+
+// Shared across map managers, projections and dialog lifetimes. No settings,
+// sockets or timers: tests inject monotonic time instead of waiting minutes.
+class MapProviderRetryPolicy {
+public:
+    struct Admission {
+        qint64 delayMs{0};
+        quint64 generation{0};
+        bool probe{false};
+    };
+    explicit MapProviderRetryPolicy(std::function<qint64()> clock = {});
+    static QString provider(const QUrl& url);
+    static qint64 retryAfterMs(const QByteArray& value, const QDateTime& now);
+    Admission admit(const QUrl& url);
+    void complete(const QUrl& url, Admission admission, bool failed, bool canceled,
+                  const QByteArray& retryAfter = {},
+                  const QDateTime& wallNow = QDateTime::currentDateTimeUtc());
+
+private:
+    struct State {
+        qint64 until{0};
+        unsigned failures{0};
+        quint64 generation{0};
+        bool probeInFlight{false};
+    };
+    qint64 now() const;
+    QElapsedTimer m_elapsed;
+    std::function<qint64()> m_clock;
+    QMutex m_mutex;
+    QHash<QString, State> m_states;
+};
+
+// Only the explicitly named NASA GIBS and NWS imagery hosts are gated. Other
+// map providers retain the existing QNetworkAccessManager behavior. During a
+// cooldown a local asynchronous error feeds existing UI retry/status paths;
+// it never starts HTTP or restarts/extends the provider's cooldown.
+class MapProviderNetworkAccessManager : public QNetworkAccessManager {
+public:
+    explicit MapProviderNetworkAccessManager(QObject* parent = nullptr,
+        std::shared_ptr<MapProviderRetryPolicy> policy = {});
+
+protected:
+    QNetworkReply* createRequest(Operation operation, const QNetworkRequest& request,
+                                QIODevice* outgoingData = nullptr) override;
+    // Injected-reply seam; production delegates to Qt's real transport/cache.
+    virtual QNetworkReply* sendRequest(Operation operation, const QNetworkRequest& request,
+                                      QIODevice* outgoingData);
+
+private:
+    std::shared_ptr<MapProviderRetryPolicy> m_policy;
+};
+
+} // namespace AetherSDR

--- a/src/gui/map/MapView.cpp
+++ b/src/gui/map/MapView.cpp
@@ -1,4 +1,5 @@
 #include "MapView.h"
+#include "MapProviderNetworkAccessManager.h"
 #include "CityLightsItem.h"
 #include "MapMarkerBatchItem.h"
 #include "MapMarkerItem.h"
@@ -78,7 +79,7 @@ void MapView::ensureTileNetworkManager()
     // the HTTP cache headers OSM serves — required by the OSM tile usage
     // policy — and the User-Agent uniquely identifies AetherSDR (library
     // defaults and browser impersonation are documented blocking causes).
-    auto* nam = new QNetworkAccessManager(QCoreApplication::instance());
+    auto* nam = new MapProviderNetworkAccessManager(QCoreApplication::instance());
     nam->setTransferTimeout(kTransferTimeoutMs);
     auto* cache = new QNetworkDiskCache(nam);
     cache->setCacheDirectory(

--- a/src/gui/map/WeatherRadarTileLayer.cpp
+++ b/src/gui/map/WeatherRadarTileLayer.cpp
@@ -18,17 +18,28 @@ WeatherRadarTileLayer::WeatherRadarTileLayer()
     setHorizontalWrapEnabled(true);
     setOpacity(kWeatherRadarOpacity);
     m_readinessTimer.setInterval(25);
+    m_retryElapsed.start();
     connect(&m_readinessTimer, &QTimer::timeout, this, [this] {
-        checkReadiness(m_readinessElapsed.elapsed());
+        checkReadiness(m_readinessElapsed.elapsed(), m_retryElapsed.elapsed());
     });
 }
 
-void WeatherRadarTileLayer::checkReadiness(qint64 elapsedMs)
+void WeatherRadarTileLayer::checkReadiness(qint64 elapsedMs, qint64 retryElapsedMs)
 {
     const int pending = pendingRequestCount();
+    // Camera processing is coalesced by QGeoView. Give it a short window
+    // to enqueue requests; an all-cache hit legitimately stays at zero.
+    if (pending == 0 && currentTilesComplete()
+        && elapsedMs >= 300) {
+        m_readinessTimer.stop();
+        m_loadFailed = false;
+        m_readyFrameId = m_source.frameId();
+        emit frameReady(m_source.frameTime());
+        return;
+    }
     if (pending == 0
         && failedTileRequestCount() > m_failureBaseline) {
-        if (elapsedMs < 60000) {
+        if (retryElapsedMs < (m_loadFailed ? 5000 : 1000)) {
             return;
         }
         if (m_retryCount >= 3 && !m_loadFailed) {
@@ -38,20 +49,12 @@ void WeatherRadarTileLayer::checkReadiness(qint64 elapsedMs)
         m_retryCount = std::min(3, m_retryCount + 1);
         m_failureBaseline = failedTileRequestCount();
         m_readinessElapsed.restart();
+        m_retryElapsed.restart();
         // Retain completed tiles and retry real null placeholders even
         // without camera movement. After reporting failure, keep retrying
-        // quietly at the one-minute cadence until disabled or superseded.
+        // quietly at a slower cadence. The shared manager gates provider HTTP.
         retryUnfinishedTiles();
         return;
-    }
-    // Camera processing is coalesced by QGeoView. Give it a short window
-    // to enqueue requests; an all-cache hit legitimately stays at zero.
-    if (pending == 0 && currentTilesComplete()
-        && elapsedMs >= 300) {
-        m_readinessTimer.stop();
-        m_loadFailed = false;
-        m_readyFrameId = m_source.frameId();
-        emit frameReady(m_source.frameTime());
     }
 }
 
@@ -98,6 +101,7 @@ void WeatherRadarTileLayer::beginReadinessCheck()
     }
     m_failureBaseline = failedTileRequestCount();
     m_retryCount = 0;
+    m_retryElapsed.start();
     m_readinessElapsed.restart();
     m_readinessTimer.start();
 }
@@ -111,7 +115,8 @@ void WeatherRadarTileLayer::onCamera(
         // the newly visible high-resolution coverage succeeded.
         m_readyFrameId.clear();
         // A small pan can keep exactly the same completed tile set. Preserve
-        // failure accounting too: a pan must not forgive an unfinished tile.
+        // failure accounting and its retry clock too: a pan must not forgive
+        // an unfinished tile or postpone recovery indefinitely.
         m_readinessElapsed.restart();
         m_readinessTimer.start();
     }

--- a/src/gui/map/WeatherRadarTileLayer.cpp
+++ b/src/gui/map/WeatherRadarTileLayer.cpp
@@ -19,35 +19,40 @@ WeatherRadarTileLayer::WeatherRadarTileLayer()
     setOpacity(kWeatherRadarOpacity);
     m_readinessTimer.setInterval(25);
     connect(&m_readinessTimer, &QTimer::timeout, this, [this] {
-        const int pending = pendingRequestCount();
-        if (pending == 0
-            && failedTileRequestCount() > m_failureBaseline) {
-            if (m_readinessElapsed.elapsed() < (m_loadFailed ? 5000 : 1000)) {
-                return;
-            }
-            if (m_retryCount >= 3 && !m_loadFailed) {
-                m_loadFailed = true;
-                emit frameLoadFailed(m_source.frameTime());
-            }
-            m_retryCount = std::min(3, m_retryCount + 1);
-            m_failureBaseline = failedTileRequestCount();
-            m_readinessElapsed.restart();
-            // Retain completed tiles and retry real null placeholders even
-            // without camera movement. After reporting failure, keep retrying
-            // quietly at a slower cadence until disabled or superseded.
-            retryUnfinishedTiles();
+        checkReadiness(m_readinessElapsed.elapsed());
+    });
+}
+
+void WeatherRadarTileLayer::checkReadiness(qint64 elapsedMs)
+{
+    const int pending = pendingRequestCount();
+    if (pending == 0
+        && failedTileRequestCount() > m_failureBaseline) {
+        if (elapsedMs < 60000) {
             return;
         }
-        // Camera processing is coalesced by QGeoView. Give it a short window
-        // to enqueue requests; an all-cache hit legitimately stays at zero.
-        if (pending == 0 && currentTilesComplete()
-            && m_readinessElapsed.elapsed() >= 300) {
-            m_readinessTimer.stop();
-            m_loadFailed = false;
-            m_readyFrameId = m_source.frameId();
-            emit frameReady(m_source.frameTime());
+        if (m_retryCount >= 3 && !m_loadFailed) {
+            m_loadFailed = true;
+            emit frameLoadFailed(m_source.frameTime());
         }
-    });
+        m_retryCount = std::min(3, m_retryCount + 1);
+        m_failureBaseline = failedTileRequestCount();
+        m_readinessElapsed.restart();
+        // Retain completed tiles and retry real null placeholders even
+        // without camera movement. After reporting failure, keep retrying
+        // quietly at the one-minute cadence until disabled or superseded.
+        retryUnfinishedTiles();
+        return;
+    }
+    // Camera processing is coalesced by QGeoView. Give it a short window
+    // to enqueue requests; an all-cache hit legitimately stays at zero.
+    if (pending == 0 && currentTilesComplete()
+        && elapsedMs >= 300) {
+        m_readinessTimer.stop();
+        m_loadFailed = false;
+        m_readyFrameId = m_source.frameId();
+        emit frameReady(m_source.frameTime());
+    }
 }
 
 void WeatherRadarTileLayer::setSource(const WeatherRadarSource& source)

--- a/src/gui/map/WeatherRadarTileLayer.h
+++ b/src/gui/map/WeatherRadarTileLayer.h
@@ -32,6 +32,8 @@ protected:
     QString tilePosToUrl(const QGV::GeoTilePos& tilePos) const override;
 
 private:
+    friend class WeatherRadarLoadingTest;
+    void checkReadiness(qint64 elapsedMs);
     void beginReadinessCheck();
 
     WeatherRadarSource m_source;

--- a/src/gui/map/WeatherRadarTileLayer.h
+++ b/src/gui/map/WeatherRadarTileLayer.h
@@ -33,12 +33,13 @@ protected:
 
 private:
     friend class WeatherRadarLoadingTest;
-    void checkReadiness(qint64 elapsedMs);
+    void checkReadiness(qint64 elapsedMs, qint64 retryElapsedMs);
     void beginReadinessCheck();
 
     WeatherRadarSource m_source;
     QTimer m_readinessTimer;
     QElapsedTimer m_readinessElapsed;
+    QElapsedTimer m_retryElapsed;
     QString m_readyFrameId;
     quint64 m_failureBaseline{0};
     int m_retryCount{0};

--- a/tests/city_lights_source_test.cpp
+++ b/tests/city_lights_source_test.cpp
@@ -1,9 +1,12 @@
 #include "gui/map/CityLightsShading.h"
 #include "gui/map/CityLightsSource.h"
+#include "gui/map/MapProviderNetworkAccessManager.h"
 #include "gui/map/SolarTerminator.h"
 
 #include <QBuffer>
 #include <QNetworkReply>
+#include <QNetworkDiskCache>
+#include <QTemporaryDir>
 #include <QSignalSpy>
 #include <QTest>
 #include <QUrlQuery>
@@ -48,6 +51,14 @@ public:
             emit readyRead();
         }
         setFinished(true);
+        emit finished();
+    }
+    void completeInvalidImage()
+    {
+        m_bytes = "not a PNG";
+        setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
+        setFinished(true);
+        emit readyRead();
         emit finished();
     }
     qint64 bytesAvailable() const override { return m_bytes.size() + QIODevice::bytesAvailable(); }
@@ -198,6 +209,45 @@ private slots:
         };
         QCOMPARE(polar(1.9e7), 0);
         QCOMPARE(polar(-1.9e7), 255);
+    }
+
+    void transportFailurePreservesCacheButInvalidPayloadIsEvicted()
+    {
+        LightsNetwork network;
+        QTemporaryDir directory;
+        QVERIFY(directory.isValid());
+        auto* cache = new QNetworkDiskCache(&network);
+        cache->setCacheDirectory(directory.path());
+        network.setCache(cache);
+        const WeatherRadarViewGeometry view{QRectF(-1e7, 2e6, 1e6, 1e6), QSize(32, 32)};
+        const auto bounded = CityLightsSource::boundedView(view);
+        const QUrl url = CityLightsSource::imageUrl(bounded);
+        QNetworkCacheMetaData metadata;
+        metadata.setUrl(url);
+        metadata.setExpirationDate(QDateTime::currentDateTimeUtc().addDays(1));
+        metadata.setSaveToDisk(true);
+        QIODevice* data = cache->prepare(metadata);
+        QVERIFY(data != nullptr);
+        QImage image(bounded.size, QImage::Format_ARGB32);
+        image.fill(Qt::white);
+        QVERIFY(image.save(data, "PNG"));
+        cache->insert(data);
+        CityLightsSource source(nullptr, &network);
+        source.setView(view);
+        source.setEnabled(true);
+        QTRY_COMPARE(network.requests.size(), 1);
+        QSignalSpy statuses(&source, &CityLightsSource::statusChanged);
+        network.requests.last()->complete(true);
+        QTRY_VERIFY(!statuses.isEmpty());
+        QVERIFY(cache->metaData(url).isValid());
+        source.setEnabled(false);
+        source.setEnabled(true);
+        QTRY_COMPARE(network.requests.size(), 2);
+        // A successful HTTP response with invalid image bytes must still
+        // evict its payload.
+        network.requests.last()->completeInvalidImage();
+        statuses.clear();
+        QTRY_VERIFY(!cache->metaData(url).isValid());
     }
 
     void loadingCancellationRetentionAndReuse()

--- a/tests/map_provider_retry_test.cpp
+++ b/tests/map_provider_retry_test.cpp
@@ -1,6 +1,8 @@
 #include "gui/map/MapProviderNetworkAccessManager.h"
 
 #include <QNetworkReply>
+#include <QNetworkDiskCache>
+#include <QTemporaryDir>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -51,6 +53,25 @@ protected:
         return reply;
     }
 };
+// Qt may only execute cache-only requests in this fixture. Even a broken guard
+// cannot contact a provider: any attempted wire operation becomes an inert reply.
+class CacheOnlyNetwork final : public MapProviderNetworkAccessManager {
+public:
+    using MapProviderNetworkAccessManager::MapProviderNetworkAccessManager;
+    int wireAttempts{0};
+protected:
+    QNetworkReply* sendRequest(Operation operation, const QNetworkRequest& request,
+                              QIODevice* data) override
+    {
+        if (request.attribute(QNetworkRequest::CacheLoadControlAttribute).toInt()
+            != QNetworkRequest::AlwaysCache) {
+            ++wireAttempts;
+            return new Reply(request, this);
+        }
+        return MapProviderNetworkAccessManager::sendRequest(operation, request, data);
+    }
+};
+
 }
 
 class MapProviderRetryTest final : public QObject {
@@ -65,7 +86,9 @@ private slots:
         for (const QByteArray text : {QByteArray(), QByteArray("-1"), QByteArray("broken"), QByteArray("1.5")}) {
             QCOMPARE(MapProviderRetryPolicy::retryAfterMs(text, now), 0);
         }
-        QVERIFY(MapProviderRetryPolicy::retryAfterMs("99999999999999999999999999999", now) > 86400000);
+        QCOMPARE(MapProviderRetryPolicy::retryAfterMs("99999999999999999999999999999", now), 86400000);
+        QCOMPARE(MapProviderRetryPolicy::retryAfterMs("86401", now), 86400000);
+        QCOMPARE(MapProviderRetryPolicy::retryAfterMs("Wed, 09 Sep 2026 12:00:00 GMT", now), 86400000);
     }
 
     void cooldownEscalatesAndOldSuccessCannotClearIt()
@@ -184,6 +207,91 @@ private slots:
         QVERIFY(policy->admit(nws).delayMs > 0);
         network.sent.last()->finish(200);
         QVERIFY(!policy->admit(nws).probe);
+    }
+
+    void simultaneousFailuresCountOnceAndConsumerTimerCoversJitter()
+    {
+        qint64 time = 0;
+        MapProviderRetryPolicy policy([&time] { return time; });
+        QList<MapProviderRetryPolicy::Admission> admitted;
+        for (int i = 0; i < 20; ++i) {
+            admitted.append(policy.admit(nws));
+        }
+        for (const auto admission : admitted) {
+            policy.complete(nws, admission, true, false);
+        }
+        const qint64 delay = policy.admit(nws).delayMs;
+        QVERIFY(delay >= 60000 && delay <= 66000);
+        QVERIFY(MapProviderRetryPolicy::kConsumerRetryMs >= 66000);
+        time = MapProviderRetryPolicy::kConsumerRetryMs;
+        const auto recovery = policy.admit(nws);
+        QCOMPARE(recovery.delayMs, 0);
+        QVERIFY(recovery.probe);
+    }
+
+    void lateServerDeadlineIsHonoredWithoutMultiplyingBackoff()
+    {
+        qint64 time = 0;
+        MapProviderRetryPolicy policy([&time] { return time; });
+        const auto first = policy.admit(nws);
+        const auto late = policy.admit(nws);
+        policy.complete(nws, first, true, false);
+        time = 10000;
+        policy.complete(nws, late, true, false, "3600");
+        QCOMPARE(policy.admit(nws).delayMs, 3600000);
+        time += 3600000;
+        const auto probe = policy.admit(nws);
+        policy.complete(nws, probe, true, false);
+        const qint64 delay = policy.admit(nws).delayMs;
+        QVERIFY(delay >= 120000 && delay <= 126000);
+    }
+
+    void diskCacheRemainsAvailableDuringCooldown()
+    {
+        qint64 time = 0;
+        auto policy = std::make_shared<MapProviderRetryPolicy>([&time] { return time; });
+        CacheOnlyNetwork network(nullptr, policy);
+        QTemporaryDir directory;
+        QVERIFY(directory.isValid());
+        auto* cache = new QNetworkDiskCache(&network);
+        cache->setCacheDirectory(directory.path());
+        network.setCache(cache);
+        QNetworkCacheMetaData metadata;
+        metadata.setUrl(nws);
+        metadata.setSaveToDisk(true);
+        metadata.setExpirationDate(QDateTime::currentDateTimeUtc().addDays(1));
+        metadata.setRawHeaders({{"Content-Type", "image/png"}, {"Cache-Control", "max-age=86400"}});
+        QIODevice* data = cache->prepare(metadata);
+        QVERIFY(data != nullptr);
+        data->write("cached-image");
+        cache->insert(data);
+        const auto admitted = policy->admit(nws);
+        policy->complete(nws, admitted, true, false, "180");
+        for (const auto mode : {QNetworkRequest::PreferCache, QNetworkRequest::AlwaysCache}) {
+            QNetworkRequest request(nws);
+            request.setAttribute(QNetworkRequest::CacheLoadControlAttribute, mode);
+            QNetworkReply* reply = network.get(request);
+            QSignalSpy done(reply, &QNetworkReply::finished);
+            QTRY_COMPARE(done.size(), 1);
+            QCOMPARE(reply->error(), QNetworkReply::NoError);
+            QVERIFY(reply->attribute(QNetworkRequest::SourceIsFromCacheAttribute).toBool());
+            QCOMPARE(reply->readAll(), QByteArray("cached-image"));
+            QCOMPARE(policy->admit(nws).delayMs, 180000);
+            delete reply;
+        }
+        // A miss and an explicit network-only load are denied locally.
+        for (const auto mode : {QNetworkRequest::PreferCache, QNetworkRequest::AlwaysNetwork}) {
+            QNetworkRequest request(mode == QNetworkRequest::AlwaysNetwork ? nws
+                : QUrl(nws.toString() + "/missing"));
+            request.setAttribute(QNetworkRequest::CacheLoadControlAttribute, mode);
+            QNetworkReply* reply = network.get(request);
+            QSignalSpy done(reply, &QNetworkReply::finished);
+            QTRY_COMPARE(done.size(), 1);
+            QVERIFY(reply->error() != QNetworkReply::NoError);
+            QCOMPARE(policy->admit(nws).delayMs, 180000);
+            delete reply;
+        }
+        QCOMPARE(network.wireAttempts, 0);
     }
 
     void canceledAndDestroyedProbeCanBeRetried()

--- a/tests/map_provider_retry_test.cpp
+++ b/tests/map_provider_retry_test.cpp
@@ -1,0 +1,211 @@
+#include "gui/map/MapProviderNetworkAccessManager.h"
+
+#include <QNetworkReply>
+#include <QSignalSpy>
+#include <QTest>
+
+using namespace AetherSDR;
+namespace {
+const QUrl nasa("https://gibs.earthdata.nasa.gov/wms/test");
+const QUrl nws("https://mapservices.weather.noaa.gov/eventdriven/test");
+
+class Reply final : public QNetworkReply {
+public:
+    Reply(const QNetworkRequest& request, QObject* parent) : QNetworkReply(parent)
+    {
+        setRequest(request);
+        setUrl(request.url());
+        open(QIODevice::ReadOnly);
+    }
+    void abort() override
+    {
+        if (!isFinished()) {
+            setError(OperationCanceledError, "Canceled");
+            setFinished(true);
+            emit finished();
+        }
+    }
+    void finish(int status, const QByteArray& retryAfter = {}, bool cached = false)
+    {
+        setAttribute(QNetworkRequest::SourceIsFromCacheAttribute, cached);
+        setAttribute(QNetworkRequest::HttpStatusCodeAttribute, status);
+        setRawHeader("Retry-After", retryAfter);
+        if (status >= 400) {
+            setError(TemporaryNetworkFailureError, "Injected provider failure");
+        }
+        setFinished(true);
+        emit finished();
+    }
+protected:
+    qint64 readData(char*, qint64) override { return -1; }
+};
+class Network final : public MapProviderNetworkAccessManager {
+public:
+    using MapProviderNetworkAccessManager::MapProviderNetworkAccessManager;
+    QList<Reply*> sent;
+protected:
+    QNetworkReply* sendRequest(Operation, const QNetworkRequest& request, QIODevice*) override
+    {
+        auto* reply = new Reply(request, this);
+        sent.append(reply);
+        return reply;
+    }
+};
+}
+
+class MapProviderRetryTest final : public QObject {
+    Q_OBJECT
+private slots:
+    void parsesRetryAfterWithoutOverflow()
+    {
+        const QDateTime now = QDateTime::fromString("2026-09-07T12:00:00Z", Qt::ISODate);
+        QCOMPARE(MapProviderRetryPolicy::retryAfterMs("120", now), 120000);
+        QCOMPARE(MapProviderRetryPolicy::retryAfterMs("Mon, 07 Sep 2026 12:03:00 GMT", now), 180000);
+        QCOMPARE(MapProviderRetryPolicy::retryAfterMs("Mon, 07 Sep 2026 11:59:00 GMT", now), 0);
+        for (const QByteArray text : {QByteArray(), QByteArray("-1"), QByteArray("broken"), QByteArray("1.5")}) {
+            QCOMPARE(MapProviderRetryPolicy::retryAfterMs(text, now), 0);
+        }
+        QVERIFY(MapProviderRetryPolicy::retryAfterMs("99999999999999999999999999999", now) > 86400000);
+    }
+
+    void cooldownEscalatesAndOldSuccessCannotClearIt()
+    {
+        qint64 time = 0;
+        MapProviderRetryPolicy policy([&time] { return time; });
+        const auto first = policy.admit(nws);
+        const auto older = policy.admit(nws);
+        policy.complete(nws, first, true, false);
+        qint64 delay = policy.admit(nws).delayMs;
+        QVERIFY(delay >= 60000 && delay <= 66000);
+        policy.complete(nws, older, false, false);
+        QCOMPARE(policy.admit(nws).delayMs, delay);
+        time += delay;
+        const auto probe = policy.admit(nws);
+        QCOMPARE(probe.delayMs, 0);
+        QVERIFY(probe.probe);
+        QVERIFY(policy.admit(nws).delayMs > 0); // One recovery request across all views.
+        policy.complete(nws, probe, true, false);
+        delay = policy.admit(nws).delayMs;
+        QVERIFY(delay >= 120000 && delay <= 126000);
+        time += delay;
+        const auto recovered = policy.admit(nws);
+        policy.complete(nws, recovered, false, false);
+        const auto fresh = policy.admit(nws);
+        QVERIFY(!fresh.probe);
+        policy.complete(nws, fresh, true, false);
+        QVERIFY(policy.admit(nws).delayMs >= 60000 && policy.admit(nws).delayMs <= 66000);
+    }
+
+    void lateFailureCannotStrandAnOlderProbe()
+    {
+        qint64 time = 0;
+        MapProviderRetryPolicy policy([&time] { return time; });
+        const auto first = policy.admit(nws);
+        const auto late = policy.admit(nws);
+        policy.complete(nws, first, true, false);
+        time += policy.admit(nws).delayMs;
+        const auto probe = policy.admit(nws);
+        policy.complete(nws, late, true, false);
+        policy.complete(nws, probe, false, false);
+        time += policy.admit(nws).delayMs;
+        const auto next = policy.admit(nws);
+        QCOMPARE(next.delayMs, 0);
+        QVERIFY(next.probe);
+    }
+
+    void retryAfterWinsAndProvidersAreIndependent()
+    {
+        qint64 time = 0;
+        MapProviderRetryPolicy policy([&time] { return time; });
+        const auto first = policy.admit(nasa);
+        policy.complete(nasa, first, true, false, "3600");
+        QCOMPARE(policy.admit(nasa).delayMs, 3600000);
+        QCOMPARE(policy.admit(QUrl("https://gibs-a.earthdata.nasa.gov/other")).delayMs, 3600000);
+        QCOMPARE(policy.admit(nws).delayMs, 0);
+        QCOMPARE(policy.admit(QUrl("https://gibs.earthdata.nasa.gov.evil.example/")).delayMs, 0);
+        time += 3599999;
+        QCOMPARE(policy.admit(nasa).delayMs, 1);
+    }
+
+    void networkManagersShareCooldownAndCancelWithoutRequests()
+    {
+        qint64 time = 0;
+        auto policy = std::make_shared<MapProviderRetryPolicy>([&time] { return time; });
+        Network flat(nullptr, policy);
+        Network globe(nullptr, policy);
+        flat.get(QNetworkRequest(nws));
+        QCOMPARE(flat.sent.size(), 1);
+        flat.sent.last()->finish(429, "180");
+        QNetworkReply* denied = globe.get(QNetworkRequest(QUrl(nws.toString() + "/new-viewport")));
+        QSignalSpy done(denied, &QNetworkReply::finished);
+        QTRY_COMPARE(done.size(), 1);
+        QCOMPARE(globe.sent.size(), 0);
+        QCOMPARE(denied->rawHeader("Retry-After"), QByteArray("180"));
+        QVERIFY(denied->error() != QNetworkReply::NoError);
+        // Local denials do not slide the deadline on every UI retry.
+        QCOMPARE(policy->admit(nws).delayMs, 180000);
+        QNetworkReply* canceled = globe.get(QNetworkRequest(nws));
+        QSignalSpy canceledDone(canceled, &QNetworkReply::finished);
+        canceled->abort();
+        QTest::qWait(10);
+        QCOMPARE(canceledDone.size(), 1);
+        QCOMPARE(canceled->error(), QNetworkReply::OperationCanceledError);
+        QCOMPARE(globe.sent.size(), 0);
+        globe.get(QNetworkRequest(QUrl("https://tile.openstreetmap.org/0/0/0.png")));
+        QCOMPARE(globe.sent.size(), 1); // Other services retain their normal behavior.
+        time = 180000;
+        globe.get(QNetworkRequest(nws));
+        QCOMPARE(globe.sent.size(), 2);
+        flat.get(QNetworkRequest(nws));
+        QCOMPARE(flat.sent.size(), 1); // A second projection cannot race the probe.
+        globe.sent.last()->finish(200);
+        flat.get(QNetworkRequest(nws));
+        QCOMPARE(flat.sent.size(), 2);
+    }
+
+    void backoffCapsAndCachedSuccessDoesNotReleaseRecovery()
+    {
+        qint64 time = 0;
+        auto policy = std::make_shared<MapProviderRetryPolicy>([&time] { return time; });
+        Network network(nullptr, policy);
+        for (int attempt = 0; attempt < 8; ++attempt) {
+            network.get(QNetworkRequest(nws));
+            network.sent.last()->finish(503);
+            const qint64 delay = policy->admit(nws).delayMs;
+            QVERIFY(delay >= 60000 && delay <= 906000);
+            if (attempt >= 4) {
+                QVERIFY(delay >= 900000);
+            }
+            time += delay;
+        }
+        network.get(QNetworkRequest(nws));
+        network.sent.last()->finish(200, {}, true);
+        network.get(QNetworkRequest(nws)); // Still a single recovery probe.
+        QVERIFY(policy->admit(nws).delayMs > 0);
+        network.sent.last()->finish(200);
+        QVERIFY(!policy->admit(nws).probe);
+    }
+
+    void canceledAndDestroyedProbeCanBeRetried()
+    {
+        qint64 time = 0;
+        auto policy = std::make_shared<MapProviderRetryPolicy>([&time] { return time; });
+        {
+            Network network(nullptr, policy);
+            network.get(QNetworkRequest(nasa));
+            network.sent.last()->finish(503, "60");
+            time += policy->admit(nasa).delayMs;
+            network.get(QNetworkRequest(nasa));
+            QVERIFY(policy->admit(nasa).delayMs > 0);
+        }
+        Network reopened(nullptr, policy);
+        QNetworkReply* probe = reopened.get(QNetworkRequest(nasa));
+        QCOMPARE(reopened.sent.size(), 1);
+        probe->abort();
+        reopened.get(QNetworkRequest(nasa));
+        QCOMPARE(reopened.sent.size(), 2);
+        reopened.sent.last()->finish(200);
+    }
+};
+QTEST_GUILESS_MAIN(MapProviderRetryTest)
+#include "map_provider_retry_test.moc"

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1197,8 +1197,17 @@ add_test(NAME map_image_cache_test COMMAND map_image_cache_test)
 set_tests_properties(map_image_cache_test PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
+# Injected HTTP replies and virtual time: no sockets, provider traffic or minute-long waits.
+add_executable(map_provider_retry_test tests/map_provider_retry_test.cpp
+    src/gui/map/MapProviderNetworkAccessManager.cpp)
+target_include_directories(map_provider_retry_test PRIVATE src)
+target_link_libraries(map_provider_retry_test PRIVATE Qt6::Core Qt6::Network Qt6::Test)
+add_test(NAME map_provider_retry_test COMMAND map_provider_retry_test)
+set_tests_properties(map_provider_retry_test PROPERTIES TIMEOUT 30)
+
 # Injected public HTTP replies; this test binds no sockets and contacts no provider.
 add_executable(city_lights_source_test tests/city_lights_source_test.cpp
+    src/gui/map/MapProviderNetworkAccessManager.cpp
     src/gui/map/CityLightsSource.cpp)
 target_include_directories(city_lights_source_test PRIVATE src)
 target_link_libraries(city_lights_source_test PRIVATE
@@ -1238,6 +1247,7 @@ set_tests_properties(weather_radar_wrap_render_test PROPERTIES
 # Proves delayed/out-of-order downloads, view cache reuse, and retained geometry.
 add_executable(weather_radar_loading_test
     tests/weather_radar_loading_test.cpp
+    src/gui/map/MapProviderNetworkAccessManager.cpp
     src/gui/map/CityLightsItem.cpp
     src/gui/map/CityLightsSource.cpp
     src/gui/map/MapDisplayWidget.cpp src/gui/map/MapView.cpp src/gui/map/GlobeMapView.cpp

--- a/tests/weather_radar_loading_test.cpp
+++ b/tests/weather_radar_loading_test.cpp
@@ -1,4 +1,5 @@
 #include "gui/map/MapDisplayWidget.h"
+#include "gui/map/MapProviderNetworkAccessManager.h"
 #include "gui/map/CityLightsItem.h"
 #include "gui/map/GlobeMapView.h"
 #include "gui/map/WeatherRadarTexture.h"
@@ -444,15 +445,87 @@ private slots:
         for (int i = 0; i < replies.size(); ++i) {
             replies.at(i)->complete(i == 0);
         }
-        layer->checkReadiness(59999);
+        layer->checkReadiness(999, 999);
         QCOMPARE(network.allReplies.size(), requests);
-        layer->checkReadiness(60000);
+        layer->checkReadiness(5000, 5000);
         QTRY_COMPARE_WITH_TIMEOUT(network.allReplies.size(), requests + 1, 3000);
         QVERIFY(ready.isEmpty());
         network.allReplies.last()->complete();
         QTRY_COMPARE(ready.size(), 1);
         QVERIFY(!layer->loadFailed());
         QCOMPARE(layer->pendingRequestCount(), 0);
+        layer->setEnabled(false);
+        QGV::setNetworkManager(nullptr);
+    }
+
+    void liveTilesRetryDuringCameraMovement()
+    {
+        ControlledRadarNetwork network;
+        QGV::setNetworkManager(&network);
+        QGVMap map;
+        map.resize(600, 400);
+        map.show();
+        QTest::qWait(20);
+        map.cameraTo(QGVCameraActions(&map).scaleTo(.0001)
+            .moveTo(QPointF(-1.05e7, -4.0e6)), false);
+        QCoreApplication::processEvents();
+        auto* layer = new WeatherRadarTileLayer();
+        layer->setEnabled(false);
+        map.addItem(layer);
+        QSignalSpy ready(layer, &WeatherRadarTileLayer::frameReady);
+        layer->setEnabled(true);
+        QTRY_VERIFY(!network.allReplies.isEmpty());
+        QTest::qWait(200);
+        const int requests = network.allReplies.size();
+        const auto replies = network.allReplies;
+        for (int i = 0; i < replies.size(); ++i) {
+            replies.at(i)->complete(i == 0);
+        }
+        // Real camera events repeatedly reset the readiness settle clock, but
+        // must not reset the independent retry clock. Stay within the same tiles.
+        for (int i = 0; i < 12; ++i) {
+            map.cameraTo(QGVCameraActions(&map)
+                .moveTo(QPointF(-1.05e7 + (i % 2) * 10000, -4.0e6)), false);
+            QTest::qWait(150);
+        }
+        QCOMPARE(network.allReplies.size(), requests + 1);
+        network.allReplies.last()->complete();
+        QTRY_COMPARE(ready.size(), 1);
+        layer->setEnabled(false);
+        QGV::setNetworkManager(nullptr);
+    }
+
+    void completedCoverageDoesNotWaitForOldFailures()
+    {
+        ControlledRadarNetwork network;
+        QGV::setNetworkManager(&network);
+        QGVMap map;
+        map.resize(600, 400);
+        map.show();
+        QTest::qWait(20);
+        map.cameraTo(QGVCameraActions(&map).scaleTo(.0001)
+            .moveTo(QPointF(-1.05e7, -4.0e6)), false);
+        QCoreApplication::processEvents();
+        auto* layer = new WeatherRadarTileLayer();
+        layer->setEnabled(false);
+        map.addItem(layer);
+        QSignalSpy ready(layer, &WeatherRadarTileLayer::frameReady);
+        layer->setEnabled(true);
+        QTRY_VERIFY(!network.allReplies.isEmpty());
+        QTest::qWait(200);
+        const int requests = network.allReplies.size();
+        const auto replies = network.allReplies;
+        for (int i = 0; i < replies.size(); ++i) {
+            replies.at(i)->complete(i == 0);
+        }
+        // Recover the tile outside the readiness callback, leaving its old
+        // failure count intact. Completed current coverage must win immediately.
+        layer->retryUnfinishedTiles();
+        QCOMPARE(network.allReplies.size(), requests + 1);
+        network.allReplies.last()->complete();
+        QVERIFY(layer->currentTilesComplete());
+        layer->checkReadiness(300, 0);
+        QCOMPARE(ready.size(), 1);
         layer->setEnabled(false);
         QGV::setNetworkManager(nullptr);
     }
@@ -491,7 +564,7 @@ private slots:
                     reply->complete(true);
                 }
             }
-            layer->checkReadiness(60000); // Advance retry time without sleeping a minute.
+            layer->checkReadiness(5000, 5000); // Advance retry time without sleeping.
             QTest::qWait(25);
         }
         QCOMPARE(failures.size(), 1);
@@ -843,8 +916,10 @@ private slots:
         QVERIFY(map.m_weatherRadarTimelineFailed);
         QVERIFY(map.m_weatherRadarRebufferTimer->isActive());
         QVERIFY(errors.isEmpty());
+        QCOMPARE(map.m_weatherRadarRebufferTimer->interval(), MapProviderRetryPolicy::kConsumerRetryMs);
+        QCOMPARE(map.m_weatherRadarRebufferTimer->timerType(), Qt::PreciseTimer);
         map.m_weatherRadarRebufferTimer->stop();
-        map.rebufferWeatherRadarPlayback(); // Same callback as the one-minute retry.
+        map.rebufferWeatherRadarPlayback(); // Same callback as the jitter-aware retry.
         QVERIFY(map.m_weatherRadarTimelineReply);
         QCOMPARE(map.m_weatherRadarTimelineReply->url(), WeatherRadarSource::noaaTimelineUrl());
         map.stopWeatherRadarAnimation();

--- a/tests/weather_radar_loading_test.cpp
+++ b/tests/weather_radar_loading_test.cpp
@@ -444,6 +444,9 @@ private slots:
         for (int i = 0; i < replies.size(); ++i) {
             replies.at(i)->complete(i == 0);
         }
+        layer->checkReadiness(59999);
+        QCOMPARE(network.allReplies.size(), requests);
+        layer->checkReadiness(60000);
         QTRY_COMPARE_WITH_TIMEOUT(network.allReplies.size(), requests + 1, 3000);
         QVERIFY(ready.isEmpty());
         network.allReplies.last()->complete();
@@ -488,6 +491,7 @@ private slots:
                     reply->complete(true);
                 }
             }
+            layer->checkReadiness(60000); // Advance retry time without sleeping a minute.
             QTest::qWait(25);
         }
         QCOMPARE(failures.size(), 1);
@@ -840,7 +844,7 @@ private slots:
         QVERIFY(map.m_weatherRadarRebufferTimer->isActive());
         QVERIFY(errors.isEmpty());
         map.m_weatherRadarRebufferTimer->stop();
-        map.rebufferWeatherRadarPlayback(); // Same callback as the five-second retry.
+        map.rebufferWeatherRadarPlayback(); // Same callback as the one-minute retry.
         QVERIFY(map.m_weatherRadarTimelineReply);
         QCOMPARE(map.m_weatherRadarTimelineReply->url(), WeatherRadarSource::noaaTimelineUrl());
         map.stopWeatherRadarAnimation();


### PR DESCRIPTION
NASA GIBS and NWS imagery failures could trigger repeated requests when retry timers fired, the viewport moved, or a map dialog reopened. This follow-up to #5479 adds a process-wide cooldown per provider across city lights, live radar, globe tiles, and radar history/playback.

After an HTTP or transport failure, new network requests wait at least one minute. Repeated failed recovery attempts back off to 2, 4, 8, and 15 minutes with up to six seconds of positive jitter. Longer `Retry-After` values take precedence up to a one-day cap, including overflowing numeric values. Only one recovery request is admitted at expiry. Cached successes and cancellations do not falsely signal recovery, and older in-flight successes cannot erase a newer failure. Late failures may conservatively extend the deadline using their bounded server `Retry-After`; a simultaneous failure burst does not multiply the backoff.

During cooldown, cache-eligible requests can read Qt's disk cache in `AlwaysCache` mode, which cannot fall back to HTTP. Cache misses and explicit network-only requests fail locally without extending the deadline. City-light transport errors and local denials preserve cached images; actual invalid image payloads are still evicted. Existing decoded imagery and playback frames remain usable.

City-light and radar-history recovery timers use a precise 66-second interval to cover the initial cooldown plus jitter. Live-tile readiness retains short recovery checks with an independent retry clock that camera movement cannot reset; completed coverage is acknowledged before old failures. The shared manager enforces the provider network cooldown in either case.

Cooldown state resets on process restart and is not an aggregate limit across machines sharing an IP. Other map providers are unaffected. No layout, dependency, radio protocol, settings schema, or CHANGELOG changes.

Validation of head `fe9034984bd4d8b31f82c6dc260a5c1ad4ba184d` combined with current main `d1b26a4f4b2953089619046b6dba353b7c3b94a3` (verified merge tree `41f69448e41561043622c94e58469dea63ac0d50`):

- Full macOS ARM64 RelWithDebInfo app and all three focused targets built with the local ARM64 toolchain, RADE enabled, and `-j8`. Final executable and CMake processors are ARM64; no RNNoise x86 sources. Native macOS access was needed for icon generation. Optional DFNR was unavailable in this local build.
- 3/3 focused CTests passed: `map_provider_retry_test`, `city_lights_source_test`, and `weather_radar_loading_test` (18.65 seconds).
- Added socket-free coverage for actual Qt disk-cache hits/misses under cooldown, simultaneous failures, bounded Retry-After, late server deadlines, invalid-payload versus transport-error eviction, real camera movement during retry, completed coverage with historical failures, and consumer timer timing. The cache fixture permits Qt transport only in `AlwaysCache` mode; all potential wire operations are intercepted.
- Five mutations were detected: removing cooldown cache access, escalating every burst failure, restoring unconditional image eviction, resetting the retry clock on camera movement, and shortening the consumer retry to 60 seconds. Restored code passed the focused suite.
- Isolated offscreen automation smoke verified initial disconnection, explicitly connected only `DEMO-0001`, opened/closed/reopened PSK Reporter, and read back `transmitting=false`. The demo was disconnected and the test app closed. Provider failure/recovery was exercised through injected replies, not live provider throttling. Offscreen smoke is not native GPU-rendering proof; GPU-only test cases retain their explicit opt-in/skip behavior.
- Test registration, frozen CI gate, strict engine boundary, and whitespace checks passed. The per-PR test allow-list is unchanged; the new registered target follows the normal full-suite lane.

Hosted CI on the updated head and maintainer re-review remain required. Linux/Windows execution is not claimed locally.

AI-assisted implementation and review repairs: OpenAI Codex (GPT-6 Astra).
