### PR TITLE
fix(tnc): HF 300 correlator lowpass wider than the tone shift; HdlcCodec concatenates back-to-back frames

### DIFF
--- a/src/core/tnc/AetherAx25LibmodemShim.cpp
+++ b/src/core/tnc/AetherAx25LibmodemShim.cpp
@@ -572,9 +572,15 @@ struct AetherAx25LibmodemShim::Impl {
             auto& lane = lanes.emplace_back();
             lane.phaseOffsetSamples = phaseOffsetSamples;
             lane.samplesUntilStart  = phaseOffsetSamples;
+            // sinc_bw is the correlator lowpass as a fraction of baud. At
+            // 1200 baud Bell 202 the shift is 1000 Hz and 0.75 gives a 900 Hz
+            // lowpass, narrower than the shift, so each correlator rejects the
+            // other tone. At 300 baud the shift is only 200 Hz and 0.75 gives
+            // 225 Hz — wider than the shift, so both correlators see both
+            // tones and the difference carries almost no information.
             lane.demod = std::make_unique<LibmodemAfskDemod>(
                 mark, space, config.baud, config.sampleRate,
-                0.75, 6.0, 0.75, 3.0, 0.008, 0.005, pllAlpha);
+                0.75, 6.0, 0.50, 3.0, 0.008, 0.005, pllAlpha);
         };
 
         if (config.profile == Ax25ModemProfile::Hf300) {

--- a/src/core/tnc/HdlcCodec.cpp
+++ b/src/core/tnc/HdlcCodec.cpp
@@ -142,6 +142,11 @@ bool HdlcCodec::processBit(uint8_t nrziTone)
     if (m_complete) {
         m_complete = false;
         m_aborted  = false;
+        // The caller has now consumed the completed frame. closeFrame() left
+        // the buffer intact for that read but never cleared it, so the next
+        // frame appended to the previous one whenever two frames were
+        // separated by a single flag (the normal back-to-back case).
+        beginFrame();
     }
 
     // NRZI decode: no transition = 1 (mark held), transition = 0 (space).

--- a/src/core/tnc/HdlcCodec.h
+++ b/src/core/tnc/HdlcCodec.h
@@ -41,8 +41,11 @@ public:
     int frameSizeBits()  const { return m_frameSizeBits; }
     int preambleCount()  const { return m_preambleCount; }
 
-    // Frame bytes including the 2-byte FCS field.  Valid from the
-    // processBit() call that set complete() until reset() is called.
+    // Frame bytes including the 2-byte FCS field.  Valid only from the
+    // processBit() call that set complete() until the NEXT processBit()
+    // call, which clears the buffer for the incoming frame.  Read
+    // frameData()/frameSize()/fcsValid() immediately after processBit()
+    // returns true; do not hold them across a subsequent call.
     const uint8_t* frameData() const { return m_frameBuffer.data(); }
     size_t         frameSize() const { return m_frameByteCount; }
 

--- a/tests/hdlc_codec_test.cpp
+++ b/tests/hdlc_codec_test.cpp
@@ -248,6 +248,140 @@ void testLongPayload()
 
 } // namespace
 
+// ── Back-to-back frame regression helpers  ──────────────────────────────────────────────────────────────────
+
+uint16_t testFcs(const std::vector<uint8_t>& data)
+{
+    uint16_t crc = 0xFFFF;
+    for (uint8_t b : data) {
+        crc ^= b;
+        for (int i = 0; i < 8; ++i)
+            crc = (crc & 1) ? static_cast<uint16_t>((crc >> 1) ^ 0x8408)
+                            : static_cast<uint16_t>(crc >> 1);
+    }
+    return static_cast<uint16_t>(crc ^ 0xFFFF);
+}
+
+void appendFlagBits(std::vector<uint8_t>& out)
+{
+    static const uint8_t kFlag[8] = {0, 1, 1, 1, 1, 1, 1, 0};
+    for (uint8_t b : kFlag)
+        out.push_back(b);
+}
+
+// Appends body + FCS as bit-stuffed data bits (LSB first), no flags.
+void appendStuffedFrameBits(std::vector<uint8_t>& out, std::vector<uint8_t> body)
+{
+    const uint16_t crc = testFcs(body);
+    body.push_back(static_cast<uint8_t>(crc & 0xFF));
+    body.push_back(static_cast<uint8_t>((crc >> 8) & 0xFF));
+
+    int ones = 0;
+    for (uint8_t byte : body) {
+        for (int i = 0; i < 8; ++i) {
+            const uint8_t bit = static_cast<uint8_t>((byte >> i) & 1);
+            out.push_back(bit);
+            if (bit) {
+                if (++ones == 5) {
+                    out.push_back(0);  // stuffed zero
+                    ones = 0;
+                }
+            } else {
+                ones = 0;
+            }
+        }
+    }
+}
+
+// NRZI encode: data 1 holds the tone, data 0 toggles it.
+std::vector<uint8_t> nrziEncode(const std::vector<uint8_t>& bits)
+{
+    std::vector<uint8_t> tones;
+    tones.reserve(bits.size());
+    uint8_t tone = 1;
+    for (uint8_t bit : bits) {
+        if (!bit)
+            tone ^= 1;
+        tones.push_back(tone);
+    }
+    return tones;
+}
+
+std::vector<uint8_t> testAddress(const char* call, int ssid, bool last)
+{
+    std::vector<uint8_t> a;
+    for (int i = 0; i < 6; ++i)
+        a.push_back(static_cast<uint8_t>((call[i] ? call[i] : ' ') << 1));
+    a.push_back(static_cast<uint8_t>(0x60 | (ssid << 1) | (last ? 1 : 0)));
+    return a;
+}
+
+std::vector<uint8_t> testUiFrame(const char* payload)
+{
+    std::vector<uint8_t> f;
+    const auto dest = testAddress("TEST  ", 0, false);
+    const auto src  = testAddress("N0CALL", 1, true);
+    f.insert(f.end(), dest.begin(), dest.end());
+    f.insert(f.end(), src.begin(), src.end());
+    f.push_back(0x03);  // UI
+    f.push_back(0xF0);  // no layer 3
+    for (const char* p = payload; *p; ++p)
+        f.push_back(static_cast<uint8_t>(*p));
+    return f;
+}
+
+int decodeGoodFrames(const std::vector<uint8_t>& tones)
+{
+    HdlcCodec codec;
+    codec.reset();
+    int good = 0;
+    for (uint8_t t : tones)
+        if (codec.processBit(t) && codec.fcsValid())
+            ++good;
+    return good;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+// Regression: closeFrame() leaves the frame buffer intact so the caller can
+// read frameData() after processBit() returns, but nothing cleared it
+// afterwards. beginFrame() only ran in InPreamble when a *second* flag
+// arrived, so two frames sharing a single separating flag — the ordinary
+// back-to-back case, and what a connected-mode session looks like on the air —
+// were concatenated. The second frame arrived byte-misaligned and closeFrame()
+// rejected it on the m_bitIndex != 7 check.
+void testBackToBackFramesSingleSeparatingFlag()
+{
+    std::vector<uint8_t> bits;
+    for (int i = 0; i < 8; ++i)
+        appendFlagBits(bits);  // preamble
+    appendStuffedFrameBits(bits, testUiFrame("first frame payload"));
+    appendFlagBits(bits);      // exactly one separating flag
+    appendStuffedFrameBits(bits, testUiFrame("second frame payload"));
+    appendFlagBits(bits);
+
+    const int good = decodeGoodFrames(nrziEncode(bits));
+    report("back-to-back frames with one separating flag both decode", good == 2);
+}
+
+// Control: two separating flags always worked, because the second flag hit the
+// InPreamble branch that calls beginFrame(). Guards against a fix that trades
+// one case for the other.
+void testBackToBackFramesTwoSeparatingFlags()
+{
+    std::vector<uint8_t> bits;
+    for (int i = 0; i < 8; ++i)
+        appendFlagBits(bits);
+    appendStuffedFrameBits(bits, testUiFrame("alpha"));
+    appendFlagBits(bits);
+    appendFlagBits(bits);
+    appendStuffedFrameBits(bits, testUiFrame("bravo"));
+    appendFlagBits(bits);
+
+    const int good = decodeGoodFrames(nrziEncode(bits));
+    report("back-to-back frames with two separating flags both decode", good == 2);
+}
+
 int main()
 {
     testStateTransitions();
@@ -259,6 +393,8 @@ int main()
     testPreambleCount();
     testReset();
     testLongPayload();
+    testBackToBackFramesSingleSeparatingFlag();
+    testBackToBackFramesTwoSeparatingFlags();
 
     if (g_failed == 0)
         std::printf("All tests passed.\n");

--- a/tests/hdlc_codec_test.cpp
+++ b/tests/hdlc_codec_test.cpp
@@ -246,7 +246,6 @@ void testLongPayload()
     report("long payload: decoded", r.goodFcs == 1);
 }
 
-} // namespace
 
 // ── Back-to-back frame regression helpers  ──────────────────────────────────────────────────────────────────
 
@@ -381,6 +380,8 @@ void testBackToBackFramesTwoSeparatingFlags()
     const int good = decodeGoodFrames(nrziEncode(bits));
     report("back-to-back frames with two separating flags both decode", good == 2);
 }
+
+} // namespace
 
 int main()
 {

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -2980,6 +2980,7 @@ add_executable(ax25_session_analyze EXCLUDE_FROM_ALL
     tools/ax25_session_analyze.cpp
     src/core/tnc/AetherAx25LibmodemShim.cpp
     src/core/tnc/Ax25FrameFormatter.cpp
+    src/core/tnc/HdlcCodec.cpp
     src/core/tnc/Ax25.cpp
     src/core/tnc/Ax25Connection.cpp
     src/core/tnc/KissFraming.cpp

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -2967,6 +2967,7 @@ add_executable(ax25_replay EXCLUDE_FROM_ALL
     tools/ax25_replay.cpp
     src/core/tnc/AetherAx25LibmodemShim.cpp
     src/core/tnc/Ax25FrameFormatter.cpp
+    src/core/tnc/HdlcCodec.cpp
     src/core/tnc/KissFraming.cpp
     src/core/LogManager.cpp
     src/core/AsyncLogWriter.cpp


### PR DESCRIPTION
## Summary

HF 300-baud AX.25 decoded **zero** frames from on-air audio that Dire Wolf reads without difficulty. Root cause is one constant: `sinc_bw` is the correlator lowpass expressed as a fraction of the baud rate, and it must be narrower than the tone shift or each correlator also passes the other tone. At 1200 baud Bell 202 the shift is 1000 Hz and 0.75 gives a 900 Hz lowpass — correct. At 300 baud the shift is only 200 Hz and 0.75 gives 225 Hz, *wider* than the shift, so both correlators see both tones and their difference carries almost no information. Changing the HF lane's `sinc_bw` to 0.50 (150 Hz) fixes it; VHF 1200 is untouched.

Sweeping `sinc_bw` across the 21 shipped HF lane phases on a 14.105 MHz capture: 0.75 gives 0 valid frames, 0.50 gives 62, with a plateau from 0.45 to 0.60. `pll_alpha` had no effect at any value from 0 to 0.05, so the free-running phase-diversity lane design was never the problem. End to end, `ax25_replay` on that capture goes from **0 frames to 7** — one more than Dire Wolf 1.8.1 recovers from the same file.

Two smaller fixes are included because they were found on the way and are needed to reproduce the result:

**`HdlcCodec` concatenated back-to-back frames.** `closeFrame()` leaves the frame buffer intact so the caller can read `frameData()` after `processBit()` returns, and nothing cleared it afterwards — `beginFrame()` only ran in `InPreamble` when a *second* flag arrived. Two frames separated by a single flag were concatenated; the second arrived byte-misaligned and was rejected on the `m_bitIndex != 7` check. Clearing in the deferred-reset block at the top of `processBit()` runs after the caller has consumed the frame, preserving the read-after-close contract. Measured in isolation on the same capture across ±100 Hz offset × 80 clock phases: 63 → 300 valid frames.

**`ax25_replay` did not link.** `tests/tests.cmake` omitted `src/core/tnc/HdlcCodec.cpp` from the target while including `AetherAx25LibmodemShim.cpp`, which calls into it. One line. The tool is the documented way to debug an on-air decode failure from a captured WAV with no radio in the loop, and it has not been buildable since `HdlcCodec` was introduced.

**Why existing tests did not catch this.** `ax25_libmodem_shim_test` has a synthetic 300-baud AFSK loopback that passes both before and after. A self-generated tone pair with no noise, no filter shaping and no path distortion survives a correlator lowpass wider than the shift; real signals do not. The synthetic loopback is a useful plumbing check but cannot detect a discrimination failure of this kind.

## Constitution principle honored

**Principle XI — Fixes Are Demonstrated.** The `sinc_bw` change is demonstrated by `ax25_replay` against an attached capture (0 → 7 frames). The `HdlcCodec` change is demonstrated by `testBackToBackFramesSingleSeparatingFlag`, which fails before the change and passes after; a two-flag control passes both ways, so the test isolates this defect rather than something incidental. Per the principle, these are the author's measurements, not independent verification.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio — FLEX-8400, live connected-mode AX.25 session established with KA0PND-7 (BPQ node, Cascade IA) on 14.105 MHz from Sandy OR, ~1450 mi, `retry 0/8 drop 0 resent 0`. Before this change the same station produced no decodes at all.
- [x] Existing tests pass — `hdlc_codec_test`, `ax25_libmodem_shim_test`, `ax25_frame_formatter_test`, `ax25_link_timing_test`, including every VHF 1200 loopback and Bell 202 TX check
- [x] Reproduction steps documented — capture attached; `./build/ax25_replay 14105_mono_f32.wav 300`

## Checklist

- [x] Commits are signed
- [x] No new flat-key `AppSettings` calls
- [x] Code is clean-room
- [x] All meter UI uses `MeterSmoother` — n/a, no UI change
- [x] Documentation updated if user-visible behavior changed — no doc change; behavior described above
- [x] Security-sensitive changes reference a GHSA if applicable — n/a



## Limitations

`sinc_bw = 0.50` is validated against one recording of one station. The 0.45–0.60 plateau suggests the optimum is not sharp, but weaker or more distorted signals may prefer a different point; a wider corpus would be worth collecting.

## Capture

24 kHz mono float32, 25.3 s. `./build/ax25_replay 14105_mono_f32.wav 300` — 7 frames after this change, 0 before.
[14105_mono_f32.wav](https://github.com/user-attachments/files/31937423/14105_mono_f32.wav)