### PR TITLE
docs(tci): name the real audio path in ensureDaxForTci (closes #4957)

### DIFF
--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -4139,11 +4139,13 @@ void TciServer::ensureDaxForTci()
     if (!m_model || !m_model->isConnected()) return;
 
     // In-process backend (HL2): there is no DAX plane to arrange. RX audio
-    // reaches onDaxAudioReady() on channel 1 straight from the backend's
-    // demodulator (MainWindow wires backendAudioFrameReady), and the
-    // channel→TRX fallback there maps channel 1 to trx 0 — which is the whole
-    // mapping on a single-slice radio. Assigning slice DAX channels here would
-    // emit Flex `slice set … dax=` commands into a socket that ignores them.
+    // reaches onDaxAudioReady() straight from the backend's demodulator —
+    // MainWindow wires backendSliceAudioFrameReady per slice, as channel
+    // sliceId + 1 (#4545) — and the channel→TRX fallback there maps channel N
+    // to trx N-1. backendAudioFrameReady is the MIXED speaker feed and does not
+    // reach TCI; routing TCI from it was the single-receiver bug #4545 fixed.
+    // Assigning slice DAX channels here would emit Flex `slice set … dax=`
+    // commands into a socket that ignores them.
     if (!m_model->panStream()) return;
 
     QSet<int> channelsNeeded;


### PR DESCRIPTION
## Summary

Closes #4957. **Comment-only: one hunk, one file, no behaviour change and no test change.**

`TciServer::ensureDaxForTci()` carries a comment naming `RadioModel::backendAudioFrameReady` — the mixed speaker feed — as the path by which HL2 RX audio reaches `TciServer::onDaxAudioReady()`, on channel 1. Neither particular is true. The real path is `RadioModel::backendSliceAudioFrameReady`, per slice, as channel `sliceId + 1`. The comment accurately describes the code as it stood *before* #4545, and #4545's own commentary calls that arrangement the bug it was fixing.

**Why this is worth a commit.** `backendAudioFrameReady` is not a removed symbol that would trip a reader up — it is live, and it still feeds the AudioEngine speaker path. A maintainer following the stale comment lands in a working subsystem and reads plausible code, which is the expensive failure mode for a wrong comment rather than a merely untidy one.

The replacement text is the one proposed on the issue, adopted **verbatim**. It was not reworded: every clause was checked true (below) and upstream had already agreed it, so a private improvement to agreed text would be a round-trip with no gain.

### The change, by symbol

`src/core/TciServer.cpp`, `TciServer::ensureDaxForTci()` — the comment immediately above `if (!m_model->panStream()) return;`.

**Kept deliberately:** the early-return rationale (a host-modulating backend has no DAX plane, so assigning slice DAX channels would emit Flex `slice set … dax=` into a socket that ignores them), and an explicit note that `backendAudioFrameReady` is *not* the TCI path — the signal still exists and still carries audio, so naming the near miss is what stops the next rewrite landing back on it.

**Dropped deliberately:** *"which is the whole mapping on a single-slice radio"* — false since #4545, and the precise clause that made the comment describe the defect rather than the fix.

### How each clause was checked

Verified by reading source and git objects at `8a358c5f`. No radio was connected and nothing was keyed — see *Not verified*.

| clause | evidence |
|---|---|
| the stale comment is still on `main` verbatim | `src/core/TciServer.cpp`, `TciServer::ensureDaxForTci` |
| the TCI feed is `backendSliceAudioFrameReady` at `sliceId + 1` | `src/gui/MainWindow_Session.cpp`, `MainWindow::wireCatPorts` — the lambda calls `tciServer()->onDaxAudioReady(sliceId + 1, pcm)` |
| `backendAudioFrameReady` reaches `TciServer` nowhere | it occurs exactly once in `src/core/TciServer.cpp`: inside the stale comment itself |
| it is the mixed speaker feed | `src/models/RadioModel.h` — the header comment on `backendSliceAudioFrameReady` calls it "the mixed speaker feed" in those words |
| it is live, not dangling | `src/gui/MainWindow_Session.cpp` connects it to `AudioEngine::feedAudioData` behind `backendFeedsEngineDirectly()` |
| the fallback maps channel N to trx N-1 | `src/core/TciServer.cpp`, `TciServer::onDaxAudioReady` — `m_channelTrx.value(channel, std::max(0, channel - 1))` |
| #4545 is what changed it, and left this comment alone | its diff to `MainWindow_Session.cpp` makes exactly this substitution — `backendAudioFrameReady` → `backendSliceAudioFrameReady` and `onDaxAudioReady(1, pcm)` → `onDaxAudioReady(sliceId + 1, pcm)`. It *does* touch `TciServer.cpp`, but in a different function (the route-transition refusal); no line it adds or removes matches this comment's text |

The strongest single piece is the control: at the pre-#4545 tree the wiring reads `backendAudioFrameReady` and `onDaxAudioReady(1, pcm)` — **exactly the two particulars the stale comment asserts.** The comment is not vaguely out of date; it is an accurate description of a specific superseded revision.

### A note for whoever replies on the thread

Every line number quoted on issue #4957 and on its triage comment is now stale by several hundred lines, and `main` has moved again since. Every **symbol** resolves. Nothing in the issue's argument depends on the numbers, so this changes no conclusion — but a reply that quotes them will be quoting positions that no longer exist. Citations here are by file and symbol for that reason (and see #5504).

### Why no test

A comment change cannot fail a test: anything added here would pass identically on the stale tree and the fixed one.

The regression cover that *would* have value — a test pinning that the TCI feed is `backendSliceAudioFrameReady` at `sliceId + 1`, so the next rewire cannot silently invalidate this comment again — is a different piece of work. The wiring lives in `MainWindow::wireCatPorts()`, and nothing in `tests/` constructs a `MainWindow`; the existing TCI tests exercise `TciServer::onDaxAudioReady()` directly, below the seam where the staleness happened. Standing that up has its own scope and is not a rider on a comment fix.

### Adjacent, deliberately not done

The guard tests `!m_model->panStream()` while `TciServer::hostModulatingBackend()` — the direct capability test, and what the file's other DAX guards use — sits immediately above. Behaviourally equivalent today, but a proxy test where a direct one exists. Upstream triage raised the same point and scoped it out; agreed, a comment-only PR should not carry a behaviour-adjacent edit.

### Why `Closes` and not `Refs`

Judged rather than assumed: the issue's own *Fix* section is exactly this one hunk, this is that hunk verbatim, and the only other point raised on the thread was explicitly scoped out by its own author. Nothing in #4957 remains after this commit.

## Constitution principle honored

**Principle VIII — Evidence Over Assertion.** Each clause of the replacement comment is tied to a symbol that was read, and the claim that the old text described a superseded revision is backed by a known-answer control (the pre-#4545 tree reads the two particulars the stale comment states) rather than by confidence in the reading.

Principle XI is deliberately **not** cited. XI's demonstration is CI on the squash-merge commit, maintainer reproduction, or reporter confirmation, and it explicitly excludes agent self-grading; none of those has happened yet, so citing it here would be exactly the substitution XI rules out.

## Test plan

- [x] Local build passes (`cmake --build build`) — configured with the project's CMake line, built with Ninja, **0 `FAILED:` edges** over the full unpiped log.
- [ ] Behavior verified on a real radio if applicable — **not applicable and not done.** This changes only a comment; there is no behaviour to observe. No radio was connected and nothing was keyed.
- [x] Existing tests pass (CI) — full `ctest` run locally, **not** a filtered `-R` subset: **370 tests registered, 370 passed, 0 failed, 5 skipped**, ctest exit 0, 234 s. The five skips are the standing environmental ones (`crdv_quarantined_test`, `app_settings_safety_explicit-profile-path-isolation`, `weather_radar_texture_gl_test`, `range_slider_a11y_test`, `relay_bar_a11y_test`) — the standing environmental set this machine always skips; I did not separately run the suite on the base to confirm the skip list matches there, so take that as unverified rather than asserted. `vkamp_connection_test`, the known under-load flake, **passed** and needed no isolated re-run — though it did fail once earlier in the session when two ctest runs overlapped in the same build directory, which is a port collision rather than a defect; the number above is from a single clean run. CI has not run yet; that is the maintainer's gate, not mine.
- [ ] Reproduction steps documented if user-reported bug — not a runtime bug; the defect is the comment text itself, quoted in full in the issue and in the diff.

## Checklist

- [x] Commits are signed — SSH-signed; verified on the rebased commit with `git cat-file commit <sha> | grep '^gpgsig'`.
- [x] No new flat-key `AppSettings` calls — no code changed at all.
- [x] Code is clean-room — no code changed; the comment text is original and was proposed on the issue.
- [x] All meter UI uses `MeterSmoother` — no UI touched.
- [ ] Documentation updated if user-visible behavior changed — no user-visible behaviour changed, so nothing in `docs/` needed updating. (This change *is* documentation, in a source comment.)
- [x] Security-sensitive changes reference a GHSA if applicable — not security-sensitive.

**On the template's self-assignment step:** `on8st` has pull-only access to this repository, so `gh issue edit 4957 --add-assignee on8st` fails with *"on8st does not have the correct permissions to execute `ReplaceActorsForAssignable`"*. Recorded here rather than left silently unticked. Happy for a maintainer to assign if that matters for triage.

**Base:** rebased onto `main` at `8a358c5f`; one commit, clean rebase, no conflicts.

**On the `maintainer-review` label:** the originating issue carries it ("Requires maintainer review before any action is taken"). This PR is offered as a proposal for that review, not as a way around it — nothing here has been merged or acted on upstream, and if the label means the issue should not have been worked at all, say so and I will close this without argument.

