### PR TITLE
Fix Flex manual squelch reconciliation after band recall

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -1546,6 +1546,17 @@ re-poll `get slices`.
 | `fixture` | `<sliceId> [A-H]` | disconnected-only test fixture: synthesize an owned slice through the normal slice-status path, optionally with a single radio `index_letter`, so `dumpTree` can assert UI without a radio |
 | `clearfixture` | `<sliceId>` | remove a slice created by `fixture`; when the final fixture is removed, restores the pre-fixture disconnected model/max-slice state |
 
+For a manual SQL band/profile-restore check, compare `get slice`'s
+`squelch`/`squelchLevel` with `dumpTree`'s **RX applet → Squelch threshold**
+and the VFO SQL control immediately after the transition. A radio-driven
+Off → Manual transition must adopt the incoming threshold before refreshing
+the controls (#5501). Use distinct thresholds on the two bands and retain
+each checkpoint: a later mode change can conceal a stale slider by causing
+another status update. In Auto, the slider is the margin, so it is not
+expected to equal the radio's computed threshold. Passive command suppression
+is covered by the socket-free `rx_applet_squelch_reconciliation_test`; a live
+snapshot alone cannot prove that no command was sent.
+
 ### `notch`
 
 Manual notch filters — a Flex TNF, or the WDSP null that stands in for one on a

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -1557,6 +1557,13 @@ expected to equal the radio's computed threshold. Passive command suppression
 is covered by the socket-free `rx_applet_squelch_reconciliation_test`; a live
 snapshot alone cannot prove that no command was sent.
 
+A full SQL-on report after leaving Auto is adopted as current radio state,
+even when its threshold matches an earlier Auto calculation. The report
+does not identify whether it is a delayed echo or a restore. A later Off
+acknowledgement supersedes it; neither passive report triggers a SQL write.
+The socket-free regression pins both operator-driven and radio-driven Off
+sequences. It does not establish their occurrence on particular firmware.
+
 ### `notch`
 
 Manual notch filters — a Flex TNF, or the WDSP null that stands in for one on a

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -2493,6 +2493,14 @@ void RxApplet::connectSlice(SliceModel* s)
     });
 
     auto applySquelchState = [this](bool on, int level, bool externalReceive) {
+        // A band/profile restore can enable SQL and publish its manual level
+        // in the same status while our echo gate still reflects Off (#5501).
+        // Adopt that level before setSqlMode() repaints from the manual cache.
+        // SliceModel publishes SQL before modeChanged for a combined delta;
+        // the button's enabled state can still describe the previous mode.
+        const bool radioEnablesManual =
+            on && m_sqlMode == SqlMode::Off
+            && squelchAvailableInMode(m_slice->mode());
         // In Auto mode the slider represents the operator-chosen dB margin,
         // NOT the algorithm-suggested threshold — skip the value update so
         // the algorithm's tick-by-tick setSquelch echoes don't overwrite
@@ -2504,7 +2512,8 @@ void RxApplet::connectSlice(SliceModel* s)
             // Keep only the Flex manual-level cache in sync with radio-side
             // squelch changes. Kiwi replacement SQL is independent and lives
             // in the external receive state on the slice.
-            if (!externalReceive && m_sqlMode == SqlMode::Manual) {
+            if (!externalReceive
+                && (m_sqlMode == SqlMode::Manual || radioEnablesManual)) {
                 setManualSqlLevelForCurrentSurface(level);
             }
         }
@@ -2516,7 +2525,7 @@ void RxApplet::connectSlice(SliceModel* s)
         if (!on && m_sqlMode != SqlMode::Off) {
             setSqlMode(SqlMode::Off, /*propagateToRadio=*/false);
             modeChanged = true;
-        } else if (on && m_sqlMode == SqlMode::Off && m_sqlBtn->isEnabled()) {
+        } else if (radioEnablesManual) {
             setSqlMode(SqlMode::Manual, /*propagateToRadio=*/false);
             modeChanged = true;
         }
@@ -2900,6 +2909,15 @@ QString RxApplet::formatStepLabel(int hz)
     return QString::number(hz);
 }
 
+bool RxApplet::squelchAvailableInMode(const QString& mode) const
+{
+    const bool allModeSquelch = m_radioModel && m_radioModel->isConnected()
+        && m_radioModel->backendCapabilities().hasModeIndependentSquelch
+        && !(m_slice && m_slice->externalReceiveReplacementActive());
+    return allModeSquelch || !(mode == "DIGU" || mode == "DIGL" || mode == "NT"
+                              || mode == "RTTY" || isCwMode(mode));
+}
+
 void RxApplet::updateModeSettings(const QString& mode)
 {
     const auto& settings = modeSettingsFor(mode);
@@ -2963,12 +2981,7 @@ void RxApplet::updateModeSettings(const QString& mode)
     // Digital/RTTY: audio feeds external decoders via DAX, SQL not meaningful
     //   and gates weak FSK signals (#2504)
     // CW: radio locks squelch on at fixed level, rejects changes
-    const bool allModeSquelch = m_radioModel && m_radioModel->isConnected()
-        && m_radioModel->backendCapabilities().hasModeIndependentSquelch
-        && !(m_slice && m_slice->externalReceiveReplacementActive());
-    bool sqlDisabled = !allModeSquelch && (mode == "DIGU" || mode == "DIGL" || mode == "NT"
-                        || mode == "RTTY"
-                        || isCwMode(mode));
+    const bool sqlDisabled = !squelchAvailableInMode(mode);
     m_sqlBtn->setEnabled(!sqlDisabled);
     // Slider enabled when the mode allows squelch AND we're not in SqlMode::Off.
     // Manual mode = threshold input; Auto mode = dB margin input.

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -178,6 +178,7 @@ private:
     void updateFilterButtons();
     void refreshFilterWidth();   // "AUTO" while adaptive is live, else the width
     void updateModeSettings(const QString& mode);
+    bool squelchAvailableInMode(const QString& mode) const;
     void rebuildFilterButtons();
 public:
     // Narrow the filter buttons to the widths a radio can actually reach.

--- a/tests/rx_applet_squelch_reconciliation_test.cpp
+++ b/tests/rx_applet_squelch_reconciliation_test.cpp
@@ -1,0 +1,302 @@
+#include "TestSettingsProfile.h"
+#include "core/AppSettings.h"
+#include "core/backends/SliceDelta.h"
+#include "gui/RxApplet.h"
+#include "gui/VfoWidget.h"
+#include "models/SliceModel.h"
+
+#include <QApplication>
+#include <QPushButton>
+#include <QSignalSpy>
+#include <QSlider>
+#include <QtTest>
+
+using namespace AetherSDR;
+
+namespace {
+
+// Inject normalized radio state, never a socket peer or a copied UI machine.
+void status(SliceModel& slice, bool on, int level, const QString& mode = {})
+{
+    SliceDelta delta;
+    delta.squelchOn = on;
+    delta.squelchLevel = level;
+    if (!mode.isEmpty()) {
+        delta.mode = mode;
+    }
+    slice.applyChanges(delta);
+}
+
+template <typename T>
+T* control(QWidget& widget, const QString& name)
+{
+    for (T* child : widget.findChildren<T*>()) {
+        if (child->accessibleName() == name) {
+            return child;
+        }
+    }
+    return nullptr;
+}
+
+} // namespace
+
+class RxAppletSquelchReconciliationTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void bandRestore_data()
+    {
+        QTest::addColumn<bool>("vfoFirst");
+        QTest::newRow("applet-connected-first") << false;
+        QTest::newRow("vfo-connected-first") << true;
+    }
+
+    void bandRestore()
+    {
+        QFETCH(bool, vfoFirst);
+        SliceModel slice(0);
+        status(slice, true, 26, QStringLiteral("USB"));
+        RxApplet rx;
+        VfoWidget vfo;
+        if (vfoFirst) {
+            vfo.setSlice(&slice);
+            rx.setSlice(&slice);
+        } else {
+            rx.setSlice(&slice);
+            vfo.setSlice(&slice);
+        }
+        vfo.setRxApplet(&rx);
+        QSlider* slider = control<QSlider>(rx, QStringLiteral("Squelch threshold"));
+        QSlider* mirror = control<QSlider>(vfo, QStringLiteral("Squelch threshold"));
+        QVERIFY(slider);
+        QVERIFY(mirror);
+        QSignalSpy commands(&slice, &SliceModel::commandReady);
+        QSignalSpy line(&rx, &RxApplet::squelchStateChanged);
+        QSignalSpy intents(&slice, &SliceModel::squelchCommandIssued);
+
+        // Ordered mode/off burst captured on FLEX-8400M fw 4.2.18.41174
+        // (#5501), including the disabled CW SQL surface between bands.
+        status(slice, false, 20, QStringLiteral("LSB"));
+        status(slice, true, 20, QStringLiteral("CW"));
+        status(slice, false, 20, QStringLiteral("USB"));
+        status(slice, true, 26);
+        QCOMPARE(slice.squelchLevel(), 26);
+        QCOMPARE(slice.manualSquelchLevel(), 26);
+        QCOMPARE(rx.sqlMode(), RxApplet::SqlMode::Manual);
+        QCOMPARE(slider->value(), 26);
+        QCOMPARE(mirror->value(), 26);
+        QCOMPARE(line.last().at(0).toBool(), true);
+        QCOMPARE(line.last().at(1).toInt(), 26);
+        QVERIFY(commands.isEmpty());
+        QVERIFY(intents.isEmpty());
+
+        status(slice, true, 26); // repeated truth stays passive
+        QVERIFY(commands.isEmpty());
+        QVERIFY(intents.isEmpty());
+
+        // A later real SQL-button cycle must replay the adopted 26.
+        QPushButton* button = control<QPushButton>(rx, QStringLiteral("Squelch mode"));
+        QVERIFY(button);
+        button->click(); // Manual -> Auto
+        button->click(); // Auto -> Off
+        status(slice, false, 20); // a different off-state level is not intent
+        commands.clear();
+        button->click(); // Off -> Manual
+        QCOMPARE(slice.squelchLevel(), 26);
+        QCOMPARE(slice.manualSquelchLevel(), 26);
+        QCOMPARE(commands.count(), 2);
+        QCOMPARE(commands.at(1).at(0).toString(),
+                 QStringLiteral("slice set 0 squelch_level=26"));
+    }
+
+    void splitStatus_data()
+    {
+        QTest::addColumn<bool>("levelFirst");
+        QTest::newRow("level-before-enable") << true;
+        QTest::newRow("enable-before-level") << false;
+    }
+
+    void splitStatus()
+    {
+        QFETCH(bool, levelFirst);
+        SliceModel slice(0);
+        status(slice, false, 20, QStringLiteral("USB"));
+        RxApplet rx;
+        rx.setSlice(&slice);
+        QSignalSpy commands(&slice, &SliceModel::commandReady);
+        SliceDelta level;
+        level.squelchLevel = 37;
+        SliceDelta enabled;
+        enabled.squelchOn = true;
+        slice.applyChanges(levelFirst ? level : enabled);
+        slice.applyChanges(levelFirst ? enabled : level);
+        QCOMPARE(slice.squelchLevel(), 37);
+        QCOMPARE(slice.manualSquelchLevel(), 37);
+        QCOMPARE(rx.sqlMode(), RxApplet::SqlMode::Manual);
+        QSlider* slider = control<QSlider>(rx, QStringLiteral("Squelch threshold"));
+        QVERIFY(slider);
+        QCOMPARE(slider->value(), 37);
+        QVERIFY(commands.isEmpty());
+    }
+
+    void autoKeepsManualChoice()
+    {
+        AppSettings::instance().setValue("AutoSqlMarginDb", "10");
+        SliceModel slice(0);
+        status(slice, true, 45, QStringLiteral("USB"));
+        RxApplet rx;
+        rx.setSlice(&slice);
+        QSlider* slider = control<QSlider>(rx, QStringLiteral("Squelch threshold"));
+        QVERIFY(slider);
+        rx.cycleSqlModeExternal(); // Manual -> Auto
+        slice.setSquelch(true, 8); // production algorithm's entry point
+        QSignalSpy commands(&slice, &SliceModel::commandReady);
+        status(slice, true, 8);
+        QCOMPARE(rx.sqlMode(), RxApplet::SqlMode::Auto);
+        QCOMPARE(slider->value(), 10);
+        QCOMPARE(slice.manualSquelchLevel(), 45);
+        QVERIFY(commands.isEmpty());
+
+        rx.cycleSqlModeExternal(); // Auto -> Off
+        commands.clear();
+        // A late threshold-only update and the Off echo must not replace
+        // manual memory with an Auto threshold or margin (#4604).
+        SliceDelta lateLevel;
+        lateLevel.squelchLevel = 8;
+        slice.applyChanges(lateLevel);
+        status(slice, false, 8);
+        QCOMPARE(rx.sqlMode(), RxApplet::SqlMode::Off);
+        QCOMPARE(slice.manualSquelchLevel(), 45);
+        QVERIFY(commands.isEmpty());
+        rx.cycleSqlModeExternal(); // Off -> Manual is operator intent
+        QCOMPARE(slice.squelchLevel(), 45);
+        QCOMPARE(slice.manualSquelchLevel(), 45);
+        QCOMPARE(slider->value(), 45);
+    }
+
+    void detachedSlicesRemainIndependent()
+    {
+        SliceModel first(0);
+        SliceModel second(1);
+        status(first, false, 20, QStringLiteral("USB"));
+        status(second, true, 63, QStringLiteral("USB"));
+        RxApplet rx;
+        rx.setSlice(&first); // closes first's manual-echo gate
+        rx.setSlice(&second); // production detach reopens it
+        QSignalSpy firstCommands(&first, &SliceModel::commandReady);
+        QSignalSpy secondCommands(&second, &SliceModel::commandReady);
+        status(first, true, 37);
+        QCOMPARE(first.manualSquelchLevel(), 37);
+        QCOMPARE(second.manualSquelchLevel(), 63);
+        QCOMPARE(rx.sqlManualLevel(), 63);
+        rx.setSlice(&first);
+        QCOMPARE(rx.sqlManualLevel(), 37);
+        rx.setSlice(nullptr);
+        status(first, true, 48);
+        QCOMPARE(first.manualSquelchLevel(), 48);
+        QVERIFY(firstCommands.isEmpty());
+        QVERIFY(secondCommands.isEmpty());
+    }
+
+    void externalReceiveDoesNotOverwriteFlexMemory()
+    {
+        SliceModel slice(0);
+        status(slice, true, 45, QStringLiteral("USB"));
+        slice.setExternalReceiveAudioReplacementMute(true);
+        slice.setManualSquelch(false, 17);
+        RxApplet rx;
+        rx.setSlice(&slice);
+        QSignalSpy commands(&slice, &SliceModel::commandReady);
+        slice.setManualSquelch(true, 71);
+        QCOMPARE(rx.sqlMode(), RxApplet::SqlMode::Manual);
+        QCOMPARE(rx.sqlManualLevel(), 71);
+        QCOMPARE(slice.manualSquelchLevel(), 45);
+        status(slice, true, 33); // underlying Flex state is hidden by Kiwi
+        QCOMPARE(rx.sqlManualLevel(), 71);
+        QCOMPARE(slice.manualSquelchLevel(), 45);
+        QVERIFY(commands.isEmpty());
+    }
+
+    void digitalOverrideResetsOnDetach()
+    {
+        SliceModel first(0);
+        SliceModel second(1);
+        status(first, true, 45, QStringLiteral("USB"));
+        status(second, false, 20, QStringLiteral("USB"));
+        RxApplet rx;
+        rx.setSlice(&first);
+        QSignalSpy firstCommands(&first, &SliceModel::commandReady);
+        SliceDelta digital;
+        digital.mode = QStringLiteral("DIGU");
+        first.applyChanges(digital);
+        QVERIFY(!first.squelchOn());
+        QVERIFY(!firstCommands.isEmpty()); // existing paired override
+        QSignalSpy secondCommands(&second, &SliceModel::commandReady);
+        rx.setSlice(&second);
+        QCOMPARE(rx.sqlMode(), RxApplet::SqlMode::Off);
+        QVERIFY(!second.squelchOn());
+        QVERIFY(secondCommands.isEmpty()); // no orphaned restore (#3268)
+    }
+
+    void combinedModeStatusUsesIncomingMode()
+    {
+        SliceModel slice(0);
+        status(slice, false, 45, QStringLiteral("USB"));
+        RxApplet rx;
+        rx.setSlice(&slice);
+        QSignalSpy commands(&slice, &SliceModel::commandReady);
+        // The button still describes USB when this combined delta publishes
+        // SQL, so eligibility must use the incoming model mode instead.
+        status(slice, true, 19, QStringLiteral("CW"));
+        QCOMPARE(rx.sqlMode(), RxApplet::SqlMode::Off);
+        QCOMPARE(slice.manualSquelchLevel(), 45);
+        QPushButton* button = control<QPushButton>(rx, QStringLiteral("Squelch mode"));
+        QVERIFY(button);
+        QVERIFY(!button->isEnabled());
+        QVERIFY(commands.isEmpty());
+
+        // The converse must adopt USB's manual value even though the button
+        // is still disabled when the combined delta first publishes SQL.
+        status(slice, true, 37, QStringLiteral("USB"));
+        QCOMPARE(rx.sqlMode(), RxApplet::SqlMode::Manual);
+        QCOMPARE(slice.manualSquelchLevel(), 37);
+        QSlider* slider = control<QSlider>(rx, QStringLiteral("Squelch threshold"));
+        QVERIFY(slider);
+        QCOMPARE(slider->value(), 37);
+        QVERIFY(button->isEnabled());
+        QVERIFY(commands.isEmpty());
+    }
+
+    void digitalRoundTripWithSqlOffStaysOff()
+    {
+        // #3505's clarified starting state: Auto and SQL both off. This
+        // pins the injected path only, not that issue's hardware outcome.
+        SliceModel slice(0);
+        status(slice, false, 20, QStringLiteral("USB"));
+        RxApplet rx;
+        rx.setSlice(&slice);
+        QSignalSpy commands(&slice, &SliceModel::commandReady);
+        SliceDelta mode;
+        mode.mode = QStringLiteral("DIGU");
+        slice.applyChanges(mode);
+        mode.mode = QStringLiteral("USB");
+        slice.applyChanges(mode);
+        QCOMPARE(rx.sqlMode(), RxApplet::SqlMode::Off);
+        QVERIFY(!slice.squelchOn());
+        QVERIFY(commands.isEmpty());
+    }
+};
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile profile(QStringLiteral("rx-squelch-reconciliation"));
+    if (!profile.isValid()) {
+        return 1;
+    }
+    QApplication app(argc, argv);
+    RxAppletSquelchReconciliationTest test;
+    return QTest::qExec(&test, argc, argv);
+}
+
+#include "rx_applet_squelch_reconciliation_test.moc"

--- a/tests/rx_applet_squelch_reconciliation_test.cpp
+++ b/tests/rx_applet_squelch_reconciliation_test.cpp
@@ -175,6 +175,64 @@ private slots:
         QCOMPARE(slider->value(), 45);
     }
 
+    void fullOnReportAfterAuto_data()
+    {
+        QTest::addColumn<bool>("operatorTurnsOff");
+        QTest::newRow("operator-off-late-auto-report") << true;
+        QTest::newRow("radio-off-then-on-report") << false;
+    }
+
+    void fullOnReportAfterAuto()
+    {
+        QFETCH(bool, operatorTurnsOff);
+        SliceModel slice(0);
+        status(slice, true, 45, QStringLiteral("USB"));
+        RxApplet rx;
+        rx.setSlice(&slice);
+        VfoWidget vfo;
+        vfo.setSlice(&slice);
+        vfo.setRxApplet(&rx);
+        QSlider* slider = control<QSlider>(rx, QStringLiteral("Squelch threshold"));
+        QSlider* mirror = control<QSlider>(vfo, QStringLiteral("Squelch threshold"));
+        QVERIFY(slider);
+        QVERIFY(mirror);
+
+        rx.cycleSqlModeExternal(); // Manual -> Auto
+        slice.setSquelch(true, 8); // production algorithm's entry point
+        if (operatorTurnsOff) {
+            rx.cycleSqlModeExternal(); // requests Off with manual 45
+        } else {
+            status(slice, false, 8); // radio-driven Off retains computed 8
+        }
+        QCOMPARE(rx.sqlMode(), RxApplet::SqlMode::Off);
+        QCOMPARE(slice.manualSquelchLevel(), 45);
+        QSignalSpy commands(&slice, &SliceModel::commandReady);
+        QSignalSpy intents(&slice, &SliceModel::squelchCommandIssued);
+
+        // A full on-report has no provenance that distinguishes a delayed
+        // Auto echo from a radio restore. Reconcile to its reported state
+        // (Principle II), including the manual cache, without writing back.
+        status(slice, true, 8);
+        QCOMPARE(rx.sqlMode(), RxApplet::SqlMode::Manual);
+        QCOMPARE(slice.squelchLevel(), 8);
+        QCOMPARE(slice.manualSquelchLevel(), 8);
+        QCOMPARE(slider->value(), 8);
+        QCOMPARE(mirror->value(), 8);
+        QVERIFY(commands.isEmpty());
+        QVERIFY(intents.isEmpty());
+
+        if (operatorTurnsOff) {
+            // The later acknowledgement of the operator's Off/45 request
+            // supersedes that report and restores the retained manual value.
+            status(slice, false, 45);
+            QCOMPARE(rx.sqlMode(), RxApplet::SqlMode::Off);
+            QCOMPARE(slice.squelchLevel(), 45);
+            QCOMPARE(slice.manualSquelchLevel(), 45);
+            QVERIFY(commands.isEmpty());
+            QVERIFY(intents.isEmpty());
+        }
+    }
+
     void detachedSlicesRemainIndependent()
     {
         SliceModel first(0);

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -4417,6 +4417,33 @@ target_link_libraries(amp_applet_test PRIVATE
 set_target_properties(amp_applet_test PROPERTIES AUTOMOC ON)
 add_test(NAME amp_applet_test COMMAND amp_applet_test)
 
+# Socket-free injection into real SliceModel/RxApplet/VfoWidget objects.
+# No RadioModel instance, radio connection, or firmware peer is constructed.
+add_executable(rx_applet_squelch_reconciliation_test
+    tests/rx_applet_squelch_reconciliation_test.cpp
+    src/gui/RxApplet.cpp
+    src/gui/VfoWidget.cpp
+    src/gui/FrequencyEntryParser.cpp
+    src/gui/DragValuePopup.cpp
+    src/gui/FilterPassbandWidget.cpp
+    src/gui/SliceColorManager.cpp
+    src/gui/SliceLabel.cpp
+    src/gui/PhaseKnob.cpp
+    src/gui/SmartMtrWidget.cpp
+    src/gui/SmartMtrConfig.cpp
+    src/gui/MeterViewController.cpp
+    src/gui/AdaptiveFilterControls.cpp
+    src/gui/GuardedSlider.h
+)
+target_include_directories(rx_applet_squelch_reconciliation_test PRIVATE src)
+target_link_libraries(rx_applet_squelch_reconciliation_test PRIVATE
+    aethercore Qt6::Widgets Qt6::Test
+)
+add_test(NAME rx_applet_squelch_reconciliation_test
+         COMMAND rx_applet_squelch_reconciliation_test)
+set_tests_properties(rx_applet_squelch_reconciliation_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
 add_executable(tx_applet_power_reconciliation_test
     tests/tx_applet_power_reconciliation_test.cpp
     src/gui/TxApplet.cpp
@@ -4588,6 +4615,7 @@ target_link_libraries(CAT_Flex_test PRIVATE Qt6::Core Qt6::Network)
 # directly (rather than linking aethercore) needs the vendored SQLite engine.
 # Conditional targets are guarded with if(TARGET ...).
 set(AETHER_SETTINGS_CONSUMERS
+    rx_applet_squelch_reconciliation_test
     rtl_slice_settings_test
     weather_radar_loading_test
     hl2_gain_restore_test


### PR DESCRIPTION
## Summary

Fixes #5501. When Flex restores manual SQL 26 after a band change, the RX applet currently enters Manual using its stale cached threshold 20. Adopt the incoming threshold before refreshing the manual controls, so the slice cache, RX slider and VFO slider agree without another SQL write.

Combined slice deltas publish SQL before `modeChanged`. Reuse the existing mode-eligibility rule against the current model mode, rather than the button's previous enabled state. This keeps incoming CW state out of an Off-to-Manual transition and permits an incoming USB threshold to be adopted in the same delta. The existing mode/capability policy itself is unchanged.

Production changes are limited to RxApplet. No new persistence, command encoding, timer, backend logic, or dependency is introduced. Detached slices already reopen their manual-echo gate; the tests exercise that production detach path.

## Constitution principle honored

Principle II: reconcile incoming radio state without replaying the client's remembered threshold. Principle XI: drive the real applet/model transition and verify that removing the fix makes the regression fail.

## Validation

- Local macOS ARM64 RelWithDebInfo app build, `cmake --build build -j22`.
- Headless, socket-free CTest selection: `rx_applet_squelch_reconciliation_test`, `slice_model_squelch_memory_test`, `rx_filter_step_test` (3/3 passed at signed commit `05c68846cc0dcbfe882962a036cc09a6b6aa27da`).
- The new target constructs production SliceModel, RxApplet and VfoWidget objects, with no RadioModel instance, radio connection or firmware peer. It checks the captured band/status burst in both widget connection orders, split-field updates, repeated reports, later SQL-button writes, Auto(8)/margin(10)/Manual(45) separation, detached and distinct slices, Kiwi exclusion, combined CW/USB status, and the existing digital override/detach behavior. The Auto-off starting sequence from [issue 3505](https://github.com/aethersdr/AetherSDR/issues/3505) is an injected regression check only. That separate issue remains open and requires independent verification.
- Mutation: restoring the previous manual-cache condition makes both band-burst rows fail with actual 20 versus expected 26. The level-first split row and combined mode/status row also fail. The production fix was restored, rebuilt at the signed commit, and all 3 selected CTests passed again.
- Engine-boundary, test-registration, frozen CI test-gate, bridge documentation, and whitespace checks passed.
- Commits signed. No new socket-owning test, CI gate addition, or CHANGELOG entry.

## Review follow-up validation

Signed follow-up `b539715affa079dde897685a13478881bc7ddac0` adds two socket-free full-on-report rows and documents the reconciliation contract. The focused ARM64 RelWithDebInfo build (dedicated `build-codex-arm64`, local ARM64 toolchain, RADE enabled) passed all three selected CTests. Removing the Off-to-Manual cache adoption made both new rows fail with manual cache 45 versus expected 8; restoring the guard returned all three CTests to green. The prior independent review also removed the complete production fix and observed four failures in the original band/split/mode rows. No additional hardware run was performed for this test/documentation follow-up.

The new test runs locally and joins the unfiltered post-merge Full Suite and weekly sanitizer workflows. The frozen per-PR CI selection compiles it but does not execute it.

## Live proof

Receive-only agent automation bridge run on FLEX-8400M firmware 4.2.18.41174, one owned slice/pan, isolated settings, stable GUIClientID, TX permission disabled.

| Observation on return to 20m USB | Radio/live SQL | Manual cache | RX slider | VFO slider state |
|---|---:|---:|---:|---:|
| Unfixed binary | 26 | 20 | 20 | 20 |
| Fixed, before restart | 26 | 26 | 26 | 26 |
| Fixed, after normal Quit/relaunch | 26 | 26 | 26 | 26 |

Seeded 20m USB Manual/26 versus 40m LSB Off/20 with actual SQL controls, then used the production BAND actions. The old binary reproduced the mismatch without an intervening mode change. The fixed binary reconciled two complete pre-restart returns and two complete post-restart returns; an additional post-restart return was sampled during temporary slice teardown, retained, then observed converged before proceeding. Normal restart changed PID 71740 to 71766 with unchanged GUIClientID and first process exit code 0. Before restarting, a Manual → Auto → Off → Manual button cycle preserved the manual 26 separately from the computed Auto level (62 observed) and margin 10, then sent/restored 26.

The retained capture contains 201 model snapshots and 5,815 unique log events across old/fixed phases, with zero detected log gaps. Captured band-return intervals contained no outgoing SQL commands; the socket-free regression is the proof of the isolated no-write requirement. Original 20m and 40m slice/pan values were restored with empty comparison diffs (excluding session object/handle identifiers), returning to 20m USB SQL Off/20. All observed snapshots reported no transmitting; the client quit and lock was released.

The live binary is verification merge `9a8ea1b59eea5226dd6e1788608c5f9a22abc650`: this fix at `05c68846cc0dcbfe882962a036cc09a6b6aa27da` plus #5500 at `93bbff39cf59605bde00405a0bb4a935ba4aae38`, which supplies the Persist diagnostic fields. Those diagnostic changes are excluded from this PR. The combined app also built successfully and passed the same 3/3 focused CTests. Fixed executable SHA-256: `a785be3ed2f4904c0ac9528334024ee61ec1075bd8ddcae4166bc40b8c2dfa43`; unfixed executable: `9e0b0b7447ee48a354e5a8cd97778550ff5ec2eb8b877327d6e536e6131ad8e3`.

Before → after RX applet captures below. The native slider has no numeric label; the table and [structured evidence](https://raw.githubusercontent.com/jensenpat/AetherSDR/7096420249e7cd6c4098f12aeb687a8bc664b676/.pr-assets/5501-proof.json) provide its numeric state. VFO state was read from its widget while that surface was hidden; no rendered VFO claim is made.

![Before: stale RX squelch slider at 20](https://raw.githubusercontent.com/jensenpat/AetherSDR/7096420249e7cd6c4098f12aeb687a8bc664b676/.pr-assets/5501-before.png)
![After: RX squelch slider reconciles to 26](https://raw.githubusercontent.com/jensenpat/AetherSDR/7096420249e7cd6c4098f12aeb687a8bc664b676/.pr-assets/5501-after.png)

This is focused SQL diagnostic evidence, not a full RadioCert Persist certification or proof of physical audio gating. Other Flex models/firmware, MultiFlex, hardware occurrence of arbitrary delayed full SQL-on report ordering, and Icom remain unverified. The Auto regression covers active Auto, delayed threshold-only/off reports, and full on-reports after both operator-driven and radio-driven Off. Full on-reports are reconciled as current radio truth, including their threshold; a later Off/45 acknowledgement supersedes a delayed on/8 report. Both sequences assert RX/VFO agreement and zero outgoing commands or squelch intents. These are injected ordering tests, not claims that specific firmware produces these sequences. No bridge addition was needed beyond the already proposed #5500 diagnostics.

Generated with OpenAI Codex (GPT-6 Astra)

