### PR TITLE
fix(gui): explain why ATU Pre-tune is disabled (#5510)

### DIFF
--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -779,9 +779,13 @@ void TxApplet::setBandPlanManager(BandPlanManager* bandPlan)
     m_bandPlanMgr = bandPlan;
 }
 
-void TxApplet::showAtuContextMenu(const QPoint& pos)
+void TxApplet::buildAtuContextMenu(QMenu& menu)
 {
-    QMenu menu(m_atuBtn);
+    // Qt has suppressed per-action tooltips since 5.1 unless the menu opts in,
+    // so the "why is this disabled" text below never reached the operator: a
+    // correctly-greyed Pre-tune item read as a dead control, because a disabled
+    // QAction also does not highlight on hover. (#5510)
+    menu.setToolTipsVisible(true);
 
     auto* preTune = menu.addAction(QString::fromUtf8("Pre-tune bands\xE2\x80\xA6"));
     const bool memOn = m_model && m_model->memoriesEnabled();
@@ -797,15 +801,22 @@ void TxApplet::showAtuContextMenu(const QPoint& pos)
     clearMem->setEnabled(m_radioHasTunerMemories);
     connect(clearMem, &QAction::triggered,
             this, &TxApplet::confirmAndClearAtuMemories);
+}
 
+void TxApplet::showAtuContextMenu(const QPoint& pos)
+{
+    QMenu menu(m_atuBtn);
+    buildAtuContextMenu(menu);
     menu.exec(m_atuBtn->mapToGlobal(pos));
 }
 
-void TxApplet::showTuneContextMenu(const QPoint& pos)
+void TxApplet::buildTuneContextMenu(QMenu& menu)
 {
     if (!m_model) return;
 
-    QMenu menu(m_tuneBtn);
+    // Same opt-in as the ATU menu: without it these entries' tooltips, which
+    // say what the next Tune press will actually transmit, never render.
+    menu.setToolTipsVisible(true);
 
     // Reflect the radio's current tune_mode in the check marks so the user
     // can see what the next Tune press will do.  Selecting either entry is
@@ -832,7 +843,14 @@ void TxApplet::showTuneContextMenu(const QPoint& pos)
         if (m_model)
             m_model->setTuneMode(QStringLiteral("two_tone"));
     });
+}
 
+void TxApplet::showTuneContextMenu(const QPoint& pos)
+{
+    if (!m_model) return;
+
+    QMenu menu(m_tuneBtn);
+    buildTuneContextMenu(menu);
     menu.exec(m_tuneBtn->mapToGlobal(pos));
 }
 

--- a/src/gui/TxApplet.h
+++ b/src/gui/TxApplet.h
@@ -5,6 +5,7 @@
 #include <QElapsedTimer>
 #include <QMetaObject>
 
+class QMenu;
 class QPushButton;
 class QLabel;
 class QSlider;
@@ -45,6 +46,13 @@ public:
     // and command routing. (#2624)
     void setRadioModel(RadioModel* radio);
     void setBandPlanManager(BandPlanManager* bandPlan);
+
+    // Building a context menu is split from showing it so the actions, their
+    // enabled state and their explanatory tooltips can be asserted without
+    // entering the modal QMenu::exec() loop. The show* slots build then exec.
+    // (#5510)
+    void buildAtuContextMenu(QMenu& menu);
+    void buildTuneContextMenu(QMenu& menu);
 
 public slots:
     void updateMeters(float fwdPower, float swr, bool swrValid);

--- a/tests/tx_applet_power_reconciliation_test.cpp
+++ b/tests/tx_applet_power_reconciliation_test.cpp
@@ -5,8 +5,12 @@
 #include "models/RadioModel.h"
 #include "models/TransmitModel.h"
 
+#include <QAction>
 #include <QApplication>
 #include <QLabel>
+#include <QHelpEvent>
+#include <QMenu>
+#include <QToolTip>
 #include <QSignalSpy>
 #include <QPushButton>
 #include <QSlider>
@@ -379,6 +383,94 @@ void testTuneAvailability()
 
 } // namespace
 
+// #5510 — a disabled menu entry must be able to say WHY it is disabled.
+//
+// The ATU right-click menu has always set an explanatory tooltip on a disabled
+// "Pre-tune bands…", but Qt has suppressed per-action tooltips since 5.1 unless
+// the menu opts in, and a disabled QAction does not highlight on hover either.
+// The operator therefore saw an inert item with no feedback at all and reported
+// it as a broken control. These assertions pin the opt-in and the reason text;
+// deleting menu.setToolTipsVisible(true) fails the first one.
+void testAtuContextMenuExplainsWhyPreTuneIsDisabled()
+{
+    TransmitModel model;
+    TxApplet applet;
+    applet.setTransmitModel(&model);
+
+    // The reporter's state: the radio HAS an ATU memory database, but memories
+    // are switched off, so the sweep is legitimately unavailable.
+    model.setHasTunerMemories(true);
+    TransmitDelta memoriesOff;
+    memoriesOff.memoriesEnabled = false;
+    model.applyChanges(memoriesOff);
+
+    QMenu menu;
+    applet.buildAtuContextMenu(menu);
+
+    report("ATU menu opts into per-action tooltips",
+           menu.toolTipsVisible(),
+           menu.toolTipsVisible()
+               ? QString()
+               : QStringLiteral("QMenu::toolTipsVisible() is false, so every "
+                                "disabled-item explanation is unreachable"));
+
+    QAction* preTune = nullptr;
+    for (QAction* action : menu.actions()) {
+        if (action->text().startsWith(QStringLiteral("Pre-tune"))) {
+            preTune = action;
+            break;
+        }
+    }
+
+    report("ATU menu offers a Pre-tune entry", preTune != nullptr);
+    if (preTune == nullptr) {
+        return;
+    }
+
+    report("Pre-tune is disabled while ATU memories are off",
+           !preTune->isEnabled());
+    report("Disabled Pre-tune carries a reason",
+           !preTune->toolTip().isEmpty(),
+           preTune->toolTip());
+
+    // Assert the RENDER, not the property. toolTipsVisible() being true only means
+    // the menu opted in; what the operator needs is Qt actually painting the text
+    // over a DISABLED entry. Qt's QMenu::actionAt() does not filter on enabled
+    // state, but that is Qt's behaviour to demonstrate here, not ours to assume.
+    menu.popup(QPoint(50, 50));
+    QCoreApplication::processEvents();
+    const QRect tipRect = menu.actionGeometry(preTune);
+    QHelpEvent tipEvent(QEvent::ToolTip, tipRect.center(),
+                        menu.mapToGlobal(tipRect.center()));
+    QApplication::sendEvent(&menu, &tipEvent);
+    QCoreApplication::processEvents();
+    const QString shownTip = QToolTip::text();
+    report("Disabled Pre-tune actually renders its reason",
+           shownTip == preTune->toolTip(),
+           shownTip.isEmpty() ? QStringLiteral("<nothing rendered>") : shownTip);
+    QToolTip::hideText();
+    menu.close();
+    QCoreApplication::processEvents();
+
+    // Control: the SAME construction with memories on must enable the entry, so
+    // the assertion above cannot pass just because the item is always disabled.
+    TransmitDelta memoriesOn;
+    memoriesOn.memoriesEnabled = true;
+    model.applyChanges(memoriesOn);
+
+    QMenu enabledMenu;
+    applet.buildAtuContextMenu(enabledMenu);
+    QAction* enabledPreTune = nullptr;
+    for (QAction* action : enabledMenu.actions()) {
+        if (action->text().startsWith(QStringLiteral("Pre-tune"))) {
+            enabledPreTune = action;
+            break;
+        }
+    }
+    report("Pre-tune is enabled once ATU memories are on",
+           enabledPreTune != nullptr && enabledPreTune->isEnabled());
+}
+
 int main(int argc, char** argv)
 {
     TestSettingsProfile settingsProfile(
@@ -404,6 +496,7 @@ int main(int argc, char** argv)
     testAtuSuccessTogglesToBypass();
     testAtuCapabilityUsesThreeVisibleStates();
     testTuneAvailability();
+    testAtuContextMenuExplainsWhyPreTuneIsDisabled();
 
     std::printf("\n%s\n",
                 g_failed == 0


### PR DESCRIPTION
## Summary

Closes #5510.

The ATU right-click menu greys out "Pre-tune bands..." when the radio has not
reported `atu memories_enabled=1`, and sets a tooltip saying why. That tooltip has
never been able to render: Qt has suppressed per-action tooltips since 5.1 unless
`QMenu::setToolTipsVisible(true)` is called, and `git grep setToolTipsVisible` finds
no such call anywhere in the tree. A disabled `QAction` does not highlight on hover
either, so the operator gets an item that looks dead and says nothing, which is
exactly how it was reported ("Click not responding and button not accepting mouse
focus").

This opts the ATU menu into per-action tooltips, and its Tune sibling too, whose
entries describe what the next Tune press will transmit and were equally silent.

The gate itself is not changed. `memoriesEnabled()` mirrors the radio's own
`atu memories_enabled`, so enabling the entry client-side would put the client's
guess above the radio's reported state. This surfaces that state instead of
overriding it.

Menu construction is split from display (`buildAtuContextMenu` /
`buildTuneContextMenu`) so the actions, their enabled state and their tooltips can be
asserted without entering the modal `QMenu::exec()` loop. The regression test drives
that seam rather than asserting on source text.

## Constitution principle honored

**Principle II (The Radio Is Authoritative On Live State).** The disabled state is
the client correctly mirroring `atu memories_enabled` from the radio. The obvious
alternative fix, leaving the entry enabled and letting the client decide, would make
the client's guess outrank the radio's reported state. The reason the item is
disabled is the radio's to give; the client's job was to show it, and it was not
showing it.

## Root cause

`src/gui/TxApplet.cpp` `showAtuContextMenu()`:

- `preTune->setEnabled(m_radioHasTunerMemories && memOn)` where `memOn` is
  `TransmitModel::memoriesEnabled()`
- that member initialises `false` (`TransmitModel.cpp:27`) and is only ever written
  from the radio's `atu` status (`FlexBackend.cpp:953` -> `TransmitModel.cpp:176`)
- both tooltip branches below it are unreachable output, because no `QMenu` in the
  app sets `toolTipsVisible`

## Test plan

- [x] Local build passes (`cmake --build build`) - Nobara, ninja, 0 errors
- [x] Behavior verified on a real radio if applicable - FLEX-6700, see Proof
- [ ] Existing tests pass (CI) - left unchecked only because the Linux `build` job is
      still running as of writing. `Static checks`, `Sanitizer option configures`,
      `check-macos` and `check-windows` all pass. The full
      `tx_applet_power_reconciliation_test` suite passes locally, 24 assertions
- [x] Reproduction steps documented if user-reported bug - see Proof

## Proof

**Reproduced on hardware.** FLEX-6700, this branch built and run with the automation
bridge, connected to the live radio. The radio reports its ATU state on subscribe:

```
S2E211A77|atu status=TUNE_MANUAL_BYPASS atu_enabled=1 memories_enabled=1 using_mem=0
```

Toggling MEM off through the app's own button reproduces the reporting condition, and
the gate follows the radio exactly as before this change:

```
before toggle   "atuMemories": true
after toggle    "atuMemories": false
after restore   "atuMemories": true
```

Nothing was transmitted. The radio was left as found.

**Built clean on all three platforms** from this PR head, not just the dev box:

| Host | Result |
|---|---|
| Linux (Nobara, gcc, ninja) | clean, 0 errors, 1181/1182 |
| macOS | clean, 917/918 |
| Windows (MSVC, windeployqt) | clean, 0 errors |

The Windows leg is the one worth calling out: this is a `src/gui/` change, and MSVC
catches a class of break the other two do not see.

**Regression test, mutation checked.** Six assertions added to
`tx_applet_power_reconciliation_test`, including a control case so the disabled
assertion cannot pass vacuously, and a render-level check so the test is not merely
asserting the property it sets:

```
[ OK ] ATU menu opts into per-action tooltips
[ OK ] ATU menu offers a Pre-tune entry
[ OK ] Pre-tune is disabled while ATU memories are off
[ OK ] Disabled Pre-tune carries a reason              Enable MEM before running the pre-tune sweep
[ OK ] Disabled Pre-tune actually renders its reason   Enable MEM before running the pre-tune sweep
[ OK ] Pre-tune is enabled once ATU memories are on
```

The last one pops the menu and delivers a real `QEvent::ToolTip` over the disabled
entry, then compares `QToolTip::text()` to the action's tooltip. That matters because
`toolTipsVisible() == true` only proves the menu opted in; whether Qt paints a tooltip
for a **disabled** action is Qt's behaviour, and worth demonstrating rather than
assuming. It does (verified on Qt 6.11.1).

Deleting the `setToolTipsVisible` call and rebuilding fails exactly those two, with
exit 1, while the other four stay green:

```
[FAIL] ATU menu opts into per-action tooltips          QMenu::toolTipsVisible() is false, so every
                                                       disabled-item explanation is unreachable
[FAIL] Disabled Pre-tune actually renders its reason   <nothing rendered>
```

## Notes for reviewers

**This is not the whole defect, deliberately.** `setToolTipsVisible` is absent tree
wide, so the same dead-tooltip problem exists in `MainWindow_Menus.cpp`,
`RxApplet.cpp`, `VfoWidget.cpp`, `WaveformsDialog.cpp`, `TciApplet.cpp`,
`MainWindow.cpp` and `Ax25HfPacketDecodeDialog.cpp`. Fixing all eight in a PR about
ATU pre-tune seemed like the wrong scope. Happy to file a follow-up issue, or to widen
this PR if you would rather have it in one go.

**One nit found while in here, not changed.** The `if (!m_radioHasTunerMemories)`
branch inside `showAtuContextMenu()` is unreachable: `updateAtuAvailability()` sets
`Qt::NoContextMenu` on that same condition, so the menu never opens in that state. It
is harmless defensive code and removing it felt like a judgement call rather than a
fix.

**A separate suggestion, for you rather than for me.** With MEM off, the entry is a
dead end: the operator now learns why, but still has to know to go and switch MEM on.
Keeping it enabled and prompting "ATU memories are off, so sweep results will not be
stored. Enable MEM and continue?" would turn that into one click. That is a UX
behaviour change, so per GOVERNANCE.md it is yours to call, not an agent's. Not done
here.

**Automation bridge gap.** This fix could not be proven through the bridge. `menu` is
menu-bar only (`menu list | open <name>`), and `hover` and `tooltip` both take widget
targets, but a `QMenu`'s actions are not widgets and the menu is a transient built
inside the slot. There is no verb that opens a widget's context menu or reads a
`QAction`'s enabled state or tooltip. The unit test covers it instead. Flagging it
because a whole class of context-menu behaviour is currently unreachable from the
bridge.

**Related:** #5484 (RFC on naming shortcuts in tooltips) touches tooltips, but on
buttons rather than menu actions, so the two do not overlap.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V) — no settings calls added
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (Principle II) — no meter UI touched
- [ ] Documentation updated if user-visible behavior changed — `docs/` and the
      affected READMEs. **Not `CHANGELOG.md`**, which is a release-prep file a
      PR must not add to (AGENTS.md); describe it in the Summary above instead
      — left unchecked: the change makes an existing tooltip render, it adds no
      new documented behaviour. Say the word if you want a line in `docs/`
- [ ] Security-sensitive changes reference a GHSA if applicable — not applicable

---

73, Ozy **K6OZY** - model: claude-opus-5
