### PR TITLE
fix(kiwi): derive waterfall start scale from the server's zoom_max

### DIFF
--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -52,7 +52,6 @@ constexpr int kWaterfallAutoMinRows = kWaterfallAutoHistoryRows;
 constexpr float kWaterfallAutoReuseToleranceDb = 5.0f;
 constexpr quint64 kMaxSequenceGapPaddingFrames = 8;
 constexpr int kWaterfallGuiMinIntervalMs = 33;
-constexpr double kWaterfallStartFixedPointScale = 16777216.0; // 2^24
 constexpr quint64 kWebSocketSessionIdBase = 1ULL << 62;
 constexpr const char* kSoundCompressionEnv = "AETHER_KIWI_SND_COMP";
 constexpr const char* kWaterfallCompressionEnv = "AETHER_KIWI_WF_COMP";
@@ -196,29 +195,6 @@ double waterfallZoomScale(int zoom)
 double waterfallRowSpanMhz(double fullBandwidthMhz, int zoom)
 {
     return fullBandwidthMhz / waterfallZoomScale(zoom);
-}
-
-quint32 waterfallStartFixedPoint(double fullLowMhz, double fullBandwidthMhz,
-                                 double rowLowMhz)
-{
-    const double requested = fullBandwidthMhz > 0.0
-        ? ((rowLowMhz - fullLowMhz) / fullBandwidthMhz)
-              * kWaterfallStartFixedPointScale
-        : 0.0;
-    return static_cast<quint32>(std::clamp(
-        std::isfinite(requested) ? std::round(requested) : 0.0,
-        0.0,
-        std::min(kWaterfallStartFixedPointScale - 1.0,
-                 static_cast<double>(std::numeric_limits<quint32>::max()))));
-}
-
-double waterfallStartFixedPointToLowMhz(double fullLowMhz,
-                                        double fullBandwidthMhz,
-                                        quint32 start)
-{
-    return fullLowMhz
-        + (static_cast<double>(start) / kWaterfallStartFixedPointScale)
-            * fullBandwidthMhz;
 }
 
 double waterfallMetadataValueToMhz(double value)
@@ -1478,6 +1454,10 @@ void KiwiSdrClient::sendWaterfallViewToServer()
     const double fullLowMhz = fullCenterMhz - fullBandwidthMhz * 0.5;
     const double fullHighMhz = fullCenterMhz + fullBandwidthMhz * 0.5;
     const int zoomCap = std::clamp(m_waterfallZoomCap, 0, 20);
+    // Server fixed-point scale: 1024 << the zoom_max the server advertised
+    // (KiwiSdrProtocol::waterfallStartFixedPointScale).
+    const double startScale =
+        KiwiSdrProtocol::waterfallStartFixedPointScale(zoomCap);
     const double halfBandwidthMhz = std::max(0.0005, viewBandwidthMhz * 0.5);
     const double viewLowMhz = std::clamp(viewCenterMhz - halfBandwidthMhz,
                                          fullLowMhz,
@@ -1506,10 +1486,11 @@ void KiwiSdrClient::sendWaterfallViewToServer()
             viewMidMhz - candidateRowSpanMhz * 0.5,
             fullLowMhz,
             std::max(fullLowMhz, fullHighMhz - candidateRowSpanMhz));
-        const quint32 candidateStart = waterfallStartFixedPoint(
-            fullLowMhz, fullBandwidthMhz, candidateLowMhz);
-        candidateLowMhz = waterfallStartFixedPointToLowMhz(
-            fullLowMhz, fullBandwidthMhz, candidateStart);
+        const quint32 candidateStart = KiwiSdrProtocol::waterfallStartFixedPoint(
+            fullLowMhz, fullBandwidthMhz, candidateLowMhz, startScale);
+        candidateLowMhz =
+            KiwiSdrProtocol::waterfallStartFixedPointToLowMhz(
+                fullLowMhz, fullBandwidthMhz, candidateStart, startScale);
         const double candidateHighMhz = candidateLowMhz
             + std::min(fullBandwidthMhz,
                        waterfallRowSpanMhz(fullBandwidthMhz, candidate));
@@ -1521,7 +1502,7 @@ void KiwiSdrClient::sendWaterfallViewToServer()
         // requested.
         const double coverEpsilonMhz = std::max(
             1.0e-9,
-            (fullBandwidthMhz / kWaterfallStartFixedPointScale) * 2.0);
+            (fullBandwidthMhz / startScale) * 2.0);
         if (candidateLowMhz <= viewLowMhz + coverEpsilonMhz
             && candidateHighMhz + coverEpsilonMhz >= viewHighMhz) {
             zoom = candidate;
@@ -1534,8 +1515,8 @@ void KiwiSdrClient::sendWaterfallViewToServer()
     }
     if (!selectedRequest) {
         zoom = 0;
-        start = waterfallStartFixedPoint(fullLowMhz, fullBandwidthMhz,
-                                         fullLowMhz);
+        start = KiwiSdrProtocol::waterfallStartFixedPoint(
+            fullLowMhz, fullBandwidthMhz, fullLowMhz, startScale);
         requestLowMhz = fullLowMhz;
         requestHighMhz = fullHighMhz;
     }
@@ -2282,8 +2263,13 @@ void KiwiSdrClient::handleWaterfallFrame(const QByteArray& frame)
             ? m_waterfallServerCenterMhz
             : kDefaultWaterfallCenterMhz;
         const double fullLowMhz = fullCenterMhz - fullBandwidthMhz * 0.5;
-        rowLowMhz = waterfallStartFixedPointToLowMhz(
-            fullLowMhz, fullBandwidthMhz, frameStart);
+        // The frame header start uses the same server fixed-point scale as
+        // the SET zoom/start request: 1024 << the zoom_max the server
+        // advertised (see sendWaterfallViewToServer).
+        const double headerScale =
+            KiwiSdrProtocol::waterfallStartFixedPointScale(m_waterfallZoomCap);
+        rowLowMhz = KiwiSdrProtocol::waterfallStartFixedPointToLowMhz(
+            fullLowMhz, fullBandwidthMhz, frameStart, headerScale);
         rowHighMhz = rowLowMhz
             + std::min(fullBandwidthMhz,
                        waterfallRowSpanMhz(fullBandwidthMhz, frameZoom));

--- a/src/core/KiwiSdrProtocol.cpp
+++ b/src/core/KiwiSdrProtocol.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 namespace AetherSDR::KiwiSdrProtocol {
 namespace {
@@ -848,6 +849,33 @@ QString formatSoundCompressionCommand(bool compressed)
 QString formatWaterfallCompressionCommand(bool compressed)
 {
     return QStringLiteral("SET wf_comp=%1").arg(compressed ? 1 : 0);
+}
+
+double waterfallStartFixedPointScale(int zoomMax)
+{
+    return static_cast<double>(
+        kDefaultWaterfallFftBins << std::clamp(zoomMax, 0, 20));
+}
+
+quint32 waterfallStartFixedPoint(double fullLowMhz, double fullBandwidthMhz,
+                                 double rowLowMhz, double fixedPointScale)
+{
+    const double requested = fullBandwidthMhz > 0.0
+        ? ((rowLowMhz - fullLowMhz) / fullBandwidthMhz) * fixedPointScale
+        : 0.0;
+    return static_cast<quint32>(std::clamp(
+        std::isfinite(requested) ? std::round(requested) : 0.0,
+        0.0,
+        std::min(fixedPointScale - 1.0,
+                 static_cast<double>(std::numeric_limits<quint32>::max()))));
+}
+
+double waterfallStartFixedPointToLowMhz(double fullLowMhz,
+                                        double fullBandwidthMhz,
+                                        quint32 start, double fixedPointScale)
+{
+    return fullLowMhz
+        + (static_cast<double>(start) / fixedPointScale) * fullBandwidthMhz;
 }
 
 FrameObservation classifySoundFrame(const QByteArray& frame)

--- a/src/core/KiwiSdrProtocol.h
+++ b/src/core/KiwiSdrProtocol.h
@@ -339,6 +339,21 @@ MeterReading computeRelativeAudioLevel(const float* samples, int sampleCount);
 MeterReading computeRelativeWaterfallLevel(const QVector<float>& bins);
 QString convertDbmToSUnits(float dbm);
 
+// Waterfall start fixed-point scale, per server: WF_WIDTH(1024) << the
+// server's advertised zoom_max (RaspSDR rx_waterfall.cpp: HZperStart =
+// ui_srate / (WF_WIDTH << MAX_ZOOM)). Not a universal constant — a KiwiSDR
+// (zoom_max=14) uses 2^24, a Web-888 (zoom_max=11) uses 2^21. Starts
+// encoded with the wrong scale are clamped by the server to
+// MAX_START(z) = (WF_WIDTH << zoom_max) - (WF_WIDTH << (zoom_max - z)),
+// pinning the waterfall view at the band edge (band switch showed a black
+// waterfall). zoomMax is clamped to [0, 20].
+double waterfallStartFixedPointScale(int zoomMax);
+quint32 waterfallStartFixedPoint(double fullLowMhz, double fullBandwidthMhz,
+                                 double rowLowMhz, double fixedPointScale);
+double waterfallStartFixedPointToLowMhz(double fullLowMhz,
+                                        double fullBandwidthMhz,
+                                        quint32 start, double fixedPointScale);
+
 } // namespace AetherSDR::KiwiSdrProtocol
 
 Q_DECLARE_METATYPE(AetherSDR::KiwiSdrProtocol::MeterReading)

--- a/tests/kiwi_sdr_waterfall_scale_test.cpp
+++ b/tests/kiwi_sdr_waterfall_scale_test.cpp
@@ -1,11 +1,13 @@
 // Per-server waterfall start fixed-point scale (1024 << zoom_max, not a
 // universal 2^24). Socket-free regression guard for the band-switch
-// waterfall freeze on Kiwi-path servers with zoom_max < 24: starts encoded
+// waterfall freeze on Kiwi-path servers with zoom_max < 14: starts encoded
 // with the wrong scale are clamped by the server to MAX_START, pinning the
 // view at the band edge. Values mirror the live A/B proof on the
 // zoom_max=11 Web-888 at 192.168.0.71:8073 (old-scale start clamped by the
 // server to MAX_START(7)=2080768; per-server-scale start echoed back
-// unclamped). See docs/web888-cleanroom-design.md.
+// unclamped). Protocol source: RaspSDR/server rx/rx_waterfall.cpp,
+// revision 68a64e1b39a3f291762904576f47c9d437fd3509 (MAX_START, HZperStart):
+// https://github.com/RaspSDR/server/blob/68a64e1b39a3f291762904576f47c9d437fd3509/rx/rx_waterfall.cpp
 #include "core/KiwiSdrProtocol.h"
 
 #include <cmath>

--- a/tests/kiwi_sdr_waterfall_scale_test.cpp
+++ b/tests/kiwi_sdr_waterfall_scale_test.cpp
@@ -1,0 +1,100 @@
+// Per-server waterfall start fixed-point scale (1024 << zoom_max, not a
+// universal 2^24). Socket-free regression guard for the band-switch
+// waterfall freeze on Kiwi-path servers with zoom_max < 24: starts encoded
+// with the wrong scale are clamped by the server to MAX_START, pinning the
+// view at the band edge. Values mirror the live A/B proof on the
+// zoom_max=11 Web-888 at 192.168.0.71:8073 (old-scale start clamped by the
+// server to MAX_START(7)=2080768; per-server-scale start echoed back
+// unclamped). See docs/web888-cleanroom-design.md.
+#include "core/KiwiSdrProtocol.h"
+
+#include <cmath>
+#include <cstdio>
+
+namespace {
+
+int fail(const char* message)
+{
+    std::fprintf(stderr, "kiwi_sdr_waterfall_scale_test: %s\n", message);
+    return 1;
+}
+
+bool nearlyEqualMhz(double a, double b, double epsilonMhz = 1.0e-4)
+{
+    return std::fabs(a - b) <= epsilonMhz;
+}
+
+} // namespace
+
+int main()
+{
+    using namespace AetherSDR::KiwiSdrProtocol;
+
+    // The scale is WF_WIDTH << zoom_max: a KiwiSDR (zoom_max=14) uses 2^24
+    // and its behavior must not change; a Web-888 (zoom_max=11) uses 2^21.
+    // Out-of-range zoom_max values clamp to [0, 20].
+    if (waterfallStartFixedPointScale(14) != 16777216.0) {
+        return fail("zoom_max=14 must keep the KiwiSDR 2^24 scale");
+    }
+    if (waterfallStartFixedPointScale(11) != 2097152.0) {
+        return fail("zoom_max=11 must use the 2^21 scale");
+    }
+    if (waterfallStartFixedPointScale(-1) != waterfallStartFixedPointScale(0)
+        || waterfallStartFixedPointScale(25)
+               != waterfallStartFixedPointScale(20)) {
+        return fail("zoom_max must clamp to [0, 20]");
+    }
+
+    // Web-888 scenario, 0-30.72 MHz full band, row starting at 14.104 MHz:
+    // encode/decode round trip with the server's own scale is lossless up
+    // to fixed-point quantization.
+    const double fullLowMhz = 0.0;
+    const double fullBandwidthMhz = 30.72;
+    const double rowLowMhz = 14.104;
+    const double web888Scale = waterfallStartFixedPointScale(11);
+    const quint32 start =
+        waterfallStartFixedPoint(fullLowMhz, fullBandwidthMhz,
+                                 rowLowMhz, web888Scale);
+    if (start != 962833u) {
+        return fail("Web-888 row start did not encode to the expected value");
+    }
+    const double decodedMhz = waterfallStartFixedPointToLowMhz(
+        fullLowMhz, fullBandwidthMhz, start, web888Scale);
+    if (!nearlyEqualMhz(decodedMhz, rowLowMhz)) {
+        return fail("Web-888 scale round trip did not decode the row low");
+    }
+
+    // The freeze scenario: the same row encoded with the old universal 2^24
+    // scale overshoots the zoom_max=11 server's scale, so the server clamps
+    // it to MAX_START(7) = (1024 << 11) - (1024 << (11 - 7)) = 2080768 — the
+    // value the live server was observed clamping to. Decoded at the
+    // server's scale that pins the view at the band edge, not at 14.104 MHz.
+    const double kiwiScale = waterfallStartFixedPointScale(14);
+    const quint32 wrongScaleStart = waterfallStartFixedPoint(
+        fullLowMhz, fullBandwidthMhz, rowLowMhz, kiwiScale);
+    if (wrongScaleStart <= static_cast<quint32>(web888Scale - 1.0)) {
+        return fail("2^24-encoded start should overshoot the 2^21 server scale");
+    }
+    const quint32 maxStart7 = static_cast<quint32>(
+        web888Scale - static_cast<double>(1024 << (11 - 7)));
+    if (maxStart7 != 2080768u) {
+        return fail("MAX_START(7) does not match the live clamp observation");
+    }
+    const double clampedMhz = waterfallStartFixedPointToLowMhz(
+        fullLowMhz, fullBandwidthMhz, maxStart7, web888Scale);
+    if (nearlyEqualMhz(clampedMhz, rowLowMhz, 1.0)) {
+        return fail("clamped start must land at the band edge, not the row low");
+    }
+
+    // KiwiSDR regression: the same round trip at zoom_max=14 is unchanged.
+    const quint32 kiwiStart = waterfallStartFixedPoint(
+        fullLowMhz, fullBandwidthMhz, rowLowMhz, kiwiScale);
+    if (!nearlyEqualMhz(waterfallStartFixedPointToLowMhz(
+            fullLowMhz, fullBandwidthMhz, kiwiStart, kiwiScale),
+            rowLowMhz)) {
+        return fail("KiwiSDR 2^24 scale round trip regressed");
+    }
+
+    std::printf("All tests passed.\n");
+    return 0;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1932,6 +1932,15 @@ target_include_directories(kiwi_sdr_protocol_test PRIVATE src)
 target_link_libraries(kiwi_sdr_protocol_test PRIVATE Qt6::Core)
 add_test(NAME kiwi_sdr_protocol_test COMMAND kiwi_sdr_protocol_test)
 
+add_executable(kiwi_sdr_waterfall_scale_test
+    tests/kiwi_sdr_waterfall_scale_test.cpp
+    src/core/KiwiSdrProtocol.cpp
+)
+target_include_directories(kiwi_sdr_waterfall_scale_test PRIVATE src)
+target_link_libraries(kiwi_sdr_waterfall_scale_test PRIVATE Qt6::Core)
+add_test(NAME kiwi_sdr_waterfall_scale_test
+         COMMAND kiwi_sdr_waterfall_scale_test)
+
 add_executable(kiwi_sdr_manager_password_test
     tests/kiwi_sdr_manager_password_test.cpp
 )


### PR DESCRIPTION
Fixes #5536
Related to #5528. The Web-888 receiver-family changes are in stacked PR #5530.

## What and why

Waterfall SET zoom/start offsets use a per-server fixed-point scale: WF_WIDTH (1024) << zoom_max. The old universal 2^24 scale is correct for the default zoom_max=14, but on a server advertising zoom_max=11 it encodes starts eight times too large. Requests can be clamped to the band edge, producing the misplaced or black/frozen waterfall reported during band switches.

This change derives the scale from the already-parsed zoom_max/zoom_cap, retaining the existing default of 14. Request encoding, quantization tolerance, and W/F frame-header decoding all use the same scale. The conversion helpers move to KiwiSdrProtocol so they can be tested without sockets.

Protocol source: [RaspSDR rx_waterfall.cpp at 68a64e1](https://github.com/RaspSDR/server/blob/68a64e1b39a3f291762904576f47c9d437fd3509/rx/rx_waterfall.cpp), specifically MAX_START and HZperStart.

## Startup ordering

The initial request can precede inbound zoom_max metadata and therefore use the default scale. The existing zoom_cap/zoom_max handler updates the stored cap, invalidates the cached request, and calls sendWaterfallViewToServer again. When the waterfall socket is connected, that request uses the corrected scale. A later metadata message follows the same path.

The author reports a Web-888 advertising zoom_max=11 and live A/B observations where the old-scale request was clamped to MAX_START(7)=2080768 while the corrected request was echoed unclamped. These are author-reported hardware observations; the independent review did not connect to that receiver. Family-specific burst handling belongs to #5530, not this PR.

## Scope

Only scale conversion, its existing client call sites, and socket-free regression coverage change. No UI, settings, receiver-family selection, new wire commands, or external dependencies are added.

## Validation

- New registered socket-free kiwi_sdr_waterfall_scale_test covers the 2^24 and 2^21 scales, cap bounds, an encode/decode round trip, and the reported clamp arithmetic.
- Independent ARM64 review of the merge with main 868428330 passed kiwi_sdr_waterfall_scale_test and kiwi_sdr_protocol_test.
- Mutation check: restoring the universal 2^24 scale made the new test fail; restoring the implementation returned both tests to green.
- The full Mac app built successfully. The isolated offscreen startup check did not expose its automation socket, so no GUI or hardware convergence proof is claimed.
- Client resend ordering was inspected, but is not covered by the arithmetic test. A future client-level regression should use socket-free transport/state injection, not a synthetic firmware peer.
- The new test runs in the unfiltered main/full-suite and sanitizer lanes; it does not join the frozen per-PR test allow-list.
