### PR TITLE
feat(ux): Grouped applet picker and pinned S-Meter alignment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1084,6 +1084,7 @@ set(GUI_SOURCES
     src/gui/PanadapterStack.cpp
     src/gui/PanLayoutDialog.cpp
     src/gui/AppletPanel.cpp
+    src/gui/AppletPicker.cpp
     src/gui/KiwiSdrApplet.cpp
     src/gui/KiwiPublicReceiverPicker.cpp
     src/gui/FavoritesPickerDialog.cpp

--- a/docs/applet-picker.md
+++ b/docs/applet-picker.md
@@ -1,0 +1,36 @@
+# Applet picker and pinned meter
+
+The sidebar starts with one fixed **Add:** row: a grouped applet selector,
+an explicit **+** button, and the existing **LOCK** control. Categories and
+full names come from the shared applet catalog. Non-selectable category
+headers use bold primary text on the existing raised-surface theme token,
+rather than the muted appearance of disabled applet entries. Open applets remain listed
+as **open**, and hardware-dependent applets as **unavailable** until their
+existing capability/presence checks allow them. Neither can be added twice.
+Selecting a name does nothing until **+** is pressed; adding reveals its
+header in the scroll area. Each applet's **×** hides it without clearing
+its settings. Aetherial DSP stages remain managed inside the existing CHAIN
+surface rather than becoming independent picker entries.
+
+Existing applet visibility, order, float state, and hardware gates are
+preserved. Legacy favorites/drawer preferences are left untouched for older
+builds but no longer control the new picker. The S-Meter stays pinned;
+its horizontal margins now follow the actual scroll viewport on either
+dock side, including scrollbar appearance/disappearance. A floating or
+canvas-placed S-Meter leaves no empty pinned placeholder.
+
+Local validation at `0de5a2b6` with working-tree changes: the macOS Qt 6.12
+application build and all five selected offscreen tests passed (four
+chrome/connection tests plus `applet_picker_test`). Native disconnected
+bridge checks covered explicit add, no selection side effect, close/re-add,
+duplicate prevention, unavailable hardware, S-Meter close/re-add and float/dock,
+left/right/floating panel alignment, dark/light themes, and the scrollbar-free
+layout. Separate native dropdown captures verified the category headings.
+No live-radio/TX testing or Windows/Linux certification is implied.
+
+## Independent PR scope
+
+The picker and pinned-meter alignment are independent of the Qt 6.12 window
+chrome migration. The source branch retains main's Qt 6.8 minimum and does not
+change window decorations or the radio switcher. The earlier combined-build
+evidence above is not a substitute for validation of the standalone PR.

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -591,6 +591,14 @@ alias.
 An unknown index returns `{"ok":false,"error":"no pan with index N","available":[0]}`.
 
 ### `invoke`
+The sidebar's Add row uses the existing widget verbs: inspect
+`appletPickerCombo` in `dumpTree`, choose an enabled row with
+`invoke appletPickerCombo setCurrentIndex <index>`, then
+`invoke addAppletButton click`. Selection alone must not open a tile.
+`<container>/containerClose` hides it again. `appletViewport`, `VU`, and
+`pinnedMeterHost` expose geometry for checking the pinned meter against the
+scrollable column on both dock sides; `appletPicker` remains above both.
+
 Drive a control deterministically — no pixel-hunting. Resolves `target` exactly
 like `grab`.
 

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -65,7 +65,6 @@
 #include <QTimer>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
-#include <QGridLayout>
 #include <QLabel>
 #include <QFrame>
 #include <QDrag>
@@ -80,10 +79,9 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QScopeGuard>
 #include "core/LogManager.h"
 #include "core/ThemeManager.h"
-#include "FavoritesPickerDialog.h"
+#include "AppletPicker.h"
 
 namespace AetherSDR {
 
@@ -294,76 +292,11 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     root->setContentsMargins(0, 0, 0, 0);
     root->setSpacing(0);
 
-    // ── Top button bar: single favorites row + push-down drawer ────────────
-    //
-    // The bar shows kFavoriteCount (5) user-chosen "favorite" buttons in a
-    // single row, with a 6th slot acting as the drawer toggle (▾/▴).
-    // Toggling the drawer reveals/hides a grid containing every other
-    // bar button.  Right-click any bar button to open the picker dialog.
-    //
-    // Construction: every bar button (LCK, VU, RX, …) is created with the
-    // drawer's widget+layout as its rowParent/rowLayout.  Once all are
-    // registered, applyBarLayout() lifts the favorites out of the drawer
-    // into m_favRow.  See registerBarButton() / applyBarLayout().
-    //
-    // All colour values resolved through ThemeManager so the bar
-    // re-themes live alongside the rest of the UI.
-    const QString kBarContainerStyle =
-        QStringLiteral("QWidget#barContainer { background: {{color.background.0}}; }");
-    const QString kBarBtnStyle =
-        QStringLiteral(
-            "QPushButton { background: {{color.background.1}}; "
-            "border: 1px solid {{color.background.2}}; border-radius: 3px; "
-            "padding: 2px 3px; font-size: 11px; font-weight: bold; "
-            "color: {{color.text.primary}}; }"
-            "QPushButton:hover { background: {{color.background.2}}; }"
-            // Active/checked state mirrors the kBlueActive style used by
-            // the RxApplet filter-preset buttons (1.8K/2.1K/…): dim cyan
-            // fill, light text, slightly brighter outline.
-            "QPushButton:checked { background: {{color.accent.dim}}; "
-            "color: {{color.text.primary}}; "
-            "border: 1px solid {{color.accent.bright}}; }"
-            "QPushButton:disabled { color: {{color.text.disabled}}; "
-            "border-color: {{color.background.1}}; }");
-
-    m_favRow = new QWidget;
-    m_favRow->setObjectName("barContainer");
-    ThemeManager::instance().applyStyleSheet(m_favRow, kBarContainerStyle + kBarBtnStyle);
-    m_favLayout = new QGridLayout(m_favRow);
-    m_favLayout->setContentsMargins(2, 3, 2, 3);
-    m_favLayout->setSpacing(2);
-    root->addWidget(m_favRow);
-
-    m_drawer = new QWidget;
-    m_drawer->setObjectName("barContainer");
-    ThemeManager::instance().applyStyleSheet(m_drawer, kBarContainerStyle + kBarBtnStyle +
-        QStringLiteral("QWidget#barContainer { border-bottom: 1px solid {{color.border.subtle}}; }"));
-    m_drawerLayout = new QGridLayout(m_drawer);
-    m_drawerLayout->setContentsMargins(2, 0, 2, 3);
-    m_drawerLayout->setSpacing(2);
-    m_drawer->hide();
-    root->addWidget(m_drawer);
-
-    // Drawer toggle button — always occupies the last slot of the
-    // favorites row.  Right-click also opens the favorites picker
-    // so users can reach it without clicking through to find a favorite.
-    // Uses full-size triangle glyphs (▼/▲) at a larger font size so the
-    // affordance reads at panel-bar scale; the small caret glyphs (▾/▴)
-    // were nearly invisible at the bar's 11px default.
-    m_drawerToggleBtn = new QPushButton(QString::fromUtf8("\xe2\x96\xbc"), m_favRow); // ▼
-    m_drawerToggleBtn->setCheckable(true);
-    m_drawerToggleBtn->setToolTip("Show / hide additional buttons\nRight-click: customize favorites");
-    m_drawerToggleBtn->setAccessibleName("Toggle button drawer");
-    m_drawerToggleBtn->setAccessibleDescription(
-        "Show or hide the panel of non-favorite buttons");
-    m_drawerToggleBtn->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-    m_drawerToggleBtn->setFixedHeight(20);
-    m_drawerToggleBtn->setStyleSheet("QPushButton { font-size: 14px; padding: 0px; }");
-    m_drawerToggleBtn->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(m_drawerToggleBtn, &QPushButton::toggled,
-            this, &AppletPanel::setDrawerOpen);
-    connect(m_drawerToggleBtn, &QWidget::customContextMenuRequested,
-            this, [this](const QPoint&){ openFavoritesPicker(); });
+    m_picker = new AppletPicker(this);
+    root->addWidget(m_picker);
+    connect(m_picker, &AppletPicker::addRequested, this, &AppletPanel::addSelectedApplet);
+    m_toggleStorage = new QWidget(this);
+    m_toggleStorage->hide();
 
     // Phase 4a (#1713) — container system groundwork.  Created early
     // so the S-Meter (and any future root-level containers) can wrap
@@ -446,10 +379,23 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     const bool sMeterOn = AppSettings::instance()
         .value("Applet_VU", "True").toString() == "True";
     m_sMeterContainer->setContainerVisible(sMeterOn);
-    root->addWidget(m_sMeterContainer);
+    m_pinnedMeterHost = new QWidget(this);
+    m_pinnedMeterHost->setObjectName(QStringLiteral("pinnedMeterHost"));
+    m_pinnedMeterLayout = new QHBoxLayout(m_pinnedMeterHost);
+    m_pinnedMeterLayout->setContentsMargins(0, 0, 0, 0);
+    m_pinnedMeterLayout->addWidget(m_sMeterContainer);
+    root->addWidget(m_pinnedMeterHost);
+    m_sMeterContainer->installEventFilter(this);
+    connect(m_sMeterContainer, &ContainerWidget::dockModeChanged, this, [this]() {
+        QTimer::singleShot(0, this, &AppletPanel::syncPinnedMeter);
+        QTimer::singleShot(0, this, &AppletPanel::refreshAppletPicker);
+    });
 
     // ── Scrollable applet stack (drop-aware) ────────────────────────────────
     m_scrollArea = new AppletDropArea(this);
+    m_scrollArea->setObjectName(QStringLiteral("appletScrollArea"));
+    m_scrollArea->viewport()->setObjectName(QStringLiteral("appletViewport"));
+    m_scrollArea->viewport()->installEventFilter(this);
     m_scrollArea->setFrameShape(QFrame::NoFrame);
     m_scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_scrollArea->setWidgetResizable(true);
@@ -568,7 +514,6 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     // the right path.
     auto makeEntry = [&](const QString& id, const QString& label,
                          QWidget* contentOrContainer, bool defaultOn,
-                         QWidget* rowParent, QLayout* rowLayout,
                          const QString& buttonText = QString()) -> AppletEntry {
         ContainerWidget* c =
             qobject_cast<ContainerWidget*>(contentOrContainer);
@@ -577,20 +522,14 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
             c->setContent(contentOrContainer);
         }
 
-        QPushButton* btn = nullptr;
-        // rowLayout != nullptr is the legacy "this applet has a bar button"
-        // signal — we now register the button into m_barButtons and let
-        // applyBarLayout() decide whether it lands in the favorites
-        // row or the drawer.  The rowParent/rowLayout args themselves
-        // are ignored (kept in the signature only to minimise churn at
-        // the call sites).
-        (void)rowParent;
-        if (rowLayout) {
-            const QString visible = buttonText.isEmpty() ? id : buttonText;
-            btn = new QPushButton(visible, m_drawer);
-            btn->setCheckable(true);
-            registerBarButton(id, visible, label, btn, defaultOn);
-        }
+        const QString visible = buttonText.isEmpty() ? id : buttonText;
+        auto* btn = new QPushButton(visible, m_toggleStorage);
+        btn->setCheckable(true);
+        registerBarButton(id, visible, label, btn, defaultOn);
+        c->installEventFilter(this);
+        connect(c, &ContainerWidget::dockModeChanged, this, [this]() {
+            QTimer::singleShot(0, this, &AppletPanel::refreshAppletPicker);
+        });
 
         const QString key = QStringLiteral("Applet_%1").arg(id);
         bool on = settings.value(key, defaultOn ? "True" : "False").toString() == "True";
@@ -643,6 +582,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
                 QSignalBlocker b(btn);
                 btn->setChecked(visible);
             }
+            QTimer::singleShot(0, this, &AppletPanel::refreshAppletPicker);
             // Recall-driven changes are workspace state, not preference
             // changes (red-team B2) — the button sync above still runs so
             // the bar stays honest either way.
@@ -656,7 +596,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
 
     // Controls lock toggle — disables wheel/mouse on sidebar sliders (#745)
     {
-        m_lockBtn = new QPushButton("LOCK", m_drawer);
+        m_lockBtn = new QPushButton("LOCK", m_toggleStorage);
         m_lockBtn->setCheckable(true);
         m_lockBtn->setToolTip("Lock sidebar controls — prevent accidental\n"
                               "value changes while scrolling");
@@ -668,7 +608,13 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
         m_lockBtn->setChecked(false);
         ControlsLock::setLocked(false);
         // ID stays "LCK" so saved layouts from earlier builds still match.
-        registerBarButton("LCK", "LOCK", "Lock sidebar controls", m_lockBtn);
+        m_lockBtn->setParent(m_picker);
+        m_lockBtn->setFixedSize(40, 28);
+        m_lockBtn->setFocusPolicy(Qt::StrongFocus);
+        m_picker->layout()->addWidget(m_lockBtn);
+        ThemeManager::instance().applyStyleSheet(m_lockBtn, QStringLiteral(
+            "QPushButton { font-size: 10px; padding: 0px; min-width: 0px; }"
+            "QPushButton:checked { background: {{color.accent.dim}}; border-color: {{color.border.accent}}; }"));
         connect(m_lockBtn, &QPushButton::toggled, this, [this](bool on) {
             setControlsLocked(on);
         });
@@ -677,7 +623,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     // VU button — toggles the S-Meter container (not in the
     // reorderable stack; sits permanently at the top of the sidebar).
     {
-        m_vuBtn = new QPushButton("VU", m_drawer);
+        m_vuBtn = new QPushButton("VU", m_toggleStorage);
         m_vuBtn->setCheckable(true);
         m_vuBtn->setChecked(sMeterOn);
         registerBarButton("VU", "VU", "S-Meter", m_vuBtn);
@@ -704,6 +650,8 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
                 QSignalBlocker b(m_vuBtn);
                 m_vuBtn->setChecked(visible);
             }
+            QTimer::singleShot(0, this, &AppletPanel::refreshAppletPicker);
+            QTimer::singleShot(0, this, &AppletPanel::syncPinnedMeter);
             AppSettings::instance().setValue(
                 "Applet_VU", visible ? "True" : "False");
         });
@@ -726,12 +674,10 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     // PWR is independent from the fixed VU container and participates in the
     // normal order/float/visibility system. Keep it first so enabling it places
     // it directly below the S-meter, but leave it off until the user opts in.
-    // Its bar button remains visible through defaultButtonOrder().
     m_crossNeedleApplet = new CrossNeedleMeterApplet;
     {
         AppletEntry powerEntry = makeEntry("PWR", "Power & SWR",
-                                           m_crossNeedleApplet, false,
-                                           m_drawer, m_drawerLayout);
+                                           m_crossNeedleApplet, false);
         if (ContainerWidget* container =
                 qobject_cast<ContainerWidget*>(powerEntry.widget)) {
             // 640x427 meter face plus the container's fixed 18px title bar.
@@ -750,7 +696,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     }
 
     m_rxApplet = new RxApplet;
-    m_appletOrder.append(makeEntry("RX", "RX Controls", m_rxApplet, true, m_drawer, m_drawerLayout));
+    m_appletOrder.append(makeEntry("RX", "RX Controls", m_rxApplet, true));
 
     // Tuner / Amp entries use makeEntry like everything else;
     // MainWindow toggles tray-button visibility via setTunerVisible /
@@ -759,8 +705,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     // starts hidden (defaultOn = false).
     m_tunerApplet = new TunerApplet;
     {
-        auto entry = makeEntry("TUN", "TGXL", m_tunerApplet, false,
-                               m_drawer, m_drawerLayout);
+        auto entry = makeEntry("TUN", "TGXL", m_tunerApplet, false);
         m_tuneBtn = entry.btn;
         markHardwareConditional("TUN");
         m_appletOrder.append(entry);
@@ -768,8 +713,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
 
     m_ampApplet = new AmpApplet;
     {
-        auto entry = makeEntry("AMP", "PGXL", m_ampApplet, false,
-                               m_drawer, m_drawerLayout);
+        auto entry = makeEntry("AMP", "PGXL", m_ampApplet, false);
         m_ampBtn = entry.btn;
         markHardwareConditional("AMP");
         m_appletOrder.append(entry);
@@ -779,8 +723,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     // (MainWindow calls setAppletVisible("DEMO", isSyntheticDemo)). RFC #4288.
     m_demoApplet = new DemoApplet;
     {
-        auto entry = makeEntry("DEMO", "Demo Noise", m_demoApplet, false,
-                               m_drawer, m_drawerLayout);
+        auto entry = makeEntry("DEMO", "Demo Noise", m_demoApplet, false);
         markHardwareConditional("DEMO");
         m_appletOrder.append(entry);
     }
@@ -790,8 +733,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     // at once. See docs/architecture/acom-600s-amplifier-design.md.
     m_acomApplet = new AcomApplet;
     {
-        auto entry = makeEntry("ACOM", "ACOM Amplifier", m_acomApplet, false,
-                               m_drawer, m_drawerLayout);
+        auto entry = makeEntry("ACOM", "ACOM Amplifier", m_acomApplet, false);
         m_acomBtn = entry.btn;
         markHardwareConditional("ACOM");
         m_appletOrder.append(entry);
@@ -802,8 +744,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     // docs/architecture/spe-expert-amplifier-design.md.
     m_speApplet = new SpeApplet;
     {
-        auto entry = makeEntry("SPE", "SPE Expert Amplifier", m_speApplet, false,
-                               m_drawer, m_drawerLayout);
+        auto entry = makeEntry("SPE", "SPE Expert Amplifier", m_speApplet, false);
         m_speBtn = entry.btn;
         markHardwareConditional("SPE");
         // Popped out, the applet switches to its roomier presentation and
@@ -829,8 +770,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     // docs/architecture/vkamp-amplifier-design.md.
     m_vkampApplet = new VkampApplet;
     {
-        auto entry = makeEntry("VKAMP", "VK3AMP Amplifier", m_vkampApplet, false,
-                               m_drawer, m_drawerLayout);
+        auto entry = makeEntry("VKAMP", "VK3AMP Amplifier", m_vkampApplet, false);
         m_vkampBtn = entry.btn;
         markHardwareConditional("VKAMP");
         m_appletOrder.append(entry);
@@ -843,29 +783,28 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     // reveal it. See docs/architecture/lp-100a-wattmeter-design.md.
     m_lpMeterApplet = new LpMeterApplet;
     {
-        auto entry = makeEntry("LP100", "LP-100A Meter", m_lpMeterApplet, false,
-                               m_drawer, m_drawerLayout);
+        auto entry = makeEntry("LP100", "LP-100A Meter", m_lpMeterApplet, false);
         markHardwareConditional("LP100");
         m_appletOrder.append(entry);
     }
 
     m_txApplet = new TxApplet;
-    m_appletOrder.append(makeEntry("TX", "TX Controls", m_txApplet, true, m_drawer, m_drawerLayout));
+    m_appletOrder.append(makeEntry("TX", "TX Controls", m_txApplet, true));
 
     m_phoneApplet = new PhoneApplet;
-    m_appletOrder.append(makeEntry("PHNE", "Phone", m_phoneApplet, true, m_drawer, m_drawerLayout, "PHN"));
+    m_appletOrder.append(makeEntry("PHNE", "Phone", m_phoneApplet, true, "PHN"));
 
     m_phoneCwApplet = new PhoneCwApplet;
-    m_appletOrder.append(makeEntry("P/CW", "Phone/CW", m_phoneCwApplet, true, m_drawer, m_drawerLayout));
+    m_appletOrder.append(makeEntry("P/CW", "Phone/CW", m_phoneCwApplet, true));
 
     m_eqApplet = new EqApplet;
-    m_appletOrder.append(makeEntry("EQ", "Equalizer", m_eqApplet, true, m_drawer, m_drawerLayout));
+    m_appletOrder.append(makeEntry("EQ", "Equalizer", m_eqApplet, true));
 
     m_waveApplet = new WaveApplet;
-    m_appletOrder.append(makeEntry("WAVE", "Waveform", m_waveApplet, true, m_drawer, m_drawerLayout, "WAV"));
+    m_appletOrder.append(makeEntry("WAVE", "Waveform", m_waveApplet, true, "WAV"));
 
     m_aetherClockApplet = new AetherClockApplet;
-    m_appletOrder.append(makeEntry("CLOCK", "AetherClock", m_aetherClockApplet, false, m_drawer, m_drawerLayout, "CLK"));
+    m_appletOrder.append(makeEntry("CLOCK", "AetherClock", m_aetherClockApplet, false, "CLK"));
 
     // Mini-Pan — the K4-style narrow scope. Deliberately an applet and NOT a
     // View-menu item: the menu bar does not exist in Minimal Mode, which is
@@ -875,7 +814,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     // just re-slices the main pan's frames. Float it out via the container
     // title bar to keep it over a logging app.
     m_miniPanApplet = new MiniPanApplet;
-    m_appletOrder.append(makeEntry("MPAN", "Mini-Pan", m_miniPanApplet, false, m_drawer, m_drawerLayout, "MINI"));
+    m_appletOrder.append(makeEntry("MPAN", "Mini-Pan", m_miniPanApplet, false, "MINI"));
 
     // CEQ and CMP intentionally have no toggle button in the tray —
     // their visibility follows DSP bypass state, driven externally
@@ -959,8 +898,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     // marketing name for the whole TX-DSP composite.  Settings ID
     // stays TXDSP for persistence.
     {
-        auto entry = makeEntry("TXDSP", "Channel Strip", txDsp, false,
-                               m_drawer, m_drawerLayout, "VUDU");
+        auto entry = makeEntry("TXDSP", "Channel Strip", txDsp, false, "VUDU");
         // Make the composite's drag MIME match its owning AppletEntry.id
         // so the drop handler's fast lookup hits directly.  Container
         // persistence keys still use the internal id ("tx_dsp") — drag
@@ -972,7 +910,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
 
     m_catControlApplet = new CatControlApplet;
     {
-        auto catEntry = makeEntry("CAT", "CAT Control", m_catControlApplet, false, m_drawer, m_drawerLayout);
+        auto catEntry = makeEntry("CAT", "CAT Control", m_catControlApplet, false);
         m_appletOrder.append(catEntry);
         // Switch the applet between its simple (docked) and full-table (floating) views.
         if (auto* c = qobject_cast<ContainerWidget*>(catEntry.widget)) {
@@ -988,36 +926,34 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     }
 
     m_daxApplet = new DaxApplet;
-    m_appletOrder.append(makeEntry("DAX", "DAX Audio", m_daxApplet, false, m_drawer, m_drawerLayout));
+    m_appletOrder.append(makeEntry("DAX", "DAX Audio", m_daxApplet, false));
 
     m_tciApplet = new TciApplet;
-    m_appletOrder.append(makeEntry("TCI", "TCI Server", m_tciApplet, false, m_drawer, m_drawerLayout));
+    m_appletOrder.append(makeEntry("TCI", "TCI Server", m_tciApplet, false));
 
     m_daxIqApplet = new DaxIqApplet;
-    m_appletOrder.append(makeEntry("IQ", "DAX IQ", m_daxIqApplet, false, m_drawer, m_drawerLayout));
+    m_appletOrder.append(makeEntry("IQ", "DAX IQ", m_daxIqApplet, false));
 
     m_meterApplet = new MeterApplet;
-    m_appletOrder.append(makeEntry("MTR", "Radio Vitals", m_meterApplet, false, m_drawer, m_drawerLayout));
+    m_appletOrder.append(makeEntry("MTR", "Radio Vitals", m_meterApplet, false));
 
     m_profApplet = new ProfileSwitcherApplet;
-    m_appletOrder.append(makeEntry("PROF", "Profile Switcher", m_profApplet, false, m_drawer, m_drawerLayout));
+    m_appletOrder.append(makeEntry("PROF", "Profile Switcher", m_profApplet, false));
 
     m_kiwiSdrApplet = new KiwiSdrApplet;
-    m_appletOrder.append(makeEntry("KSDR", "KiwiSDR", m_kiwiSdrApplet, false,
-                                   m_drawer, m_drawerLayout));
+    m_appletOrder.append(makeEntry("KSDR", "KiwiSDR", m_kiwiSdrApplet, false));
 
 #ifdef HAVE_RADE
     m_radeApplet = new RadeApplet;
-    m_appletOrder.append(makeEntry("RADE", "RADE Status", m_radeApplet, false, m_drawer, m_drawerLayout));
+    m_appletOrder.append(makeEntry("RADE", "RADE Status", m_radeApplet, false));
 #endif
 
     m_healthApplet = new HealthApplet;
-    m_appletOrder.append(makeEntry("HLTH", "Antenna Health", m_healthApplet, false, m_drawer, m_drawerLayout));
+    m_appletOrder.append(makeEntry("HLTH", "Antenna Health", m_healthApplet, false));
 
     m_agApplet = new AntennaGeniusApplet;
     {
-        auto entry = makeEntry("AG", "Antenna Genius", m_agApplet, false,
-                               m_drawer, m_drawerLayout);
+        auto entry = makeEntry("AG", "Antenna Genius", m_agApplet, false);
         m_agBtn = entry.btn;
         markHardwareConditional("AG");
         m_appletOrder.append(entry);
@@ -1029,7 +965,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     // configured does not display a stray SS button in the top right.
     m_ssApplet = new ShackSwitchApplet;
     {
-        auto entry = makeEntry("SS", "ShackSwitch", m_ssApplet, false, m_drawer, m_drawerLayout);
+        auto entry = makeEntry("SS", "ShackSwitch", m_ssApplet, false);
         m_ssBtn = entry.btn;
         markHardwareConditional("SS");
         m_appletOrder.append(entry);
@@ -1044,7 +980,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     m_greenHeronApplet = new GreenHeronApplet;
     {
         AppletEntry gheEntry = makeEntry("GHE", "Green Heron", m_greenHeronApplet,
-                                         false, m_drawer, m_drawerLayout);
+                                         false);
         if (auto* c = qobject_cast<ContainerWidget*>(gheEntry.widget)) {
             // Deliberately NO setDefaultFloatingSize(). The compass is inside
             // the rotor section, so it enters and leaves the layout with the
@@ -1067,26 +1003,11 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
 
 #ifdef HAVE_MQTT
     m_mqttApplet = new MqttApplet;
-    m_appletOrder.append(makeEntry("MQTT", "MQTT", m_mqttApplet, false, m_drawer, m_drawerLayout));
+    m_appletOrder.append(makeEntry("MQTT", "MQTT", m_mqttApplet, false));
 #endif
 
-    // Place the drawer toggle into the favorites row, then apply the
-    // saved (or default) favorites layout to populate both strips.
-    loadButtonLayout();
-    applyBarLayout();
-
-    // Restore drawer open/closed state (default closed).  Signals blocked
-    // to skip the AppSettings::save() roundtrip during init.
-    const bool drawerOpen =
-        AppSettings::instance().value("ButtonBarDrawerOpen", "False").toString() == "True";
-    {
-        QSignalBlocker b(m_drawerToggleBtn);
-        m_drawerToggleBtn->setChecked(drawerOpen);
-    }
-    m_drawer->setVisible(drawerOpen);
-    m_drawerToggleBtn->setText(drawerOpen
-        ? QString::fromUtf8("\xe2\x96\xb2")
-        : QString::fromUtf8("\xe2\x96\xbc"));
+    refreshAppletPicker();
+    QTimer::singleShot(0, this, &AppletPanel::syncPinnedMeter);
 
     // ── Restore saved order ─────────────────────────────────────────────────
     QString savedOrder = settings.value("AppletOrder").toString();
@@ -1356,6 +1277,7 @@ QList<AppletPanel::AppletCatalogEntry> AppletPanel::appletCatalog() const
         {QStringLiteral("AMP"),   QStringLiteral("Amplifiers")},
         {QStringLiteral("ACOM"),  QStringLiteral("Amplifiers")},
         {QStringLiteral("SPE"),   QStringLiteral("Amplifiers")},
+        {QStringLiteral("VKAMP"), QStringLiteral("Amplifiers")},
         {QStringLiteral("EQ"),    QStringLiteral("Audio & DSP")},
         {QStringLiteral("TXDSP"), QStringLiteral("Audio & DSP")},
         {QStringLiteral("WAVE"),  QStringLiteral("Audio & DSP")},
@@ -1604,7 +1526,7 @@ int AppletPanel::dropIndexFromY(int localY) const
 
 // Mark a bar button as hardware-available / unavailable and propagate
 // the change to the applet's checked state.  Show/hide of the button
-// itself is left to applyBarLayout() so the combined (hardware-available
+// itself is left to refreshAppletPicker() so the combined (hardware-available
 // ∧ ¬user-hidden) decision lives in one place.
 void AppletPanel::updateHardwareAvailability(const QString& id,
                                              const QString& appletKey,
@@ -1613,19 +1535,8 @@ void AppletPanel::updateHardwareAvailability(const QString& id,
     for (auto& bb : m_barButtons) {
         if (bb.id != id) continue;
         if (!bb.btn) return;
-        const bool wasAvailable = bb.hardwareAvailable;
         bb.hardwareAvailable = hardwareVisible;
         if (hardwareVisible) {
-            // First-time hardware-detect for a button the user hasn't
-            // placed yet → append to Active so the picker shows it and
-            // the bar can render it.  If the user has explicitly hidden
-            // it (m_hiddenButtons), respect that.
-            if (!wasAvailable
-                && !m_buttonOrder.contains(id)
-                && !m_hiddenButtons.contains(id)) {
-                m_buttonOrder.append(id);
-                saveButtonLayout();
-            }
             // Default to THIS applet's own default when Applet_<id> is unset,
             // not to a blanket "True".
             //
@@ -1689,7 +1600,7 @@ void AppletPanel::applyCapabilityVisibility(const QString& id,
         }
         s.save();
     }
-    applyBarLayout();
+    refreshAppletPicker();
 }
 
 void AppletPanel::setRadioFilterWidths(const QList<int>& widthsHz)
@@ -1757,49 +1668,49 @@ void AppletPanel::setHardwareEqVisible(bool visible)
 void AppletPanel::setTunerVisible(bool visible)
 {
     updateHardwareAvailability("TUN", "Applet_TUN", visible);
-    applyBarLayout();
+    refreshAppletPicker();
 }
 
 void AppletPanel::setAmpVisible(bool visible)
 {
     updateHardwareAvailability("AMP", "Applet_AMP", visible);
-    applyBarLayout();
+    refreshAppletPicker();
 }
 
 void AppletPanel::setAcomVisible(bool visible)
 {
     updateHardwareAvailability("ACOM", "Applet_ACOM", visible);
-    applyBarLayout();
+    refreshAppletPicker();
 }
 
 void AppletPanel::setSpeVisible(bool visible)
 {
     updateHardwareAvailability("SPE", "Applet_SPE", visible);
-    applyBarLayout();
+    refreshAppletPicker();
 }
 
 void AppletPanel::setVkampVisible(bool visible)
 {
     updateHardwareAvailability("VKAMP", "Applet_VKAMP", visible);
-    applyBarLayout();
+    refreshAppletPicker();
 }
 
 void AppletPanel::setLpMeterVisible(bool visible)
 {
     updateHardwareAvailability("LP100", "Applet_LP100", visible);
-    applyBarLayout();
+    refreshAppletPicker();
 }
 
 void AppletPanel::setAgVisible(bool visible)
 {
     updateHardwareAvailability("AG", "Applet_AG", visible);
-    applyBarLayout();
+    refreshAppletPicker();
 }
 
 void AppletPanel::setShackSwitchVisible(bool visible)
 {
     updateHardwareAvailability("SS", "Applet_SS", visible);
-    applyBarLayout();
+    refreshAppletPicker();
 }
 
 void AppletPanel::setDemoVisible(bool visible)
@@ -1812,7 +1723,7 @@ void AppletPanel::setDemoVisible(bool visible)
     // so on the one radio the applet exists for it was refused at the
     // door and a workspace switch could close it with no way back.
     updateHardwareAvailability("DEMO", "Applet_DEMO", visible);
-    applyBarLayout();
+    refreshAppletPicker();
     // The tile additionally auto-opens with the demo connection and
     // auto-closes when it drops (RFC #4288) — unchanged.
     setAppletVisible(QStringLiteral("DEMO"), visible);
@@ -1950,6 +1861,14 @@ bool AppletPanel::eventFilter(QObject* obj, QEvent* ev)
             break;
         }
     }
+    if (m_scrollArea && obj == m_scrollArea->viewport()
+        && (ev->type() == QEvent::Resize || ev->type() == QEvent::Move)) {
+        QTimer::singleShot(0, this, &AppletPanel::syncPinnedMeter);
+    }
+    if (qobject_cast<ContainerWidget*>(obj)
+        && (ev->type() == QEvent::Show || ev->type() == QEvent::Hide)) {
+        QTimer::singleShot(0, this, &AppletPanel::refreshAppletPicker);
+    }
     return QWidget::eventFilter(obj, ev);
 }
 
@@ -1964,8 +1883,6 @@ void AppletPanel::setScrollHandleActive(bool active)
     sb->style()->polish(sb);
 }
 
-// ── Button-bar (active + drawer + hidden) ──────────────────────────────────
-
 void AppletPanel::registerBarButton(const QString& id, const QString& label,
                                     const QString& tooltip, QPushButton* btn,
                                     bool defaultOn)
@@ -1973,102 +1890,16 @@ void AppletPanel::registerBarButton(const QString& id, const QString& label,
     if (!btn) return;
     btn->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     btn->setFixedHeight(20);
-    btn->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(btn, &QWidget::customContextMenuRequested, this,
-            [this](const QPoint&) { openFavoritesPicker(); });
+    btn->hide();
+    connect(btn, &QPushButton::toggled, this, [this]() {
+        QTimer::singleShot(0, this, &AppletPanel::refreshAppletPicker);
+    });
     m_barButtons.append(BarButton{id, label, tooltip, btn,
                                   /*hardwareAvailable=*/true, defaultOn});
 }
 
-QStringList AppletPanel::defaultButtonOrder() const
-{
-    // Top kFavoriteCount entries become the bar favourites.  Remaining
-    // ids are in canonical registration order so a fresh install matches
-    // the old fixed two-row bar.  IDs are the canonical persistence
-    // keys, which differ from a few labels (WAVE→"WAV", PHNE→"PHN",
-    // TXDSP→"VUDU").
-    //
-    // TUN/AMP/AG are intentionally omitted — these are hardware-
-    // conditional and should not clutter the picker's Active column
-    // until the matching device is detected.  updateHardwareAvailability()
-    // auto-adds them when MainWindow reports the hardware as present,
-    // and the user's explicit Hidden choice is respected from then on.
-    QStringList out = {"VU", "PWR", "RX", "TX", "P/CW"};
-    const QStringList rest = {
-        "LCK", "PHNE", "EQ", "WAVE", "TXDSP",
-        "CAT", "DAX", "TCI", "IQ", "MTR", "PROF", "SS", "MQTT"
-    };
-    for (const auto& id : rest)
-        if (!out.contains(id)) out.append(id);
-    return out;
-}
-
-void AppletPanel::loadButtonLayout()
-{
-    m_buttonOrder.clear();
-    m_hiddenButtons.clear();
-
-    // New canonical key: ButtonBarLayout = {"order":[...], "hidden":[...]}.
-    const QString rawLayout =
-        AppSettings::instance().value("ButtonBarLayout").toString();
-    if (!rawLayout.isEmpty()) {
-        QJsonParseError err{};
-        const QJsonDocument doc = QJsonDocument::fromJson(rawLayout.toUtf8(), &err);
-        if (err.error == QJsonParseError::NoError && doc.isObject()) {
-            const QJsonObject obj = doc.object();
-            for (const auto& v : obj.value("order").toArray())
-                if (v.isString()) m_buttonOrder.append(v.toString());
-            for (const auto& v : obj.value("hidden").toArray())
-                if (v.isString()) m_hiddenButtons.insert(v.toString());
-            return;
-        }
-    }
-
-    // Migration: legacy ButtonBarFavorites (5-item array of canonical
-    // favourite IDs) → ButtonBarLayout.  We adopt the saved favourites
-    // as the head of the order list; applyBarLayout()'s sanitize pass
-    // fills in the rest from defaultButtonOrder() and persists.
-    const QString rawFavs =
-        AppSettings::instance().value("ButtonBarFavorites").toString();
-    if (!rawFavs.isEmpty()) {
-        QJsonParseError err{};
-        const QJsonDocument doc = QJsonDocument::fromJson(rawFavs.toUtf8(), &err);
-        if (err.error == QJsonParseError::NoError && doc.isArray()) {
-            for (const auto& v : doc.array())
-                if (v.isString()) m_buttonOrder.append(v.toString());
-        }
-        AppSettings::instance().remove("ButtonBarFavorites");
-        return;
-    }
-
-    // First launch — use defaults.
-    m_buttonOrder = defaultButtonOrder();
-}
-
-void AppletPanel::saveButtonLayout()
-{
-    QJsonArray orderArr;
-    for (const auto& id : m_buttonOrder) orderArr.append(id);
-    // QSet has no guaranteed iteration order; the hidden list doesn't
-    // need ordering since hidden buttons aren't displayed.
-    QJsonArray hiddenArr;
-    for (const auto& id : m_hiddenButtons) hiddenArr.append(id);
-    QJsonObject obj;
-    obj["order"] = orderArr;
-    obj["hidden"] = hiddenArr;
-    const QString json = QString::fromUtf8(
-        QJsonDocument(obj).toJson(QJsonDocument::Compact));
-    AppSettings::instance().setValue("ButtonBarLayout", json);
-    AppSettings::instance().save();
-}
-
 void AppletPanel::markHardwareConditional(const QString& id)
 {
-    // Mark a bar button as hardware-conditional: it defaults to invisible
-    // in the bar and won't be auto-appended to Active by applyBarLayout()'s
-    // sanitize pass.  When MainWindow later confirms the hardware is
-    // present, updateHardwareAvailability() flips hardwareAvailable=true
-    // and adds the button to Active.
     for (auto& bb : m_barButtons) {
         if (bb.id != id) continue;
         bb.hardwareAvailable = false;
@@ -2077,203 +1908,85 @@ void AppletPanel::markHardwareConditional(const QString& id)
     }
 }
 
-void AppletPanel::disableAppletForButton(const QString& id)
+ContainerWidget* AppletPanel::appletContainer(const QString& id) const
 {
-    for (const auto& bb : m_barButtons) {
-        if (bb.id != id) continue;
-        if (bb.btn && bb.btn->isChecked()) {
-            // Triggers the existing toggled handler — sets
-            // Applet_<id>=False and hides the container.  Works for
-            // LCK/VU via their own handlers too.
-            bb.btn->setChecked(false);
-        }
-        break;
+    if (id == QStringLiteral("VU")) {
+        return m_sMeterContainer;
     }
+    for (const AppletEntry& entry : m_appletOrder) {
+        if (entry.id == id) {
+            return qobject_cast<ContainerWidget*>(entry.widget);
+        }
+    }
+    return nullptr;
 }
 
-void AppletPanel::applyBarLayout()
+bool AppletPanel::appletIsOpen(const QString& id) const
 {
-    if (!m_favLayout || !m_drawerLayout || !m_drawerToggleBtn) return;
-
-    // Batch all reparent + addWidget calls so Qt does a single layout
-    // pass and style polish at the end.  Without this, ~19 individual
-    // setParent() calls each trigger a cascading invalidation — visible
-    // as a startup delay when MainWindow's hardware-presence setters
-    // fire applyBarLayout() several times in a row.
-    const bool favWasUpdating = m_favRow->updatesEnabled();
-    const bool drawerWasUpdating = m_drawer->updatesEnabled();
-    m_favRow->setUpdatesEnabled(false);
-    m_drawer->setUpdatesEnabled(false);
-    auto restoreUpdates = qScopeGuard([&] {
-        m_favRow->setUpdatesEnabled(favWasUpdating);
-        m_drawer->setUpdatesEnabled(drawerWasUpdating);
-    });
-
-    // Sanitize: drop unknown IDs from both lists, then append any
-    // newly-registered buttons (e.g. a freshly added applet in a future
-    // build) to the active list so they appear.
-    {
-        QSet<QString> registered;
-        for (const auto& bb : m_barButtons) registered.insert(bb.id);
-
-        QStringList validOrder;
-        for (const auto& id : m_buttonOrder)
-            if (registered.contains(id) && !validOrder.contains(id))
-                validOrder.append(id);
-
-        QSet<QString> validHidden;
-        for (const auto& id : m_hiddenButtons)
-            if (registered.contains(id)) validHidden.insert(id);
-
-        // Buttons known to the build but missing from both lists →
-        // default to Active (visible).  Skip hardware-conditional
-        // buttons (TUN/AMP/AG/SS) until the corresponding device is
-        // detected — updateHardwareAvailability() adds them on first
-        // hardware-present transition.
-        for (const auto& bb : m_barButtons) {
-            if (validOrder.contains(bb.id) || validHidden.contains(bb.id)) continue;
-            if (!bb.hardwareAvailable) continue;
-            validOrder.append(bb.id);
-        }
-
-        if (validOrder != m_buttonOrder || validHidden != m_hiddenButtons) {
-            m_buttonOrder = validOrder;
-            m_hiddenButtons = validHidden;
-            saveButtonLayout();
-        }
+    const ContainerWidget* container = appletContainer(id);
+    if (!container || !container->isContainerVisible()) {
+        return false;
     }
-
-    auto detach = [](QLayout* layout, QWidget* widget) {
-        if (!widget || !layout) return;
-        layout->removeWidget(widget);
-    };
-
-    // Detach every registered bar button + the drawer toggle from
-    // whichever container they're in.  They keep their parent (we
-    // re-parent below) so signal connections survive.
-    for (const auto& bb : m_barButtons) {
-        if (auto* l = bb.btn->parentWidget() ? bb.btn->parentWidget()->layout() : nullptr)
-            detach(l, bb.btn);
-    }
-    if (auto* l = m_drawerToggleBtn->parentWidget()
-                      ? m_drawerToggleBtn->parentWidget()->layout()
-                      : nullptr) {
-        detach(l, m_drawerToggleBtn);
-    }
-
-    // Both the favorites strip and the drawer use the same column
-    // count so cell widths match exactly across the two grids.
-    constexpr int kCols = 6;
-
-    auto findButton = [this](const QString& id) -> BarButton* {
-        for (auto& bb : m_barButtons)
-            if (bb.id == id) return &bb;
-        return nullptr;
-    };
-
-    // Walk m_buttonOrder, placing each visible button first into the
-    // favourites row (positions 0..kFavoriteCount-1) and then into the
-    // drawer grid.  Hidden buttons and hardware-unavailable buttons get
-    // parked + hidden — they consume no slot.
-    int favSlot = 0;
-    int drawerIdx = 0;
-    for (const auto& id : m_buttonOrder) {
-        BarButton* bb = findButton(id);
-        if (!bb || !bb->btn) continue;
-
-        const bool wantsVisible =
-            bb->hardwareAvailable && !m_hiddenButtons.contains(bb->id);
-        if (!wantsVisible) {
-            bb->btn->setParent(m_drawer);
-            bb->btn->hide();
-            continue;
-        }
-
-        if (favSlot < kFavoriteCount) {
-            bb->btn->setParent(m_favRow);
-            m_favLayout->addWidget(bb->btn, 0, favSlot);
-            bb->btn->setVisible(true);
-            ++favSlot;
-        } else {
-            bb->btn->setParent(m_drawer);
-            m_drawerLayout->addWidget(bb->btn, drawerIdx / kCols, drawerIdx % kCols);
-            bb->btn->setVisible(true);
-            ++drawerIdx;
-        }
-    }
-
-    // User-hidden buttons (not in m_buttonOrder) — defensively park them.
-    for (auto& bb : m_barButtons) {
-        if (!m_hiddenButtons.contains(bb.id)) continue;
-        bb.btn->setParent(m_drawer);
-        bb.btn->hide();
-    }
-
-    // Equal-stretch on both grids so favourite cell width tracks drawer
-    // cell width even when the favourites row isn't fully populated.
-    for (int c = 0; c < kCols; ++c) {
-        m_favLayout->setColumnStretch(c, 1);
-        m_drawerLayout->setColumnStretch(c, 1);
-    }
-
-    // Drawer-toggle is always the last slot of the favorites row.
-    m_drawerToggleBtn->setParent(m_favRow);
-    m_favLayout->addWidget(m_drawerToggleBtn, 0, kCols - 1);
-    m_drawerToggleBtn->show();
+    return !container->isFloating() || !container->window()->isHidden();
 }
 
-void AppletPanel::setDrawerOpen(bool open)
+void AppletPanel::refreshAppletPicker()
 {
-    if (!m_drawer || !m_drawerToggleBtn) return;
-    m_drawer->setVisible(open);
-    // Full-size triangle: ▼ closed, ▲ open
-    m_drawerToggleBtn->setText(open
-        ? QString::fromUtf8("\xe2\x96\xb2")
-        : QString::fromUtf8("\xe2\x96\xbc"));
-    AppSettings::instance().setValue(
-        "ButtonBarDrawerOpen", open ? "True" : "False");
+    if (!m_picker) {
+        return;
+    }
+    QList<AppletPicker::Entry> entries;
+    for (const AppletCatalogEntry& applet : appletCatalog()) {
+        entries.append({applet.id, applet.title, applet.category,
+                        appletHardwareAvailable(applet.id), appletIsOpen(applet.id)});
+    }
+    m_picker->setEntries(entries);
+}
+
+void AppletPanel::addSelectedApplet(const QString& id)
+{
+    ContainerWidget* container = appletContainer(id);
+    if (!container || !appletHardwareAvailable(id) || appletIsOpen(id)) {
+        refreshAppletPicker();
+        return;
+    }
+    for (const BarButton& entry : m_barButtons) {
+        if (entry.id == id && entry.btn) {
+            entry.btn->setChecked(true);
+            break;
+        }
+    }
+    container->setContainerVisible(true);
+    if (container->isFloating()) {
+        container->window()->show();
+        container->window()->raise();
+    } else if (!container->isOnCanvas() && container != m_sMeterContainer) {
+        const QPointer<ContainerWidget> guard(container);
+        QTimer::singleShot(0, this, [this, guard]() {
+            if (guard && !guard->isFloating() && !guard->isOnCanvas()) {
+                m_scrollArea->ensureWidgetVisible(guard->titleBar(), 0, 4);
+            }
+        });
+    }
     AppSettings::instance().save();
+    syncPinnedMeter();
+    refreshAppletPicker();
 }
 
-void AppletPanel::openFavoritesPicker()
+void AppletPanel::syncPinnedMeter()
 {
-    // Lazy-construct + raise pattern per docs/style/dialog-patterns.md.
-    // The dialog is non-modal, WA_DeleteOnClose'd, and frameless-aware
-    // via its PersistentDialog base.  Subsequent right-clicks while the
-    // picker is open just raise it.
-    if (!m_favoritesPicker) {
-        QList<FavoritesPickerDialog::Entry> entries;
-        for (const auto& bb : m_barButtons)
-            entries.append({bb.id, bb.label, bb.tooltip});
-
-        const QStringList hiddenList(m_hiddenButtons.cbegin(),
-                                     m_hiddenButtons.cend());
-
-        auto* dlg = new FavoritesPickerDialog(
-            entries, m_buttonOrder, hiddenList, kFavoriteCount, window());
-        dlg->setAttribute(Qt::WA_DeleteOnClose);
-        connect(dlg, &FavoritesPickerDialog::layoutAccepted, this,
-                [this](const QStringList& activeOrder,
-                       const QStringList& hidden) {
-                    const QSet<QString> newHidden(hidden.cbegin(),
-                                                  hidden.cend());
-                    // Newly-hidden buttons: disable their applets so a
-                    // hidden tile doesn't keep occupying screen real
-                    // estate after the user hides its toggle.
-                    for (const auto& id : newHidden) {
-                        if (m_hiddenButtons.contains(id)) continue;
-                        disableAppletForButton(id);
-                    }
-                    m_buttonOrder = activeOrder;
-                    m_hiddenButtons = newHidden;
-                    saveButtonLayout();
-                    applyBarLayout();
-                });
-        m_favoritesPicker = dlg;
+    if (!m_pinnedMeterHost || !m_scrollArea) {
+        return;
     }
-    m_favoritesPicker->show();
-    m_favoritesPicker->raise();
-    m_favoritesPicker->activateWindow();
+    const bool docked = !m_sMeterContainer->isFloating() && !m_sMeterContainer->isOnCanvas();
+    m_pinnedMeterHost->setVisible(docked && m_sMeterContainer->isContainerVisible());
+    const QWidget* viewport = m_scrollArea->viewport();
+    const int left = viewport->mapTo(this, QPoint()).x();
+    const int right = qMax(0, width() - left - viewport->width());
+    const QMargins margins(left, 0, right, 0);
+    if (m_pinnedMeterLayout->contentsMargins() != margins) {
+        m_pinnedMeterLayout->setContentsMargins(margins);
+    }
 }
 
 } // namespace AetherSDR

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -16,7 +16,6 @@ class QScrollArea;
 class QTimer;
 class QVBoxLayout;
 class QHBoxLayout;
-class QGridLayout;
 
 namespace AetherSDR {
 class ContainerManager;
@@ -66,13 +65,11 @@ class ProfileSwitcherApplet;
 class HealthApplet;
 class MqttApplet;
 class KiwiSdrApplet;
-class FavoritesPickerDialog;
+class AppletPicker;
 #ifdef HAVE_RADE
 class RadeApplet;
 #endif
 
-// AppletPanel — right-side panel with a row of toggle buttons at the top,
-// an S-Meter gauge below them, and a scrollable stack of applets.
 // Multiple applets can be visible simultaneously. Applets can be reordered
 // by dragging their title bars (QDrag with custom MIME type).
 class AppletPanel : public QWidget {
@@ -338,17 +335,6 @@ private:
     int dropIndexFromY(int localY) const;
     void setScrollHandleActive(bool active);
 
-    // ── Button-bar (active + drawer + hidden) ────────────────────────────────
-    //
-    // Bar model — three buckets, all driven by m_buttonOrder + m_hiddenButtons:
-    //
-    //   * Active (top kFavoriteCount entries of m_buttonOrder that aren't in
-    //     m_hiddenButtons) → favorites row
-    //   * Drawer (remaining shown entries, in m_buttonOrder order) → grid below
-    //   * Hidden (m_hiddenButtons) → not in the bar at all; their applets
-    //     are forced off (Applet_<id>=False) when first moved here
-    //
-    // Reordering in the picker updates m_buttonOrder; the drawer follows.
     struct BarButton {
         QString      id;     // canonical persistence id (e.g. "P/CW")
         QString      label;  // bar label (e.g. "P/CW", "VUDU")
@@ -369,13 +355,11 @@ private:
     void registerBarButton(const QString& id, const QString& label,
                            const QString& tooltip, QPushButton* btn,
                            bool defaultOn = true);
-    void applyBarLayout();
-    void setDrawerOpen(bool open);
-    void openFavoritesPicker();
-    void loadButtonLayout();
-    void saveButtonLayout();
-    QStringList defaultButtonOrder() const;
-    void disableAppletForButton(const QString& id);
+    void refreshAppletPicker();
+    void addSelectedApplet(const QString& id);
+    void syncPinnedMeter();
+    ContainerWidget* appletContainer(const QString& id) const;
+    bool appletIsOpen(const QString& id) const;
     void updateHardwareAvailability(const QString& id,
                                     const QString& appletKey,
                                     bool hardwareVisible);
@@ -388,7 +372,6 @@ private:
     void markHardwareConditional(const QString& id);
     void persistVuMeterSettings() const;
     void showStandardMeterContextMenu(QWidget* source, const QPoint& position);
-    static const int kFavoriteCount = 5;
 
     ContainerManager* m_containerMgr{nullptr};
     ContainerWidget*  m_rootSidebar{nullptr};
@@ -464,17 +447,11 @@ private:
     QWidget*     m_dropIndicator{nullptr};
     QPushButton* m_lockBtn{nullptr};   // controls-lock toggle (#745)
 
-    // Button-bar widgets — both rows are QGridLayout with the same
-    // column count so cell widths match between favorites and drawer.
-    QWidget*     m_favRow{nullptr};
-    QGridLayout* m_favLayout{nullptr};
-    QWidget*     m_drawer{nullptr};
-    QGridLayout* m_drawerLayout{nullptr};
-    QPushButton* m_drawerToggleBtn{nullptr};
+    AppletPicker* m_picker{nullptr};
+    QWidget* m_toggleStorage{nullptr};
+    QWidget* m_pinnedMeterHost{nullptr};
+    QHBoxLayout* m_pinnedMeterLayout{nullptr};
     QVector<BarButton> m_barButtons;
-    QStringList  m_buttonOrder;     // shown buttons in user-chosen order
-    QSet<QString> m_hiddenButtons;  // ids removed from the bar entirely
-    QPointer<FavoritesPickerDialog> m_favoritesPicker;
 
     // Ordered list of applets (drag-reorderable)
     QVector<AppletEntry> m_appletOrder;

--- a/src/gui/AppletPicker.cpp
+++ b/src/gui/AppletPicker.cpp
@@ -1,0 +1,140 @@
+#include "AppletPicker.h"
+#include "ComboStyle.h"
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QListView>
+#include <QPushButton>
+#include <QSignalBlocker>
+#include <QStandardItemModel>
+#include <QStyledItemDelegate>
+#include <algorithm>
+
+namespace AetherSDR {
+
+class AppletCategoryDelegate : public QStyledItemDelegate {
+public:
+    explicit AppletCategoryDelegate(QObject* parent) : QStyledItemDelegate(parent) {}
+
+    void paint(QPainter* painter, const QStyleOptionViewItem& option,
+               const QModelIndex& index) const override
+    {
+        if (!index.data(Qt::UserRole).toString().isEmpty()) {
+            QStyledItemDelegate::paint(painter, option, index);
+            return;
+        }
+        ThemeManager& theme = ThemeManager::instance();
+        painter->save();
+        painter->fillRect(option.rect, theme.brush(option.widget, "color.background.2", option.rect));
+        painter->setPen(theme.color(option.widget, "color.text.primary"));
+        QFont font = option.font;
+        font.setBold(true);
+        painter->setFont(font);
+        painter->drawText(option.rect.adjusted(8, 0, -8, 0),
+                          Qt::AlignVCenter | Qt::AlignLeading, index.data().toString());
+        painter->restore();
+    }
+};
+
+AppletPicker::AppletPicker(QWidget* parent) : QWidget(parent)
+{
+    setObjectName(QStringLiteral("appletPicker"));
+    auto* row = new QHBoxLayout(this);
+    row->setContentsMargins(4, 4, 4, 4);
+    row->setSpacing(4);
+    auto* label = new QLabel(tr("Add:"), this);
+    m_combo = new QComboBox(this);
+    m_combo->setObjectName(QStringLiteral("appletPickerCombo"));
+    m_combo->setAccessibleName(tr("Applet to add"));
+    m_combo->setAccessibleDescription(tr("Choose an applet, then press Add. Open or unavailable applets cannot be added."));
+    m_combo->setPlaceholderText(tr("Add applet…"));
+    m_combo->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    m_combo->setMinimumWidth(0);
+    m_combo->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
+    m_combo->setMinimumContentsLength(8);
+    m_combo->setMaxVisibleItems(14);
+    m_combo->setView(new QListView(m_combo));
+    m_combo->setItemDelegate(new AppletCategoryDelegate(m_combo));
+    label->setBuddy(m_combo);
+    applyComboStyle(m_combo, QStringLiteral(
+        "QComboBox { min-height: 22px; combobox-popup: 0; }"
+        "QComboBox:focus { border-color: {{color.border.accent}}; }"
+        "QComboBox QAbstractItemView { min-width: 240px; }"
+        "QComboBox QAbstractItemView::item { min-height: 26px; }"
+        "QComboBox QAbstractItemView::item:disabled { color: {{color.text.secondary}}; }"));
+    m_addButton = new QPushButton(QStringLiteral("+"), this);
+    m_addButton->setObjectName(QStringLiteral("addAppletButton"));
+    m_addButton->setAccessibleName(tr("Add selected applet"));
+    m_addButton->setToolTip(tr("Add selected applet"));
+    m_addButton->setFixedSize(28, 28);
+    m_addButton->setFocusPolicy(Qt::StrongFocus);
+    ThemeManager::instance().applyStyleSheet(this, QStringLiteral(
+        "QWidget#appletPicker, QLabel { background: {{color.background.0}}; color: {{color.text.primary}}; }"
+        "QPushButton { background: {{color.background.1}}; color: {{color.text.primary}};"
+        " border: 1px solid {{color.border.strong}}; border-radius: 3px; font-size: 18px; }"
+        "QPushButton:hover, QPushButton:focus { border-color: {{color.border.accent}}; }"
+        "QPushButton:disabled { background: {{color.button.background.disabled}};"
+        " color: {{color.button.foreground.disabled}}; border-color: {{color.button.border.disabled}}; }"));
+    row->addWidget(label);
+    row->addWidget(m_combo, 1);
+    row->addWidget(m_addButton);
+    connect(m_combo, &QComboBox::currentIndexChanged, this, &AppletPicker::updateAddButton);
+    connect(m_addButton, &QPushButton::clicked, this, [this]() {
+        updateAddButton();
+        if (m_addButton->isEnabled()) {
+            emit addRequested(m_combo->currentData().toString());
+        }
+    });
+    updateAddButton();
+}
+
+void AppletPicker::setEntries(const QList<Entry>& entries)
+{
+    const QString selected = m_combo->currentData().toString();
+    const QSignalBlocker blocker(m_combo);
+    QList<Entry> sorted = entries;
+    std::stable_sort(sorted.begin(), sorted.end(), [](const Entry& left, const Entry& right) {
+        const int categoryOrder = QString::localeAwareCompare(left.category, right.category);
+        return categoryOrder == 0
+            ? QString::localeAwareCompare(left.title, right.title) < 0 : categoryOrder < 0;
+    });
+    m_combo->clear();
+    auto* model = qobject_cast<QStandardItemModel*>(m_combo->model());
+    QString category;
+    for (const Entry& entry : sorted) {
+        if (category != entry.category) {
+            category = entry.category;
+            auto* heading = new QStandardItem(category);
+            QFont font = heading->font();
+            font.setBold(true);
+            heading->setFont(font);
+            heading->setFlags(Qt::NoItemFlags);
+            model->appendRow(heading);
+        }
+        QString text = entry.title;
+        if (!entry.available) {
+            text += tr(" — unavailable");
+        } else if (entry.open) {
+            text += tr(" — open");
+        }
+        auto* item = new QStandardItem(text);
+        item->setData(entry.id, Qt::UserRole);
+        item->setToolTip(text);
+        item->setData(text, Qt::AccessibleTextRole);
+        item->setFlags(entry.available && !entry.open
+            ? Qt::ItemIsEnabled | Qt::ItemIsSelectable : Qt::NoItemFlags);
+        model->appendRow(item);
+    }
+    const int index = selected.isEmpty() ? -1 : m_combo->findData(selected);
+    m_combo->setCurrentIndex(index >= 0 && model->item(index)->isEnabled() ? index : -1);
+    updateAddButton();
+}
+
+void AppletPicker::updateAddButton()
+{
+    const QModelIndex index = m_combo->model()->index(m_combo->currentIndex(), 0);
+    m_addButton->setEnabled(!m_combo->currentData().toString().isEmpty()
+        && index.flags().testFlag(Qt::ItemIsEnabled));
+}
+
+}

--- a/src/gui/AppletPicker.h
+++ b/src/gui/AppletPicker.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <QWidget>
+#include <QList>
+#include <QString>
+
+class QComboBox;
+class QPushButton;
+
+namespace AetherSDR {
+
+class AppletPicker : public QWidget {
+    Q_OBJECT
+
+public:
+    struct Entry {
+        QString id;
+        QString title;
+        QString category;
+        bool available{true};
+        bool open{false};
+    };
+
+    explicit AppletPicker(QWidget* parent = nullptr);
+    void setEntries(const QList<Entry>& entries);
+
+signals:
+    void addRequested(const QString& id);
+
+private:
+    void updateAddButton();
+    QComboBox* m_combo{nullptr};
+    QPushButton* m_addButton{nullptr};
+};
+
+}

--- a/tests/applet_picker_test.cpp
+++ b/tests/applet_picker_test.cpp
@@ -1,0 +1,109 @@
+#include "gui/AppletPicker.h"
+#include "core/ThemeManager.h"
+#include <QComboBox>
+#include <QPushButton>
+#include <QSignalSpy>
+#include <QStandardItemModel>
+#include <QAbstractItemView>
+#include <QPainter>
+#include <QtTest>
+
+using namespace AetherSDR;
+
+class AppletPickerTest : public QObject {
+    Q_OBJECT
+
+private slots:
+    void selectionRequiresExplicitAdd()
+    {
+        AppletPicker picker;
+        picker.setEntries({{"RX", "RX Controls", "Receive"},
+                           {"VU", "S-Meter", "Metering", true, true},
+                           {"AMP", "PGXL", "Transmit", false, false}});
+        auto* combo = picker.findChild<QComboBox*>("appletPickerCombo");
+        auto* add = picker.findChild<QPushButton*>("addAppletButton");
+        QSignalSpy requested(&picker, &AppletPicker::addRequested);
+        QVERIFY(combo);
+        QVERIFY(add);
+        QVERIFY(!add->isEnabled());
+        QCOMPARE(combo->currentIndex(), -1);
+        combo->setCurrentIndex(combo->findData("RX"));
+        QCOMPARE(requested.count(), 0);
+        QVERIFY(add->isEnabled());
+        QTest::keyClick(add, Qt::Key_Space);
+        QCOMPARE(requested.count(), 1);
+        QCOMPARE(requested.first().first().toString(), QStringLiteral("RX"));
+        for (const QString& id : {QStringLiteral("VU"), QStringLiteral("AMP")}) {
+            combo->setCurrentIndex(combo->findData(id));
+            QVERIFY(!add->isEnabled());
+            add->click();
+        }
+        QCOMPARE(requested.count(), 1);
+    }
+
+    void groupingAndLiveAvailability()
+    {
+        AppletPicker picker;
+        QList<AppletPicker::Entry> entries = {
+            {"RX", "RX Controls", "Receive"}, {"VU", "S-Meter", "Metering"},
+            {"PWR", "Power & SWR", "Metering"}, {"AMP", "PGXL", "Amplifiers", false}};
+        picker.setEntries(entries);
+        auto* combo = picker.findChild<QComboBox*>("appletPickerCombo");
+        auto* add = picker.findChild<QPushButton*>("addAppletButton");
+        auto* model = qobject_cast<QStandardItemModel*>(combo->model());
+        QCOMPARE(combo->count(), 7);
+        QVERIFY(!model->item(0)->isEnabled());
+        QCOMPARE(combo->itemText(0), QStringLiteral("Amplifiers"));
+        QCOMPARE(combo->findData("VU"), combo->findData("PWR") + 1);
+        combo->setCurrentIndex(combo->findData("RX"));
+        entries[3].available = true;
+        picker.setEntries(entries);
+        QCOMPARE(combo->currentData().toString(), QStringLiteral("RX"));
+        QVERIFY(model->item(combo->findData("AMP"))->isEnabled());
+        entries[0].open = true;
+        picker.setEntries(entries);
+        QCOMPARE(combo->currentIndex(), -1);
+        QVERIFY(!add->isEnabled());
+        entries[0].open = false;
+        picker.setEntries(entries);
+        QVERIFY(model->item(combo->findData("RX"))->isEnabled());
+        entries[0].available = false;
+        combo->setCurrentIndex(combo->findData("RX"));
+        picker.setEntries(entries);
+        QVERIFY(!add->isEnabled());
+    }
+
+    void themesAndCompactLayout()
+    {
+        AppletPicker picker;
+        picker.resize(260, 36);
+        picker.show();
+        picker.setEntries({{"RX", "RX Controls", "Receive"}});
+        auto* combo = picker.findChild<QComboBox*>("appletPickerCombo");
+        auto* add = picker.findChild<QPushButton*>("addAppletButton");
+        for (const QString& theme : {QStringLiteral("Default Light"), QStringLiteral("Default Dark")}) {
+            QVERIFY(ThemeManager::instance().setActiveTheme(theme));
+            QCoreApplication::processEvents();
+            QVERIFY(!picker.styleSheet().contains("{{"));
+            QVERIFY(!combo->styleSheet().contains("{{"));
+            QVERIFY(picker.rect().contains(add->geometry()));
+            QVERIFY(combo->width() > 100);
+            QVERIFY(!combo->accessibleName().isEmpty());
+            QVERIFY(!add->accessibleName().isEmpty());
+            QImage header(240, 26, QImage::Format_ARGB32_Premultiplied);
+            QPainter painter(&header);
+            QStyleOptionViewItem option;
+            option.initFrom(combo->view());
+            option.widget = combo->view();
+            option.rect = header.rect();
+            combo->itemDelegate()->paint(&painter, option, combo->model()->index(0, 0));
+            painter.end();
+            QCOMPARE(header.pixelColor(0, 0),
+                     ThemeManager::instance().color(combo->view(), "color.background.2"));
+            QVERIFY(!combo->model()->index(0, 0).flags().testFlag(Qt::ItemIsEnabled));
+        }
+    }
+};
+
+QTEST_MAIN(AppletPickerTest)
+#include "applet_picker_test.moc"

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -4321,6 +4321,23 @@ set_tests_properties(hl2_pc_audio_lock_test PROPERTIES
 
 # Title-bar headphone mute reconcile contract (#4722) — needs QApplication +
 # Widgets, same dependency set as hl2_pc_audio_lock_test above.
+add_executable(applet_picker_test
+    tests/applet_picker_test.cpp
+    src/gui/AppletPicker.cpp
+    ${AETHER_SETTINGS_SOURCES}
+    src/core/ThemeManager.cpp
+    src/core/ThemeSeedGenerated.cpp
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+    ${THEME_TEST_RESOURCES}
+)
+target_include_directories(applet_picker_test PRIVATE src)
+target_link_libraries(applet_picker_test PRIVATE
+    aether_sqlite3 Qt6::Core Qt6::Widgets Qt6::Network Qt6::Test)
+set_target_properties(applet_picker_test PROPERTIES AUTOMOC ON)
+add_test(NAME applet_picker_test COMMAND applet_picker_test)
+set_tests_properties(applet_picker_test PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
 add_executable(titlebar_headphone_mute_test
     tests/titlebar_headphone_mute_test.cpp
     src/gui/TitleBar.cpp
@@ -4563,6 +4580,7 @@ target_link_libraries(CAT_Flex_test PRIVATE Qt6::Core Qt6::Network)
 # directly (rather than linking aethercore) needs the vendored SQLite engine.
 # Conditional targets are guarded with if(TARGET ...).
 set(AETHER_SETTINGS_CONSUMERS
+    applet_picker_test
     weather_radar_loading_test
     hl2_gain_restore_test
     icom_identity_test


### PR DESCRIPTION
## Summary

Design/tracking issue: #5491. Maintainer RFC approval remains pending.

Split the applet picker out of #5489 into an independent, main-based change. Replace the sidebar's many applet toggle buttons and favorites drawer with one **Add:** row containing a grouped selector, one **+** button, and the existing **LOCK** control.

- Reuse the existing applet catalog and full names; category headings use bold primary text on the existing raised-surface theme token.
- Selecting a name does not open anything. **+** explicitly opens the applet and reveals its header. Already-open and hardware-unavailable entries remain visible but cannot be selected or added.
- Preserve hardware/capability gates, saved visibility/order, and floating behavior. **×** hides an applet without resetting it; legacy favorites/drawer preferences remain untouched for older builds.
- Keep the S-Meter pinned, but align its width and horizontal position with the actual scroll viewport on either dock side. Its placeholder disappears while the meter is floating or on the canvas.
- Keep individual Aetherial DSP stages inside the existing CHAIN surface.

This PR does **not** include the Qt 6.12 migration, window decorations, or radio switcher. It retains main's Qt 6.8 minimum; its only root-CMake change adds `AppletPicker.cpp`. The proposed UX remains subject to maintainer review; no project-wide design approval is implied by this testing draft.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated: distinguish the standalone branch's build/test/bridge evidence from the earlier combined Qt 6.12 laptop build. Principle V — preserve existing feature-owned settings rather than introducing new preferences for the picker.

## Validation

- Full macOS app build passed on Qt 6.11.0 at signed commit `633eae0c`, clean working tree. The source minimum remains Qt 6.8.
- **4/4 focused offscreen tests passed:** `applet_picker_test`, `titlebar_headphone_mute_test`, `hl2_pc_audio_lock_test`, and `connection_panel_size_test`.
- Native macOS automation bridge, isolated disconnected profile: selection alone does not add; explicit + reveals the header; duplicates and unavailable hardware are blocked; closing returns the entry to the picker; S-Meter close/add and float/dock work.
- Bridge geometry assertions passed for the pinned meter against the scroll viewport on both dock sides, with a floating panel, in Default Light/Dark, and without a scrollbar. Captures confirm brighter grouped headings and aligned meter edges.
- Registration, accessibility, engine-boundary, and whitespace checks passed. No live radio connected or TX performed; full regression suite and Windows/Linux validation were not run.

The earlier combined Qt 6.12 test build remains on the test Mac as `AetherSDR qt612-applet-picker-0de5a2b6-dirty 1748.app`. It contains both PRs' features and is not evidence that either standalone branch was deployed.

## Scope and review

- Base: upstream `main` at `d1b26a4f`; signed picker commit `633eae0c`.
- Nine files; no radio command, transport, meter value/smoothing, theme-palette, or CI-workflow changes.
- The new test is socket-free and registered in `tests/tests.cmake`; it does not expand the frozen per-PR test gate.
- Documentation: `docs/applet-picker.md` and the existing automation-bridge reference.
- Windows/Linux native validation and full-suite CI are not claimed.

Generated with OpenAI Codex (GPT-6 Astra)
