### PR TITLE
fix(hl2): linearize the SWR detector and re-derive its noise gate (refs #4578)

### DIFF
--- a/docs/HERMES.md
+++ b/docs/HERMES.md
@@ -2184,7 +2184,24 @@ replaces the table and nothing else.
 
 SWR remains the one directional quantity that is meaningful without
 calibration — it is a ratio from the same converter, so the unknown scale
-cancels.
+cancels. **The unknown scale cancels; the detector's CURVE does not.** A ratio
+of raw counts is scale-invariant, not curve-invariant, and the detector is a
+diode with a knee: `k = counts / sqrt(watts)` from the table above runs 512 at
+26 counts to a flat ~1516 above ~1200. The reverse channel always sits further
+down that knee than the forward one, so a raw-count ratio always reads
+*optimistically low* — at 265 forward counts a true 2.0:1 displayed 1.44
+(#4578). `swrFromRaw()` therefore maps both counts through `detectorVolts()`,
+the inverse of this same curve, before taking the ratio. Above the knee that
+converges to what the raw ratio already gave, so it is a low-end correction.
+
+Linearizing does **not** rescue the bottom. Two counts one LSB apart are two
+nearly-equal numbers on either side of the curve and the ratio still runs away —
+harder, if anything, because the knee's slope amplifies the reverse channel down
+there. That is what `kMinForwardCountsForSwr` is for, and it was re-derived at
+the same time: 16 counts admitted a live reading of SWR 256.00 on an antenna a
+RigExpert AA-170 measured at 1.50. The constant's own comment carries the
+criterion and the sweep. Both halves are **derived from the reference curve, not
+measured on this radio**.
 
 ### 17.6 Meter pacing
 

--- a/docs/HERMES.md
+++ b/docs/HERMES.md
@@ -2200,8 +2200,19 @@ harder, if anything, because the knee's slope amplifies the reverse channel down
 there. That is what `kMinForwardCountsForSwr` is for, and it was re-derived at
 the same time: 16 counts admitted a live reading of SWR 256.00 on an antenna a
 RigExpert AA-170 measured at 1.50. The constant's own comment carries the
-criterion and the sweep. Both halves are **derived from the reference curve, not
-measured on this radio**.
+criterion and the sweep.
+
+The two halves rest on different evidence, and the difference matters. The
+**linearization** is derived from the reference curve and has **not** been
+measured on any radio — it inherits every caveat the curve carries. The
+**gate** was measured: bench run D89 read `fwd_pwr` and `rev_pwr` out of a
+Hermes-Lite 2's response registers into a dummy load and found the reverse
+channel carries a fixed ~3.41-count offset with no reflected power plus 2.73
+counts of sd with RF, against the one count the original derivation assumed.
+The channels are independent, so that noise does not cancel in the ratio.
+Re-running the same criterion against the measured distributions gives **320**,
+not 96. That is one radio, and the offset is a per-unit diode property — what
+generalises is that it is not zero, not its value.
 
 ### 17.6 Meter pacing
 

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -4408,9 +4408,10 @@ IRadioBackend::HealthSnapshot Hl2Backend::healthSnapshot() const
     put("reversePowerW", QStringLiteral("Reverse (W, approx)"),
         m_telemetry.reversePowerRaw
             ? QVariant(directionalWatts(*m_telemetry.reversePowerRaw)) : QVariant());
-    // Meaningful without calibration — it is a ratio of two readings from the
-    // same converter, so the unknown scale cancels. Absent below the noise
-    // floor, where a ratio of two noise samples is not a mismatch reading.
+    // Meaningful without calibration — it is a ratio, so the unknown SCALE
+    // cancels. The detector's CURVE does not cancel, which is why swrFromRaw()
+    // linearizes both counts first (#4578). Absent below the noise floor, where
+    // a ratio of two noise samples is not a mismatch reading.
     //
     // That last sentence described the intent but not the code: this site had no
     // floor, so with no carrier it recomputed a noise ratio at the dialog's
@@ -5172,8 +5173,11 @@ void Hl2Backend::publishTelemetry(const Hl2Telemetry& t)
     // build one, and that raw counts must not be presented as watts), only the
     // quantities that are actually meaningful get published.
     //
-    // SWR is meaningful WITHOUT calibration because it is a ratio of two
-    // readings from the same converter, so the unknown scale cancels.
+    // SWR is meaningful WITHOUT calibration because it is a RATIO — but of two
+    // linearized readings, not of two raw counts. The unknown SCALE cancels in
+    // a raw ratio; the detector's CURVE does not, and taking the raw ratio read
+    // optimistically low at low drive (#4578). swrFromRaw() maps both counts
+    // through detectorVolts() first; see its comment for the whole argument.
     // SWR only means something with real forward power behind it.
     //
     // Measured on the live radio: with no carrier the forward and reverse counts

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -96,22 +96,6 @@ SampleRate sampleRateEnum(int hz) noexcept
 // drift apart, which is exactly the failure being fixed here.
 constexpr int kIqSampleRatesHz[] = {48000, 96000, 192000, 384000};
 
-// Minimum forward-power reading, in raw converter counts, below which an SWR
-// ratio is noise rather than a measurement.
-//
-// With no carrier, forward and reverse are both near zero and dominated by
-// noise; reverse frequently exceeds forward and the ratio saturates. An
-// operator glancing at that sees a catastrophic mismatch on an antenna that is
-// fine. Raw counts because that is what we have — this is a noise floor, not a
-// calibrated power level.
-//
-// File-scope so EVERY consumer shares one threshold. It was previously local to
-// the meter path, so the Radio Health snapshot computed an unguarded ratio and
-// bounced at its 500 ms refresh while the meter beside it stayed silent — two
-// surfaces disagreeing about the same radio because only one of them had the
-// guard.
-constexpr int kMinForwardCountsForSwr = 16;
-
 // The radio's rated output, in watts, as the gauges' full-scale reference.
 //
 // The HL2 wiki's own FAQ: "The Hermes-Lite 2.0 is a QRP transceiver and
@@ -5199,8 +5183,9 @@ void Hl2Backend::publishTelemetry(const Hl2Telemetry& t)
     // catastrophic mismatch on an antenna that is fine.
     //
     // The threshold is in raw counts because that is what we have; it is a
-    // noise floor, not a calibrated power level. It lives at file scope so the
-    // Radio Health snapshot applies the SAME floor — see kMinForwardCountsForSwr.
+    // noise floor, not a calibrated power level. It lives in MetisProtocol.h,
+    // beside the calibration curve its value is derived from, so the Radio
+    // Health snapshot applies the SAME floor — see kMinForwardCountsForSwr.
     if (t.forwardPowerRaw && t.reversePowerRaw
         && *t.forwardPowerRaw >= kMinForwardCountsForSwr) {
         if (const auto swr = swrFromRaw(*t.forwardPowerRaw, *t.reversePowerRaw))
@@ -5319,66 +5304,6 @@ void Hl2Backend::publishTelemetry(const Hl2Telemetry& t)
         }
         m_adcOverloadAssertions = 0;
     }
-}
-
-double Hl2Backend::directionalWatts(int raw)
-{
-    // Quisk's `power_meter_std_calibrations['HL2FilterE3']` verbatim
-    // (quisk_conf_defaults.py): measured [ADC count, watts] pairs for a
-    // Hermes-Lite 2 with an N2ADR companion filter board, rev E3. Quisk is the
-    // reference client and tier 3 on the source-precedence ladder, and this is
-    // the only published curve for this coupler.
-    //
-    // WHAT THIS IS NOT: a calibration of THIS radio. The oracle (§6) is explicit
-    // that these counts need a per-unit calibration against a dummy load to mean
-    // watts, because the coupler, the toroid winding and the detector diode all
-    // vary between boards. A reading from this curve is the right ORDER OF
-    // MAGNITUDE and roughly the right shape; it is not a measurement.
-    //
-    // It is still much better than the alternative, which was publishing
-    // nothing: an operator had no way to tell 100 mW from 5 W, and on a radio
-    // where a mis-set drive level is silent that is the difference between
-    // "working" and "not transmitting". The meters are labelled uncalibrated
-    // (defineMeters) so nobody reads them as a power measurement.
-    //
-    // A future per-unit calibration replaces this table and nothing else.
-    struct Point { double counts; double watts; };
-    static constexpr Point kCurve[] = {
-        {    0.000000, 0.000000 }, {   25.865385, 0.002550 },
-        {  101.024540, 0.012752 }, {  265.290123, 0.050601 },
-        {  647.915584, 0.216458 }, { 1196.593548, 0.665480 },
-        { 1603.703226, 1.155723 }, { 2012.327160, 1.811892 },
-        { 2616.772727, 3.008585 }, { 3173.818182, 4.392743 },
-        { 3382.792208, 4.979133 }, { 3721.071429, 6.024751 },
-        { 4093.178571, 7.289948 }, { 4502.496429, 8.820838 },
-        { 4952.746071, 10.673214 },
-    };
-    constexpr std::size_t kN = std::size(kCurve);
-
-    const double counts = static_cast<double>(raw);
-    if (counts <= kCurve[0].counts)
-        return 0.0;
-    // Above the top of the table, extrapolate along the last segment rather
-    // than clamping. Clamping would pin the meter at 10.7 W and hide the one
-    // reading an operator most needs to see — that they are past where the
-    // curve was ever measured.
-    if (counts >= kCurve[kN - 1].counts) {
-        const Point& a = kCurve[kN - 2];
-        const Point& b = kCurve[kN - 1];
-        const double slope = (b.watts - a.watts) / (b.counts - a.counts);
-        return b.watts + (counts - b.counts) * slope;
-    }
-    for (std::size_t i = 1; i < kN; ++i) {
-        if (counts <= kCurve[i].counts) {
-            const Point& a = kCurve[i - 1];
-            const Point& b = kCurve[i];
-            const double span = b.counts - a.counts;
-            if (span <= 0.0)
-                return b.watts;
-            return a.watts + (counts - a.counts) * (b.watts - a.watts) / span;
-        }
-    }
-    return kCurve[kN - 1].watts;
 }
 
 double Hl2Backend::wattsToDbm(double watts)

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -260,9 +260,10 @@ private:
     // Shared by setTxPower() and setTune() so the mapping exists exactly once.
     void applyDrive(int percent);
     static double temperatureCelsius(int raw);
-    // Uncalibrated directional-coupler counts -> watts. See the table in the
-    // .cpp for what this curve is and, more importantly, what it is not.
-    static double directionalWatts(int raw);
+    // Uncalibrated directional-coupler counts -> watts now lives beside the
+    // curve itself, as AetherSDR::hl2::directionalWatts() in MetisProtocol —
+    // swrFromRaw() needs the same table and this layer already depends on that
+    // one. Call sites here resolve it unqualified from the enclosing namespace.
     // Watts -> dBm for the meter seam, floored so 0 W does not become -inf.
     static double wattsToDbm(double watts);
 

--- a/src/core/backends/hl2/MetisProtocol.cpp
+++ b/src/core/backends/hl2/MetisProtocol.cpp
@@ -305,6 +305,85 @@ void Hl2Telemetry::apply(const Ep6Response& r) noexcept
     }
 }
 
+double directionalWatts(int raw) noexcept
+{
+    // MOVED here from Hl2Backend with #4578: swrFromRaw() below needs this same
+    // curve to linearize the detector, and MetisProtocol is the layer Hl2Backend
+    // already includes. One copy, at the lower layer, no new dependency edge.
+    //
+    // Quisk's `power_meter_std_calibrations['HL2FilterE3']` verbatim
+    // (quisk_conf_defaults.py): measured [ADC count, watts] pairs for a
+    // Hermes-Lite 2 with an N2ADR companion filter board, rev E3. Quisk is the
+    // reference client and tier 3 on the source-precedence ladder, and this is
+    // the only published curve for this coupler.
+    //
+    // WHAT THIS IS NOT: a calibration of THIS radio. The oracle (§6) is explicit
+    // that these counts need a per-unit calibration against a dummy load to mean
+    // watts, because the coupler, the toroid winding and the detector diode all
+    // vary between boards. A reading from this curve is the right ORDER OF
+    // MAGNITUDE and roughly the right shape; it is not a measurement.
+    //
+    // It is still much better than the alternative, which was publishing
+    // nothing: an operator had no way to tell 100 mW from 5 W, and on a radio
+    // where a mis-set drive level is silent that is the difference between
+    // "working" and "not transmitting". The meters are labelled uncalibrated
+    // (defineMeters) so nobody reads them as a power measurement.
+    //
+    // A future per-unit calibration replaces this table and nothing else.
+    struct Point { double counts; double watts; };
+    static constexpr Point kCurve[] = {
+        {    0.000000, 0.000000 }, {   25.865385, 0.002550 },
+        {  101.024540, 0.012752 }, {  265.290123, 0.050601 },
+        {  647.915584, 0.216458 }, { 1196.593548, 0.665480 },
+        { 1603.703226, 1.155723 }, { 2012.327160, 1.811892 },
+        { 2616.772727, 3.008585 }, { 3173.818182, 4.392743 },
+        { 3382.792208, 4.979133 }, { 3721.071429, 6.024751 },
+        { 4093.178571, 7.289948 }, { 4502.496429, 8.820838 },
+        { 4952.746071, 10.673214 },
+    };
+    constexpr std::size_t kN = std::size(kCurve);
+
+    const double counts = static_cast<double>(raw);
+    if (counts <= kCurve[0].counts)
+        return 0.0;
+    // Above the top of the table, extrapolate along the last segment rather
+    // than clamping. Clamping would pin the meter at 10.7 W and hide the one
+    // reading an operator most needs to see — that they are past where the
+    // curve was ever measured.
+    if (counts >= kCurve[kN - 1].counts) {
+        const Point& a = kCurve[kN - 2];
+        const Point& b = kCurve[kN - 1];
+        const double slope = (b.watts - a.watts) / (b.counts - a.counts);
+        return b.watts + (counts - b.counts) * slope;
+    }
+    for (std::size_t i = 1; i < kN; ++i) {
+        if (counts <= kCurve[i].counts) {
+            const Point& a = kCurve[i - 1];
+            const Point& b = kCurve[i];
+            const double span = b.counts - a.counts;
+            if (span <= 0.0)
+                return b.watts;
+            return a.watts + (counts - a.counts) * (b.watts - a.watts) / span;
+        }
+    }
+    return kCurve[kN - 1].watts;
+}
+
+
+
+double detectorVolts(int raw) noexcept
+{
+    // The inverse of the count->power curve, taken back to VOLTAGE, in
+    // arbitrary units — only ratios of two of these are ever used.
+    //
+    // sqrt() of directionalWatts() rather than a second table, deliberately:
+    // the interpolation scheme is then the SAME scheme by construction, and the
+    // two functions cannot drift apart when a per-unit calibration replaces the
+    // points. A separate voltage table would be a second thing to keep in step.
+    const double w = directionalWatts(raw);
+    return w > 0.0 ? std::sqrt(w) : 0.0;
+}
+
 std::optional<double> swrFromRaw(int forwardRaw, int reverseRaw) noexcept
 {
     // No carrier, no SWR. Returning 1.0 here would render as a perfect match

--- a/src/core/backends/hl2/MetisProtocol.cpp
+++ b/src/core/backends/hl2/MetisProtocol.cpp
@@ -401,13 +401,57 @@ std::optional<double> swrFromRaw(int forwardRaw, int reverseRaw) noexcept
     // (one branch uses the voltage form (Vf+Vr)/(Vf-Vr), another a sqrt form
     // whose arguments are the wrong way round and would return a NEGATIVE SWR),
     // so it is not usable as the tie-breaker.
-    const double fwd = static_cast<double>(forwardRaw);
-    double rev = static_cast<double>(reverseRaw < 0 ? 0 : reverseRaw);
+    //
+    // ---- and the caveat that reasoning does not cover (#4578) ----
+    //
+    // All of the above is about the FORM of the expression and it is correct.
+    // What it does not establish is that the counts may be used RAW. This
+    // function used to compute (fwd + rev) / (fwd - rev) directly on counts,
+    // defended by "a ratio of two readings from the same converter, so the
+    // unknown scale cancels". A ratio of raw counts is scale-invariant; it is
+    // not CURVE-invariant, and a diode detector's curve is not a straight line.
+    //
+    // Write a count as c = k(c)·V. Then
+    //
+    //     rho_shown / rho_true = k(c_rev) / k(c_fwd)
+    //
+    // and k, from directionalWatts()'s own table (k = counts / sqrt(watts)),
+    // rises from 512 at 26 counts to a flat ~1516 above ~1200:
+    //
+    //     counts   26   101   265   648  1197  2012  4953
+    //     k       512   895  1179  1393  1467  1495  1516
+    //
+    // c_rev is below c_fwd always, so k(c_rev) <= k(c_fwd) always, so the shown
+    // reflection coefficient is always LOW and the shown SWR always optimistic
+    // — never conservative. That is the unsafe direction on a meter whose whole
+    // job is to warn about a mismatch. Reported by ten9876 (#4578): at 265
+    // forward counts a true 2.0:1 displayed 1.44.
+    //
+    // The repair is to undo the curve before taking the ratio: detectorVolts()
+    // is sqrt(directionalWatts()), the inverse curve in arbitrary voltage units,
+    // and rho is the ratio of two of those. Everything else here is unchanged —
+    // the nullopt on no carrier, the clamp, and the voltage form with no square
+    // root. Above the knee this converges to what the raw ratio already gave
+    // (at 4953 counts a true 2.0 read 1.975 before and 2.000 after), so it is a
+    // low-end correction and not a rescaling of every reading in the log.
+    //
+    // What this does NOT fix, and must not be read as fixing: two counts one LSB
+    // apart are two nearly-equal numbers on either side of the curve, so the
+    // ratio still runs away down at the noise floor — harder, if anything, since
+    // the knee's slope amplifies the reverse channel relative to the forward one
+    // there. At 20/19 counts the raw ratio gave 39.0 and this gives 78.0. That
+    // case is refused by kMinForwardCountsForSwr, which is why that constant had
+    // to be re-derived at the same time; it is not repaired here.
+    const double fwd = detectorVolts(forwardRaw);
+    if (!(fwd > 0.0))
+        return std::nullopt;          // below the bottom of the curve entirely
+    double rev = detectorVolts(reverseRaw < 0 ? 0 : reverseRaw);
     // Reverse above forward is physically impossible; it means noise on a tiny
     // reading. Clamp rather than emit a negative or infinite SWR.
     if (rev >= fwd)
         rev = fwd * 0.999;
-    return (fwd + rev) / (fwd - rev);
+    const double rho = rev / fwd;
+    return (1.0 + rho) / (1.0 - rho);
 }
 
 std::array<std::uint8_t, 64> metisCommand(std::uint8_t cmd) noexcept

--- a/src/core/backends/hl2/MetisProtocol.h
+++ b/src/core/backends/hl2/MetisProtocol.h
@@ -558,10 +558,13 @@ double detectorVolts(int raw) noexcept;
 //     forward counts    16     32     64     96    128    256    512
 //     worst SWR error  0.85   0.50   0.30   0.20   0.16   0.10   0.05
 //
-// 96 is the smallest count at and above which the criterion holds. That is
-// ~12 mW forward on the reference curve, against ~1.6 mW at 16 — so the cost is
-// SWR reading "absent" between 1.6 and 12 mW, which is the right trade for a
-// number that could not tell 1.5 from 2.35 down there.
+// 96 is the smallest count at and above which the criterion holds UNDER THE
+// ONE-COUNT MODEL. That model was subsequently measured and found wrong; the
+// paragraph beginning "and then it WAS measured" below carries the correction
+// and the value this constant actually holds. The sweep is kept because it is
+// still the right arithmetic for the question it asks, and because the two
+// derivations agreeing where they overlap is what makes the correction
+// credible rather than a second opinion.
 //
 // NOT ~1200, which #4578 suggested. Gating on FORWARD counts does nothing to
 // lift the REVERSE channel out of the knee: at a true 1.5 the reverse sits a
@@ -570,12 +573,100 @@ double detectorVolts(int raw) noexcept;
 // produces. At 1200 forward counts a true 2.0 still displayed 1.76 under the
 // old raw ratio. It buys nothing and costs SWR below ~0.67 W.
 //
-// DERIVED ANALYTICALLY FROM THE REFERENCE CURVE — NOT MEASURED ON HARDWARE. It
-// assumes the channel-to-channel disagreement at the floor is one count, which
-// is what the field report describes and what nobody has yet measured on a
-// bench. If the real noise amplitude is larger than one count, 96 is still too
-// low. hl2_metis_protocol_test runs this derivation rather than restating it.
-inline constexpr int kMinForwardCountsForSwr = 96;
+// ---- and then it WAS measured, and 96 was too low (bench run D89) ----
+//
+// The paragraph that used to end this comment said 96 was derived analytically,
+// that it assumed a ONE-COUNT channel-to-channel disagreement nobody had put an
+// instrument on, and that if the real disagreement were larger then 96 was
+// still too low. That measurement has now been made, on a Hermes-Lite 2 into a
+// dummy load, reading fwd_pwr and rev_pwr straight out of the response
+// registers with no client application in the path. The prediction was right
+// and the direction was the unfavourable one.
+//
+// TWO THINGS WERE MEASURED THAT THE ONE-COUNT MODEL CANNOT EXPRESS.
+//
+// (1) NOISE, and it is not one count. With RF in the load the reverse channel
+//     has a standard deviation of 2.73 counts and a full range of 0..12 counts
+//     (2311 settled samples over 15 drive levels). It does not shrink at low
+//     drive, because it does not come from the signal: with the PA keyed and
+//     the drive register at zero the same channel reads 0.67, and unkeyed it
+//     reads 0.63..0.70 (6418 samples over 300 s). The forward channel's
+//     residual standard deviation is 3.77 counts.
+//
+// (2) OFFSET, which is not noise at all and which the criterion above has no
+//     term for. Fitting the reverse channel against the forward one across 16
+//     legs spanning 1.3 to 822 forward counts gives
+//
+//         rev = 3.41 + 0.00097 * fwd        (residual sd 0.21 counts)
+//
+//     so with NO reflected power the reverse channel still reads ~3.4 counts.
+//     That is a bias. Averaging does not remove it and a gate does not remove
+//     it either — a gate only shrinks its weight against a growing forward
+//     reading. The intercept was stable to 0.05 counts across seven captures
+//     over forty minutes and is identical keyed and unkeyed, so it is the
+//     converter and not the PA.
+//
+// WHAT THAT DOES TO THE READING. On a dummy load the true answer is known and
+// near 1.0, so every departure IS the instrument. At 96 forward counts this
+// radio's reverse channel is ~97% offset, and the linearized form reports
+//
+//     gate 96 -> 1.40      gate 160 -> 1.25      gate 320 -> 1.14
+//
+// against a load measured at 1.03..1.06 by the same instrument where it is
+// trustworthy. 0.40 of error at 96 counts is 1.6x the 0.25 the criterion above
+// was chosen to hold, and the empirical settling curve agrees: pooling every
+// keyed sample and binning by forward count, the linearized median first comes
+// within 0.25 of the truth in the 200..260 bin and its 95th percentile in the
+// 260..340 bin.
+//
+// SO THE CRITERION IS UNCHANGED AND ITS ANSWER MOVED. Re-derived by resampling
+// the MEASURED distributions rather than perturbing by an assumed count:
+//
+//     forward counts        16     32     64     96    160    256    320
+//     p95 error (measured) 6.35   1.95   0.91   0.65   0.38   0.26   0.20
+//     p95 error (1-count)  1.57   0.50   0.30   0.20    ...    ...   ...
+//
+// The second row is the old model and is reproduced exactly by the new tool
+// where the two overlap, which is why the first row is a correction and not a
+// disagreement. 320 is the smallest gridded count whose 95th-percentile error
+// stays within 0.25 everywhere above it. 256 misses by 0.008 and is a
+// defensible round alternative; 160 is the answer if the criterion is read at
+// the MEDIAN rather than as the worst case its wording states.
+//
+// THE COST, which is the real argument against going further: SWR reads absent
+// below ~74 mW forward on the reference curve, 1.5% of the HL2's rated 5 W and
+// 18 dB down, against ~12 mW at 96 and ~1.6 mW at 16.
+//
+// STILL NOT MEASURED, and it bounds what the above is worth: this is ONE radio,
+// one coupler and one dummy load. The offset is a per-unit property of a diode
+// detector and there is no reason to expect 3.4 counts on another board — only
+// to expect that it is not zero, which is the part the one-count model got
+// wrong. A per-unit calibration would replace this constant along with the
+// curve. See also kMeasuredReverseFloorCounts below, which the test uses to run
+// the offset criterion rather than restate it.
+//
+// A BETTER FIX THAN A GATE EXISTS AND IS NOT DONE HERE. Both channels are
+// readable while unkeyed and their floors are stable, so sampling them just
+// before a transmission and subtracting would remove the bias outright. On the
+// measured distributions that drops the gate this criterion needs from 320 to
+// 200 at the 95th percentile and from 160 to 16 at the median. It is a larger
+// change than raising a constant, it needs a place to hold the floor and a
+// policy for when to re-measure it, and it is recorded rather than attempted.
+inline constexpr int kMinForwardCountsForSwr = 320;
+
+// The reverse channel's reading with NO reflected power, in counts — the
+// intercept of rev = 3.41 + 0.00097*fwd fitted across bench run D89's 16 legs.
+//
+// Here so that hl2_metis_protocol_test can RUN the offset criterion instead of
+// restating it, exactly as it already runs the quantisation one: if a future
+// per-unit calibration replaces the curve, or if anyone lowers the gate, the
+// assertion re-derives rather than inheriting a stale comment.
+//
+// MEASURED ON ONE RADIO (Hermes-Lite 2, gateware v74, N2ADR filter board, into
+// a dummy load at 7.1 MHz). It is NOT a constant of the design and nothing may
+// use it to correct a reading — it is a lower bound on what the gate has to
+// tolerate, and it is used for exactly that.
+inline constexpr double kMeasuredReverseFloorCounts = 3.41;
 
 // Standing-wave ratio from raw forward/reverse counts.
 //

--- a/src/core/backends/hl2/MetisProtocol.h
+++ b/src/core/backends/hl2/MetisProtocol.h
@@ -504,12 +504,48 @@ struct Hl2Telemetry {
     void apply(const Ep6Response& r) noexcept;
 };
 
+// Directional-coupler counts -> watts, through the reference calibration curve.
+// See the table in the .cpp for what this curve is and, much more importantly,
+// what it is NOT — it is not a calibration of any particular radio.
+//
+// Lives here rather than in Hl2Backend because swrFromRaw() now needs the same
+// curve, and MetisProtocol is the layer Hl2Backend already depends on. Putting
+// one copy at the lower layer costs no new dependency edge; the alternatives
+// both cost one (see the note above swrFromRaw()).
+double directionalWatts(int raw) noexcept;
+
+// Detector output in arbitrary VOLTAGE units: sqrt(directionalWatts(raw)).
+//
+// This is the inverse of the count->power curve, taken back to voltage because
+// SWR is a voltage ratio. The units are arbitrary and deliberately so — only
+// the ratio of two of these is ever used, so any consistent scale works, and
+// pretending the number is volts would be the same mistake as pretending the
+// counts are watts.
+double detectorVolts(int raw) noexcept;
+
+// Minimum forward-power reading, in raw converter counts, below which an SWR
+// ratio is quantisation noise rather than a measurement.
+//
+// With no carrier, forward and reverse are both near zero and dominated by
+// noise; reverse frequently exceeds forward and the ratio saturates. An
+// operator glancing at that sees a catastrophic mismatch on an antenna that is
+// fine. Raw counts because that is what we have — this is a noise floor, not a
+// calibrated power level.
+//
+// It lives in this header, beside the curve it is derived from, so EVERY
+// consumer shares one threshold. It was previously local to the meter path,
+// so the Radio Health snapshot computed an unguarded ratio and bounced at its
+// 500 ms refresh while the meter beside it stayed silent — two surfaces
+// disagreeing about the same radio because only one of them had the guard.
+inline constexpr int kMinForwardCountsForSwr = 16;
+
 // Standing-wave ratio from raw forward/reverse counts.
 //
-// The counts are UNCALIBRATED ADC readings, but SWR is a RATIO, so the unknown
-// scale factor cancels as long as both come from the same converter — which is
-// why SWR is meaningful here while absolute watts are not (oracle §6: "don't
-// pretend uncalibrated counts are watts").
+// The counts are UNCALIBRATED ADC readings, and SWR is a RATIO — but a ratio of
+// raw counts is scale-invariant, NOT curve-invariant, and the detector's curve
+// is not linear. Both counts are therefore mapped through detectorVolts()
+// before the ratio is taken. See the comment on the definition for the whole
+// argument, including the part of the old reasoning that is still correct.
 //
 // Returns nullopt when there is no forward power to speak of: SWR is undefined
 // with no carrier, and 1.0 would read as a perfect match rather than "unknown".

--- a/src/core/backends/hl2/MetisProtocol.h
+++ b/src/core/backends/hl2/MetisProtocol.h
@@ -537,7 +537,45 @@ double detectorVolts(int raw) noexcept;
 // so the Radio Health snapshot computed an unguarded ratio and bounced at its
 // 500 ms refresh while the meter beside it stayed silent — two surfaces
 // disagreeing about the same radio because only one of them had the guard.
-inline constexpr int kMinForwardCountsForSwr = 16;
+//
+// ---- why 96 and not 16 (#4578, nigelfenton's half) ----
+//
+// 16 was a guess about where noise stops, and it is too low by six times. A TX
+// Cal sweep aborted on its first step at a reported SWR of 256.00 on an antenna
+// a RigExpert AA-170 and a real carrier both measured at 1.50 — a LIVE reading,
+// admitted by this gate, computed from counts barely above it. Every layer's
+// absent-handling worked; the number itself was admitted and wrong.
+//
+// CRITERION, because there is no single correct answer and the choice has to be
+// arguable: one count of quantisation on EITHER channel must not move the
+// reported SWR by more than 0.25 — half the finest distinction anything
+// downstream makes (1.5 against 2.0 against 2.5, and the 3.0 at which a sweep
+// aborts) — for every true SWR from 1.0 to 3.0. Above 3.0 the exact value stops
+// mattering because every consumer has already stopped.
+//
+// Swept against directionalWatts()'s own curve, worst case over that band:
+//
+//     forward counts    16     32     64     96    128    256    512
+//     worst SWR error  0.85   0.50   0.30   0.20   0.16   0.10   0.05
+//
+// 96 is the smallest count at and above which the criterion holds. That is
+// ~12 mW forward on the reference curve, against ~1.6 mW at 16 — so the cost is
+// SWR reading "absent" between 1.6 and 12 mW, which is the right trade for a
+// number that could not tell 1.5 from 2.35 down there.
+//
+// NOT ~1200, which #4578 suggested. Gating on FORWARD counts does nothing to
+// lift the REVERSE channel out of the knee: at a true 1.5 the reverse sits a
+// factor of five below forward in voltage, so getting it above 1200 counts
+// needs about 16 W forward — past the top of this table and past what an HL2
+// produces. At 1200 forward counts a true 2.0 still displayed 1.76 under the
+// old raw ratio. It buys nothing and costs SWR below ~0.67 W.
+//
+// DERIVED ANALYTICALLY FROM THE REFERENCE CURVE — NOT MEASURED ON HARDWARE. It
+// assumes the channel-to-channel disagreement at the floor is one count, which
+// is what the field report describes and what nobody has yet measured on a
+// bench. If the real noise amplitude is larger than one count, 96 is still too
+// low. hl2_metis_protocol_test runs this derivation rather than restating it.
+inline constexpr int kMinForwardCountsForSwr = 96;
 
 // Standing-wave ratio from raw forward/reverse counts.
 //

--- a/src/core/backends/hl2/MetisProtocol.h
+++ b/src/core/backends/hl2/MetisProtocol.h
@@ -538,7 +538,7 @@ double detectorVolts(int raw) noexcept;
 // 500 ms refresh while the meter beside it stayed silent — two surfaces
 // disagreeing about the same radio because only one of them had the guard.
 //
-// ---- why 96 and not 16 (#4578, nigelfenton's half) ----
+// ---- why not 16 (#4578, nigelfenton's half), and how 96 was first reached ----
 //
 // 16 was a guess about where noise stops, and it is too low by six times. A TX
 // Cal sweep aborted on its first step at a reported SWR of 256.00 on an antenna

--- a/tests/hl2_metis_protocol_test.cpp
+++ b/tests/hl2_metis_protocol_test.cpp
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
+#include <algorithm>
 #include <vector>
 
 using namespace AetherSDR::hl2;
@@ -671,14 +672,145 @@ int main()
         const auto flat = swrFromRaw(1000, 0);
         check(flat.has_value() && std::fabs(*flat - 1.0) < 1e-9,
               "no reflection -> 1.0:1");
-        // Voltage form: rho = 1/3 -> SWR 2.0. The power form would have given
-        // 1.0/(1-sqrt(1/3)) ~= 2.37 here, i.e. a different and wrong number.
-        const auto two = swrFromRaw(3000, 1000);
-        check(two.has_value() && std::fabs(*two - 2.0) < 1e-9,
-              "rho = 1/3 -> 2.0:1 (voltage form, no square root)");
+
+        // The voltage form, restated on counts that mean something.
+        //
+        // This assertion used to be swrFromRaw(3000, 1000) == 2.0 exactly: a
+        // RAW-COUNT ratio of 1/3, asserted to be SWR 2.0. That locked in #4578's
+        // bug — it asserted that the detector is linear, which it is not, and
+        // any correct implementation had to fail it. What is being pinned here
+        // is the voltage form itself, so the case is now written in counts that
+        // correspond to a known true SWR THROUGH the calibration curve:
+        //
+        //   forward 1000 counts -> directionalWatts 0.504594 W -> V 0.710348
+        //   true SWR 2.0 -> rho 1/3 -> V_rev 0.236782 -> 0.056066 W -> 277.9 counts
+        //
+        // so 1000/278 is a true 2.0:1, and the voltage form must return it.
+        // The POWER form would give 1/(1-sqrt(1/3)) ~= 2.37 from the same rho,
+        // i.e. a different and wrong number — that is what the original
+        // assertion was really protecting and it is still protected.
+        const auto two = swrFromRaw(1000, 278);
+        check(two.has_value() && std::fabs(*two - 2.0) < 0.01,
+              "1000/278 counts is a true 2.0:1 through the curve (voltage form, no square root)");
+
         const auto bad = swrFromRaw(100, 500);
         check(bad.has_value() && *bad > 100.0,
               "reverse above forward clamps to a very high SWR, not negative");
+
+        // ---- #4578 half A: the knee, where the raw-count ratio reads low ----
+        //
+        // 265 forward counts (~50 mW) with a TRUE 2.0:1 puts 48 counts on the
+        // reverse channel — derived through the same curve as above. The raw
+        // ratio (265+48)/(265-48) is 1.442: a 28% under-read, in the direction
+        // that hides a mismatch. Linearizing both channels first recovers 1.99.
+        const auto knee = swrFromRaw(265, 48);
+        check(knee.has_value() && std::fabs(*knee - 2.0) < 0.05,
+              "knee: 265/48 counts is a true 2.0:1 and must not read 1.44");
+        check(knee.has_value() && *knee > 1.9,
+              "knee: the reading must not be OPTIMISTIC — that is the unsafe direction");
+
+        // ---- above the knee the change is inert ----
+        //
+        // 4953 forward counts is the top of the calibration table, where k has
+        // flattened. A true 2.0:1 there is 1623 reverse counts; the raw ratio
+        // already gives 1.975. The linearized form must land within a few
+        // hundredths of that, so this change is provably a LOW-END correction
+        // and not a rescaling of every reading an operator has ever seen.
+        const auto high = swrFromRaw(4953, 1623);
+        const double rawRatioHigh = (4953.0 + 1623.0) / (4953.0 - 1623.0);   // 1.9748
+        check(high.has_value() && std::fabs(*high - 2.0) < 0.01,
+              "above the knee: 4953/1623 counts is a true 2.0:1");
+        check(high.has_value() && std::fabs(*high - rawRatioHigh) < 0.05,
+              "above the knee: linearized and raw-ratio forms agree — a low-end correction only");
+
+        // ---- #4578 half B: linearizing does NOT rescue near-equal counts ----
+        //
+        // Reported independently by nigelfenton with a RigExpert AA-170
+        // cross-check: a TX Cal sweep aborted on its first step at SWR 256.00
+        // where the analyser and a real carrier both read 1.50.
+        //
+        // Two counts one LSB apart are two nearly-equal numbers before AND
+        // after the curve, so the ratio still runs away. It in fact runs away
+        // HARDER: at 20/19 the raw ratio gives 39.0 and the linearized form
+        // gives 78.0, because the knee's slope amplifies the reverse channel
+        // relative to the forward one down here. Whatever the computation does,
+        // the number is refused by the publish gate, not repaired by the maths.
+        const auto lsb = swrFromRaw(20, 19);
+        check(lsb.has_value() && *lsb > 30.0,
+              "one LSB apart at 20 counts still runs away — linearization does not subsume the gate");
+        check(20 < kMinForwardCountsForSwr,
+              "20 forward counts is below the publish gate: nothing is published from there");
+        const auto equal = swrFromRaw(20, 20);
+        check(equal.has_value() && *equal > 100.0,
+              "equal counts hit the clamp and saturate — the 255.99 the meter shows");
+        check(20 < kMinForwardCountsForSwr,
+              "equal counts at 20 forward are below the publish gate too");
+
+        // ---- the gate value is derived from the curve, and this is the
+        //      derivation, run ----
+        //
+        // CRITERION: one count of quantisation on EITHER channel must not move
+        // the reported SWR by more than 0.25 — half the finest distinction any
+        // consumer of this number makes (1.5 vs 2.0 vs 2.5, and the 3.0 abort a
+        // TX Cal sweep uses) — for every true SWR from 1.0 to 3.0. Above 3.0 the
+        // exact value stops mattering: every consumer has already aborted.
+        //
+        // DERIVED ANALYTICALLY FROM THE REFERENCE CURVE, NOT MEASURED ON
+        // HARDWARE. It assumes the channel-to-channel disagreement is one count.
+        // The real noise amplitude on this radio's reverse channel has never
+        // been measured; if it is larger than one count the gate is too low.
+        //
+        // At the old value of 16 the same criterion gives 0.85 SWR units of
+        // error — a reading that cannot tell 1.5 from 2.35.
+        {
+            constexpr double kTol = 0.25;
+            // Integer reverse count nearest a given true SWR at a given forward
+            // count, by bisection on the shipped detectorVolts() — so this
+            // inverts the curve the code actually uses rather than restating it.
+            auto revCountsFor = [](int fwd, double trueSwr) {
+                const double rho = (trueSwr - 1.0) / (trueSwr + 1.0);
+                const double want = rho * detectorVolts(fwd);
+                int lo = 0, hi = fwd;
+                while (lo < hi) {
+                    const int mid = lo + (hi - lo) / 2;
+                    if (detectorVolts(mid) < want) lo = mid + 1; else hi = mid;
+                }
+                if (lo > 0 && std::fabs(detectorVolts(lo - 1) - want)
+                            < std::fabs(detectorVolts(lo) - want))
+                    --lo;
+                return lo;
+            };
+            auto worstErrorAt = [&](int fwd) {
+                double worst = 0.0;
+                for (int i = 0; i <= 40; ++i) {
+                    const double t = 1.0 + 0.05 * i;
+                    const int rev = revCountsFor(fwd, t);
+                    for (int df = -1; df <= 1; ++df) {
+                        for (int dr = -1; dr <= 1; ++dr) {
+                            const auto v = swrFromRaw(fwd + df, rev + dr < 0 ? 0 : rev + dr);
+                            if (v) worst = std::max(worst, std::fabs(*v - t));
+                        }
+                    }
+                }
+                return worst;
+            };
+            // Smallest forward count at or above which the criterion holds for
+            // EVERY higher count too — scanned downward so a local dip below
+            // the tolerance cannot be mistaken for the crossing.
+            int firstUsable = 9;
+            for (int c = 1200; c > 8; --c) {
+                if (worstErrorAt(c) >= kTol) { firstUsable = c + 1; break; }
+            }
+            check(kMinForwardCountsForSwr >= firstUsable,
+                  "the publish gate is at or above the count the quantisation criterion requires");
+            check(worstErrorAt(kMinForwardCountsForSwr) < kTol,
+                  "at the publish gate, one count of quantisation is worth less than 0.25 SWR");
+            if (kMinForwardCountsForSwr < firstUsable)
+                std::fprintf(stderr,
+                             "      gate is %d, criterion needs %d (worst error at the gate: %.3f)\n",
+                             kMinForwardCountsForSwr, firstUsable,
+                             worstErrorAt(kMinForwardCountsForSwr));
+        }
     }
 
     // ---- Direct I2C writes on the external bus (I2C2 / addr 0x3d) ----

--- a/tests/hl2_metis_protocol_test.cpp
+++ b/tests/hl2_metis_protocol_test.cpp
@@ -810,6 +810,54 @@ int main()
                              "      gate is %d, criterion needs %d (worst error at the gate: %.3f)\n",
                              kMinForwardCountsForSwr, firstUsable,
                              worstErrorAt(kMinForwardCountsForSwr));
+
+            // ---- the OFFSET criterion, which the bench added (#4578, D89) ----
+            //
+            // The sweep above perturbs both channels symmetrically about a
+            // reverse count that is CORRECT for the true SWR being tested. That
+            // is the right question about quantisation and it cannot see a
+            // BIAS: a reverse channel that reads ~3.4 counts with no reflected
+            // power at all shifts every reading one way, and no symmetric
+            // perturbation of a correct value expresses that.
+            //
+            // So this is a second, independent criterion on the same constant,
+            // and it is the one the measurement produced. Into a load whose
+            // true SWR is 1.0, with the reverse channel sitting at its measured
+            // floor, the gate must not admit a reading further than the same
+            // 0.25 from the truth.
+            //
+            // It is RUN, not restated: it reads kMeasuredReverseFloorCounts and
+            // calls the shipped swrFromRaw, so replacing the calibration curve
+            // or lowering the gate re-derives it. At the previous value of 96
+            // this fails at 1.40 — which is how the bench found that 96, itself
+            // a six-fold raise from 16, was still not enough.
+            {
+                const auto atGate = swrFromRaw(
+                    kMinForwardCountsForSwr,
+                    static_cast<int>(kMeasuredReverseFloorCounts + 0.5));
+                check(atGate.has_value(),
+                      "the gate's own forward count must produce a reading at all");
+                check(atGate && std::fabs(*atGate - 1.0) < kTol,
+                      "at the publish gate, a MATCHED load with the measured "
+                      "reverse-channel floor reads within 0.25 of 1.0");
+                if (atGate && std::fabs(*atGate - 1.0) >= kTol)
+                    std::fprintf(stderr,
+                                 "      gate is %d; a matched load with the measured "
+                                 "reverse floor %.2f counts reads %.3f, off by %.3f\n",
+                                 kMinForwardCountsForSwr,
+                                 kMeasuredReverseFloorCounts, *atGate,
+                                 std::fabs(*atGate - 1.0));
+
+                // AND THE DIRECTION, because it decides whether this is a
+                // safety problem or a nuisance: the offset makes the reading
+                // read HIGH on a matched load, which is the SAFE direction for
+                // a mismatch warning and the opposite of half A's under-read.
+                // Pinning it stops a future "fix" from turning an over-read
+                // into an under-read while still satisfying the bound above.
+                check(!atGate || *atGate >= 1.0,
+                      "the reverse-channel offset makes a matched load read "
+                      "HIGH, never low — the safe direction");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

`Refs #4578`. The SWR published from the HL2's directional coupler is computed from raw ADC counts that were never taken back through the detector's curve, and it is admitted from a floor that was a guess. This linearizes the ratio and re-derives the floor — the second from a hardware measurement, not from arithmetic.

Four commits: a red one that adds the assertions against the unchanged arithmetic, a green one that linearizes, a third that corrects the gate against bench data, and a fourth that brings the prose in line with the third (`docs/HERMES.md` §17.5 still described both halves as underived from hardware after one of them had been measured).

### Half A — it reads optimistically low, always

`swrFromRaw()` computed `(fwd + rev) / (fwd - rev)` on raw counts. The standing defence — repeated in `Hl2Backend::publishTelemetry`, in `Hl2Backend::healthSnapshot` and in `docs/HERMES.md` §17.5 — was *"a ratio of two readings from the same converter, so the unknown scale cancels."*

The scale cancels. **The curve does not.** Writing a count as `c = k(c)·V`,

    rho_shown / rho_true = k(c_rev) / k(c_fwd)

and `k = counts / sqrt(watts)` from the shipped table rises monotonically across the whole region of interest (512 at 26 counts to 1516 at 4953). Since `c_rev < c_fwd` always, the shown reflection coefficient is **unconditionally** low and the shown SWR **unconditionally** optimistic — never conservative, on a meter whose entire job is to warn about a mismatch. At 265 forward counts a true 2.0:1 displays **1.44**.

`swrFromRaw()` now computes `rho = detectorVolts(rev) / detectorVolts(fwd)`. Everything else is untouched: the `forwardRaw <= 0 → nullopt` case, the `rev >= fwd` clamp, and the voltage form `(1 + rho) / (1 - rho)` with no square root. The existing comment survives verbatim — its voltage-proportionality reasoning is correct and is the part people usually get wrong; the nonlinearity caveat is appended below it, not substituted for it.

`detectorVolts()` is new: `sqrt(directionalWatts(raw))`, the inverse curve in arbitrary voltage units since only the ratio is ever used. Deliberately *not* a second table — taking `sqrt()` of the existing function makes the interpolation scheme the same one by construction, so the two cannot drift apart when a per-unit calibration replaces the points.

### Half B — the noise gate, and why 320 is a measurement

Linearization does **not** fix the low-end saturation and must not be read as fixing it. Two counts one LSB apart are two nearly-equal numbers on either side of the curve, and the knee's slope amplifies the reverse channel relative to the forward one: `20/19` counts goes from a raw ratio of 39.0 to a linearized **78.0**. It runs away *harder* after the fix. The gate needed its own raise on its own grounds.

The criterion is unchanged from the original derivation: **one count of quantisation on either channel must not move the reported SWR by more than 0.25** — half the finest distinction anything downstream makes (1.5 against 2.0 against 2.5, and the 3.0 at which a TX Cal sweep aborts) — for every true SWR from 1.0 to 3.0.

An earlier revision of this branch set the gate to 96 on that criterion swept against the reference curve, and flagged in its own comment that it assumed a **one-count** channel disagreement that nobody had put an instrument on. **Bench run D89 put an instrument on it, and 96 was still too low.** The gate is 320 because it was measured, not because it was derived:

- **Offset, which is not noise at all.** Fitting the reverse channel against the forward one across 16 legs spanning 1.3 to 822 forward counts gives **`rev = 3.41 + 0.00097·fwd`**, residual sd 0.21 counts. With **no reflected power** the reverse channel still reads ~3.4 counts. Averaging does not remove a bias and neither does a gate — a gate only shrinks its weight against a growing forward reading. The intercept is stable to 0.05 counts over forty minutes and is identical keyed and unkeyed, so it is the converter and not the PA.
- **Noise.** With RF in the load the reverse channel carries **2.73 counts of standard deviation** and a 0..12 count range (2311 settled samples, 15 drive levels). It does not shrink at low drive because it does not come from the signal: keyed with the drive register at zero the same channel reads 0.67, and unkeyed 0.68 over 6418 samples.
- **The two channels are independent** (Pearson −0.135 to +0.308 across 15 RF legs; sd(fwd−rev) measures 1.052 against 1.002 predicted for independent channels), **so the noise does not partly cancel in the ratio** the way common-mode noise would. The one-count model had no term for any of this.

Re-running the *same* criterion against the measured distributions instead of the assumed one count:

    forward counts        16     32     64     96    160    256    320
    p95 error, measured  6.35   1.95   0.91   0.65   0.38   0.26   0.20
    p95 error, 1-count   1.57   0.50   0.30   0.20    —      —      —

The two rows agree exactly where they overlap, which is what makes this a correction rather than a second opinion. **320 is the smallest gridded count whose 95th-percentile error stays within 0.25 everywhere above it** (256 misses by 0.008). At 96 the linearized form publishes 1.40 on a load the same instrument reads at 1.03–1.06 where it is trustworthy. Cost: SWR absent below ~74 mW instead of ~12 mW, 18 dB below the rated 5 W.

The conclusion does not rest on the noise figure alone. If the reverse noise at 96 counts were the quiet no-RF value of 0.67, the **offset alone** still requires 164 counts. Every route lands above 160; none near 96.

`kMeasuredReverseFloorCounts = 3.41` is added beside the gate so the test can **run** the offset criterion rather than restate it, as it already runs the quantisation one.

### What did not reproduce, and it is the issue's headline

**nigelfenton's 256.00 saturation case did not reproduce on this radio.** Of 3726 keyed samples, none with forward ≥ 16 produced a linearized SWR above 10. The mechanism checks out arithmetically against the measured noise (67% of resampled readings exceed SWR 2.0 at 16 forward counts), but this radio **cannot hold a forward reading that low**: its gateware decodes only the top nibble of the drive register, so the smallest steady non-zero output is already ~165 counts. **That is a bound on the reproduction, not a confirmation of it**, and it should not be read as one.

Relatedly, the issue's own suggested fix — raising the gate to ~1200 — does not work, and gating harder is not a substitute for linearizing. At 1197 forward counts a true 2.0 still displays 1.73 on the raw ratio. Gating on the **forward** channel cannot lift the **reverse** channel out of the knee: at a true 1.5 the reverse sits a factor of five below forward in voltage, so putting it above 1200 counts needs about 16 W forward — past the top of the table and past what an HL2 makes.

### Where the calibration table lives — a decision the triage left open

Triage flagged *"whether the shared calibration table lives in `MetisProtocol` or stays in `Hl2Backend` with a seam"* as needing a maintainer. It had to be decided to write the code. **Chosen: the table moves down.** `Hl2Backend::directionalWatts()` becomes `AetherSDR::hl2::directionalWatts()` in `MetisProtocol`, with `detectorVolts()` and the two constants beside it. `Hl2Backend.h` already includes `MetisProtocol.h` and every call site is inside `namespace AetherSDR::hl2`, so the existing calls resolve unqualified and are **textually unchanged** — the only line the diff removes that names the function is its old definition. No new dependency edge, no duplicated table, no seam.

**The cost, stated because a maintainer may weigh it differently:** `MetisProtocol` now carries a calibration concern as well as a wire-format one. That is a real widening of its remit. If it is refused, the fallback that preserves the most is an injected-curve seam — it keeps the layering and keeps the test able to see the arithmetic. **This is cheap to overrule; say the word and it moves.**

### A small licensing note, offered rather than argued

Noticed while moving the code, and entirely for a maintainer to judge. The calibration table this PR relocates is Quisk's `power_meter_std_calibrations['HL2FilterE3']`, reproduced verbatim with attribution in a source comment. **Quisk does not appear in `THIRD_PARTY_LICENSES`**, while piHPSDR, openHPSDR, OpenWebRX and WDSP all do — including entries the file itself marks as *"consulted as a behavioral reference only"*.

This PR does not introduce the dependency: `MetisProtocol.h` already reproduces Quisk's `Hermes_BandDict` verbatim for the N2ADR filter-board masks, so the question predates it and is broader than this change. It may well be a non-issue — a table of measured count/watt pairs is plausibly fact rather than expression, and facts are not copyrightable. Flagging it only because it was in front of me and the file's existing entries suggest the project likes to record consulted sources even when nothing is incorporated. Happy to add an entry, or to leave it alone, on a maintainer's call.

## Tests

`tests/hl2_metis_protocol_test.cpp`, the SWR block.

**Rewritten.** `swrFromRaw(3000, 1000) == 2.0` asserted a **raw-count ratio** of 1/3 and called it SWR 2.0 — it asserted that the detector is linear, which it is not, so it locked in the bug and any correct implementation had to fail it. It is replaced with counts that are a known true SWR **through the curve** (1000 forward → 0.5046 W → V 0.7103; a true 2.0 → rho 1/3 → 277.9 reverse counts), so `swrFromRaw(1000, 278)` must return 2.0. What the original assertion was really protecting — the voltage form against the power form, which would give 2.37 from the same rho — is still protected, and the comment says so.

**Added:** the knee (`swrFromRaw(265, 48)`, a true 2.0:1 through the same curve — raw gives 1.442, linearized 1.992, asserted both within 0.05 of 2.0 *and* explicitly not optimistic); convergence above the knee (`swrFromRaw(4953, 1623)` within 0.01 of 2.0 and within 0.05 of the raw ratio's own 1.975, so the change is provably a low-end correction and not a rescaling of every reading in anyone's log); half B (`swrFromRaw(20, 19)` still exceeds 30 after linearization, and 20 is below the gate); and both criteria **run** rather than restated — the quantisation sweep and the measured-offset check, each asserting the shipped constant satisfies it.

**Kept:** the `nullopt`, flat-match and clamp assertions, all passing.

**Red before green, observed.** The red commit moves the table and adds every assertion with the arithmetic and the gate unchanged: 8 assertions fail, including `the publish gate is at or above the count the quantisation criterion requires — gate is 16, criterion needs 1201`. The green commit passes every check in that file. The gate commit shows the same shape at the old value: `gate is 96; a matched load with the measured reverse floor 3.41 counts reads 1.371, off by 0.371`, then passes at 320.

Two of the new assertions — convergence, and "linearization does not subsume the gate" — **cannot** fail against the unfixed tree, because what they guard is the fixed implementation. Rather than leave them unexamined, each was given observed failure evidence by perturbing the *fixed* code: a wrong exponent in `detectorVolts()` fires the convergence assertion, and a cap inside `swrFromRaw()` fires the half-B one.

## What a reviewer should push back on

- **The 0.25 tolerance is chosen, not measured.** Nothing in the code depends on it being right; it is the number the criterion is stated with, so that it can be disagreed with. Reading the same measured data at the median rather than the 95th percentile gives 160 instead of 320. Both are tabulated in the record so either can be taken without re-running the bench.
- **Measured on ONE radio.** The 3.41-count offset is a per-unit property of a diode detector. What generalises is that it is **not zero**, not its value. A per-unit calibration would replace this constant along with the curve.
- **Half A has no hardware behind it and cannot get any here.** It needs a real mismatch at a known true SWR; this station is on a dummy load. That half rests on the two reporters' evidence and on the algebra.
- **The publish gate is not tested where it is applied.** `publishTelemetry` is private and reachable only through a fake radio on a socket. Nothing here asserts that the meter and the Radio Health snapshot still agree — which was true by reading once before, while they in fact disagreed. Worth having; not in this PR.
- **The table's new home** — flagged above, not defended to the death.

## Constitution principle honored

**Principle VIII — Evidence Over Assertion.** The bias claim is carried by a red-before-green pair with the observed failure output, and the two assertions that could not fail against the unfixed tree were given failure evidence by deliberate perturbation instead of being left to look verified. The gate value replaces an assumption with a measurement and says so, including where the measurement *failed* to reproduce the issue's headline symptom.

Principle XI is deliberately **not** cited. Its demonstration is CI on the squash-merge commit, maintainer reproduction, or reporter confirmation, and it explicitly excludes agent self-grading. None of those has happened, and the reporter's own case did not reproduce here.

## Test plan

- [x] Local build passes (`cmake --build build`) — **0 `FAILED:` edges** over the full unpiped log.
- [x] Behavior verified on a real radio if applicable — **partially, and only the gate.** Bench run D89 read `fwd_pwr`/`rev_pwr` out of a Hermes-Lite 2's response registers over UDP with AetherSDR not in the measurement path: 3726 keyed samples across 18 legs of ≤10 s into a **dummy load**, plus 8978 unkeyed. That is what 320 rests on. **Half A was not verified on hardware and cannot be at this station**, and the reporter's saturation case did not reproduce. Ticked because real hardware genuinely carried part of this; the limits are stated rather than hidden behind the tick.
- [x] Existing tests pass (CI) — full `ctest`, not a filtered `-R` subset: **370 tests registered, 370 passed, 0 failed, 5 skipped**, ctest exit 0, 229 s, on the rebased tree. `hl2_metis_protocol_test` passes (`all checks passed`). The five skips are the standing environmental set on this machine (`crdv_quarantined_test`, `app_settings_safety_explicit-profile-path-isolation`, `weather_radar_texture_gl_test`, `range_slider_a11y_test`, `relay_bar_a11y_test`). `vkamp_connection_test`, the known under-load flake, **passed** in 10.4 s and needed no isolated re-run — note this supersedes the third commit's own message, which recorded 360/361 with that test failing; on the rebased tree at this base the suite is fully green, which is the stronger and the current result. CI has not run yet; that is the maintainer's gate.
- [x] Reproduction steps documented if user-reported bug — the arithmetic for half A is reproducible from the shipped table with no radio; the bench procedure for the gate is written up in full. Half B's reproduction is documented as a **bound**, not a success.

## Checklist

- [x] Commits are signed — all four SSH-signed; verified with `git cat-file commit <sha> | grep '^gpgsig'`.
- [x] No new flat-key `AppSettings` calls — no settings touched.
- [x] Code is clean-room — nothing decompiled or reverse-engineered from a proprietary binary. The calibration table is reproduced from Quisk, an open-source client, with attribution in the source comment; see the licensing note above.
- [x] All meter UI uses `MeterSmoother` — no meter UI changed; this is the value feeding one.
- [x] Documentation updated if user-visible behavior changed — `docs/HERMES.md` §17.5 updated twice: once because the standing "the scale cancels" justification was wrong, and again because it went on describing the gate as underived from hardware after D89 had measured it. `CHANGELOG.md` deliberately not touched.
- [x] Security-sensitive changes reference a GHSA if applicable — not security-sensitive. It is *safety*-adjacent (an SWR meter that under-reads), which is why the correction is in the conservative direction.

**On the template's self-assignment step:** `on8st` has pull-only access, so `gh issue edit 4578 --add-assignee on8st` fails with *"on8st does not have the correct permissions to execute `ReplaceActorsForAssignable`"*. Recorded rather than left silently unticked.

**Why `Refs` and not `Fixes`:** this corrects the arithmetic and the floor, but the issue's headline saturation case did not reproduce here, half A has no hardware confirmation, and a per-unit calibration is the real end state for both constants. A maintainer or the reporters are better placed than I am to say whether #4578 is finished.

**Base:** rebased onto `main` at `8a358c5f`; four commits, clean rebase, no conflicts.

**On the `maintainer-review` label:** the originating issue carries it ("Requires maintainer review before any action is taken"). This PR is offered as a proposal for that review, not as a way around it — nothing here has been merged or acted on upstream, and if the label means the issue should not have been worked at all, say so and I will close this without argument.

