### PR TITLE
fix(gui): tune + force RADE on FreeDV Reporter double-click

### DIFF
--- a/src/gui/FreeDvReporterDialog.cpp
+++ b/src/gui/FreeDvReporterDialog.cpp
@@ -235,6 +235,14 @@ void FreeDvReporterDialog::buildBody()
     m_table->setShowGrid(true);
     m_table->sortByColumn(FreeDvReporterModel::MHz, Qt::AscendingOrder);
 
+    // Double-click to tune + force RADE (#4125).
+    connect(m_table, &QTableView::doubleClicked, this, [this](const QModelIndex& idx) {
+        const QModelIndex src = m_proxy->mapToSource(idx);
+        const QModelIndex mhzIdx = m_model->index(src.row(), FreeDvReporterModel::MHz);
+        const double mhz = m_model->data(mhzIdx, Qt::UserRole).toDouble();
+        if (mhz > 0.0) emit tuneRequested(mhz);
+    });
+
     ThemeManager::instance().applyStyleSheet(m_table,
         "QTableView {"
         "  background-color: {{color.background.0}};"

--- a/src/gui/FreeDvReporterDialog.h
+++ b/src/gui/FreeDvReporterDialog.h
@@ -49,6 +49,9 @@ signals:
     // Emitted when the operator commits a new status message. MainWindow
     // forwards it to FreeDvClient::updateMessage() on the client's thread.
     void messageChanged(const QString& message);
+    // Emitted on a station row double-click; MainWindow tunes the active
+    // slice and forces RADE mode (#4125).
+    void tuneRequested(double freqMhz);
 
 private slots:
     void onSliceFrequencyChanged(double mhz);

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -983,12 +983,26 @@ void MainWindow::showFreeDvReporter()
             if (tuneBlockedByGuards(sl))
                 return;
             applyTuneRequest(sl, freqMhz, TuneIntent::AbsoluteJump, "freedv-reporter");
+#ifdef HAVE_RADE
+            // Without HAVE_RADE the build can't run the modem, so there is
+            // no activateRADE() to call — same reasoning as the FreeDV
+            // spot-click path in MainWindow_Wiring.cpp (#1846).
+            //
+            // Only a family with a PanadapterStream (Flex) can actually run
+            // RADE; activateRADE() otherwise declines with a blocking
+            // QMessageBox::warning, which would pop on every double-click
+            // here even though the gesture has nothing to do with RADE.
+            // Skip the call on those families instead of surfacing that
+            // modal (#4125 review).
+            //
             // Reuse the same auto-switch gate DX Cluster uses for its
             // CW/SSB mode-follow (#2298), so one setting controls "does
             // double-click-to-tune also change what the radio is doing"
             // everywhere (#4125).
-            if (AppSettings::instance().value("SpotAutoSwitchMode", "True").toString() == "True")
+            if (m_radioModel.panStream()
+                    && AppSettings::instance().value("SpotAutoSwitchMode", "True").toString() == "True")
                 activateRADE(sl->sliceId());
+#endif
         });
         // Seed: reporting may already be on when the dialog is first opened.
         m_freedvReporterDialog->setReportingActive(

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -974,6 +974,22 @@ void MainWindow::showFreeDvReporter()
         connect(m_freedvClient, &FreeDvClient::reportingStateChanged,
                 m_freedvReporterDialog, &FreeDvReporterDialog::setReportingActive,
                 Qt::QueuedConnection);
+        connect(m_freedvReporterDialog, &FreeDvReporterDialog::tuneRequested,
+                this, [this](double freqMhz) {
+            auto* sl = activeSlice();
+            if (!sl) return;
+            // Don't force RADE on a frequency the slice never actually moved
+            // to — pointless if the tune itself was refused (#4125 review).
+            if (tuneBlockedByGuards(sl))
+                return;
+            applyTuneRequest(sl, freqMhz, TuneIntent::AbsoluteJump, "freedv-reporter");
+            // Reuse the same auto-switch gate DX Cluster uses for its
+            // CW/SSB mode-follow (#2298), so one setting controls "does
+            // double-click-to-tune also change what the radio is doing"
+            // everywhere (#4125).
+            if (AppSettings::instance().value("SpotAutoSwitchMode", "True").toString() == "True")
+                activateRADE(sl->sliceId());
+        });
         // Seed: reporting may already be on when the dialog is first opened.
         m_freedvReporterDialog->setReportingActive(
             m_freedvClient->isReportingEnabled());


### PR DESCRIPTION
## Summary

- The standalone FreeDV Reporter window's station table had no double-click-to-tune action at all, in any mode — the `QTableView` was fully set up but never got a `doubleClicked` connection (confirmed by direct inspection, not taken on faith from the triage bot's comment on the issue, which had 4 of 6 code citations flagged as unresolved).
- Adds a `tuneRequested(double freqMhz)` signal on `FreeDvReporterDialog`, mirroring the existing DX Cluster spot-table pattern (`DxClusterDialog.cpp` → `MainWindow_Menus.cpp`).
- On double-click, `MainWindow` tunes the active slice via the shared `applyTuneRequest(..., TuneIntent::AbsoluteJump, "freedv-reporter")` policy path, then forces RADE via `activateRADE()` — landing on a FreeDV Reporter station's frequency without RADE active would just produce demodulated modem noise with no way to decode it.
- RADE is only forced when the tune itself wasn't refused (pre-checks `tuneBlockedByGuards()` — locked slice, SWR sweep in progress), and is gated behind the existing `SpotAutoSwitchMode` setting so one toggle controls "does double-click-to-tune also change what the radio is doing" across both DX Cluster and FreeDV Reporter.

## Why RADE via `activateRADE()`, not `slice->setMode()`

RADE isn't a `SliceModel` mode string like CW/SSB — it's a separate engine/toggle (`MainWindow::activateRADE(sliceId)`) that sets the slice to DIGU/DIGL, moves the TX-slice badge, mutes audio, and starts the RADE engine thread. It already no-ops safely if the slice is already the active RADE slice, and declines cleanly (warning dialog, no half-applied state) if the radio has no DAX audio path.

## Test plan

- [x] Builds clean (MinGW/`RelWithDebInfo`, incremental against `C:\AetherBuild`) — no new warnings or errors in the three changed files.
- [x] Live verification with a connected FLEX radio: open FreeDV Reporter, double-click a row, confirm the active slice tunes and RADE activates (DIGU/DIGL mode, RADE engine starts, audio mutes). Double-click a second row on the same already-RADE slice and confirm no redundant engine restart.
- [x] Confirm `SpotAutoSwitchMode = False` leaves RADE untouched on double-click (tune-only).

Fixes #4125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)