### PR TITLE
Add clock-aligned waterfall time markers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1068,6 +1068,7 @@ set(GUI_SOURCES
     src/gui/PanadapterMessageOverlay.h
     src/gui/PanadapterRenderScheduler.cpp
     src/gui/SpectrumWidget.cpp
+    src/gui/SpectrumWidget_TimeMarkers.cpp
     src/gui/WaterfallHistoryBuffer.cpp
     src/gui/SpectrumOverlayMenu.cpp
     src/gui/SpectrumOverlayWheelGuard.cpp

--- a/docs/architecture/aetherd-touchpoints.md
+++ b/docs/architecture/aetherd-touchpoints.md
@@ -142,7 +142,7 @@ Burndown manifest for the engine/UI decoupling ([RFC](../aetherd-headless-engine
 | `core/SystemInventory.h` | 1 | ui-support — Startup and support-bundle inventory of host CPU, SIMD and RAM capabilities. Process diagnostics, not radio state. | unconverted |
 | `core/TciServer.h` | 3 | mixed(flex) — TCI WebSocket server for WSJT-X et al: protocol surface is canonical radio state, but audio/IQ rides Flex DAX | unconverted |
 | `core/TgxlConnection.h` | 2 | peripheral(4o3a) — Direct TCP client for the 4O3A Tuner Genius XL (port 9010, relay/autotune), reverse-engineered from the 4O3A management app — a standalone accessory transport, not SmartSDR. Not radio-family wire; a peripheral accessory, NOT behind the IRadioBackend radio seam (reclassified from vendor(flex), #4087 follow-up). | unconverted |
-| `core/ThemeManager.h` | 146 | ui-support — Qt token-based theming singleton (colors/fonts/QSS, theme files, editor hooks) — pure client GUI plumbing, no radio state. | unconverted |
+| `core/ThemeManager.h` | 147 | ui-support — Qt token-based theming singleton (colors/fonts/QSS, theme files, editor hooks) — pure client GUI plumbing, no radio state. | unconverted |
 | `core/ThreadCpuRing.h` | 2 | ui-support — Short host-thread CPU history used by Runtime Monitor peak and sparkline presentation. Diagnostic UI support, not radio state. | unconverted |
 | `core/TimeFrameVoter.h` | 1 | universal — Shared AetherClock time-frame types plus confidence-weighted cross-frame bit voting over a sliding window. Map-agnostic pure DSP/logic — no Qt, no GUI, no vendor ties. | unconverted |
 | `core/TxKeyingMarker.h` | 6 | ui-support — QWidget property marker guarding TX-keying controls from the automation bridge; GUI-shell plumbing, no radio state. | unconverted |

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -3315,7 +3315,7 @@ Actions:
 
 | action | value | effect |
 |---|---|---|
-| `snapshot` | optional pan target | Read `live`, current center/bandwidth MHz, waterfall/DSS history row counts, visible DSS row count, the current front-row peak bin/min/max/span, localized plateau metrics (`dssVisibleFrontMinValueBins`, `dssVisibleFrontLongestFlatRunBins`, and visible maxima), and flat/non-flat visible-row counts. |
+| `snapshot` | optional pan target | Read `live`, current center/bandwidth MHz, waterfall/DSS history row counts, visible DSS row count, the current front-row peak bin/min/max/span, localized plateau metrics (`dssVisibleFrontMinValueBins`, `dssVisibleFrontLongestFlatRunBins`, and visible maxima), flat/non-flat visible-row counts, and the waterfall time-marker state (`waterfallTimeMarkerSeconds`, `waterfallTimeMarkers`). |
 | `reset` | `native` or `kiwi` | Clear the selected stream's current/history rows and make that stream active for subsequent injection. |
 | `inject` | `<count> <firstPeakBin> <stepBin> [native\|kiwi [rowLowMhz rowHighMhz]]` | Add synthetic rows with one strong peak per row. `count` is rejected if it exceeds the retained waterfall history capacity. Native injection adds one fallback-style waterfall/DSS row per input row; Kiwi injection drives `updateKiwiSdrWaterfallRow()`. Kiwi frame arguments override the source row's frequency span, so tests can cover partial-overlap rows. |
 | `scrollback` | `<offsetRows>` | Enter waterfall history mode and rebuild the 3D surface using the same offset. |
@@ -3328,6 +3328,32 @@ on the same paused historical row, then set `scrollback 0` and confirm the newly
 injected peak becomes visible. The total row counts are still returned, but the
 `*RowsAdded` fields are the deterministic assertion surface if live data is also
 arriving between bridge requests.
+
+### Waterfall time markers
+
+`dss snapshot` reports the clock-aligned waterfall time markers (#5537):
+
+| field | meaning |
+|---|---|
+| `waterfallTimeMarkerSeconds` | Selected interval for this pan slot, in seconds. `0` means Off (the default). Only `0`, `15`, `30`, `60`, `300`, `600` and `900` are valid; anything else fails closed to `0`. |
+| `waterfallTimeMarkers` | Markers currently inside the waterfall viewport, newest first. Each entry is `{"timestampMs", "y"}`: `timestampMs` is the **clock boundary** the marker labels (always an exact multiple of the interval, never the packet arrival time), and `y` is its offset in pixels from the top of the waterfall rect. |
+
+The interval is set from the panadapter context menu (**Waterfall Time
+Markers**) and persists per pan slot in the `Display` settings document. It is
+not settable over the bridge; seed `DisplaySettings` or use the menu.
+
+Markers are attached to the signal row that was captured when the boundary was
+crossed, so they scroll with the waterfall rather than with wall-clock time.
+Two useful assertions:
+
+- Every `timestampMs` is divisible by `waterfallTimeMarkerSeconds * 1000`.
+- A marker's `y` advances at `1000 / waterfallTimeScaleMsPerRow` pixels per
+  second while live, and holds still under `dss scrollback`.
+
+An empty array is normal: a screenful of waterfall is only
+`waterfallRows * waterfallTimeScaleMsPerRow` milliseconds deep (typically
+11-19 s), so intervals longer than that window have no marker on screen most
+of the time.
 
 To reproduce a low-coverage Kiwi row, read `centerMhz` and `bandwidthMhz` from
 `dss snapshot`, then inject a Kiwi source row whose span overlaps less than 5%

--- a/docs/theming/canonical-tokens.md
+++ b/docs/theming/canonical-tokens.md
@@ -206,3 +206,12 @@ PSK Reporter dark-map luminance ramp. Both bundled themes use the same dark
 cartographic palette; selecting the light app theme does not turn an explicitly
 enabled dark map light. These tokens affect only basemap images, not data
 overlays, attribution, or window chrome.
+
+### Waterfall time markers
+
+`color.waterfall.timeMarker.foreground` is the pale gray-blue foreground for
+UTC row annotations. Lines use 55% of its opacity; timestamp text uses its full
+opacity. `color.waterfall.timeMarker.background` provides a compact translucent
+dark text backing. Both bundled themes retain the same colors because waterfall
+signal palettes do not invert when application chrome changes theme. These
+annotations are independent of RX/TX, warning, and selection colors.

--- a/resources/themes/default-dark.json
+++ b/resources/themes/default-dark.json
@@ -48,6 +48,8 @@
           "accent.warning": "{color.amber.500}",
           "accent.danger":  "{color.red.500}",
           "accent.success": "{color.green.500}",
+          "waterfall.timeMarker.foreground": "#c8d8e8",
+          "waterfall.timeMarker.background": "#dc0f0f1a",
           "waterfall.live":    "{color.red.500}",
           "waterfall.history": "{color.gray.500}",
           "tx.mox.border":       "#d08020",

--- a/resources/themes/default-light.json
+++ b/resources/themes/default-light.json
@@ -49,6 +49,8 @@
           "accent.warning": "{color.amber.500}",
           "accent.danger":  "{color.red.500}",
           "accent.success": "{color.green.500}",
+          "waterfall.timeMarker.foreground": "#c8d8e8",
+          "waterfall.timeMarker.background": "#dc0f0f1a",
           "waterfall.live":    "{color.red.500}",
           "waterfall.history": "{color.gray.300}",
           "tx.mox.border":       "#d08020",

--- a/src/core/ThemeSeedGenerated.cpp
+++ b/src/core/ThemeSeedGenerated.cpp
@@ -207,6 +207,8 @@ void ThemeManager::seedGeneratedDefaults()
     }
     m_tokens.insert("color.waterfall.history", QString("#506070"));
     m_tokens.insert("color.waterfall.live", QString("#ff4d4d"));
+    m_tokens.insert("color.waterfall.timeMarker.background", QString("#dc0f0f1a"));
+    m_tokens.insert("color.waterfall.timeMarker.foreground", QString("#c8d8e8"));
     {
         ThemeFont f;
         f.family = QStringLiteral("DSEG7 Modern");

--- a/src/gui/DisplaySettings.h
+++ b/src/gui/DisplaySettings.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/AppSettings.h"
+#include "WaterfallTimeMarkers.h"
 
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -29,6 +30,28 @@ namespace AetherSDR {
 //     spelling migrated by the now-removed TitleBarSettings helper.
 class DisplaySettings {
 public:
+    static int waterfallTimeMarkerSeconds(int slot)
+    {
+        if (!isValidPanSlotIndex(slot)) {
+            return 0;
+        }
+        return validWaterfallMarkerInterval(readObj()
+            .value("waterfallTimeMarkers").toObject()
+            .value(QString::number(slot)).toInt(0));
+    }
+
+    static void setWaterfallTimeMarkerSeconds(int slot, int seconds)
+    {
+        if (!isValidPanSlotIndex(slot)) {
+            return;
+        }
+        QJsonObject document = readObj();
+        QJsonObject slotStates = document.value("waterfallTimeMarkers").toObject();
+        slotStates[QString::number(slot)] = validWaterfallMarkerInterval(seconds);
+        document["waterfallTimeMarkers"] = slotStates;
+        write(document);
+    }
+
     // Global panadapter marker overlay preference. Default False preserves the
     // waterfall as signal history unless the operator opts into the overlay.
     static bool extendedPassband()

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -10164,8 +10164,8 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
             for (const int seconds : kWaterfallMarkerIntervals) {
                 const QString label = seconds == 0 ? tr("Off")
                     : seconds < 60 ? tr("%1 seconds").arg(seconds)
-                    : seconds < 3600 ? (seconds == 60 ? tr("1 minute") : tr("%1 minutes").arg(seconds / 60))
-                    : tr("1 hour");
+                    : seconds == 60 ? tr("1 minute")
+                    : tr("%1 minutes").arg(seconds / 60);
                 QAction* action = timeMenu->addAction(label);
                 action->setObjectName(QStringLiteral("waterfallTimeMarkers%1").arg(seconds));
                 action->setCheckable(true);

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -38,6 +38,7 @@
 #include <QWheelEvent>
 #include <QNativeGestureEvent>
 #include <QMenu>
+#include <QActionGroup>
 #include <QToolTip>
 #include <QDialog>
 #include <QFormLayout>
@@ -1285,6 +1286,14 @@ QVariantMap SpectrumWidget::automationDssSnapshot() const
         static_cast<qulonglong>(m_frequencyRangeCommandCount);
     m[QStringLiteral("historyOffsetRows")] = m_wfHistoryOffsetRows;
     m[QStringLiteral("maxHistoryOffsetRows")] = maxWaterfallHistoryOffsetRows();
+    m[QStringLiteral("waterfallTimeMarkerSeconds")] = m_wfTimeMarkerSeconds;
+    QVariantList timeMarkers;
+    for (const WaterfallTimeMarker& marker : visibleWaterfallTimeMarkers(m_waterfall.height())) {
+        timeMarkers.append(QVariantMap{
+            {QStringLiteral("timestampMs"), marker.timestampMs},
+            {QStringLiteral("y"), marker.y}});
+    }
+    m[QStringLiteral("waterfallTimeMarkers")] = timeMarkers;
     m[QStringLiteral("waterfallRows")] = m_waterfall.height();
     m[QStringLiteral("waterfallWidth")] = m_waterfall.width();
     m[QStringLiteral("waterfallWriteRow")] = m_wfWriteRow;
@@ -2315,6 +2324,7 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     // recolours as it is scrolled back in.
     connect(&ThemeManager::instance(), &ThemeManager::themeChanged,
             this, [this]() {
+        m_wfTimeMarkerAtlasDirty = true;
         rebuildWfStopsCacheFromTheme();
         recolorWaterfallViewport();
         markOverlayDirty();
@@ -2334,6 +2344,8 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
         "color.background.2",
         "color.background.3",
         "color.background.spectrum",
+        "color.waterfall.timeMarker.foreground",
+        "color.waterfall.timeMarker.background",
         "color.spectrum.trace",
         "color.spectrum.peakHold",
         "color.spectrum.average",
@@ -2490,6 +2502,8 @@ QString SpectrumWidget::settingsKey(const QString& base) const
 void SpectrumWidget::setPanIndex(int idx)
 {
     m_panIndex = idx;
+    m_wfTimeMarkerSeconds = DisplaySettings::waterfallTimeMarkerSeconds(idx);
+    update();
     // Let the overlay menu (the +RX/+TNF/Band/ANT/Display/Memory/DAX button
     // rail) key its persisted collapsed/expanded state to this slot.
     if (m_overlayMenu) {
@@ -2499,6 +2513,7 @@ void SpectrumWidget::setPanIndex(int idx)
 
 void SpectrumWidget::loadSettings()
 {
+    m_wfTimeMarkerSeconds = DisplaySettings::waterfallTimeMarkerSeconds(m_panIndex);
     auto& s = AppSettings::instance();
     // These four values are stored by the radio (including in profiles). Older
     // releases persisted a competing client copy and reasserted it after status
@@ -5409,7 +5424,12 @@ void SpectrumWidget::appendVisibleRow(const QRgb* rowData,
 
     QElapsedTimer timer;
     timer.start();
+    if (m_wfVisibleTimeRows.size() != h) {
+        m_wfVisibleTimeRows = QVector<WaterfallTimeRow>(h);
+    }
+    const qint64 previousMs = m_wfVisibleTimeRows[m_wfWriteRow].timestampMs;
     m_wfWriteRow = (m_wfWriteRow - 1 + h) % h;
+    m_wfVisibleTimeRows[m_wfWriteRow] = {m_wfIncomingTimestampMs, previousMs};
     auto* row = reinterpret_cast<QRgb*>(m_waterfall.bits() + m_wfWriteRow * m_waterfall.bytesPerLine());
     std::memcpy(row, rowData, m_waterfall.width() * sizeof(QRgb));
     if (m_waterfallSupplemental.size() != m_waterfall.size()) {
@@ -5464,6 +5484,7 @@ void SpectrumWidget::appendHistoryRow(const quint8* intensityData,
                                       double supplementalCenterMhz,
                                       double supplementalBandwidthMhz)
 {
+    m_wfIncomingTimestampMs = timestampMs;
     // A hidden Flex/Kiwi source keeps only its small viewport and 96-row live
     // DSS surface warm. Retained scrollback belongs to the visible source; it
     // is rebuilt from new rows after a source switch (#4081, #4083).
@@ -5935,6 +5956,7 @@ void SpectrumWidget::paintWaterfallRowsFromHistory(
         resetVisibleWaterfallFrequencyFrames(centerMhz, bandwidthMhz);
     }
 
+    m_wfVisibleTimeRows = QVector<WaterfallTimeRow>(height);
     const int w = m_waterfall.width();
     const bool haveFrames = m_wfHistoryRowCenterMhz.size()
         == m_waterfallHistory.capacityRows();
@@ -5965,6 +5987,10 @@ void SpectrumWidget::paintWaterfallRowsFromHistory(
 
         const int destinationRow =
             waterfallVisibleRowForAge(writeRowOrigin, age, height);
+        const int previousIndex = historyRowIndexForAge(m_wfHistoryOffsetRows + age + 1);
+        m_wfVisibleTimeRows[destinationRow] = {
+            m_wfHistoryTimestamps.value(rowIndex),
+            m_wfHistoryTimestamps.value(previousIndex)};
         auto* dst = reinterpret_cast<QRgb*>(
             m_waterfall.scanLine(destinationRow));
         // With no stamped frames the rows carry no capture information at all,
@@ -6103,6 +6129,7 @@ void SpectrumWidget::rebuildWaterfallViewportForFrame(double centerMhz,
         m_waterfallSupplemental.fill(Qt::black);
     }
     m_wfWriteRow = 0;
+    m_wfVisibleTimeRows = QVector<WaterfallTimeRow>(m_waterfall.height());
     resetVisibleWaterfallFrequencyFrames(centerMhz, bandwidthMhz);
     m_wfVisiblePaletteToken = waterfallPaletteToken();
 
@@ -6507,6 +6534,8 @@ void SpectrumWidget::clearDisplay()
 
 void SpectrumWidget::clearCurrentWaterfallRows()
 {
+    m_wfVisibleTimeRows = QVector<WaterfallTimeRow>(m_waterfall.height());
+    m_wfIncomingTimestampMs = 0;
     if (!m_waterfall.isNull()) {
         m_waterfall.fill(Qt::black);
     }
@@ -6668,6 +6697,7 @@ void SpectrumWidget::saveCurrentWaterfallStreamState()
     updated.waterfall = std::move(m_waterfall);
     updated.waterfallSupplemental = std::move(m_waterfallSupplemental);
     updated.wfWriteRow = m_wfWriteRow;
+    updated.visibleTimeRows = std::move(m_wfVisibleTimeRows);
     updated.visibleRowCenterMhz = std::move(m_wfVisibleRowCenterMhz);
     updated.visibleRowBwMhz = std::move(m_wfVisibleRowBwMhz);
     updated.visibleSupplementalCenterMhz =
@@ -6790,6 +6820,7 @@ void SpectrumWidget::restoreCurrentWaterfallStreamState()
         m_waterfallStreamSizeHint = m_waterfall.size();
     }
     m_wfWriteRow = restored.wfWriteRow;
+    m_wfVisibleTimeRows = std::move(restored.visibleTimeRows);
     m_wfVisibleRowCenterMhz = std::move(restored.visibleRowCenterMhz);
     m_wfVisibleRowBwMhz = std::move(restored.visibleRowBwMhz);
     m_wfVisibleSupplementalCenterMhz =
@@ -10123,6 +10154,24 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
             }
 
             menu.addSeparator();
+            QMenu* timeMenu = menu.addMenu(tr("Waterfall Time Markers"));
+            timeMenu->setObjectName(QStringLiteral("waterfallTimeMarkersMenu"));
+            QActionGroup* timeGroup = new QActionGroup(timeMenu);
+            timeGroup->setExclusive(true);
+            for (const int seconds : kWaterfallMarkerIntervals) {
+                const QString label = seconds == 0 ? tr("Off")
+                    : seconds < 60 ? tr("%1 seconds").arg(seconds)
+                    : seconds < 3600 ? (seconds == 60 ? tr("1 minute") : tr("%1 minutes").arg(seconds / 60))
+                    : tr("1 hour");
+                QAction* action = timeMenu->addAction(label);
+                action->setObjectName(QStringLiteral("waterfallTimeMarkers%1").arg(seconds));
+                action->setCheckable(true);
+                action->setChecked(seconds == m_wfTimeMarkerSeconds);
+                timeGroup->addAction(action);
+                connect(action, &QAction::triggered, this, [this, seconds]() {
+                    setWaterfallTimeMarkerSeconds(seconds);
+                });
+            }
             QAction* tuneGuideAction = menu.addAction("Show Tune Guides");
             tuneGuideAction->setCheckable(true);
             tuneGuideAction->setChecked(m_showTuneGuides);
@@ -14805,6 +14854,10 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                 static_cast<quint64>(panStatsFftTimer.nsecsElapsed() / 1000);
     }
 
+    prepareWaterfallTimeMarkersGpu(batch,
+        QRect(wfRect.x(), wfRect.y(),
+              std::min(wfContentW, waterfallTimeScaleRect(wfRect).left() - wfRect.left()),
+              wfRect.height()), logicalSize);
     cb->resourceUpdate(batch);
 
     // Begin render pass
@@ -14987,6 +15040,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
         cb->draw(4);
     }
 
+    drawWaterfallTimeMarkersGpu(cb);
     cb->endPass();
 
     // VFO flag/widget repositioning now runs earlier (repositionVfoFlags(),
@@ -15041,6 +15095,7 @@ void SpectrumWidget::render(QRhiCommandBuffer* cb)
 
 void SpectrumWidget::releaseResources()
 {
+    releaseWaterfallTimeMarkersGpu();
     releaseWaterfallFramePipelineResources();
     delete m_wfPipeline;     m_wfPipeline = nullptr;
     delete m_wfSrb;          m_wfSrb = nullptr;
@@ -15412,6 +15467,9 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
     } else {
         drawDbmScale(p, specRect);
     }
+    drawWaterfallTimeMarkers(p, QRect(wfRect.x(), wfRect.y(),
+        std::min(wfContentRect.width(), waterfallTimeScaleRect(wfRect).left() - wfRect.left()),
+        wfRect.height()));
     drawTimeScale(p, wfRect);
 
     if (PerfTelemetry::instance().enabled()) {

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -6820,6 +6820,9 @@ void SpectrumWidget::restoreCurrentWaterfallStreamState()
         m_waterfallStreamSizeHint = m_waterfall.size();
     }
     m_wfWriteRow = restored.wfWriteRow;
+    // The viewport-size guard above preserves matching timestamp rows. Both
+    // marker readers also tolerate a mismatch: drawing skips it and append
+    // reinitializes the metadata before writing the next row.
     m_wfVisibleTimeRows = std::move(restored.visibleTimeRows);
     m_wfVisibleRowCenterMhz = std::move(restored.visibleRowCenterMhz);
     m_wfVisibleRowBwMhz = std::move(restored.visibleRowBwMhz);

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -27,6 +27,7 @@
 #include "DssRenderer.h"
 #include "SpectrumPreviewLogic.h"
 #include "WaterfallHistoryBuffer.h"
+#include "WaterfallTimeMarkers.h"
 
 class QVariantAnimation;
 class QSoundEffect;
@@ -139,6 +140,10 @@ public:
     // Per-pan settings persistence
     void setPanIndex(int idx);
     int panIndex() const { return m_panIndex; }
+    Q_PROPERTY(int waterfallTimeMarkerSeconds READ waterfallTimeMarkerSeconds WRITE setWaterfallTimeMarkerSeconds)
+    int waterfallTimeMarkerSeconds() const { return m_wfTimeMarkerSeconds; }
+    void setWaterfallTimeMarkerSeconds(int seconds);
+
     QString settingsKey(const QString& base) const;
     void loadSettings();
 
@@ -1091,6 +1096,7 @@ private:
         QImage waterfall;
         QImage waterfallSupplemental;
         int wfWriteRow{0};
+        QVector<WaterfallTimeRow> visibleTimeRows;
         QVector<double> visibleRowCenterMhz;
         QVector<double> visibleRowBwMhz;
         QVector<double> visibleSupplementalCenterMhz;
@@ -1217,6 +1223,14 @@ private:
         const QRgb* supplementalRowData = nullptr,
         double supplementalCenterMhz = -1.0,
         double supplementalBandwidthMhz = -1.0);
+    QVector<WaterfallTimeMarker> visibleWaterfallTimeMarkers(qreal height) const;
+    void prepareWaterfallTimeMarkerAtlas(const QVector<WaterfallTimeMarker>& markers);
+    void drawWaterfallTimeMarkers(QPainter& painter, const QRect& rect);
+#ifdef AETHER_GPU_SPECTRUM
+    void prepareWaterfallTimeMarkersGpu(QRhiResourceUpdateBatch* batch, const QRect& rect, const QSize& logicalSize);
+    void drawWaterfallTimeMarkersGpu(QRhiCommandBuffer* cb);
+    void releaseWaterfallTimeMarkersGpu();
+#endif
     int waterfallHistoryCapacityRows() const;
     int maxWaterfallHistoryOffsetRows() const;
     int historyRowIndexForAge(int ageRows) const;
@@ -1608,6 +1622,13 @@ private:
     float m_wfMaxDbm{-50.0f};
 
     // Scrolling waterfall image (Format_RGB32)
+    int m_wfTimeMarkerSeconds{0};
+    qint64 m_wfIncomingTimestampMs{0};
+    QVector<WaterfallTimeRow> m_wfVisibleTimeRows;
+    QImage m_wfTimeMarkerAtlas;
+    QVector<qint64> m_wfTimeMarkerLabels;
+    bool m_wfTimeMarkerAtlasDirty{true};
+    int m_wfTimeMarkerLabelHeight{0};
     QImage m_waterfall;
     // Same ring topology as m_waterfall. Native FLEX tiles are rasterized over
     // their full (wider) frequency frame here; the primary viewport row wins
@@ -2023,6 +2044,10 @@ private:
     bool m_kiwiSdrDisplaySourceKiwi{false};
 
 #ifdef AETHER_GPU_SPECTRUM
+    QRhiTexture* m_wfTimeMarkerTexture{nullptr};
+    QRhiShaderResourceBindings* m_wfTimeMarkerSrb{nullptr};
+    QRhiBuffer* m_wfTimeMarkerVbo{nullptr};
+    int m_wfTimeMarkerQuadCount{0};
     bool m_rhiInitialized{false};
     bool m_rhiFailureForcedForAutomation{false};
     SpectrumRhiFailureState m_rhiFailure;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -15,6 +15,7 @@
 #include <QPointer>
 #include <QMap>
 #include <QImage>
+#include <QFont>
 #include <QColor>
 #include <QDateTime>
 #include <QElapsedTimer>
@@ -1626,6 +1627,7 @@ private:
     qint64 m_wfIncomingTimestampMs{0};
     QVector<WaterfallTimeRow> m_wfVisibleTimeRows;
     QImage m_wfTimeMarkerAtlas;
+    QFont m_wfTimeMarkerAtlasFont;
     QVector<qint64> m_wfTimeMarkerLabels;
     bool m_wfTimeMarkerAtlasDirty{true};
     int m_wfTimeMarkerLabelHeight{0};

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -141,7 +141,10 @@ public:
     // Per-pan settings persistence
     void setPanIndex(int idx);
     int panIndex() const { return m_panIndex; }
-    Q_PROPERTY(int waterfallTimeMarkerSeconds READ waterfallTimeMarkerSeconds WRITE setWaterfallTimeMarkerSeconds)
+    // Read-only by design: the interval is set through the context menu (or
+    // DisplaySettings), never by reflection. Exposing it for reads keeps the
+    // automation bridge's dss snapshot honest without adding settable surface.
+    Q_PROPERTY(int waterfallTimeMarkerSeconds READ waterfallTimeMarkerSeconds)
     int waterfallTimeMarkerSeconds() const { return m_wfTimeMarkerSeconds; }
     void setWaterfallTimeMarkerSeconds(int seconds);
 

--- a/src/gui/SpectrumWidget_TimeMarkers.cpp
+++ b/src/gui/SpectrumWidget_TimeMarkers.cpp
@@ -87,8 +87,10 @@ void SpectrumWidget::prepareWaterfallTimeMarkerAtlas(
     }
     m_wfTimeMarkerAtlasDirty = false;
 #ifdef AETHER_GPU_SPECTRUM
-    // Recreate/upload only when the text, theme, or scale changes; row motion
-    // updates small vertex data, never the full-screen static overlay.
+    // Row motion normally updates only vertex data. The position-dependent
+    // label set can also change at visibility/crowding thresholds, requiring
+    // an atlas upload, as do font, theme, and scale changes. None of these
+    // updates rebuilds the full-screen static overlay.
     if (m_wfTimeMarkerTexture && m_wfTimeMarkerTexture->pixelSize() != pixels) {
         m_wfTimeMarkerTexture->setPixelSize(pixels);
         if (!m_wfTimeMarkerTexture->create()

--- a/src/gui/SpectrumWidget_TimeMarkers.cpp
+++ b/src/gui/SpectrumWidget_TimeMarkers.cpp
@@ -3,8 +3,11 @@
 #include "core/ThemeManager.h"
 
 #include <QAccessible>
+#include <QDateTime>
+#include <QFont>
 #include <QFontMetrics>
 #include <QPainter>
+#include <QRectF>
 #include <QTimeZone>
 #include <QtMath>
 #include <algorithm>
@@ -56,11 +59,13 @@ void SpectrumWidget::prepareWaterfallTimeMarkerAtlas(
     const QSize pixels(qCeil(atlasWidth * dpr),
                        qCeil((2 + labels.size() * labelHeight) * dpr));
     if (!m_wfTimeMarkerAtlasDirty && labels == m_wfTimeMarkerLabels
+        && m_wfTimeMarkerAtlasFont == labelFont
         && m_wfTimeMarkerAtlas.size() == pixels
         && m_wfTimeMarkerAtlas.devicePixelRatio() == dpr) {
         return;
     }
     m_wfTimeMarkerLabels = labels;
+    m_wfTimeMarkerAtlasFont = labelFont;
     m_wfTimeMarkerLabelHeight = labelHeight;
     m_wfTimeMarkerAtlas = QImage(pixels, QImage::Format_RGBA8888_Premultiplied);
     m_wfTimeMarkerAtlas.setDevicePixelRatio(dpr);

--- a/src/gui/SpectrumWidget_TimeMarkers.cpp
+++ b/src/gui/SpectrumWidget_TimeMarkers.cpp
@@ -1,0 +1,240 @@
+#include "SpectrumWidget.h"
+#include "DisplaySettings.h"
+#include "core/ThemeManager.h"
+
+#include <QAccessible>
+#include <QFontMetrics>
+#include <QPainter>
+#include <QTimeZone>
+#include <QtMath>
+#include <algorithm>
+
+namespace AetherSDR {
+
+void SpectrumWidget::setWaterfallTimeMarkerSeconds(int seconds)
+{
+    seconds = validWaterfallMarkerInterval(seconds);
+    if (m_wfTimeMarkerSeconds == seconds) {
+        return;
+    }
+    m_wfTimeMarkerSeconds = seconds;
+    DisplaySettings::setWaterfallTimeMarkerSeconds(m_panIndex, seconds);
+    QAccessibleValueChangeEvent event(this, seconds);
+    QAccessible::updateAccessibility(&event);
+    update();
+}
+
+QVector<WaterfallTimeMarker> SpectrumWidget::visibleWaterfallTimeMarkers(qreal height) const
+{
+    if (m_wfVisibleTimeRows.size() != m_waterfall.height()) {
+        return {};
+    }
+    const qreal offset = m_waterfallScrollClock.isValid()
+        ? m_waterfallScrollDistanceRows - waterfallScrollProgressRows() : 0.0;
+    return waterfallTimeMarkers(m_wfVisibleTimeRows, m_wfWriteRow,
+                                m_wfTimeMarkerSeconds, offset, height);
+}
+
+void SpectrumWidget::prepareWaterfallTimeMarkerAtlas(
+    const QVector<WaterfallTimeMarker>& markers)
+{
+    QFont labelFont = font();
+    labelFont.setPointSize(8);
+    labelFont.setBold(false);
+    const QFontMetrics metrics(labelFont);
+    const int labelHeight = metrics.height() + 2;
+    QVector<qint64> labels;
+    qreal previousY = -labelHeight - 4;
+    for (const WaterfallTimeMarker& marker : markers) {
+        if (marker.y - previousY >= labelHeight + 4) {
+            labels.push_back(marker.timestampMs);
+            previousY = marker.y;
+        }
+    }
+    const qreal dpr = devicePixelRatioF();
+    const int atlasWidth = metrics.horizontalAdvance(QStringLiteral("00:00:00Z")) + 8;
+    const QSize pixels(qCeil(atlasWidth * dpr),
+                       qCeil((2 + labels.size() * labelHeight) * dpr));
+    if (!m_wfTimeMarkerAtlasDirty && labels == m_wfTimeMarkerLabels
+        && m_wfTimeMarkerAtlas.size() == pixels
+        && m_wfTimeMarkerAtlas.devicePixelRatio() == dpr) {
+        return;
+    }
+    m_wfTimeMarkerLabels = labels;
+    m_wfTimeMarkerLabelHeight = labelHeight;
+    m_wfTimeMarkerAtlas = QImage(pixels, QImage::Format_RGBA8888_Premultiplied);
+    m_wfTimeMarkerAtlas.setDevicePixelRatio(dpr);
+    m_wfTimeMarkerAtlas.fill(Qt::transparent);
+    QPainter painter(&m_wfTimeMarkerAtlas);
+    painter.setFont(labelFont);
+    ThemeManager& theme = ThemeManager::instance();
+    const QColor foreground = theme.color("color.waterfall.timeMarker.foreground");
+    QColor line = foreground;
+    line.setAlphaF(line.alphaF() * 0.55);
+    painter.fillRect(QRect(0, 0, atlasWidth, 2), line);
+    for (int index = 0; index < labels.size(); ++index) {
+        const QRect box(0, 2 + index * labelHeight, atlasWidth, labelHeight);
+        painter.fillRect(box, theme.color("color.waterfall.timeMarker.background"));
+        painter.setPen(foreground);
+        painter.drawText(box.adjusted(4, 0, -4, 0), Qt::AlignVCenter | Qt::AlignLeft,
+            QDateTime::fromMSecsSinceEpoch(labels[index], QTimeZone::utc())
+                .toString(QStringLiteral("HH:mm:ss'Z'")));
+    }
+    m_wfTimeMarkerAtlasDirty = false;
+#ifdef AETHER_GPU_SPECTRUM
+    // Recreate/upload only when the text, theme, or scale changes; row motion
+    // updates small vertex data, never the full-screen static overlay.
+    if (m_wfTimeMarkerTexture && m_wfTimeMarkerTexture->pixelSize() != pixels) {
+        m_wfTimeMarkerTexture->setPixelSize(pixels);
+        if (!m_wfTimeMarkerTexture->create()
+            || (m_wfTimeMarkerSrb && !m_wfTimeMarkerSrb->create())) {
+            releaseWaterfallTimeMarkersGpu();
+        }
+    }
+#endif
+}
+
+void SpectrumWidget::drawWaterfallTimeMarkers(QPainter& painter, const QRect& rect)
+{
+    const QVector<WaterfallTimeMarker> markers = visibleWaterfallTimeMarkers(rect.height());
+    if (markers.isEmpty()) {
+        return;
+    }
+    prepareWaterfallTimeMarkerAtlas(markers);
+    const qreal dpr = m_wfTimeMarkerAtlas.devicePixelRatio();
+    const qreal labelWidth = m_wfTimeMarkerAtlas.width() / dpr;
+    painter.save();
+    painter.setClipRect(rect);
+    for (const WaterfallTimeMarker& marker : markers) {
+        const qreal y = rect.y() + marker.y;
+        painter.drawImage(QRectF(rect.x(), y, rect.width(), 1), m_wfTimeMarkerAtlas,
+                          QRectF(0, 0, m_wfTimeMarkerAtlas.width(), dpr));
+        const int index = m_wfTimeMarkerLabels.indexOf(marker.timestampMs);
+        if (index >= 0) {
+            painter.drawImage(QRectF(rect.x() + 3, y + 2, labelWidth, m_wfTimeMarkerLabelHeight),
+                m_wfTimeMarkerAtlas,
+                QRectF(0, (2 + index * m_wfTimeMarkerLabelHeight) * dpr,
+                       m_wfTimeMarkerAtlas.width(), m_wfTimeMarkerLabelHeight * dpr));
+        }
+    }
+    painter.restore();
+}
+
+#ifdef AETHER_GPU_SPECTRUM
+void SpectrumWidget::releaseWaterfallTimeMarkersGpu()
+{
+    delete m_wfTimeMarkerSrb;
+    m_wfTimeMarkerSrb = nullptr;
+    delete m_wfTimeMarkerTexture;
+    m_wfTimeMarkerTexture = nullptr;
+    delete m_wfTimeMarkerVbo;
+    m_wfTimeMarkerVbo = nullptr;
+    m_wfTimeMarkerQuadCount = 0;
+}
+
+void SpectrumWidget::prepareWaterfallTimeMarkersGpu(
+    QRhiResourceUpdateBatch* batch, const QRect& rect, const QSize& logicalSize)
+{
+    m_wfTimeMarkerQuadCount = 0;
+    const QVector<WaterfallTimeMarker> markers = visibleWaterfallTimeMarkers(rect.height());
+    if (markers.isEmpty() || !m_ovPipeline || !m_ovSampler) {
+        return;
+    }
+    const qint64 previousCacheKey = m_wfTimeMarkerAtlas.cacheKey();
+    prepareWaterfallTimeMarkerAtlas(markers);
+    bool upload = previousCacheKey != m_wfTimeMarkerAtlas.cacheKey();
+    if (!m_wfTimeMarkerTexture) {
+        m_wfTimeMarkerTexture = rhi()->newTexture(QRhiTexture::RGBA8, m_wfTimeMarkerAtlas.size());
+        if (!m_wfTimeMarkerTexture->create()) {
+            releaseWaterfallTimeMarkersGpu();
+            return;
+        }
+        m_wfTimeMarkerSrb = rhi()->newShaderResourceBindings();
+        m_wfTimeMarkerSrb->setBindings({QRhiShaderResourceBinding::sampledTexture(
+            1, QRhiShaderResourceBinding::FragmentStage, m_wfTimeMarkerTexture, m_ovSampler)});
+        if (!m_wfTimeMarkerSrb->create()) {
+            releaseWaterfallTimeMarkersGpu();
+            return;
+        }
+        upload = true;
+    }
+    if (upload) {
+        batch->uploadTexture(m_wfTimeMarkerTexture, m_wfTimeMarkerAtlas);
+    }
+    QVector<float> vertices;
+    const qreal dpr = m_wfTimeMarkerAtlas.devicePixelRatio();
+    const qreal atlasWidth = m_wfTimeMarkerAtlas.width() / dpr;
+    const qreal atlasHeight = m_wfTimeMarkerAtlas.height() / dpr;
+    // Clip both geometry and UVs on the CPU. This reuses the existing overlay
+    // pipeline without changing its scissor state for unrelated drawing.
+    const auto addQuad = [&](const QRectF& destination, const QRectF& source) {
+        const QRectF clipped = destination.intersected(QRectF(rect));
+        if (clipped.isEmpty()) {
+            return;
+        }
+        const qreal u0 = (source.x() + (clipped.left() - destination.left())
+            / destination.width() * source.width()) / atlasWidth;
+        const qreal u1 = (source.x() + (clipped.right() - destination.left())
+            / destination.width() * source.width()) / atlasWidth;
+        const qreal v0 = (source.y() + (clipped.top() - destination.top())
+            / destination.height() * source.height()) / atlasHeight;
+        const qreal v1 = (source.y() + (clipped.bottom() - destination.top())
+            / destination.height() * source.height()) / atlasHeight;
+        const float x0 = 2.0 * clipped.left() / logicalSize.width() - 1.0;
+        const float x1 = 2.0 * clipped.right() / logicalSize.width() - 1.0;
+        const float y0 = 1.0 - 2.0 * clipped.top() / logicalSize.height();
+        const float y1 = 1.0 - 2.0 * clipped.bottom() / logicalSize.height();
+        vertices << x0 << y1 << float(u0) << float(v1)
+                 << x1 << y1 << float(u1) << float(v1)
+                 << x0 << y0 << float(u0) << float(v0)
+                 << x1 << y0 << float(u1) << float(v0);
+        ++m_wfTimeMarkerQuadCount;
+    };
+    for (const WaterfallTimeMarker& marker : markers) {
+        const qreal y = rect.y() + marker.y;
+        addQuad(QRectF(rect.x(), y, rect.width(), 1), QRectF(0, 0.5, atlasWidth, 0));
+        const int index = m_wfTimeMarkerLabels.indexOf(marker.timestampMs);
+        if (index >= 0) {
+            addQuad(QRectF(rect.x() + 3, y + 2, atlasWidth, m_wfTimeMarkerLabelHeight),
+                    QRectF(0, 2 + index * m_wfTimeMarkerLabelHeight,
+                           atlasWidth, m_wfTimeMarkerLabelHeight));
+        }
+    }
+    if (vertices.isEmpty()) {
+        return;
+    }
+    const int bytes = vertices.size() * int(sizeof(float));
+    if (!m_wfTimeMarkerVbo) {
+        m_wfTimeMarkerVbo = rhi()->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::VertexBuffer, bytes);
+        if (!m_wfTimeMarkerVbo->create()) {
+            releaseWaterfallTimeMarkersGpu();
+            return;
+        }
+    } else if (m_wfTimeMarkerVbo->size() < static_cast<quint32>(bytes)) {
+        m_wfTimeMarkerVbo->setSize(bytes);
+        if (!m_wfTimeMarkerVbo->create()) {
+            releaseWaterfallTimeMarkersGpu();
+            return;
+        }
+    }
+    batch->updateDynamicBuffer(m_wfTimeMarkerVbo, 0, bytes, vertices.constData());
+}
+
+void SpectrumWidget::drawWaterfallTimeMarkersGpu(QRhiCommandBuffer* cb)
+{
+    if (m_wfTimeMarkerQuadCount == 0 || !m_wfTimeMarkerSrb || !m_wfTimeMarkerVbo) {
+        return;
+    }
+    cb->setGraphicsPipeline(m_ovPipeline);
+    cb->setShaderResources(m_wfTimeMarkerSrb);
+    const QSize output = renderTarget()->pixelSize();
+    cb->setViewport({0, 0, float(output.width()), float(output.height())});
+    const QRhiCommandBuffer::VertexInput binding(m_wfTimeMarkerVbo, 0);
+    cb->setVertexInput(0, 1, &binding);
+    for (int index = 0; index < m_wfTimeMarkerQuadCount; ++index) {
+        cb->draw(4, 1, index * 4);
+    }
+}
+#endif
+
+} // namespace AetherSDR

--- a/src/gui/WaterfallTimeMarkers.h
+++ b/src/gui/WaterfallTimeMarkers.h
@@ -7,8 +7,13 @@
 
 namespace AetherSDR {
 
-inline constexpr std::array<int, 9> kWaterfallMarkerIntervals{
-    0, 15, 30, 60, 300, 600, 900, 1800, 3600};
+// Intervals longer than the retained history can never place a visible line:
+// kWaterfallHistoryMs caps retention at 20 minutes, and a screenful of
+// waterfall is only ~11-19 s at typical rates, so 30-minute and 1-hour
+// entries would sit in the menu doing nothing. 15 minutes is already the
+// point of diminishing returns and is kept as the documented upper bound.
+inline constexpr std::array<int, 7> kWaterfallMarkerIntervals{
+    0, 15, 30, 60, 300, 600, 900};
 
 inline int validWaterfallMarkerInterval(int seconds)
 {
@@ -47,6 +52,9 @@ inline QVector<WaterfallTimeMarker> waterfallTimeMarkers(
         const WaterfallTimeRow& row = rows[(head + age) % rows.size()];
         // No invented rows across a gap, and no repeated boundary on a batch
         // of equal timestamps. A backward clock adjustment starts a new run.
+        // The `<=` deliberately overlaps the bucket comparison below: a row
+        // that did not advance the clock is already caught there, so this is
+        // defence in depth rather than the sole guard for it.
         if (row.previousMs <= 0 || row.timestampMs <= row.previousMs
             || row.timestampMs / intervalMs == row.previousMs / intervalMs) {
             continue;

--- a/src/gui/WaterfallTimeMarkers.h
+++ b/src/gui/WaterfallTimeMarkers.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <QVector>
+#include <QtGlobal>
+#include <array>
+#include <cmath>
+
+namespace AetherSDR {
+
+inline constexpr std::array<int, 9> kWaterfallMarkerIntervals{
+    0, 15, 30, 60, 300, 600, 900, 1800, 3600};
+
+inline int validWaterfallMarkerInterval(int seconds)
+{
+    for (const int value : kWaterfallMarkerIntervals) {
+        if (value == seconds) {
+            return seconds;
+        }
+    }
+    return 0;
+}
+
+// Capture metadata follows the same physical ring slot as the signal pixels.
+// Retaining the predecessor also preserves a crossing at the viewport bottom.
+struct WaterfallTimeRow {
+    qint64 timestampMs{0};
+    qint64 previousMs{0};
+};
+
+struct WaterfallTimeMarker {
+    qint64 timestampMs{0};
+    qreal y{0};
+};
+
+inline QVector<WaterfallTimeMarker> waterfallTimeMarkers(
+    const QVector<WaterfallTimeRow>& rows, int head, int seconds,
+    qreal sampleOffsetRows, qreal displayHeight)
+{
+    QVector<WaterfallTimeMarker> markers;
+    if (validWaterfallMarkerInterval(seconds) == 0 || rows.isEmpty()
+        || head < 0 || head >= rows.size() || displayHeight <= 0
+        || !std::isfinite(sampleOffsetRows)) {
+        return markers;
+    }
+    const qint64 intervalMs = qint64(seconds) * 1000;
+    for (int age = 0; age < rows.size(); ++age) {
+        const WaterfallTimeRow& row = rows[(head + age) % rows.size()];
+        // No invented rows across a gap, and no repeated boundary on a batch
+        // of equal timestamps. A backward clock adjustment starts a new run.
+        if (row.previousMs <= 0 || row.timestampMs <= row.previousMs
+            || row.timestampMs / intervalMs == row.previousMs / intervalMs) {
+            continue;
+        }
+        const qreal y = (age - sampleOffsetRows) * displayHeight / rows.size();
+        if (y >= 0 && y < displayHeight) {
+            // Label the clock boundary, not the first packet's arrival time
+            // after it. Keep the line attached to that captured signal row.
+            const qint64 boundaryMs = (row.timestampMs / intervalMs) * intervalMs;
+            markers.push_back({boundaryMs, y});
+        }
+    }
+    return markers;
+}
+
+} // namespace AetherSDR

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -2219,6 +2219,17 @@ add_executable(pan_recenter_policy_test
 target_include_directories(pan_recenter_policy_test PRIVATE src)
 add_test(NAME pan_recenter_policy_test COMMAND pan_recenter_policy_test)
 
+add_executable(waterfall_time_marker_settings_test tests/waterfall_time_marker_settings_test.cpp)
+target_include_directories(waterfall_time_marker_settings_test PRIVATE src)
+target_link_libraries(waterfall_time_marker_settings_test PRIVATE aethercore Qt6::Core)
+add_test(NAME waterfall_time_marker_settings_test COMMAND waterfall_time_marker_settings_test)
+
+# Pure row/timestamp geometry, no sockets or radio peer.
+add_executable(waterfall_time_markers_test tests/waterfall_time_markers_test.cpp)
+target_include_directories(waterfall_time_markers_test PRIVATE src)
+target_link_libraries(waterfall_time_markers_test PRIVATE Qt6::Core)
+add_test(NAME waterfall_time_markers_test COMMAND waterfall_time_markers_test)
+
 add_executable(waterfall_history_buffer_test
     tests/waterfall_history_buffer_test.cpp
     src/gui/WaterfallHistoryBuffer.cpp
@@ -5022,6 +5033,7 @@ set(AETHER_SETTINGS_CONSUMERS
     extension_namespace_gate_test
     tx_operation_integration_test
     backend_slice_lifecycle_test
+    waterfall_time_marker_settings_test
     client_display_settings_test
     gui_nested_lifetime_test
     rx_applet_squelch_reconciliation_test

--- a/tests/waterfall_time_marker_settings_test.cpp
+++ b/tests/waterfall_time_marker_settings_test.cpp
@@ -20,15 +20,15 @@ int main(int argc, char** argv)
     check(DisplaySettings::waterfallTimeMarkerSeconds(0) == 0, "defaults off");
     DisplaySettings::setExtendedPassband(true);
     DisplaySettings::setWaterfallTimeMarkerSeconds(0, 15);
-    DisplaySettings::setWaterfallTimeMarkerSeconds(1, 3600);
+    DisplaySettings::setWaterfallTimeMarkerSeconds(1, 900);
     check(DisplaySettings::waterfallTimeMarkerSeconds(0) == 15, "first slot retained");
-    check(DisplaySettings::waterfallTimeMarkerSeconds(1) == 3600, "second slot independent");
+    check(DisplaySettings::waterfallTimeMarkerSeconds(1) == 900, "second slot independent");
     check(DisplaySettings::extendedPassband(), "sibling settings preserved");
     settings.load();
     check(DisplaySettings::waterfallTimeMarkerSeconds(0) == 15, "saved document reloads");
     DisplaySettings::setWaterfallTimeMarkerSeconds(0, 0);
     check(DisplaySettings::waterfallTimeMarkerSeconds(0) == 0, "off persists");
-    check(DisplaySettings::waterfallTimeMarkerSeconds(1) == 3600, "off leaves other pan alone");
+    check(DisplaySettings::waterfallTimeMarkerSeconds(1) == 900, "off leaves other pan alone");
     DisplaySettings::setWaterfallTimeMarkerSeconds(-1, 30);
     check(DisplaySettings::waterfallTimeMarkerSeconds(-1) == 0, "invalid slot rejected");
     const auto storedMarkers = [&settings]() {
@@ -38,6 +38,13 @@ int main(int argc, char** argv)
     check(!storedMarkers().contains("-1"), "invalid slot is not stored");
     DisplaySettings::setWaterfallTimeMarkerSeconds(0, 17);
     check(DisplaySettings::waterfallTimeMarkerSeconds(0) == 0, "unknown interval defaults off");
+    // 30 minutes and 1 hour were retired: they exceed the retained history and
+    // could never place a visible line. A stored value from an older build
+    // must fail closed to Off rather than silently persisting.
+    DisplaySettings::setWaterfallTimeMarkerSeconds(0, 1800);
+    check(DisplaySettings::waterfallTimeMarkerSeconds(0) == 0, "retired 30-minute interval falls back to off");
+    DisplaySettings::setWaterfallTimeMarkerSeconds(0, 3600);
+    check(DisplaySettings::waterfallTimeMarkerSeconds(0) == 0, "retired 1-hour interval falls back to off");
     check(storedMarkers().value("0").toInt(-1) == 0, "invalid interval is stored as off");
     return failures ? 1 : 0;
 }

--- a/tests/waterfall_time_marker_settings_test.cpp
+++ b/tests/waterfall_time_marker_settings_test.cpp
@@ -1,13 +1,14 @@
+#include "TestSettingsProfile.h"
 #include "gui/DisplaySettings.h"
 #include <QCoreApplication>
-#include <QTemporaryDir>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QDebug>
 
 int main(int argc, char** argv)
 {
-    QTemporaryDir settingsDirectory;
-    if (!settingsDirectory.isValid()) { return 1; }
-    qputenv("AETHER_SETTINGS_DIR", settingsDirectory.path().toUtf8());
+    TestSettingsProfile profile(QStringLiteral("waterfall-time-marker-settings"));
+    if (!profile.isValid()) { return 1; }
     QCoreApplication app(argc, argv);
     using namespace AetherSDR;
     AppSettings& settings = AppSettings::instance();
@@ -30,7 +31,13 @@ int main(int argc, char** argv)
     check(DisplaySettings::waterfallTimeMarkerSeconds(1) == 3600, "off leaves other pan alone");
     DisplaySettings::setWaterfallTimeMarkerSeconds(-1, 30);
     check(DisplaySettings::waterfallTimeMarkerSeconds(-1) == 0, "invalid slot rejected");
+    const auto storedMarkers = [&settings]() {
+        return QJsonDocument::fromJson(settings.value("Display").toString().toUtf8())
+            .object().value("waterfallTimeMarkers").toObject();
+    };
+    check(!storedMarkers().contains("-1"), "invalid slot is not stored");
     DisplaySettings::setWaterfallTimeMarkerSeconds(0, 17);
     check(DisplaySettings::waterfallTimeMarkerSeconds(0) == 0, "unknown interval defaults off");
+    check(storedMarkers().value("0").toInt(-1) == 0, "invalid interval is stored as off");
     return failures ? 1 : 0;
 }

--- a/tests/waterfall_time_marker_settings_test.cpp
+++ b/tests/waterfall_time_marker_settings_test.cpp
@@ -1,0 +1,36 @@
+#include "gui/DisplaySettings.h"
+#include <QCoreApplication>
+#include <QTemporaryDir>
+#include <QDebug>
+
+int main(int argc, char** argv)
+{
+    QTemporaryDir settingsDirectory;
+    if (!settingsDirectory.isValid()) { return 1; }
+    qputenv("AETHER_SETTINGS_DIR", settingsDirectory.path().toUtf8());
+    QCoreApplication app(argc, argv);
+    using namespace AetherSDR;
+    AppSettings& settings = AppSettings::instance();
+    settings.load();
+    int failures = 0;
+    const auto check = [&](bool ok, const char* label) {
+        if (!ok) { qCritical() << label; ++failures; }
+    };
+    check(DisplaySettings::waterfallTimeMarkerSeconds(0) == 0, "defaults off");
+    DisplaySettings::setExtendedPassband(true);
+    DisplaySettings::setWaterfallTimeMarkerSeconds(0, 15);
+    DisplaySettings::setWaterfallTimeMarkerSeconds(1, 3600);
+    check(DisplaySettings::waterfallTimeMarkerSeconds(0) == 15, "first slot retained");
+    check(DisplaySettings::waterfallTimeMarkerSeconds(1) == 3600, "second slot independent");
+    check(DisplaySettings::extendedPassband(), "sibling settings preserved");
+    settings.load();
+    check(DisplaySettings::waterfallTimeMarkerSeconds(0) == 15, "saved document reloads");
+    DisplaySettings::setWaterfallTimeMarkerSeconds(0, 0);
+    check(DisplaySettings::waterfallTimeMarkerSeconds(0) == 0, "off persists");
+    check(DisplaySettings::waterfallTimeMarkerSeconds(1) == 3600, "off leaves other pan alone");
+    DisplaySettings::setWaterfallTimeMarkerSeconds(-1, 30);
+    check(DisplaySettings::waterfallTimeMarkerSeconds(-1) == 0, "invalid slot rejected");
+    DisplaySettings::setWaterfallTimeMarkerSeconds(0, 17);
+    check(DisplaySettings::waterfallTimeMarkerSeconds(0) == 0, "unknown interval defaults off");
+    return failures ? 1 : 0;
+}

--- a/tests/waterfall_time_markers_test.cpp
+++ b/tests/waterfall_time_markers_test.cpp
@@ -44,6 +44,9 @@ int main()
     check(waterfallTimeMarkers({{900000, 1000}}, 0, 15, 0, 40).size() == 1, "gap does not invent skipped rows");
     check(waterfallTimeMarkers({{1000, 900000}}, 0, 15, 0, 40).isEmpty(), "backward clock jump");
     check(waterfallTimeMarkers({{30000, 0}}, 0, 15, 0, 40).isEmpty(), "unstamped row");
+    check(waterfallTimeMarkers({{60000, 60000}}, 0, 15, 0, 40).isEmpty(), "a row that did not advance the clock");
+    check(waterfallTimeMarkers({{1800000, 1799999}}, 0, 1800, 0, 40).isEmpty(), "retired 30-minute interval is not accepted");
+    check(waterfallTimeMarkers({{3600000, 3599999}}, 0, 3600, 0, 40).isEmpty(), "retired 1-hour interval is not accepted");
     check(waterfallTimeMarkers({{60000, 59999}}, 0, 15, 1, 40).isEmpty(), "not-yet-presented top row is clipped");
     return failed ? 1 : 0;
 }

--- a/tests/waterfall_time_markers_test.cpp
+++ b/tests/waterfall_time_markers_test.cpp
@@ -1,0 +1,49 @@
+#include "gui/WaterfallTimeMarkers.h"
+#include <QDebug>
+#include <limits>
+
+using namespace AetherSDR;
+int main()
+{
+    int failed = 0;
+    const auto check = [&](bool ok, const char* message) {
+        if (!ok) { qCritical() << message; ++failed; }
+    };
+    for (const int seconds : kWaterfallMarkerIntervals) {
+        if (seconds == 0) { continue; }
+        const qint64 boundary = qint64(seconds) * 1000 * 100;
+        QVector<WaterfallTimeRow> rows{{boundary, boundary - 1}};
+        check(waterfallTimeMarkers(rows, 0, seconds, 0, 100).size() == 1, "exact clock crossing");
+        rows[0] = {boundary - 1, boundary - 2};
+        check(waterfallTimeMarkers(rows, 0, seconds, 0, 100).isEmpty(), "before boundary");
+        rows[0] = {boundary + 2345, boundary - 1};
+        const auto delayed = waterfallTimeMarkers(rows, 0, seconds, 0, 100);
+        check(delayed.size() == 1 && delayed[0].timestampMs == boundary,
+              "delayed row labels the exact clock boundary for every interval");
+    }
+    QVector<WaterfallTimeRow> ring(4);
+    ring[3] = {60001, 60001}; // a batched tile must not repeat a timestamp
+    ring[0] = {60001, 59999};
+    ring[1] = {59999, 59000};
+    ring[2] = {30001, 29999};
+    const auto live = waterfallTimeMarkers(ring, 3, 15, 0.25, 40);
+    check(live.size() == 2, "wrapped ring retains both crossings");
+    if (live.size() == 2) {
+        check(live[0].timestampMs == 60000 && live[0].y == 7.5, "fractional scroll follows row");
+        check(live[1].y == 27.5, "oldest row retains predecessor");
+    }
+    const auto paused = waterfallTimeMarkers(ring, 3, 15, 0, 40);
+    check(paused.size() == 2 && paused[0].y == 10, "paused viewport uses discrete rows");
+    const auto resized = waterfallTimeMarkers(ring, 3, 15, 0.25, 80);
+    check(resized.size() == 2 && resized[0].y == 15, "resize uses signal scaling");
+    check(waterfallTimeMarkers(ring, 3, 60, 0, 40).size() == 1, "interval change reinterprets retained rows");
+    check(waterfallTimeMarkers(ring, 3, 0, 0, 40).isEmpty(), "off");
+    check(waterfallTimeMarkers(ring, 3, 17, 0, 40).isEmpty(), "invalid interval fails closed");
+    check(waterfallTimeMarkers(ring, -1, 15, 0, 40).isEmpty(), "invalid head");
+    check(waterfallTimeMarkers(ring, 3, 15, std::numeric_limits<double>::quiet_NaN(), 40).isEmpty(), "invalid scroll");
+    check(waterfallTimeMarkers({{900000, 1000}}, 0, 15, 0, 40).size() == 1, "gap does not invent skipped rows");
+    check(waterfallTimeMarkers({{1000, 900000}}, 0, 15, 0, 40).isEmpty(), "backward clock jump");
+    check(waterfallTimeMarkers({{30000, 0}}, 0, 15, 0, 40).isEmpty(), "unstamped row");
+    check(waterfallTimeMarkers({{60000, 59999}}, 0, 15, 1, 40).isEmpty(), "not-yet-presented top row is clipped");
+    return failed ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Closes #5537.

Right-click the panadapter or waterfall and choose **Waterfall Time Markers** to display thin horizontal lines with small UTC timestamps at the left edge. Intervals are Off, 15/30 seconds, and 1/5/10/15 minutes. Off remains the default, and the selection persists independently per panadapter slot in the existing Display document.

Markers align to clock boundaries (for example, HH:mm:00 for one-minute markers) and follow their captured signal rows through live scrolling, paused history, and resize. Changing the waterfall rate affects future row cadence; existing history retains its captured row spacing. GPU and software rendering share timestamp geometry and a cached label atlas. Dedicated theme tokens provide subdued pale gray-blue lines/text with a dark label backing.

This is a client display feature with no radio protocol, TX, dependency, or unrelated behavior changes. Final visual/UX acceptance is requested from the maintainer. The minimum interval is intentionally 15 seconds to limit clutter.

## Review follow-up (maintainer-requested)

Four review nits from #5538 are addressed in `Address review nits on waterfall time markers`:

- **30-minute and 1-hour intervals retired.** Issue #5537 proposed nine
  intervals, but `kWaterfallHistoryMs` caps retained history at 20 minutes and
  a screenful of waterfall is only ~11-19 s at typical rates — measured on the
  demo simulator at 230-410 rows and 40-47 ms/row. A 1-hour marker would be on
  screen roughly 0.4% of the time and a 30-minute one ~0.9%. The menu now tops
  out at 15 minutes. This is a deliberate deviation from the issue text, agreed
  with the maintainer. A value written by an earlier build fails closed to Off
  through `validWaterfallMarkerInterval()`; the settings test pins that.
- **`waterfallTimeMarkerSeconds` Q_PROPERTY is now read-only.** Nothing needs
  to set the interval by reflection, and the `dss snapshot` field already
  carries it for reads.
- **The new `dss snapshot` fields are documented** in
  `docs/automation-bridge.md` next to the sibling DSS fields, with the two
  assertions that make markers checkable from the bridge.
- **The `<=` clock-advance guard's overlap with the bucket comparison is now
  a deliberate, commented choice**, and the zero-advance row is pinned
  directly in the geometry test.

Rebased onto current `main` (the only conflict was both sides appending to
`AETHER_SETTINGS_CONSUMERS` in `tests/tests.cmake`) and the touchpoint manifest
regenerated for current main.

Independently verified on **Linux** (`AETHER_GPU_SPECTRUM=ON`), the platform the
original test plan did not cover, driving the demo simulator over the automation
bridge: markers land exactly on clock boundaries, scroll at
`1000/msPerRow` px/s (measured 20.82 vs 21.09 expected), survive resize
(410→350→230 rows), history scrub, `sim stallscope`/`dropslice`/`malformed`, and
disconnect/reconnect, and the interval persists across a process restart.
Mutation testing killed 5 of 6 deliberate reversions of the geometry.

## Constitution principle honored

- Principle V: preference lives in the existing nested Display settings document, without a new flat settings key.
- Principle IV: original Qt implementation; WSJT-X is a behavioral reference only, with no proprietary binary-derived code.
- Principle XI: demonstrated via focused tests and native Demo automation-bridge checks.

## Test plan

- [x] Native macOS ARM64 RelWithDebInfo build with the local toolchain and RADE enabled; ARM64 executable verified and RNNoise x86 sources absent from the build graph.
- [x] Four focused CTests passed: `waterfall_time_markers_test`, `waterfall_time_marker_settings_test`, `waterfall_history_buffer_test`, and `spectrum_preview_logic_test`.
- [x] Geometry tests cover all intervals, wrap, fractional scrolling, paused rows, resize mapping, duplicate timestamps, missing timestamps, gaps, backward clock movement, Off, and invalid values. Settings test checks independent slots, sibling preservation, and reload.
- [x] Mutation checks: reversing fractional-scroll direction fails the geometry checks; reverting clock-boundary labeling fails delayed-row assertions for every interval.
- [x] Native Cocoa/Metal automation bridge using isolated settings, DEMO-0001, and TX disabled: menu selections, live motion, paused history, resize, themes, Off, and restart persistence. A retained marker stayed at row 226 when the paused waterfall grew from 410 to 470 rows. Corrected timestamps were asserted divisible by the selected 15000 ms interval and rendered pixels inspected.
- [x] Theme seed, touchpoint manifest, test registration, engine-boundary strict check, and whitespace checks passed. No increase in the hardcoded-color ratchet.
- [ ] Windows/Linux GPU runtime verification and actual Flex/Kiwi source-switching validation have not been performed. Software renderer was syntax-checked but not exercised as a full runtime build.
- [ ] CI results pending the PR run.

New CTests are socket-free. Bridge proof is a separate manual Demo session. No live-radio validation is claimed; reopening the earlier testing profile briefly auto-connected to a saved FLEX, so that instance was closed without transmit and the final handoff used the clean Demo profile.

## Checklist

- [x] Commit is SSH-signed and locally verified.
- [x] No new flat-key AppSettings calls.
- [x] Clean-room code.
- [x] Theme token documentation and generated inventories updated; CHANGELOG unchanged.
- [x] Local code review completed; identified packet-arrival timestamp labeling corrected before this PR.

Prepared with Codex assistance. Meter smoothing and GHSA references are not applicable to this display-only feature.

