### PR TITLE
fix(gui): gate the primary Split paths on a command plane (refs #5277)

### DIFF
--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -517,6 +517,10 @@ private:
     void syncTxWaterfallSliceToSpectrums();
     void updateSplitState();
     void disableSplit();
+    // One status-bar notice per connect session for a control this radio
+    // cannot honor. Shared by the commandDropped path and by the
+    // capability gates that refuse BEFORE the send (M0, #5263).
+    void showUnsupportedControlNotice();
     // Constructor wiring blocks extracted per #3351 Phase 2 — each runs once
     // from the constructor, in original order, defined in its subject TU.
     void wireModemAudioCompletion(); // MainWindow_Wiring.cpp

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -734,15 +734,7 @@ void MainWindow::wireRadioModel()
         }
     });
     connect(&m_radioModel, &RadioModel::commandDropped,
-            this, [this](const QString&) {
-        if (m_commandDroppedNoticeShown)
-            return;
-        m_commandDroppedNoticeShown = true;
-        statusBar()->showMessage(
-            tr("This radio doesn't support that control — nothing was sent to "
-               "the radio. Further unsupported controls are logged."),
-            8000);
-    });
+            this, [this](const QString&) { showUnsupportedControlNotice(); });
     // Slice Link: disconnect teardown never emits sliceRemoved (stale slices
     // are staged for reconnect reclaim), so dissolve the link explicitly.
     // Both transitions dissolve — a link never crosses a session boundary
@@ -2923,6 +2915,27 @@ void MainWindow::applyTxAudioCapabilities(bool connected, const RadioCapabilitie
         // Observation only: never restore a client setting into DATA OFF MOD.
         m_radioModel.notePcAudioEnabled(pcAudioEnabled);
     }
+}
+
+// One notice per connect session, latch reset on the connect edge (M0, #5263).
+//
+// Held here rather than inline in the commandDropped lambda because a
+// capability gate REFUSES BEFORE THE SEND: `sendCmd` is never reached, so
+// `commandDropped` never fires, and a control converted from "drops silently"
+// to "refuses" would otherwise have taken the operator's only feedback away
+// with it. #5266 landed its four gates on 2026-08-26 and #5265 made the drop
+// loud on 2026-08-27, so that trade was invisible at the time; it is not
+// invisible now. A gate calls this so a refused control says exactly what a
+// dropped one says.
+void MainWindow::showUnsupportedControlNotice()
+{
+    if (m_commandDroppedNoticeShown)
+        return;
+    m_commandDroppedNoticeShown = true;
+    statusBar()->showMessage(
+        tr("This radio doesn't support that control — nothing was sent to "
+           "the radio. Further unsupported controls are logged."),
+        8000);
 }
 
 } // namespace AetherSDR

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -2927,6 +2927,15 @@ void MainWindow::applyTxAudioCapabilities(bool connected, const RadioCapabilitie
 // loud on 2026-08-27, so that trade was invisible at the time; it is not
 // invisible now. A gate calls this so a refused control says exactly what a
 // dropped one says.
+//
+// The latch is now SHARED between two producers: this helper's gate callers and
+// the commandDropped path. One refusal per connect session therefore consumes
+// the notice for both, so an operator who trips a capability gate first sees
+// nothing for a genuinely dropped command later in the same session. That is
+// the pre-existing one-shot semantics extended to a second producer rather than
+// a new rule, and the message is deliberately generic enough to stand for
+// either cause — but it is a real consequence and is recorded here rather than
+// left to be rediscovered.
 void MainWindow::showUnsupportedControlNotice()
 {
     if (m_commandDroppedNoticeShown)

--- a/src/gui/MainWindow_Shortcuts.cpp
+++ b/src/gui/MainWindow_Shortcuts.cpp
@@ -975,6 +975,17 @@ void MainWindow::registerShortcutActions()
     m_shortcutManager.registerAction("split_toggle", "Split Toggle", "Slice",
         QKeySequence(), [this]() {
             if (!m_splitActive) {
+                // Same gate, same reasons, as the VfoWidget::splitToggled
+                // lambda in MainWindow_Wiring.cpp — see the comment there for
+                // why this returns ahead of the m_splitActive write rather
+                // than only skipping the send (issue 5277).
+                if (!m_radioModel.hasCommandPlane()) {
+                    qCWarning(lcDevices)
+                        << "split_toggle ignored: this backend takes no Flex"
+                        << "slice-create command";
+                    showUnsupportedControlNotice();
+                    return;
+                }
                 if (m_radioModel.slices().size() >= m_radioModel.maxSlices()) return;
                 auto* s = activeSlice();
                 if (!s) return;

--- a/src/gui/MainWindow_Shortcuts.cpp
+++ b/src/gui/MainWindow_Shortcuts.cpp
@@ -978,7 +978,9 @@ void MainWindow::registerShortcutActions()
                 // Same gate, same reasons, as the VfoWidget::splitToggled
                 // lambda in MainWindow_Wiring.cpp — see the comment there for
                 // why this returns ahead of the m_splitActive write rather
-                // than only skipping the send (issue 5277).
+                // than only skipping the send (issue 5277) — and for why it
+                // is deliberately not permissive on disconnect, and which
+                // families the predicate refuses.
                 if (!m_radioModel.hasCommandPlane()) {
                     qCWarning(lcDevices)
                         << "split_toggle ignored: this backend takes no Flex"

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -5863,6 +5863,44 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
     // Split toggle — per-widget, slice-aware (#328)
     connect(w, &VfoWidget::splitToggled, this, [this, sliceId]() {
         if (!m_splitActive) {
+            // Split creates its TX slice with Flex wire text, which a backend
+            // with no command plane drops before any wire write. Same gate
+            // #5266 put on the FlexControl and RC-28/HID Split actions; this
+            // on-screen badge and the split_toggle shortcut are the two
+            // primary operator paths and were not in #5263's item-3
+            // enumeration (issue 5277).
+            //
+            // It returns BEFORE the three writes below rather than merely
+            // skipping the send, because the writes are the worse half of the
+            // defect: m_splitActive is latched AHEAD of the command, so an HL2
+            // that never created the slice left the application believing
+            // split was on while the SPLIT badge — derived from model truth in
+            // updateSplitState() — correctly showed it off. From there
+            // startSwrSweep() refuses with "Disable split before running an
+            // SWR sweep" for a split the operator does not have,
+            // TxFollowsActiveSlice silently stops following, and the next
+            // slice to arrive from ANY source is adopted as the split TX
+            // slice, muted and made TX, by MainWindow::onSliceAdded.
+            //
+            // qCWarning, not the qCDebug the #5266 sites use: since #5265 an
+            // UNGATED dead control warns and shows the operator a status-bar
+            // notice, so a gate that logged at debug and said nothing would
+            // make the CONVERTED control the quieter of the two. The refusal
+            // is the drop, one layer up, and it reports the same way.
+            //
+            // This is the M0 gate, not the end state. TciServer::
+            // createTxSliceForVfoB already carries a family-blind split for
+            // exactly this radio — createPanadapter() brings up another DDC
+            // with its slice synchronously — so #5263's own "conversion beats
+            // gating where the seam verb exists" applies to these two GUI
+            // sites as an M4 item.
+            if (!m_radioModel.hasCommandPlane()) {
+                qCWarning(lcDevices)
+                    << "VFO split toggle ignored: this backend takes no Flex"
+                    << "slice-create command";
+                showUnsupportedControlNotice();
+                return;
+            }
             // Entering split: this slice becomes RX, create a new TX slice
             if (m_radioModel.slices().size() >= m_radioModel.maxSlices())
                 return;

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -5894,6 +5894,28 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
             // with its slice synchronously — so #5263's own "conversion beats
             // gating where the seam verb exists" applies to these two GUI
             // sites as an M4 item.
+            //
+            // Deliberately NOT permissive on disconnect, unlike every gate in
+            // applyCapabilitiesToUi() (which spells that rule out at the
+            // cmdPlane/`!connected ||` gate in MainWindow.cpp). Those gate
+            // ENABLEMENT of a visible control, where staying permissive with no
+            // radio attached is right. This gates an ACTION that writes
+            // m_splitActive ahead of its send, so admitting the press while
+            // disconnected would reinstate exactly the latch this guard exists
+            // to remove. The cost is that an offline press reports "this radio
+            // doesn't support that control" when there is no radio; the wording
+            // is the price of sharing one notice with the drop path.
+            //
+            // Which families this refuses is a property of the predicate, not a
+            // list kept here: hasCommandPlane() is m_wanConn || m_connection,
+            // and RadioModel::buildBackend() harvests m_connection in exactly
+            // two branches — dynamic_cast<FlexBackend*>, and the else-if
+            // dynamic_cast<SimBackend*> that vends the synthetic connection per
+            // RFC #4288 Route A. So Flex (LAN, and WAN via m_wanConn) and Sim
+            // pass unchanged, and every family that vends no RadioConnection
+            // refuses: hl2, icom, anan and rtl alike. Nothing here enumerates
+            // them, and a future backend that vends one passes with no edit to
+            // this site.
             if (!m_radioModel.hasCommandPlane()) {
                 qCWarning(lcDevices)
                     << "VFO split toggle ignored: this backend takes no Flex"


### PR DESCRIPTION
## Summary

`Refs #5277`. Two capability gates and one extracted helper. Applies the `hasCommandPlane()` refusal that #5266 gave the FlexControl and RC-28/HID Split actions to the two **operator-facing** Split paths its milestone enumeration (#5263 item 3) did not list: the on-screen VFO **SPLIT** badge and the `split_toggle` keyboard action.

**The dead command is the smaller half of the defect.** Both sites write

```cpp
m_splitActive = true;
m_splitRxSliceId = <id>;
m_radioModel.sendCommand("slice create pan=… freq=…");
```

in that order, and `RadioModel::sendCmd` drops Flex wire text on a backend with no command plane *before any wire write*. So on a Hermes-Lite 2 the flag is latched and the slice is never created: **the application believes split is active while the radio never created a slice.** The SPLIT badge, which `MainWindow::updateSplitState` derives from model truth, correctly shows it off. The two disagree, and three further behaviours follow the wrong one. The gate returns **ahead of that write**, not merely around the send — which is the point of the fix.

### What the latched flag actually does

All reachable from one press on an HL2, all by symbol on `8a358c5f`:

- **`MainWindow::startSwrSweep`** refuses with *"Disable split before running an SWR sweep."* — naming a split the operator does not have and the UI does not show. The SWR sweep then refuses for a split that does not exist. This is the state where the application contradicts itself out loud.
- **`MainWindow::setActiveSliceInternal`** guards the `TxFollowsActiveSlice` preference on `!m_splitActive`, so a preference the operator switched on silently stops working for the rest of the session.
- **`MainWindow::onSliceAdded`** adopts the *next slice created for any reason* as the split TX slice — `setTxSlice(true)`, `setAudioMute(true)`, and the active slice moves to it — because `m_splitActive && m_splitTxSliceId < 0` is exactly the state the false latch leaves behind.
- **the second press** takes `MainWindow::disableSplit` instead of entering split, so the control's two presses do opposite things while the operator sees no change from either.

### Why `qCWarning` and an operator notice, where #5266 used `qCDebug`

This is the one place the PR deliberately does not copy #5266, and the reason is a landing-order accident rather than a disagreement.

**A gate that returns before `sendCmd` raises no warning and no operator notice at all.** `sendCmd` is never reached, so `commandDropped` never fires and the status-bar notice never shows. When #5266 was written (merged 2026-08-26) that cost nothing, because an *ungated* dead control also dropped silently. #5265 landed the loud drop the next day, 2026-08-27: `RadioModel::sendCmd` now logs at `qCWarning(lcProtocol)`, emits `commandDropped`, and `MainWindow` shows a one-shot notice. Since then a gate that logs at debug and says nothing makes the **converted** control quieter than the **unconverted** one — the exact inversion #5263 item 1 exists to prevent.

So this PR raises the notice itself rather than relying on the landed loud drop:

1. extracts the notice as `MainWindow::showUnsupportedControlNotice()` — same text, same one-shot latch `m_commandDroppedNoticeShown`, same reset on the connect edge; the `commandDropped` lambda now calls it and behaves identically — and
2. has both new gates log at `qCWarning(lcDevices)` and call it.

**Recommended follow-up, not done here:** #5266's four existing gates (`MainWindow::handleFlexControlButton`, `MainWindow::dispatchHidAction`, and the two `global.*Volume` entries in `MainWindow::registerMidiParams`) still log at `qCDebug` and show nothing. They should call the same helper. Left out so this PR stays the two sites the issue names.

### Refuse, not dim

#5262's binding doctrine is *controls are never hidden per radio; three states — dimmed/unavailable, greyed/inactive, colored/active* — and #5263 says that in M0 "dim" means the existing disabled-with-reason-tooltip pattern, with the formal visual treatment landing in **M3**. Its item-3 acceptance is worded "visibly dimmed/**refused** with a reason".

The surface here is `VfoWidget`'s `m_splitBadge`, a flat `QPushButton` whose "split is off" state is **already a ghosted grey**. A naive `setEnabled(false)` would render as that same ghosted grey, so it would not distinguish *unavailable* from *off* — it would spend the one visual signal available without adding information. That is what M3 is for. The badge is not checkable and does not latch locally, so refusing introduces no new inconsistency between what it shows and what is true.

### The end state is conversion, not this gate

#5263 item 3 says so itself: *"If `RadioModel` already has a family-blind slice-create path, route through it instead — conversion beats gating where the seam verb exists."*

It now does. `TciServer::createTxSliceForVfoB` carries a complete family-blind split for this exact radio: on `!usesFlexCommandPlane()` it calls `RadioModel::createPanadapter()`, which brings up another DDC with its slice **synchronously**, diffs the slice set to find the created id, promotes it to TX, and tears it down with `removePanadapter` on every failure exit. So split on an HL2 is achievable, and these two GUI sites should eventually route through the same mechanism.

That is a feature, not a gate: it needs `m_splitTxSliceId` to stop depending on the asynchronous `onSliceAdded` adoption hook, and `disableSplit`'s `slice remove` to become `removePanadapter`. **This PR is the M0 stop-gap**, and it is a strict improvement meanwhile because it removes the state corruption rather than only the dead write. Flagged so a maintainer can decide whether to take the conversion as an M4 item or ask for it here.

## Localization — the `docs/HERMES.md` pre-PR grep

`1457d06d` added *"For coding agents — keep bring-up inside the family backend"* to `docs/HERMES.md` after this PR was opened. Running its pre-PR grep against this branch, and answering it rather than asserting it.

**Hits: three.** (`src/gui/MainWindow.h` is also touched but matches no pattern — the list says `src/gui/MainWindow*.cpp`.)

| Hit | Symbol | What it does | Verdict |
|---|---|---|---|
| `src/gui/MainWindow_Session.cpp` | `MainWindow::showUnsupportedControlNotice()` (new); `MainWindow::wireRadioModel()` `commandDropped` lambda | Lifts the existing notice body into a named method verbatim and calls it | **Explained — no family logic at all** |
| `src/gui/MainWindow_Shortcuts.cpp` | `MainWindow::registerShortcutActions()`, `split_toggle` lambda | `hasCommandPlane()` refusal ahead of the `m_splitActive` write | **Explained — the rule's own exception** |
| `src/gui/MainWindow_Wiring.cpp` | `MainWindow::wireVfoWidget()`, `VfoWidget::splitToggled` lambda | Same refusal, same position | **Explained — the rule's own exception** |

**Nothing here needs splitting.** The three tests that matter:

**1. The predicate is a capability, not a family branch.** The rule forbids `family == "hl2"` / `usesFlexCommandPlane()` branches above the seam (#5554). `RadioModel::usesFlexCommandPlane()` is literally `m_family == QLatin1String("flex")` — and this PR does not use it. Both gates use `RadioModel::hasCommandPlane()`, which is `m_wanConn != nullptr || m_connection != nullptr`: object presence, no family string. A future backend that vends a `RadioConnection` passes automatically with no edit to either GUI site.

**2. The refusal set is exactly the drop set.** `RadioModel::sendCmd` decides whether to drop Flex wire text on the *same* predicate. So the gate refuses precisely where the send would have been thrown away — the invariant the fix wants — and cannot drift from it, because there is one predicate and not two.

**3. It is not "make this radio look right."** The prohibition is on changing shared chrome *so a radio looks right*. Nothing here touches layout, defaults, or appearance; the badge is not dimmed or hidden and no family widget is introduced. What changes is that a write which corrupted `m_splitActive` no longer happens. `disableSplit()` in the `else` branch is deliberately left ungated, so a latch set before this change can still be torn down.

### The other families, as the rule asks

The rule says to *"name the other families in the PR body and prove they still take the Flex/Icom path."* Correcting the Risk section below, which got this wrong:

| Family | `hasCommandPlane()` | Split entry |
|---|---|---|
| `flex` | **true** — `m_connection` from `FlexBackend::connection()`; `m_wanConn` on the SmartLink WAN path | Unchanged, gate passes |
| `sim` | **true** — `m_connection` from `SimBackend::connection()` (RFC #4288 Route A) | Unchanged, gate passes |
| `hl2` | false — vends no `connection()` | Refused (the fix) |
| `icom` | false — vends no `connection()` | Refused |
| `anan` | false — vends no `connection()` | Refused |
| `rtl` | false — vends no `connection()` | Refused |

`RadioModel::buildBackend()` harvests `m_connection` in exactly two branches — `dynamic_cast<FlexBackend*>`, and the `else if` `dynamic_cast<SimBackend*>` that vends the synthetic connection per RFC #4288 Route A. Flex and Sim therefore pass and are wholly unaffected; every family that vends no `RadioConnection` refuses. No site enumerates families, so a future backend that vends one passes with no edit to either GUI site.

`anan` and `rtl` were not named anywhere in the original body — the rule asks for them explicitly. They are refused on the same predicate as HL2, and for the same reason: no `RadioConnection`, so `sendCmd` would have dropped the `slice create` anyway.

### Not permissive on disconnect — deliberate, and now documented

The rule's exception ends *"restore the permissive value on disconnect."* These gates do not, and `MainWindow::applyCapabilitiesToUi` states that convention explicitly at its own `!connected || hasCommandPlane()` gate.

The deviation is intended. Those gates control **enablement of a visible control**, where staying permissive with no radio attached is right. This gates an **action that writes `m_splitActive` ahead of its send**, so admitting an offline press would reinstate exactly the latch the guard exists to remove. The cost is real and is now stated in the code: an offline press reports *"this radio doesn't support that control"* when there is no radio. Raised by review and previously undocumented; if a maintainer prefers the permissive form, say so — but it reintroduces the latch.

## Verification

Bench run D91. Real `AetherSDR` build with `AETHER_AUTOMATION=1`, connected as family `hl2` to `hpsdrsim -hermeslite2` on `127.0.0.1`. **No hardware, no antenna, no RF, nothing keyed** (`AETHER_AUTOMATION_NO_TX=1` throughout). Red before green, same driver, two binaries one commit apart.

**One honest caveat on the base.** D91 was run when `main` was at `9c400944`; this branch has since been rebased onto `8a358c5f`, and the bench was **not** re-run on the new base. The six commits in between *do* touch `MainWindow.cpp`, `MainWindow_Session.cpp`, `MainWindow_Wiring.cpp` and `RadioModel.cpp/.h`, so this is not a "nothing relevant changed" hand-wave — I checked the hunks. Across that range no added or removed line touches `m_splitActive`, `splitToggled`, `split_toggle`, the `slice create` sends, `RadioModel::sendCmd`, `hasCommandPlane()` or `commandDropped`. The mechanism the bench measured is byte-identical; the evidence therefore carries over **by inspection rather than by re-measurement**, and I would rather name that distinction than let the table imply a fresh run.

`m_splitActive` is private and no bridge verb serialises it, so it cannot be read directly. It does not need to be — **the handler branches on it**, and the branch is visible in what the handler sends:

| | red (base, ungated) | green (gated) |
|---|---|---|
| `connected: true` asserted | yes, 3.50 s | yes, 3.50 s |
| `maxSlices` (precondition ≥ 2) | 3 | 3 |
| positive control `tune_up_1mhz` | +1.000000 MHz | +1.000000 MHz |
| positive control `band_zoom` sends | 3 of 3 | 3 of 3 |
| `split_toggle` × 3, commands sent | `slice create`, **nothing**, `slice create` | nothing, nothing, nothing |
| `split_toggle` × 3, action `fired` | true ×3 | true ×3 |
| a second slice afterwards | no | no |

**The middle press sending nothing is the whole finding.** Only `m_splitActive` being true takes the handler down the `disableSplit()` branch. A control that were merely *dead* — no state kept — would send on all three, and the positive controls show what that looks like in the same log in the same seconds.

**No unit test is added, and AGENTS.md's test-layer table says one should exist.** That table puts *"a refusal, a non-event, a dropped/malformed/disconnected input"* in a socket-free CTest that injects the transport, and this gate is precisely a refusal. Stating that plainly rather than letting the omission look unconsidered:

The assertion has nowhere to live at that layer today. Both gated sites are lambdas inside `MainWindow::wireVfoWidget` and `MainWindow::registerShortcutActions`, and **nothing in `tests/` constructs a `MainWindow`** — no test includes `MainWindow.h`; the files that name it (`tci_server_review_test`, `band_recall_selection_guard_test`, and others) *mirror* its wiring by hand and drive the model and server directly, below the seam where this defect lives. So a socket-free test for this gate would have to stand the widget harness up first, which is a larger piece of work than the gate and would land as scaffolding rather than as cover.

#5266 added no test for the same reason at the same layer. The bench run is the evidence here, and it is a stronger instrument than a unit test would be for *this* claim — it reads the latch through the application's own behaviour rather than through a reconstruction of it. But it is not the test the convention asks for, and if a maintainer wants the harness stood up as a precondition, that is a reasonable thing to ask and I would rather be told than assume.

**Mutation check.** The convention also asks that a guard be broken on purpose and watched to fail. The red/green pair above is that check performed at the binary level rather than the assertion level: the same driver against two builds one commit apart, where the "broken guard" is simply its absence, and the middle press flips from silent to sending.

## What was not verified

- **Icom.** There is no Icom at this station and none was driven. Everything here about Icom is source reading: `IcomCivBackend` vends no `RadioConnection` and `m_wanConn` is set only on the Flex WAN path, so `hasCommandPlane()` is false and the gate refuses identically. One point for a maintainer's eye that the issue does not raise: a real Icom *has* native CI-V split, and `IcomCivBackend` implements no split verb — so refusing is correct for what the backend supports today and takes nothing away, but on Icom the right end state is a CI-V conversion rather than this gate. Different item from the HL2 one.
- **A real Hermes-Lite 2.** This ran against `hpsdrsim` on loopback. A loopback simulator is not RF, and nothing in this PR depends on RF.
- **The three downstream behaviours** (`startSwrSweep`, `TxFollowsActiveSlice`, `onSliceAdded`) are established from source and were **not** driven: the first is a modal dialog, and the other two need a slice arrival or a slice switch this rig did not produce.
- **The on-screen badge itself was not clicked.** The bench drove the `split_toggle` shortcut, which writes the same three values before the same send. Sound for the latch; silent on anything specific to the widget.

## Risk

None on Flex or Sim: both vend a `RadioConnection` (`FlexBackend::connection()`, `SimBackend::connection()` — RFC #4288 Route A) and `RadioModel::buildBackend()` harvests both, so `hasCommandPlane()` is true and every gate passes. `hl2`, `icom`, `anan` and `rtl` vend none and are refused on the same predicate — full matrix in the localization section above.

On HL2 the observable change is that the SPLIT badge and the shortcut stop lying, and that the operator gets the same notice an ungated dead control already produces.

## Constitution principle honored

**Principle VIII — Evidence Over Assertion.** The latch is not asserted from reading the source; it is read off an observable — two `slice create` sends across three presses with the middle one silent — through two binaries one commit apart, with positive controls in the same run to show the instrument was working. Where evidence was not obtained (Icom, the badge widget, the three downstream behaviours) it is listed as not obtained rather than covered by the reading.

Principle XI is deliberately **not** cited. Its demonstration is CI on the squash-merge commit, maintainer reproduction, or reporter confirmation, and it explicitly excludes agent self-grading; none of those has happened.

## Test plan

- [x] Local build passes (`cmake --build build`) — **0 `FAILED:` edges** over the full unpiped log.
- [x] Behavior verified on a real radio if applicable — **on a simulator, not a radio.** `hpsdrsim -hermeslite2` over loopback, red-before-green. Ticked because the behaviour was genuinely exercised end to end in the running application rather than reasoned about; the substitution of a simulator for a radio is stated here rather than hidden, and nothing in this change depends on RF.
- [ ] Existing tests pass (CI) — **the numbers below were measured on base `8a358c5f` and are now stale; see the rebase note under Base.** Full `ctest`, not a filtered `-R` subset: **370 tests registered, 370 passed, 0 failed, 5 skipped**, ctest exit 0, 216 s. The five skips are the standing environmental set on this machine (`crdv_quarantined_test`, `app_settings_safety_explicit-profile-path-isolation`, `weather_radar_texture_gl_test`, `range_slider_a11y_test`, `relay_bar_a11y_test`). `vkamp_connection_test`, the known under-load flake, **passed** in 10.4 s and needed no isolated re-run. `tools/check_a11y.py` reports 0 findings across the three touched files. The base is not red: the same suite on the same `8a358c5f` base with only a comment change (PR #5520) passes identically. CI has not run yet; that is the maintainer's gate.
- [x] Reproduction steps documented if user-reported bug — the driver script and the full run record are written up; the reproduction needs only `hpsdrsim`, no hardware.

## Checklist

- [x] Commits are signed — SSH-signed; verified with `git cat-file commit <sha> | grep '^gpgsig'`.
- [x] No new flat-key `AppSettings` calls — no settings touched.
- [x] Code is clean-room — nothing decompiled or reverse-engineered.
- [x] All meter UI uses `MeterSmoother` — no meter UI touched.
- [ ] Documentation updated if user-visible behavior changed — **not done, and arguably should be.** The user-visible change is that a control which silently did nothing now says so; that is the M0 pattern #5263 already documents, so nothing in `docs/` describes per-radio Split availability that this contradicts. If a maintainer wants it recorded, say where and I will add it. `CHANGELOG.md` deliberately not touched.
- [x] Security-sensitive changes reference a GHSA if applicable — not security-sensitive.

**On the template's self-assignment step:** `on8st` has pull-only access, so `gh issue edit 5277 --add-assignee on8st` fails with *"on8st does not have the correct permissions to execute `ReplaceActorsForAssignable`"*. Recorded rather than left silently unticked.

**Why `Refs` and not `Fixes`:** this gates the two sites #5277 names, but the issue sits under the #5263 milestone whose item 3 asks for conversion where a family-blind path exists — and one does. This is the M0 stop-gap; a maintainer should decide whether #5277 closes on the gate or stays open for the conversion.

**Base:** rebased onto current `main` at `1457d06d`; clean rebase, no conflicts. Two commits — the gate, plus a comment-only commit recording the disconnect asymmetry, the refused-family set and the shared notice latch that review asked for.

**The rebase invalidates the measurements above, and I am not hiding that behind a tick.** The previous base `8a358c5f` is 50 commits back; the delta touches 468 files and includes `RadioModel.h`, `MainWindow.h`, `SliceModel.h`, `TransmitModel.h`, `RadioCapabilities.h` and `CMakeLists.txt`, and it adds tests, so the 370/370 count cannot be assumed to carry over — the registered total alone will have moved. **This branch has not been built or tested on `1457d06d`.** A rebuild of that size would not have finished inside the bench window available, so it was not started rather than started and abandoned. The gate commit itself is unchanged from the one that was measured, and the follow-up commit adds only comment lines (verified: every added line matches `^\+\s*//`), so no *statement* in the tree differs from what was tested — but that is an argument from inspection, not a run, and CI on the new base is the thing that should settle it.

**On the `maintainer-review` label:** the originating issue carries it ("Requires maintainer review before any action is taken"). This PR is offered as a proposal for that review, not as a way around it — nothing here has been merged or acted on upstream, and if the label means the issue should not have been worked at all, say so and I will close this without argument.

