### PR TITLE
fix(gui): share one chart timeframe across the Runtime Monitor tabs (#5496)

### DIFF
--- a/src/gui/SystemInfoDialog.cpp
+++ b/src/gui/SystemInfoDialog.cpp
@@ -15,6 +15,7 @@
 #include <QPlainTextEdit>
 #include <QPushButton>
 #include <QSignalBlocker>
+#include <QSizePolicy>
 #include <QLocale>
 #include <QRegularExpression>
 #include <QStyledItemDelegate>
@@ -228,8 +229,8 @@ SystemInfoDialog::SystemInfoDialog(MemoryHistoryRing* history, CpuHistoryRing* c
     auto* header = new QHBoxLayout;
     header->addStretch(1);
     m_rangeLabel = new QLabel(QStringLiteral("Timeframe"), bodyWidget());
-    m_rangeLabel->setAccessibleName(QStringLiteral("Chart timeframe"));
     m_range = new QComboBox(bodyWidget());
+    m_rangeLabel->setBuddy(m_range);
     m_range->setObjectName(QStringLiteral("systemInfoTimeframe"));
     m_range->setAccessibleName(QStringLiteral("Chart timeframe"));
     m_range->setAccessibleDescription(
@@ -726,6 +727,10 @@ void SystemInfoDialog::refreshMemoryChart()
     // reached the history cannot look as though it did.
     const MemoryHistoryRing::Record* latest = m_memoryRing->latest();
     if (latest == nullptr) {
+        // The shared selector also applies before the first sample arrives.
+        if (m_memoryGraph != nullptr) {
+            m_memoryGraph->setSeries({}, selectedRangeSeconds());
+        }
         return;
     }
     if (m_memorySummary != nullptr) {

--- a/src/gui/SystemInfoDialog.cpp
+++ b/src/gui/SystemInfoDialog.cpp
@@ -218,12 +218,58 @@ SystemInfoDialog::SystemInfoDialog(MemoryHistoryRing* history, CpuHistoryRing* c
         m_tickLagMeter = tickLagMeter;
     }
     auto* layout = new QVBoxLayout(bodyWidget());
+
+    // One timeframe for every chart in the dialog, in the window header where
+    // the network dialog keeps its own (#5496). Two per-tab selectors with the
+    // same four choices could disagree: a range chosen on Overview was not
+    // the range Memory then showed. Hidden while a tab with no chart is
+    // current — Threads has a fixed 60 s window and Logs has no time axis —
+    // which is how the network dialog handles its Logs and TCI pages.
+    auto* header = new QHBoxLayout;
+    header->addStretch(1);
+    m_rangeLabel = new QLabel(QStringLiteral("Timeframe"), bodyWidget());
+    m_rangeLabel->setAccessibleName(QStringLiteral("Chart timeframe"));
+    m_range = new QComboBox(bodyWidget());
+    m_range->setObjectName(QStringLiteral("systemInfoTimeframe"));
+    m_range->setAccessibleName(QStringLiteral("Chart timeframe"));
+    m_range->setAccessibleDescription(
+        QStringLiteral("Choose how much recent history the charts display."));
+    m_range->setFixedWidth(132);
+    // The issue's four (#2554); the rings hold an hour raw, so nothing longer
+    // is offered.
+    m_range->addItem(QStringLiteral("1 minute"), 60);
+    m_range->addItem(QStringLiteral("5 minutes"), 5 * 60);
+    m_range->addItem(QStringLiteral("15 minutes"), 15 * 60);
+    m_range->addItem(QStringLiteral("1 hour"), 60 * 60);
+    m_range->setCurrentIndex(1);   // 5 minutes: 200 points at 1.5 s
+    // Both refreshes, not only the current tab's: switching tabs must never
+    // show a chart still drawn to the previous range.
+    connect(m_range, &QComboBox::currentIndexChanged, this,
+            &SystemInfoDialog::refreshMemoryChart);
+    connect(m_range, &QComboBox::currentIndexChanged, this,
+            &SystemInfoDialog::refreshOverview);
+    header->addWidget(m_rangeLabel);
+    header->addWidget(m_range);
+    layout->addLayout(header);
+
     auto* tabs = new QTabWidget(bodyWidget());
     // The issue's order: Overview / Threads / Memory / (Painters) / Logs.
     tabs->addTab(buildOverviewTab(), QStringLiteral("Overview"));
-    tabs->addTab(buildThreadsTab(), QStringLiteral("Threads"));
+    QWidget* threadsTab = buildThreadsTab();
+    tabs->addTab(threadsTab, QStringLiteral("Threads"));
     tabs->addTab(buildMemoryTab(), QStringLiteral("Memory"));
-    tabs->addTab(buildLogsTab(), QStringLiteral("Logs"));
+    QWidget* logsTab = buildLogsTab();
+    tabs->addTab(logsTab, QStringLiteral("Logs"));
+    // By page, not by index: the order has changed once already (#5427 put
+    // Overview first) and the rule is about which pages draw a chart.
+    const auto showTimeframeForPage = [this, tabs, threadsTab, logsTab](int) {
+        QWidget* page = tabs->currentWidget();
+        const bool showTimeframe = page != threadsTab && page != logsTab;
+        m_rangeLabel->setVisible(showTimeframe);
+        m_range->setVisible(showTimeframe);
+    };
+    connect(tabs, &QTabWidget::currentChanged, this, showTimeframeForPage);
+    showTimeframeForPage(tabs->currentIndex());
     layout->addWidget(tabs);
 
     auto* buttonRow = new QHBoxLayout;
@@ -567,36 +613,14 @@ QWidget* SystemInfoDialog::buildMemoryTab()
     auto* page = new QWidget;
     auto* layout = new QVBoxLayout(page);
 
-    // Header row: what is being measured, and — top-right, where the network
-    // dialog keeps its own — how much history the chart shows. The selector
-    // lives on this tab rather than the window because Threads has a fixed
-    // 60 s window and Logs has none; the network dialog reaches the same
-    // outcome by hiding its combo on those pages.
+    // Header row: what is being measured. How much history the chart shows
+    // is the window's timeframe above the tabs, shared with Overview (#5496).
     auto* header = new QHBoxLayout;
     m_memorySummary = new QLabel(QStringLiteral("Sampling…"), page);
     m_memorySummary->setObjectName(QStringLiteral("systemInfoMemorySummary"));
     m_memorySummary->setAccessibleName(QStringLiteral("Process memory summary"));
     header->addWidget(m_memorySummary);
     header->addStretch(1);
-    auto* rangeLabel = new QLabel(QStringLiteral("Timeframe"), page);
-    rangeLabel->setAccessibleName(QStringLiteral("Chart timeframe"));
-    m_memoryRange = new QComboBox(page);
-    m_memoryRange->setObjectName(QStringLiteral("systemInfoTimeframe"));
-    m_memoryRange->setAccessibleName(QStringLiteral("Chart timeframe"));
-    m_memoryRange->setAccessibleDescription(
-        QStringLiteral("Choose how much recent memory history the chart displays."));
-    m_memoryRange->setFixedWidth(132);
-    // The issue's four; the ring holds an hour raw, so nothing longer is offered
-    // until the compacting history arrives with the Overview tab.
-    m_memoryRange->addItem(QStringLiteral("1 minute"), 60);
-    m_memoryRange->addItem(QStringLiteral("5 minutes"), 5 * 60);
-    m_memoryRange->addItem(QStringLiteral("15 minutes"), 15 * 60);
-    m_memoryRange->addItem(QStringLiteral("1 hour"), 60 * 60);
-    m_memoryRange->setCurrentIndex(1);   // 5 minutes: 200 points at 1.5 s
-    connect(m_memoryRange, &QComboBox::currentIndexChanged, this,
-            &SystemInfoDialog::refreshMemoryChart);
-    header->addWidget(rangeLabel);
-    header->addWidget(m_memoryRange);
     layout->addLayout(header);
 
     // Readouts: the numbers, not only the line. Virtual is a readout only —
@@ -665,12 +689,12 @@ QWidget* SystemInfoDialog::buildMemoryTab()
     return page;
 }
 
-int SystemInfoDialog::selectedMemoryRangeSeconds() const
+int SystemInfoDialog::selectedRangeSeconds() const
 {
-    if (m_memoryRange == nullptr) {
+    if (m_range == nullptr) {
         return 5 * 60;
     }
-    return m_memoryRange->currentData().toInt();
+    return m_range->currentData().toInt();
 }
 
 void SystemInfoDialog::applyMemorySample(const MemorySample& sample)
@@ -732,7 +756,7 @@ void SystemInfoDialog::refreshMemoryChart()
     if (m_memoryGraph == nullptr) {
         return;
     }
-    const int rangeSeconds = selectedMemoryRangeSeconds();
+    const int rangeSeconds = selectedRangeSeconds();
     // The window ends at the newest sample, not at the wall clock: a dialog
     // whose sampling is paused shows the history it has, in place, instead of
     // sliding it off the left edge while nothing new arrives.
@@ -763,28 +787,7 @@ QWidget* SystemInfoDialog::buildOverviewTab()
     auto* page = new QWidget;
     auto* layout = new QVBoxLayout(page);
 
-    // Timeframe top-right, as on the Memory tab and in the network dialog;
-    // per tab rather than per window for the reason the Memory tab gives.
-    auto* header = new QHBoxLayout;
-    header->addStretch(1);
-    auto* rangeLabel = new QLabel(QStringLiteral("Timeframe"), page);
-    rangeLabel->setAccessibleName(QStringLiteral("Chart timeframe"));
-    m_overviewRange = new QComboBox(page);
-    m_overviewRange->setObjectName(QStringLiteral("systemInfoOverviewTimeframe"));
-    m_overviewRange->setAccessibleName(QStringLiteral("Chart timeframe"));
-    m_overviewRange->setAccessibleDescription(
-        QStringLiteral("Choose how much recent history the Overview charts display."));
-    m_overviewRange->setFixedWidth(132);
-    m_overviewRange->addItem(QStringLiteral("1 minute"), 60);
-    m_overviewRange->addItem(QStringLiteral("5 minutes"), 5 * 60);
-    m_overviewRange->addItem(QStringLiteral("15 minutes"), 15 * 60);
-    m_overviewRange->addItem(QStringLiteral("1 hour"), 60 * 60);
-    m_overviewRange->setCurrentIndex(1);
-    connect(m_overviewRange, &QComboBox::currentIndexChanged, this,
-            &SystemInfoDialog::refreshOverview);
-    header->addWidget(rangeLabel);
-    header->addWidget(m_overviewRange);
-    layout->addLayout(header);
+    // The charts' timeframe is the window's, above the tabs (#5496).
 
     // Four cards across, the network dialog's row.
     auto* cards = new QHBoxLayout;
@@ -893,14 +896,6 @@ QWidget* SystemInfoDialog::buildOverviewTab()
     return scroll;
 }
 
-int SystemInfoDialog::selectedOverviewRangeSeconds() const
-{
-    if (m_overviewRange == nullptr) {
-        return 5 * 60;
-    }
-    return m_overviewRange->currentData().toInt();
-}
-
 void SystemInfoDialog::setCardLevel(QLabel* value, SystemInfo::CardLevel level)
 {
     if (value == nullptr) {
@@ -960,7 +955,7 @@ void SystemInfoDialog::refreshOverview()
 {
     const CpuHistoryRing::Record* cpu = m_cpuRing->latest();
     const MemoryHistoryRing::Record* mem = m_memoryRing->latest();
-    const int rangeSeconds = selectedOverviewRangeSeconds();
+    const int rangeSeconds = selectedRangeSeconds();
     const double gapSeconds = CpuHistoryRing::connectGapSecondsFor(rangeSeconds);
     ThemeManager& theme = ThemeManager::instance();
 

--- a/src/gui/SystemInfoDialog.cpp
+++ b/src/gui/SystemInfoDialog.cpp
@@ -242,6 +242,13 @@ SystemInfoDialog::SystemInfoDialog(MemoryHistoryRing* history, CpuHistoryRing* c
     m_range->addItem(QStringLiteral("15 minutes"), 15 * 60);
     m_range->addItem(QStringLiteral("1 hour"), 60 * 60);
     m_range->setCurrentIndex(1);   // 5 minutes: 200 points at 1.5 s
+    // Hidden, not removed: the row keeps its height while Threads or Logs is
+    // current, so the tab strip does not jump under the pointer.
+    for (QWidget* w : {static_cast<QWidget*>(m_rangeLabel), static_cast<QWidget*>(m_range)}) {
+        QSizePolicy policy = w->sizePolicy();
+        policy.setRetainSizeWhenHidden(true);
+        w->setSizePolicy(policy);
+    }
     // Both refreshes, not only the current tab's: switching tabs must never
     // show a chart still drawn to the previous range.
     connect(m_range, &QComboBox::currentIndexChanged, this,

--- a/src/gui/SystemInfoDialog.h
+++ b/src/gui/SystemInfoDialog.h
@@ -99,9 +99,9 @@ private:
 
     void applyAlertStyle();
     void refreshMemoryChart();
-    int  selectedMemoryRangeSeconds() const;
     void refreshOverview();
-    int  selectedOverviewRangeSeconds() const;
+    // The window-level timeframe both refreshes draw to (#5496).
+    int  selectedRangeSeconds() const;
     // Colour a card's value for its band and expose the band as the label's
     // "level" property ("normal" / "warning" / "danger") for tests and the
     // automation bridge, which read properties and not stylesheets.
@@ -160,7 +160,8 @@ private:
     CpuHistoryRing*       m_cpuRing{&m_ownCpuRing};
     UiTickLagMeter        m_ownTickLagMeter;
     UiTickLagMeter*       m_tickLagMeter{&m_ownTickLagMeter};
-    QComboBox*            m_overviewRange{nullptr};
+    QLabel*               m_rangeLabel{nullptr};
+    QComboBox*            m_range{nullptr};
     QLabel*               m_cardCpuValue{nullptr};
     QLabel*               m_cardMaxThreadValue{nullptr};
     QLabel*               m_cardMaxThreadCaption{nullptr};
@@ -171,7 +172,6 @@ private:
     TimeSeriesGraphWidget* m_overviewThreadsGraph{nullptr};
     TimeSeriesGraphWidget* m_overviewTickGraph{nullptr};
     TimeSeriesGraphWidget* m_memoryGraph{nullptr};
-    QComboBox*            m_memoryRange{nullptr};
     QLabel*               m_memorySummary{nullptr};
     QLabel*               m_memoryResident{nullptr};
     QLabel*               m_memoryPeak{nullptr};

--- a/tests/system_info_dialog_test.cpp
+++ b/tests/system_info_dialog_test.cpp
@@ -492,42 +492,13 @@ int main(int argc, char** argv)
         qRegisterMetaType<AetherSDR::MemorySample>("AetherSDR::MemorySample");
         SystemInfoDialog memoryDialog;
 
-        // One timeframe for the whole dialog, in the window header (#5496):
-        // the Memory and Overview charts read the same control, so no tab
-        // carries a selector of its own.
+        // The selector is the dialog's, in the window header (#5496); the
+        // lookup on the dialog finds it there as it did on the Memory tab.
         auto* range = memoryDialog.findChild<QComboBox*>(QStringLiteral("systemInfoTimeframe"));
         report("the dialog has a timeframe selector", range != nullptr);
-        report("it is the only combo box in the dialog",
-               memoryDialog.findChildren<QComboBox*>().size() == 1);
         if (range != nullptr) {
             report("it offers the issue's four timeframes", range->count() == 4);
             report("it defaults to 5 minutes", range->currentData().toInt() == 5 * 60);
-            report("it is a child of the dialog body, not of a tab page",
-                   range->parentWidget() != nullptr
-                       && range->parentWidget()->findChild<QTabWidget*>() != nullptr);
-        }
-        // Hidden where there is no chart to draw: Threads has a fixed 60 s
-        // window and Logs has no time axis. Shown again on Overview and Memory.
-        auto* memoryTabs = memoryDialog.findChild<QTabWidget*>();
-        if (range != nullptr && memoryTabs != nullptr) {
-            const auto currentTabIs = [memoryTabs](const char* title) {
-                for (int i = 0; i < memoryTabs->count(); ++i) {
-                    if (memoryTabs->tabText(i) == QLatin1String(title)) {
-                        memoryTabs->setCurrentIndex(i);
-                        return true;
-                    }
-                }
-                return false;
-            };
-            report("the selector is shown while Overview is current",
-                   currentTabIs("Overview") && !range->isHidden());
-            report("the selector is hidden while Threads is current",
-                   currentTabIs("Threads") && range->isHidden());
-            report("the selector is shown while Memory is current",
-                   currentTabIs("Memory") && !range->isHidden());
-            report("the selector is hidden while Logs is current",
-                   currentTabIs("Logs") && range->isHidden());
-            currentTabIs("Memory");
         }
 
         auto* resident = memoryDialog.findChild<QLabel*>(QStringLiteral("systemInfoMemoryResident"));

--- a/tests/system_info_dialog_test.cpp
+++ b/tests/system_info_dialog_test.cpp
@@ -16,6 +16,7 @@
 #include "core/ThemeManager.h"
 #include "gui/SparklineDelegate.h"
 #include "gui/SystemInfoDialog.h"
+#include "gui/TimeSeriesGraphWidget.h"
 
 #include <QApplication>
 #include <QCheckBox>
@@ -483,6 +484,85 @@ int main(int argc, char** argv)
         tailing.hide();
         QCoreApplication::processEvents();
         LogManager::instance().shutdownLogging();
+    }
+
+    // One selector must update every chart, including a non-current page and
+    // an empty history. Compare the painted range captions with a reference
+    // chart; this exercises the production slots without exposing private data.
+    {
+        SystemInfoDialog shared;
+        auto* range = shared.findChild<QComboBox*>(QStringLiteral("systemInfoTimeframe"));
+        auto* tabs = shared.findChild<QTabWidget*>();
+        report("one shared timeframe exists outside the tab pages",
+               range != nullptr && tabs != nullptr
+                   && shared.findChildren<QComboBox*>().size() == 1
+                   && !tabs->isAncestorOf(range));
+        if (range != nullptr && tabs != nullptr) {
+            QLabel* rangeLabel = nullptr;
+            for (QLabel* label : shared.findChildren<QLabel*>()) {
+                if (label->buddy() == range) {
+                    rangeLabel = label;
+                }
+            }
+            report("the timeframe label is associated with its control", rangeLabel != nullptr);
+            const auto caption = [](QWidget* graph) {
+                const QPixmap pixels = graph->grab();
+                const qreal scale = pixels.devicePixelRatio();
+                return pixels.toImage().copy(pixels.width() - qRound(180 * scale),
+                                             qRound(6 * scale), qRound(166 * scale), qRound(18 * scale))
+                    .convertToFormat(QImage::Format_RGB32);
+            };
+            const char* graphNames[] = {
+                "systemInfoMemoryGraph", "systemInfoOverviewCpuGraph",
+                "systemInfoOverviewMemoryGraph", "systemInfoOverviewThreadsGraph",
+                "systemInfoOverviewTickGraph"};
+            const auto checkCharts = [&] {
+                for (const char* name : graphNames) {
+                    QWidget* graph = shared.findChild<QWidget*>(QLatin1String(name));
+                    report("shared chart exists", graph != nullptr);
+                    if (graph != nullptr) {
+                        const QImage actual = caption(graph);
+                        TimeSeriesGraphWidget reference{QString(), QString()};
+                        reference.setFont(graph->font());
+                        reference.resize(graph->size());
+                        reference.setSeries({}, range->currentData().toInt());
+                        report(name, actual == caption(&reference));
+                    }
+                }
+            };
+            range->setCurrentIndex(3);
+            checkCharts();  // no collector or sample has run yet
+            MemorySample sample;
+            sample.wallMs = 1'700'000'000'000LL;
+            sample.valid = true;
+            sample.residentBytes = 200ull * 1024 * 1024;
+            report("shared chart receives a memory sample",
+                   QMetaObject::invokeMethod(&shared, "applyMemorySample", Qt::DirectConnection,
+                                            Q_ARG(AetherSDR::MemorySample, sample)));
+            for (int index : {0, 2, 1, 3}) {
+                range->setCurrentIndex(index);
+                checkCharts();
+            }
+
+            shared.show();
+            QCoreApplication::processEvents();
+            const int tabY = tabs->y();
+            for (int index = 0; index < tabs->count(); ++index) {
+                tabs->setCurrentIndex(index);
+                QCoreApplication::processEvents();
+                const QString title = tabs->tabText(index);
+                const bool charted = title == QLatin1String("Overview") || title == QLatin1String("Memory");
+                report("timeframe visibility follows the charted page", range->isVisible() == charted);
+                report("timeframe label visibility follows its control",
+                       rangeLabel != nullptr && rangeLabel->isVisible() == charted);
+                report("hiding the timeframe does not move the tab strip", tabs->y() == tabY);
+                if (charted) {
+                    range->setCurrentIndex(index == 0 ? 0 : 3);
+                    checkCharts();
+                }
+            }
+            shared.hide();
+        }
     }
 
     // ── Memory tab (#2554 acceptance criterion 4) ──────────────────────────

--- a/tests/system_info_dialog_test.cpp
+++ b/tests/system_info_dialog_test.cpp
@@ -492,11 +492,42 @@ int main(int argc, char** argv)
         qRegisterMetaType<AetherSDR::MemorySample>("AetherSDR::MemorySample");
         SystemInfoDialog memoryDialog;
 
+        // One timeframe for the whole dialog, in the window header (#5496):
+        // the Memory and Overview charts read the same control, so no tab
+        // carries a selector of its own.
         auto* range = memoryDialog.findChild<QComboBox*>(QStringLiteral("systemInfoTimeframe"));
-        report("the Memory tab has a timeframe selector", range != nullptr);
+        report("the dialog has a timeframe selector", range != nullptr);
+        report("it is the only combo box in the dialog",
+               memoryDialog.findChildren<QComboBox*>().size() == 1);
         if (range != nullptr) {
             report("it offers the issue's four timeframes", range->count() == 4);
             report("it defaults to 5 minutes", range->currentData().toInt() == 5 * 60);
+            report("it is a child of the dialog body, not of a tab page",
+                   range->parentWidget() != nullptr
+                       && range->parentWidget()->findChild<QTabWidget*>() != nullptr);
+        }
+        // Hidden where there is no chart to draw: Threads has a fixed 60 s
+        // window and Logs has no time axis. Shown again on Overview and Memory.
+        auto* memoryTabs = memoryDialog.findChild<QTabWidget*>();
+        if (range != nullptr && memoryTabs != nullptr) {
+            const auto currentTabIs = [memoryTabs](const char* title) {
+                for (int i = 0; i < memoryTabs->count(); ++i) {
+                    if (memoryTabs->tabText(i) == QLatin1String(title)) {
+                        memoryTabs->setCurrentIndex(i);
+                        return true;
+                    }
+                }
+                return false;
+            };
+            report("the selector is shown while Overview is current",
+                   currentTabIs("Overview") && !range->isHidden());
+            report("the selector is hidden while Threads is current",
+                   currentTabIs("Threads") && range->isHidden());
+            report("the selector is shown while Memory is current",
+                   currentTabIs("Memory") && !range->isHidden());
+            report("the selector is hidden while Logs is current",
+                   currentTabIs("Logs") && range->isHidden());
+            currentTabIs("Memory");
         }
 
         auto* resident = memoryDialog.findChild<QLabel*>(QStringLiteral("systemInfoMemoryResident"));
@@ -659,8 +690,8 @@ int main(int argc, char** argv)
     {
         qRegisterMetaType<AetherSDR::CpuSample>("AetherSDR::CpuSample");
         SystemInfoDialog ov;
-        auto* range = ov.findChild<QComboBox*>(QStringLiteral("systemInfoOverviewTimeframe"));
-        report("the Overview tab has its own timeframe selector", range != nullptr && range->count() == 4);
+        report("the Overview tab has no timeframe selector of its own (#5496)",
+               ov.findChild<QComboBox*>(QStringLiteral("systemInfoOverviewTimeframe")) == nullptr);
         auto* cpuCard = ov.findChild<QLabel*>(QStringLiteral("systemInfoCardCpu"));
         auto* maxCard = ov.findChild<QLabel*>(QStringLiteral("systemInfoCardMaxThread"));
         auto* memCard = ov.findChild<QLabel*>(QStringLiteral("systemInfoCardMemory"));


### PR DESCRIPTION
## Summary

Fixes #5496. Runtime Monitor now has one chart timeframe selector in the dialog header. Changing it updates the Memory chart and all four Overview charts, including charts on a non-current tab. The selector and its label hide on Threads and Logs while retaining the row height, so the tab strip stays in place.

This implements the maintainer's follow-up ruling in #5427. The four ranges, five-minute default, bucket rules, and lack of timeframe persistence are unchanged. The combo retains `systemInfoTimeframe` and the accessible name “Chart timeframe”; `systemInfoOverviewTimeframe` is removed.

The review follow-up also makes an empty Memory chart adopt the selected range before its first sample arrives. The static label uses a buddy association with the combo instead of repeating its explicit accessible name.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The existing socket-free dialog test exercises the production refresh connections and compares the rendered range captions of all five charts, without adding a public getter. It covers empty/populated history, all four ranges, non-current charts, selector/label visibility, and stable tab geometry.

## Validation

- Native macOS arm64, Qt 6.11.1, RelWithDebInfo build and `system_info_dialog_test` pass.
- The new test fails on the original PR's empty-history Memory caption; it passes with the fix.
- Mutation checks: disconnect Memory refresh → 5 failures; disconnect Overview refresh → 20 failures; force the selector visible on every tab → 4 failures. All mutations were restored, then focused CTest passed.
- Automation bridge, isolated settings, explicit owned socket, `DEMO-0001` only, `AETHER_AUTOMATION_NO_TX=1`: reproduced the original separate-selector mismatch using the merge-base sources, then verified shared ranges, both hidden tabs, stable tab-strip position, constrained window size, close/reopen defaults, and disconnect behavior. Every owned instance was stopped afterward.
- Test registration, frozen per-PR test gate, accessibility lint for the touched dialog, and `git diff --check` pass. No test target or CI gate was added; the existing target runs in the full-suite and sanitizer workflows. No socket-owning test or synthetic firmware peer was added.

The local build disables optional ASR, RADE, DFNR, specbleach, MQTT, and D-STAR; RTL-SDR is unavailable locally. Those features are outside this UI change. Linux/Windows runtime, VoiceOver speech, live radios, and sanitizer execution were not tested locally. Per-PR CI supplies the platform build checks, not full-suite or hardware evidence.

Original contributor evidence: [initial demo captures](https://github.com/user-attachments/files/32016658/aethersdr-pr5531-shared-timeframe-2026-09-09.zip), [retained-row captures](https://github.com/user-attachments/files/32017857/aethersdr-pr5531-retain-row-2026-09-09.zip).

Original implementation by @skerker; review fixes and verification by @Ozy311.

GPT-6 Astra-High
