### PR TITLE
feat(anan): live DDC rate change, and multi-DDC encode/demux on the wire

### DIFF
--- a/src/core/backends/anan/AnanBackend.cpp
+++ b/src/core/backends/anan/AnanBackend.cpp
@@ -956,9 +956,31 @@ void AnanBackend::finishRateChange(quint64 generation, bool ok, const QString& e
     // the OLD rate, until the radio's register write takes effect. That is
     // what the mute above covers, and what the short settle below waits out
     // -- a small fraction of the old restart's cost.
-    QMetaObject::invokeMethod(
-        m_client, "setDdcRateLive", Qt::QueuedConnection,
-        Q_ARG(int, 0), Q_ARG(int, m_pendingDspConfig.inputSampleRateHz / 1000));
+    // Sent THREE times across the settle window, not once. This is
+    // fire-and-forget UDP and nothing re-asserts it -- onKeepaliveTick()
+    // resends High Priority every 100 ms but never DDC-Specific. A single
+    // lost datagram would leave the radio streaming at the old rate while
+    // the new WdspChannel, emitPanState() and AnanDroopCalibrator::
+    // setLandedRate() all record the new one: wrong span, wrong audio pitch,
+    // no error, until the next zoom. The restart path this replaces had
+    // implicit confirmation -- a lost packet meant no stream, and the
+    // 6000 ms connect timeout said so -- and that detection is gone.
+    //
+    // Repeating is safe because the packet is idempotent: p2app's
+    // WriteP2DDCRateRegister() fires on change and its companion
+    // HandlerCheckDDCSettings() is empty, so a duplicate at the same rate is
+    // a no-op on the radio. Cheaper than adding an ack this protocol does
+    // not offer. (aethersdr-agent, #5547 review, Blocker 1.)
+    const int rateKsps = m_pendingDspConfig.inputSampleRateHz / 1000;
+    auto sendRate = [this, rateKsps, generation]() {
+        if (generation != m_connectGeneration)
+            return;
+        QMetaObject::invokeMethod(m_client, "setDdcRateLive", Qt::QueuedConnection,
+                                  Q_ARG(int, 0), Q_ARG(int, rateKsps));
+    };
+    sendRate();
+    for (const int delayMs : kRateChangeResendMs)
+        QTimer::singleShot(delayMs, this, sendRate);
 
     QTimer::singleShot(kRateChangeLiveSettleMs, this, [this, generation]() {
         // Same generation guard the restart path used: a newer rate

--- a/src/core/backends/anan/AnanBackend.cpp
+++ b/src/core/backends/anan/AnanBackend.cpp
@@ -941,18 +941,37 @@ void AnanBackend::finishRateChange(quint64 generation, bool ok, const QString& e
     // guarantees it lands on m_dsp before any new session's first frame can
     // possibly exist.
     QMetaObject::invokeMethod(m_dsp, "setAudioMuted", Qt::QueuedConnection, Q_ARG(bool, true));
-    QMetaObject::invokeMethod(m_client, "stop", Qt::QueuedConnection);
-    // Give the radio real idle time before asking it to restart -- see
-    // kRateChangeRestartSettleMs's own comment for why this is now needed
-    // on purpose (the background-rebuild fix removed the accidental delay
-    // the old synchronous rebuild used to leave here). Re-checks generation
-    // after the wait: a newer rate change/connect/disconnect during the
-    // settle window supersedes this one, same guard startP2ClientSession()
-    // itself already relies on for its own queued calls.
-    QTimer::singleShot(kRateChangeRestartSettleMs, this, [this, generation]() {
+
+    // LIVE rate change: tell the radio the new rate on the RUNNING session
+    // rather than stopping and restarting it. p2app services DDC-Specific in
+    // a continuous loop and applies a rate change with a direct FPGA
+    // register write, with no teardown of its own -- verified in its source,
+    // see P2Client::setDdcRateLive()'s own comment. That answers the
+    // question beginRateChange()'s comment left open, and removes the whole
+    // stop -> settle -> restart -> reconnect-timeout sequence (seconds) that
+    // made every zoom step visibly stall.
+    //
+    // The channel swap already happened (queued just above this call), so
+    // for a brief moment the NEW channel is fed samples still arriving at
+    // the OLD rate, until the radio's register write takes effect. That is
+    // what the mute above covers, and what the short settle below waits out
+    // -- a small fraction of the old restart's cost.
+    QMetaObject::invokeMethod(
+        m_client, "setDdcRateLive", Qt::QueuedConnection,
+        Q_ARG(int, 0), Q_ARG(int, m_pendingDspConfig.inputSampleRateHz / 1000));
+
+    QTimer::singleShot(kRateChangeLiveSettleMs, this, [this, generation]() {
+        // Same generation guard the restart path used: a newer rate
+        // change/connect/disconnect during the settle window supersedes this.
         if (generation != m_connectGeneration)
             return;
-        startP2ClientSession(generation);
+        QMetaObject::invokeMethod(m_dsp, "setAudioMuted", Qt::QueuedConnection,
+                                  Q_ARG(bool, false));
+        m_rateChanging = false;
+        emitPanState();
+        // A zoom the operator kept turning while this ran: apply the latest
+        // request now rather than stranding the display a step behind.
+        retryPendingRateChange();
     });
 }
 

--- a/src/core/backends/anan/AnanBackend.h
+++ b/src/core/backends/anan/AnanBackend.h
@@ -238,20 +238,29 @@ private:
     // connect keeps the shorter, tighter default.
     static constexpr int kRateChangeConnectTimeoutMs = 6000;
     // Minimum idle time between stop() and start() on a rate-change restart.
-    // Bench-discovered (2026-08-19), not a spec citation: with the DSP
-    // rebuild moved off the stop/start path (background-rebuild fix), the
-    // radio started NOT responding to a restart fired only ~100ms after
-    // stop() -- "no DDC0 IQ within 6000ms", followed by a full disconnect/
-    // reconnect to recover. The OLD synchronous-rebuild architecture never
-    // hit this: the slow rebuild sat BETWEEN stop() and start(), so the
-    // radio always got real idle time before a restart, as an unintended
-    // side effect of what was otherwise a bug. This constant restores that
-    // gap on purpose instead of by accident. Value is a bench guess, not
-    // yet a confirmed minimum -- see finishRateChange()'s own comment.
-    // 500ms was tried first (2026-08-19) and was NOT reliably enough: a
-    // chained rapid zoom sequence still hit the 6s timeout and forced a
-    // full reconnect. Raised to 2000ms to test next.
-    static constexpr int kRateChangeRestartSettleMs = 2000;
+    // Settle window after a LIVE rate change, covering only the handoff:
+    // the new WdspChannel is already installed when the radio is told to
+    // switch, so for a moment it is fed samples still arriving at the old
+    // rate, until p2app's register write takes effect. Audio is muted across
+    // this window (finishRateChange()).
+    //
+    // Supersedes kRateChangeRestartSettleMs (2000ms), which existed for a
+    // problem that no longer occurs and whose history is worth keeping:
+    // bench-discovered 2026-08-19, once the DSP rebuild moved off the
+    // stop/start path, the radio stopped responding to a restart fired only
+    // ~100ms after stop() -- "no DDC0 IQ within 6000ms", then a full
+    // disconnect/reconnect to recover. The old synchronous-rebuild
+    // architecture never hit it only because the slow rebuild sat BETWEEN
+    // stop() and start(), giving the radio idle time by accident. 500ms was
+    // tried and was not reliably enough; 2000ms was the working value. A
+    // live rate change never stops the session at all, so none of that
+    // applies -- there is no restart for the radio to be unready for.
+    //
+    // 250ms is a starting value for the handoff itself, not a confirmed
+    // minimum; it is a fraction of the ~2s the restart path cost per zoom
+    // step. Worth revisiting on the bench if a rate change still audibly
+    // glitches, or shortening if it proves conservative.
+    static constexpr int kRateChangeLiveSettleMs = 250;
 
     QString m_mode = QStringLiteral("USB");
     int m_filterLowHz = 100;

--- a/src/core/backends/anan/AnanBackend.h
+++ b/src/core/backends/anan/AnanBackend.h
@@ -260,7 +260,26 @@ private:
     // minimum; it is a fraction of the ~2s the restart path cost per zoom
     // step. Worth revisiting on the bench if a rate change still audibly
     // glitches, or shortening if it proves conservative.
+    //
+    // It also SUPERSEDES kRateChangeAudioSettleMs (300ms) on this path, and
+    // that is a deliberate judgement rather than an oversight. That 300ms
+    // exists so a freshly built WdspChannel gets a beat of quiet before its
+    // AGC, filters and DC-blocker are unmuted against live RF -- under the
+    // restart path its clock started at linkUp, i.e. at the first new-rate
+    // frame. Here the clock starts at the channel swap, so WDSP gets
+    // 250ms minus the handoff latency: strictly less, by an amount that has
+    // not been measured. Bench-tested at 48 and 1536 ksps without an audible
+    // artifact, which is the evidence for calling it sufficient -- but if a
+    // rate change ever thumps on unmute, split the two settles before
+    // reaching for a larger number. (aethersdr-agent, #5547 review.)
     static constexpr int kRateChangeLiveSettleMs = 250;
+
+    // The DDC-Specific packet is resent at these offsets (ms) inside the
+    // settle window above, on top of the immediate send. Three copies over
+    // ~140 ms, all well inside the 250 ms mute, so a lost datagram costs
+    // nothing audible. See finishRateChange()'s own comment for why one
+    // fire-and-forget send was not enough and why repeating is safe.
+    static constexpr int kRateChangeResendMs[] = {60, 140};
 
     QString m_mode = QStringLiteral("USB");
     int m_filterLowHz = 100;

--- a/src/core/backends/anan/P2Client.cpp
+++ b/src/core/backends/anan/P2Client.cpp
@@ -179,14 +179,14 @@ bool P2Client::setDdcRateLive(int ddcIndex, int rateKsps)
         return false;
 
     auto& slot = m_activeDdcs[static_cast<std::size_t>(ddcIndex)];
-    if (slot.rateKsps == rateKsps)
-        return false;   // nothing to send; caller decides whether that is worth reporting
-
+    const bool rateChanged = slot.rateKsps != rateKsps;
     slot.rateKsps = rateKsps;
     // Whole packet, every DDC's row -- see this function's declaration
     // comment. Same destination port start() used: p2app tells DDC-Specific
     // from High Priority by which port it arrives on, so this is not
-    // interchangeable with kRadioPort.
+    // interchangeable with kRadioPort. Sent even when rateChanged is false:
+    // AnanBackend retries this call at 60/140 ms for UDP loss, and those
+    // retries must not no-op after the first write (#5547).
     sendTo(*m_socket,
           buildDdcSpecific(m_activeDdcs, /*numAdcs=*/2,
                            m_ditherEnabled, m_randomEnabled),
@@ -195,8 +195,12 @@ bool P2Client::setDdcRateLive(int ddcIndex, int rateKsps)
     // The stream's sample cadence changes underneath us from here, so the
     // sequence expectation for THIS DDC is no longer meaningful -- clear it
     // rather than let the next frame look like a gap and inflate the drop
-    // counter for what is a deliberate, operator-initiated change.
-    m_expectedSeq[static_cast<std::size_t>(ddcIndex)].reset();
+    // counter for what is a deliberate, operator-initiated change. Retries
+    // of the same rate leave the tracker alone: the cadence did not change
+    // again.
+    if (rateChanged) {
+        m_expectedSeq[static_cast<std::size_t>(ddcIndex)].reset();
+    }
     return true;
 }
 

--- a/src/core/backends/anan/P2Client.cpp
+++ b/src/core/backends/anan/P2Client.cpp
@@ -1,10 +1,13 @@
 #include "core/backends/anan/P2Client.h"
 
+#include <QLoggingCategory>
 #include <QNetworkDatagram>
 #include <QTimer>
 #include <QUdpSocket>
 
 #include <span>
+
+Q_LOGGING_CATEGORY(lcAnanP2, "aether.anan.p2")
 
 namespace AetherSDR::anan {
 
@@ -62,6 +65,7 @@ bool P2Client::start(const Params& params, int connectTimeoutMs)
     m_expectedSeq.fill(std::nullopt);
     m_activeDdcCount = 1;   // real value set once the DDC list is resolved below
     m_drops = 0;
+    m_warnedUnexpectedPorts.clear();
     m_linkUp = false;
     m_discoveryInfoSent = false;
 
@@ -102,11 +106,20 @@ bool P2Client::start(const Params& params, int connectTimeoutMs)
     m_ditherEnabled = params.ditherEnabled;
     m_randomEnabled = params.randomEnabled;
 
-    // Every DDC starts at the same frequency DDC0 was given (0/baseband
-    // unless a caller retuned first). Per-DDC tuning is a seam this class
-    // does not expose yet -- setDdc0FrequencyHz() moves DDC0 only -- so
-    // sending one shared word is honest about what is actually controllable
-    // rather than implying independent tuning that has no setter behind it.
+    // Every DDC starts at the same frequency: m_ddc0FreqWord, which start()
+    // zeroed above, so in practice baseband. Per-DDC tuning is a seam this
+    // class does not expose yet -- setDdc0FrequencyHz() moves DDC0 only --
+    // so sending one shared word is honest about what is actually
+    // controllable rather than implying independent tuning that has no
+    // setter behind it.
+    //
+    // The two other High Priority senders (setDdc0FrequencyHz() and
+    // onKeepaliveTick()) send the SAME shared word for the same count, so
+    // they cannot disagree with this packet. That matters because the
+    // keepalive fires every 100 ms: a single-DDC overload there would pin
+    // DDC1..N-1 at word 0 forever regardless of what this line sent, and the
+    // two would diverge permanently the moment DDC0 was retuned.
+    // (aethersdr-agent, #5547 review.)
     std::vector<std::uint32_t> freqWords(ddcs.size(), m_ddc0FreqWord);
 
     // Destination ports below are NOT interchangeable with kRadioPort -- see
@@ -153,7 +166,8 @@ void P2Client::setDdc0FrequencyHz(double hz)
     m_ddc0FreqWord = phaseWord(hz);
     if (m_running && m_socket)
         sendTo(*m_socket,
-              buildHighPriority(true, m_ddc0FreqWord, m_bypassAdc0Filters, m_bypassAdc1Filters),
+              buildHighPriority(true, sharedFreqWords(),
+                                m_bypassAdc0Filters, m_bypassAdc1Filters),
               m_host, kHighPriorityPort);
 }
 
@@ -193,7 +207,8 @@ void P2Client::onKeepaliveTick()
     // This IS the "any C&C packet" the watchdog needs (p.8) -- no need to
     // also replay General/DDC-Specific on this cadence, same as the spike.
     sendTo(*m_socket,
-          buildHighPriority(true, m_ddc0FreqWord, m_bypassAdc0Filters, m_bypassAdc1Filters),
+          buildHighPriority(true, sharedFreqWords(),
+                            m_bypassAdc0Filters, m_bypassAdc1Filters),
           m_host, kHighPriorityPort);
 }
 
@@ -237,6 +252,26 @@ void P2Client::onReadyRead()
             // DDC would corrupt that receiver's audio and its sequence
             // tracking, and counting it as a drop would blame this session
             // for someone else's traffic.
+            //
+            // "Not a drop" must not mean "not observable", though. If the
+            // radio's source port ever differs from basePort + n -- other
+            // firmware, a NAT or relay in the path, a future negotiated-port
+            // session -- then EVERY datagram lands here and the operator sees
+            // a dead receiver whose only diagnostic is onConnectTimeout()'s
+            // "no DDC0 IQ from the radio", which reads as a radio fault. One
+            // line naming the port turns that into a diagnosis. Logged once
+            // per distinct port per session: this is in the hot receive path
+            // and a mismatch is by nature every packet.
+            if (!m_warnedUnexpectedPorts.contains(dg.senderPort())) {
+                m_warnedUnexpectedPorts.insert(dg.senderPort());
+                qCWarning(lcAnanP2).nospace()
+                    << "ANAN: dropping DDC-shaped datagram from unexpected "
+                       "sender port " << dg.senderPort() << " (expected "
+                    << kDdc0DefaultPort << ".."
+                    << (kDdc0DefaultPort + m_activeDdcCount - 1)
+                    << " for " << m_activeDdcCount
+                    << " active DDC(s)) -- not counted as a drop";
+            }
             continue;
         }
         const std::size_t slot = static_cast<std::size_t>(*ddcIndex);

--- a/src/core/backends/anan/P2Client.cpp
+++ b/src/core/backends/anan/P2Client.cpp
@@ -96,6 +96,11 @@ bool P2Client::start(const Params& params, int connectTimeoutMs)
     if (static_cast<int>(ddcs.size()) > kMaxDdcs)
         ddcs.resize(kMaxDdcs);
     m_activeDdcCount = static_cast<int>(ddcs.size());
+    // Retained for setDdcRateLive() -- see its own comment for why the whole
+    // list (not just the count) has to survive start().
+    m_activeDdcs = ddcs;
+    m_ditherEnabled = params.ditherEnabled;
+    m_randomEnabled = params.randomEnabled;
 
     // Every DDC starts at the same frequency DDC0 was given (0/baseband
     // unless a caller retuned first). Per-DDC tuning is a seam this class
@@ -150,6 +155,35 @@ void P2Client::setDdc0FrequencyHz(double hz)
         sendTo(*m_socket,
               buildHighPriority(true, m_ddc0FreqWord, m_bypassAdc0Filters, m_bypassAdc1Filters),
               m_host, kHighPriorityPort);
+}
+
+bool P2Client::setDdcRateLive(int ddcIndex, int rateKsps)
+{
+    if (!m_running || !m_socket)
+        return false;
+    if (ddcIndex < 0 || ddcIndex >= static_cast<int>(m_activeDdcs.size()))
+        return false;
+
+    auto& slot = m_activeDdcs[static_cast<std::size_t>(ddcIndex)];
+    if (slot.rateKsps == rateKsps)
+        return false;   // nothing to send; caller decides whether that is worth reporting
+
+    slot.rateKsps = rateKsps;
+    // Whole packet, every DDC's row -- see this function's declaration
+    // comment. Same destination port start() used: p2app tells DDC-Specific
+    // from High Priority by which port it arrives on, so this is not
+    // interchangeable with kRadioPort.
+    sendTo(*m_socket,
+          buildDdcSpecific(m_activeDdcs, /*numAdcs=*/2,
+                           m_ditherEnabled, m_randomEnabled),
+          m_host, kDdcSpecificPort);
+
+    // The stream's sample cadence changes underneath us from here, so the
+    // sequence expectation for THIS DDC is no longer meaningful -- clear it
+    // rather than let the next frame look like a gap and inflate the drop
+    // counter for what is a deliberate, operator-initiated change.
+    m_expectedSeq[static_cast<std::size_t>(ddcIndex)].reset();
+    return true;
 }
 
 void P2Client::onKeepaliveTick()

--- a/src/core/backends/anan/P2Client.cpp
+++ b/src/core/backends/anan/P2Client.cpp
@@ -56,7 +56,11 @@ bool P2Client::start(const Params& params, int connectTimeoutMs)
     m_ddc0FreqWord = 0;
     m_bypassAdc0Filters = params.bypassAdc0Filters;
     m_bypassAdc1Filters = params.bypassAdc1Filters;
-    m_expectedSeq.reset();
+    // Every DDC's sequence tracker, not just DDC0's -- a stale expectation
+    // carried across a restart would report a phantom gap on the new
+    // session's first frame.
+    m_expectedSeq.fill(std::nullopt);
+    m_activeDdcCount = 1;   // real value set once the DDC list is resolved below
     m_drops = 0;
     m_linkUp = false;
     m_discoveryInfoSent = false;
@@ -82,16 +86,33 @@ bool P2Client::start(const Params& params, int connectTimeoutMs)
     // onReadyRead() already drops anything that isn't DDC0-shaped.
     sendTo(*m_socket, buildDiscovery(), m_host, kRadioPort);
     sendTo(*m_socket, buildGeneral(), m_host, kRadioPort);
+
+    // Resolve the session's DDC list ONCE: either the caller's explicit
+    // multi-DDC list, or a one-element list from the DDC0 shorthand. See
+    // Params::activeDdcs for why these are not merged.
+    std::vector<DdcConfig> ddcs = params.activeDdcs;
+    if (ddcs.empty())
+        ddcs.push_back(DdcConfig{params.ddc0RateKsps, params.ddc0AdcIndex});
+    if (static_cast<int>(ddcs.size()) > kMaxDdcs)
+        ddcs.resize(kMaxDdcs);
+    m_activeDdcCount = static_cast<int>(ddcs.size());
+
+    // Every DDC starts at the same frequency DDC0 was given (0/baseband
+    // unless a caller retuned first). Per-DDC tuning is a seam this class
+    // does not expose yet -- setDdc0FrequencyHz() moves DDC0 only -- so
+    // sending one shared word is honest about what is actually controllable
+    // rather than implying independent tuning that has no setter behind it.
+    std::vector<std::uint32_t> freqWords(ddcs.size(), m_ddc0FreqWord);
+
     // Destination ports below are NOT interchangeable with kRadioPort -- see
     // kDdcSpecificPort/kHighPriorityPort's comment. p2app tells these two
     // packet types apart by which port they arrive on.
     sendTo(*m_socket,
-          buildDdcSpecific(params.ddc0RateKsps, /*numAdcs=*/2,
-                           params.ditherEnabled, params.randomEnabled,
-                           params.ddc0AdcIndex),
+          buildDdcSpecific(ddcs, /*numAdcs=*/2,
+                           params.ditherEnabled, params.randomEnabled),
           m_host, kDdcSpecificPort);
     sendTo(*m_socket,
-          buildHighPriority(true, m_ddc0FreqWord, m_bypassAdc0Filters, m_bypassAdc1Filters),
+          buildHighPriority(true, freqWords, m_bypassAdc0Filters, m_bypassAdc1Filters),
           m_host, kHighPriorityPort);
 
     m_keepaliveTimer->start();
@@ -170,13 +191,35 @@ void P2Client::onReadyRead()
             continue;
         }
 
-        if (m_expectedSeq && frame->seq != *m_expectedSeq) {
+        // Which DDC sent this. The IQ packet carries no DDC index of its
+        // own, so the sender port is the only discriminator -- see
+        // ddcIndexForSenderPort()'s comment for how that is verified.
+        const auto ddcIndex = ddcIndexForSenderPort(
+            static_cast<std::uint16_t>(dg.senderPort()), m_activeDdcCount);
+        if (!ddcIndex) {
+            // DDC-shaped, but from a port this session did not enable --
+            // another client's stream to this host, or a DDC left running by
+            // a previous session. Dropping it is right: attributing it to a
+            // DDC would corrupt that receiver's audio and its sequence
+            // tracking, and counting it as a drop would blame this session
+            // for someone else's traffic.
+            continue;
+        }
+        const std::size_t slot = static_cast<std::size_t>(*ddcIndex);
+
+        // Per-DDC gap detection; see m_expectedSeq's own comment for why a
+        // shared counter would manufacture drops once a second DDC streams.
+        if (m_expectedSeq[slot] && frame->seq != *m_expectedSeq[slot]) {
             ++m_drops;
             emit dropsUpdated(m_drops);
         }
-        m_expectedSeq = frame->seq + 1;
+        m_expectedSeq[slot] = frame->seq + 1;
 
-        if (!m_linkUp) {
+        // linkUp stays keyed on DDC0: it is the receiver every session has,
+        // and the connect timeout's message says "no DDC0 IQ". A session
+        // whose DDC1 streamed but whose DDC0 never did is a real failure,
+        // not a connected session.
+        if (!m_linkUp && *ddcIndex == 0) {
             m_linkUp = true;
             m_connectTimeoutTimer->stop();
             emit linkUp();
@@ -184,7 +227,9 @@ void P2Client::onReadyRead()
 
         m_decodeScratch.clear();
         decodeIq(*frame, m_decodeScratch);
-        emit ddc0IqReady(m_decodeScratch);
+        emit ddcIqReady(*ddcIndex, m_decodeScratch);
+        if (*ddcIndex == 0)
+            emit ddc0IqReady(m_decodeScratch);
     }
 }
 

--- a/src/core/backends/anan/P2Client.h
+++ b/src/core/backends/anan/P2Client.h
@@ -117,9 +117,11 @@ public:
     Q_INVOKABLE void setDdc0FrequencyHz(double hz);
 
     // Change one DDC's sample rate on a LIVE session -- no stop, no restart,
-    // no reconnect. Returns false (changing nothing) if the session is not
-    // running, ddcIndex is not one this session enabled, or the rate already
-    // matches.
+    // no reconnect. Returns false (sending nothing) if the session is not
+    // running or ddcIndex is not one this session enabled. A matching rate
+    // still sends: the packet is fire-and-forget UDP and the caller retries
+    // across the settle window, so skipping an unchanged slot would drop
+    // those retransmits.
     //
     // Supported by the radio, verified in p2app's own source rather than
     // assumed: IncomingDDCSpecific.c services DDC-Specific packets in a

--- a/src/core/backends/anan/P2Client.h
+++ b/src/core/backends/anan/P2Client.h
@@ -6,6 +6,7 @@
 #include <QObject>
 #include <QString>
 
+#include <array>
 #include <complex>
 #include <cstdint>
 #include <optional>
@@ -75,6 +76,21 @@ public:
         int ddc0AdcIndex = 0;          // 0 = ADC0, 1 = ADC1/RX2
         bool bypassAdc0Filters = true;
         bool bypassAdc1Filters = true;
+
+        // Multi-DDC session. EMPTY (the default) means "single DDC0
+        // session", built from ddc0RateKsps/ddc0AdcIndex above -- so every
+        // existing caller keeps the exact bench-validated single-DDC
+        // behaviour without naming this field at all.
+        //
+        // When non-empty this is authoritative and the two shorthand fields
+        // are ignored: entry n configures DDC n. Capped at
+        // P2Protocol's kMaxDdcs by the packet builders.
+        //
+        // Deliberately not merged into the shorthand fields: a caller that
+        // sets BOTH would otherwise have two disagreeing sources of truth
+        // for DDC0's rate, and silently picking one is exactly the kind of
+        // thing that reads as a radio fault on the bench.
+        std::vector<DdcConfig> activeDdcs;
     };
 
     // start()/stop() and setDdc0FrequencyHz() MUST execute on this object's
@@ -110,7 +126,16 @@ signals:
     // Mic Data / Status traffic, which onReadyRead() rejects and does not
     // count as a connection).
     void connectionError(const QString& reason);
+    // DDC0's decoded IQ. Kept as its own signal because DDC0 is the one
+    // receiver every session always has, and it is what linkUp()/the connect
+    // timeout are keyed on. Emitted for ddcIndex 0 only; ddcIqReady() below
+    // fires for the same block as well.
     void ddc0IqReady(const std::vector<std::complex<float>>& block);
+    // Decoded IQ for ANY active DDC, demultiplexed by the datagram's sender
+    // port (see P2Protocol::ddcIndexForSenderPort()). This is the general
+    // form; a multi-receiver consumer routes on ddcIndex rather than
+    // connecting per-DDC signals.
+    void ddcIqReady(int ddcIndex, const std::vector<std::complex<float>>& block);
     void dropsUpdated(quint64 totalDrops);
     // This session's own Discovery reply -- the SAME radio start() already
     // sent a Discovery packet to, on this socket, per the class comment.
@@ -167,11 +192,27 @@ private:
     bool m_running = false;
     bool m_linkUp = false;
 
-    std::optional<std::uint32_t> m_expectedSeq;   // for DDC0 sequence-gap detection
+    // Sequence-gap detection is PER DDC: every DDC runs its own independent
+    // sequence counter on its own socket, so a single shared "expected next"
+    // would report a gap on every alternating frame the moment a second DDC
+    // started streaming -- a fault indication manufactured entirely by the
+    // client. Indexed by ddcIndex; nullopt until that DDC's first frame.
+    std::array<std::optional<std::uint32_t>, kMaxDdcs> m_expectedSeq{};
+    // Drops stay a single session-wide counter (what dropsUpdated() has
+    // always reported) -- an operator watching for a lossy link cares that
+    // the session is dropping, not which receiver.
     quint64 m_drops = 0;
 
-    // Reused decode buffer, cleared and refilled per DDC0 frame rather than
+    // How many DDCs this session enabled, so onReadyRead() knows which
+    // sender ports belong to it. Set by start() from Params::activeDdcs
+    // (or 1 for the DDC0 shorthand).
+    int m_activeDdcCount = 1;
+
+    // Reused decode buffer, cleared and refilled per frame rather than
     // reallocated -- matches MetisClient's m_blocks for the same reason.
+    // Shared across DDCs deliberately: onReadyRead() fully consumes each
+    // block (the emit is a same-thread direct connection) before touching
+    // the next datagram, so there is never more than one live at a time.
     std::vector<std::complex<float>> m_decodeScratch;
 };
 

--- a/src/core/backends/anan/P2Client.h
+++ b/src/core/backends/anan/P2Client.h
@@ -4,6 +4,7 @@
 
 #include <QHostAddress>
 #include <QObject>
+#include <QSet>
 #include <QString>
 
 #include <array>
@@ -242,6 +243,21 @@ private:
     // sender ports belong to it. Kept alongside m_activeDdcs (rather than
     // read from its size) because onReadyRead() consults it per datagram.
     int m_activeDdcCount = 1;
+
+    // One shared phase word per active DDC. Every High Priority sender uses
+    // this, so the keepalive (100 ms) can never contradict what start() sent:
+    // a single-DDC overload on that path would pin DDC1..N-1 at word 0
+    // regardless. Per-DDC tuning has no setter yet, so one word for all of
+    // them is the honest encoding -- see start()'s own comment.
+    [[nodiscard]] std::vector<std::uint32_t> sharedFreqWords() const
+    {
+        return std::vector<std::uint32_t>(
+            static_cast<std::size_t>(m_activeDdcCount), m_ddc0FreqWord);
+    }
+    // Sender ports already warned about, so a port mismatch -- which by
+    // nature affects every packet -- logs once per distinct port rather than
+    // per datagram. Session-scoped; cleared with the rest of the state.
+    QSet<quint16> m_warnedUnexpectedPorts;
 
     // Reused decode buffer, cleared and refilled per frame rather than
     // reallocated -- matches MetisClient's m_blocks for the same reason.

--- a/src/core/backends/anan/P2Client.h
+++ b/src/core/backends/anan/P2Client.h
@@ -115,6 +115,32 @@ public:
     // tick) and is what the keepalive resends from then on.
     Q_INVOKABLE void setDdc0FrequencyHz(double hz);
 
+    // Change one DDC's sample rate on a LIVE session -- no stop, no restart,
+    // no reconnect. Returns false (changing nothing) if the session is not
+    // running, ddcIndex is not one this session enabled, or the rate already
+    // matches.
+    //
+    // Supported by the radio, verified in p2app's own source rather than
+    // assumed: IncomingDDCSpecific.c services DDC-Specific packets in a
+    // continuous thread loop and, on any change, calls
+    // WriteP2DDCRateRegister(), which is a direct
+    // RegisterWrite(VADDRDDCRATES, ...) to the FPGA. Its companion
+    // "something changed" hook, HandlerCheckDDCSettings(), is an EMPTY
+    // function -- p2app writes the rate register and keeps streaming. There
+    // is no teardown on the radio side to mirror.
+    //
+    // This answers the question AnanBackend::beginRateChange()'s own comment
+    // left open ("whether the radio would accept a live rate change without
+    // a session restart at all is a separate, unverified protocol
+    // question"). The caller still has to rebuild ITS OWN WdspChannel, whose
+    // input sample rate really did change -- that part is unavoidable and is
+    // why AnanBackend builds the new channel in the background first.
+    //
+    // Resends the whole DDC-Specific packet, not a partial one: the packet
+    // carries the enable bitmap and every DDC's row, so a partial resend
+    // would disable the others.
+    Q_INVOKABLE bool setDdcRateLive(int ddcIndex, int rateKsps);
+
     [[nodiscard]] bool isRunning() const noexcept { return m_running; }
     [[nodiscard]] quint64 droppedPackets() const noexcept { return m_drops; }
 
@@ -189,6 +215,15 @@ private:
     bool m_bypassAdc0Filters = true;
     bool m_bypassAdc1Filters = true;
 
+    // The session's resolved DDC list and the dither/random flags that went
+    // with it, RETAINED (rather than consumed and dropped in start()) so
+    // setDdcRateLive() can rebuild a complete DDC-Specific packet: that
+    // packet carries every DDC's row plus the enable bitmap, so resending it
+    // with only the changed rate known would disable every other DDC.
+    std::vector<DdcConfig> m_activeDdcs;
+    bool m_ditherEnabled = true;
+    bool m_randomEnabled = true;
+
     bool m_running = false;
     bool m_linkUp = false;
 
@@ -204,8 +239,8 @@ private:
     quint64 m_drops = 0;
 
     // How many DDCs this session enabled, so onReadyRead() knows which
-    // sender ports belong to it. Set by start() from Params::activeDdcs
-    // (or 1 for the DDC0 shorthand).
+    // sender ports belong to it. Kept alongside m_activeDdcs (rather than
+    // read from its size) because onReadyRead() consults it per datagram.
     int m_activeDdcCount = 1;
 
     // Reused decode buffer, cleared and refilled per frame rather than

--- a/src/core/backends/anan/P2Protocol.cpp
+++ b/src/core/backends/anan/P2Protocol.cpp
@@ -1,5 +1,6 @@
 #include "core/backends/anan/P2Protocol.h"
 
+#include <algorithm>
 #include <cstring>
 
 namespace AetherSDR::anan {
@@ -90,9 +91,8 @@ std::array<std::uint8_t, 60> buildGeneral() noexcept
     return pkt;
 }
 
-std::array<std::uint8_t, 1444> buildDdcSpecific(int ddc0RateKsps, int numAdcs,
-                                                bool ditherEnabled, bool randomEnabled,
-                                                int ddc0AdcIndex) noexcept
+std::array<std::uint8_t, 1444> buildDdcSpecific(std::span<const DdcConfig> ddcs, int numAdcs,
+                                                bool ditherEnabled, bool randomEnabled) noexcept
 {
     std::array<std::uint8_t, 1444> pkt{};  // full spec length (80 DDCs); unused DDCs
                                             // stay zero/disabled
@@ -100,25 +100,59 @@ std::array<std::uint8_t, 1444> buildDdcSpecific(int ddc0RateKsps, int numAdcs,
                                                    // supports" (p.25)
     // Bytes 5/6: one Dither/Random control on this radio, not a per-ADC
     // pair, so both ADC0 and ADC1 bits track it together regardless of
-    // which ADC ddc0AdcIndex actually selects.
+    // which ADC any given DDC actually selects.
     pkt[5] = ditherEnabled ? 0x03 : 0x00;
     pkt[6] = randomEnabled ? 0x03 : 0x00;
-    pkt[7] = 0x01;   // bit[0]: enable DDC0 only
-    pkt[17] = static_cast<std::uint8_t>(ddc0AdcIndex);  // DDC0 -> ADC(ddc0AdcIndex)
-    writeU16be(&pkt[18], static_cast<std::uint16_t>(ddc0RateKsps));  // bytes 18-19,
-                                                                      // raw ksps value
-    pkt[22] = 24;    // DDC0 sample size, 24 bits (default, made explicit)
+
+    // Clamp rather than trust the caller: writing rows for more DDCs than
+    // kMaxDdcs would keep landing inside this 1444-byte packet (the spec has
+    // room for 80), so this is not a buffer guard -- it is a refusal to
+    // enable hardware receivers the rest of this backend is not driving.
+    const std::size_t count =
+        std::min(ddcs.size(), static_cast<std::size_t>(kMaxDdcs));
+
+    std::uint8_t enableBits = 0;
+    for (std::size_t n = 0; n < count; ++n) {
+        enableBits |= static_cast<std::uint8_t>(1u << n);
+        // One 6-byte row per DDC: ADC select, 2-byte rate, CIC1, CIC2,
+        // sample size. Offsets confirmed against the single-DDC layout this
+        // replaced (DDC0: 17 / 18-19 / 20-21 / 22), which is bench-proven.
+        const std::size_t row = 17 + 6 * n;
+        pkt[row] = static_cast<std::uint8_t>(ddcs[n].adcIndex);
+        writeU16be(&pkt[row + 1], static_cast<std::uint16_t>(ddcs[n].rateKsps));
+        // row+3, row+4 = CIC1/CIC2, "For Future use" (p.25) -- left zero.
+        pkt[row + 5] = 24;   // sample size, 24 bits (default, made explicit)
+    }
+    pkt[7] = enableBits;   // bit[n] enables DDC n
     return pkt;
 }
 
-std::array<std::uint8_t, 1444> buildHighPriority(bool run, std::uint32_t ddc0FreqWord,
+std::array<std::uint8_t, 1444> buildDdcSpecific(int ddc0RateKsps, int numAdcs,
+                                                bool ditherEnabled, bool randomEnabled,
+                                                int ddc0AdcIndex) noexcept
+{
+    // Delegates so the row layout has exactly one implementation; the
+    // single-DDC output stays byte-identical to what this function built
+    // before the multi-DDC overload existed (pinned by the existing tests).
+    const DdcConfig one{ddc0RateKsps, ddc0AdcIndex};
+    return buildDdcSpecific(std::span<const DdcConfig>(&one, 1),
+                            numAdcs, ditherEnabled, randomEnabled);
+}
+
+std::array<std::uint8_t, 1444> buildHighPriority(bool run,
+                                                  std::span<const std::uint32_t> ddcFreqWords,
                                                   bool bypassAdc0Filters,
                                                   bool bypassAdc1Filters) noexcept
 {
     std::array<std::uint8_t, 1444> pkt{};  // full spec length; attenuator fields stay zero
     pkt[4] = run ? 0x01 : 0x00;  // bit[0] = run. Bits[1..4] = PTT0..3 -- there is no
                                   // parameter to set them; see this header's own comment.
-    writeU32be(&pkt[9], ddc0FreqWord);  // bytes 9-12, DDC0 frequency/phase word
+    // One 4-byte frequency/phase word per DDC at 9 + 4*n (p.32). Same
+    // clamp-and-ignore contract as buildDdcSpecific().
+    const std::size_t count =
+        std::min(ddcFreqWords.size(), static_cast<std::size_t>(kMaxDdcs));
+    for (std::size_t n = 0; n < count; ++n)
+        writeU32be(&pkt[9 + 4 * n], ddcFreqWords[n]);
     // Alex0 register, bytes 1432-1435 -- ANT1 (bit 24) always, HF Bypass
     // (bit 12) when requested. See this function's declaration comment.
     std::uint32_t alex0 = std::uint32_t{1} << 24;
@@ -130,6 +164,31 @@ std::array<std::uint8_t, 1444> buildHighPriority(bool run, std::uint32_t ddc0Fre
     if (bypassAdc1Filters)
         writeU16be(&pkt[1430], std::uint16_t{1} << 12);
     return pkt;
+}
+
+std::array<std::uint8_t, 1444> buildHighPriority(bool run, std::uint32_t ddc0FreqWord,
+                                                  bool bypassAdc0Filters,
+                                                  bool bypassAdc1Filters) noexcept
+{
+    // Delegates, same reasoning as buildDdcSpecific()'s single-DDC overload:
+    // one implementation of the row layout, and byte-identical output to
+    // what this built before (pinned by the existing tests).
+    return buildHighPriority(run, std::span<const std::uint32_t>(&ddc0FreqWord, 1),
+                             bypassAdc0Filters, bypassAdc1Filters);
+}
+
+std::optional<int> ddcIndexForSenderPort(std::uint16_t senderPort, int numDdc,
+                                          std::uint16_t basePort) noexcept
+{
+    if (numDdc <= 0 || senderPort < basePort)
+        return std::nullopt;
+    // Widened to int before subtracting: both operands are uint16_t, and the
+    // guard above already rules out the wrap case, but doing the arithmetic
+    // in int keeps that correctness local rather than resting on the guard.
+    const int index = static_cast<int>(senderPort) - static_cast<int>(basePort);
+    if (index >= numDdc)
+        return std::nullopt;
+    return index;
 }
 
 std::optional<DdcFrame> parseDdcFrame(std::span<const std::uint8_t> data) noexcept

--- a/src/core/backends/anan/P2Protocol.h
+++ b/src/core/backends/anan/P2Protocol.h
@@ -61,6 +61,32 @@ inline constexpr std::uint16_t kHighPriorityPort = 1027;
 // not treat it as the primary demultiplexing port.
 inline constexpr std::uint16_t kDdc0DefaultPort = 1035;
 
+// Which DDC an inbound IQ datagram belongs to, decided by the port the RADIO
+// sent it FROM. Returns nullopt when the port is outside [basePort,
+// basePort + numDdc) -- Mic Data, High Priority Status and this session's own
+// Discovery reply all share the PC-side socket, so "not a DDC port" is an
+// ordinary, expected answer rather than an error.
+//
+// basePort + n is verified against p2app's own source, not just the spec,
+// and the two independent paths there agree:
+//   * generalpacket.c assigns DDC i the port `SetPort(VPORTDDCIQ0+i, Port+i)`
+//     when the General packet carries a non-zero DDC0 port (bytes 17-18).
+//   * When that field is ZERO -- which is exactly what buildGeneral() sends,
+//     per the spec's "if set to zero the default port will be used" -- SetPort
+//     falls back to p2app's DefaultPorts[] table, whose VPORTDDCIQ0..9 entries
+//     (indices 8-17) are 1035..1044. The same 1035 + n sequence.
+// So this holds whether or not a client ever negotiates the port, which is
+// what makes kDdc0DefaultPort usable as the default base here.
+//
+// This is the ONLY thing that separates one DDC's stream from another's: the
+// DDC I&Q packet itself carries no DDC index field anywhere (spec pp.53-54,
+// checked byte by byte). p2app ships each DDC through its own dedicated
+// socket rather than combining them, so the spec's "Synchronous DDC"
+// interleaved framing is never emitted and must not be expected here.
+[[nodiscard]] std::optional<int> ddcIndexForSenderPort(
+    std::uint16_t senderPort, int numDdc,
+    std::uint16_t basePort = kDdc0DefaultPort) noexcept;
+
 // Saturn boards' DSP clock. RFC §2.4; saturnregisters.c VSAMPLERATE.
 // The six DDC0 sample rates this radio can run, in ksps, ascending. DDC0 is
 // STEPPED, not continuously tunable -- see AnanBackend::nearestDdc0RateKsps(),
@@ -189,6 +215,47 @@ std::array<std::uint8_t, 1444> buildDdcSpecific(int ddc0RateKsps = 48, int numAd
                                                 bool randomEnabled = true,
                                                 int ddc0AdcIndex = 0) noexcept;
 
+// ---- Multi-DDC ----
+//
+// Ceiling on how many DDCs these builders will encode. Four is what a real
+// ANAN-G2 reports: p2app's DiscoveryReply[] has the DDC-count byte hardcoded
+// to 4 and never rewrites it at runtime, even though the gateware's own
+// VNUMDDC is 10. Callers should still clamp to whatever Discovery actually
+// reported rather than assuming this number -- this is the codec's own
+// safety bound (Principle VII), not a statement about the hardware.
+//
+// The wire format itself would allow far more (the 1444-byte packet has room
+// for 80 DDC rows), but the enable bitmap this encoder writes lives in a
+// single byte, so 8 is the structural ceiling regardless.
+inline constexpr int kMaxDdcs = 4;
+
+// One DDC's slot in the DDC-Specific packet. `rateKsps` must be one of
+// 48/96/192/384/768/1536 (p.24); `adcIndex` selects which ADC feeds it,
+// same meaning as buildDdcSpecific()'s ddc0AdcIndex above.
+struct DdcConfig {
+    int rateKsps = 48;
+    int adcIndex = 0;
+};
+
+// Multi-DDC form of the above. Enables DDC 0..N-1 where N = ddcs.size()
+// (capped at kMaxDdcs; anything beyond is IGNORED rather than truncating the
+// packet or running off the array), setting bits 0..N-1 of the byte-7 enable
+// bitmap and filling one 6-byte row per DDC at 17 + 6*n: ADC select, 2-byte
+// rate, CIC1/CIC2, sample size. CIC1/CIC2 are left zero -- the spec marks
+// them "For Future use", exactly as the single-DDC path already leaves them.
+//
+// An EMPTY span produces an all-DDCs-disabled packet, which is a legitimate
+// thing to send (it is how a session stops streaming without tearing down),
+// not an error to guard against.
+//
+// The single-DDC overload above delegates here with a one-element list, so
+// there is exactly one implementation of the row layout and the two cannot
+// drift apart.
+std::array<std::uint8_t, 1444> buildDdcSpecific(std::span<const DdcConfig> ddcs,
+                                                int numAdcs = 2,
+                                                bool ditherEnabled = true,
+                                                bool randomEnabled = true) noexcept;
+
 // ---- High Priority to Hardware (spec p.31-34) ----
 
 // 1444-byte High Priority packet. `run` sets byte 4 bit[0] ONLY -- there is
@@ -226,6 +293,24 @@ std::array<std::uint8_t, 1444> buildDdcSpecific(int ddc0RateKsps = 48, int numAd
 // software-selected one -- so there is nothing here for ANT2/ANT3-style
 // params to apply to.
 std::array<std::uint8_t, 1444> buildHighPriority(bool run, std::uint32_t ddc0FreqWord,
+                                                  bool bypassAdc0Filters = true,
+                                                  bool bypassAdc1Filters = true) noexcept;
+
+// Multi-DDC form: one 4-byte frequency/phase word per DDC at 9 + 4*n (p.32),
+// for DDC 0..N-1 where N = ddcFreqWords.size(), capped at kMaxDdcs with the
+// same ignore-the-excess contract as buildDdcSpecific() above.
+//
+// Everything else is identical to the single-DDC overload, INCLUDING the
+// structural refusal to key: there is still no PTT parameter here, and byte
+// 4 still carries only bit[0] (run). Adding DDCs does not add a way to
+// transmit (Constitution Principle VI).
+//
+// Alex0/Alex1 are written exactly as the single-DDC overload does -- they
+// are per-ADC filter/antenna registers, not per-DDC, so they do not grow
+// with the DDC count. Per-DDC ADC selection lives in the DDC-Specific
+// packet's own rows.
+std::array<std::uint8_t, 1444> buildHighPriority(bool run,
+                                                  std::span<const std::uint32_t> ddcFreqWords,
                                                   bool bypassAdc0Filters = true,
                                                   bool bypassAdc1Filters = true) noexcept;
 

--- a/tests/anan_p2_protocol_test.cpp
+++ b/tests/anan_p2_protocol_test.cpp
@@ -12,6 +12,8 @@
 #include <complex>
 #include <cstdint>
 #include <cstdio>
+#include <span>
+#include <string>
 #include <vector>
 
 using namespace AetherSDR::anan;
@@ -211,6 +213,161 @@ int main()
               "bypassAdc0Filters=false: ANT1 stays set, HF Bypass clears");
         check(readU16(hpNoBypass, 1430) == 0,
               "bypassAdc1Filters=false: Alex1 stays zero");
+    }
+
+    // ---- Multi-DDC encode (DDC-Specific rows at 17+6n, HP words at 9+4n) ----
+    // The single-DDC overloads delegate to these, so the first thing to pin
+    // is that delegation is byte-identical -- a drift there would silently
+    // change the packets the bench-validated DDC0 path already sends.
+    {
+        const std::array<DdcConfig, 1> justDdc0{DdcConfig{48, 0}};
+        check(buildDdcSpecific(justDdc0) == buildDdcSpecific(48),
+              "buildDdcSpecific: 1-element list is byte-identical to the single-DDC overload");
+
+        const std::uint32_t word = phaseWord(10'000'000.0);
+        const std::array<std::uint32_t, 1> justWord0{word};
+        check(buildHighPriority(true, justWord0) == buildHighPriority(true, word),
+              "buildHighPriority: 1-element list is byte-identical to the single-DDC overload");
+    }
+
+    {
+        // Four DDCs, deliberately all different so a row landing on the wrong
+        // offset (or every row reading DDC0's values) cannot pass.
+        const std::array<DdcConfig, 4> ddcs{
+            DdcConfig{48, 0}, DdcConfig{192, 1}, DdcConfig{768, 0}, DdcConfig{1536, 1}};
+        const auto d = buildDdcSpecific(ddcs);
+
+        check(d[7] == 0x0F, "byte7 bits 0-3 set: DDC0-3 all enabled");
+
+        bool rowsOk = true;
+        for (std::size_t n = 0; n < ddcs.size(); ++n) {
+            const std::size_t row = 17 + 6 * n;
+            const int rate = static_cast<int>(d[row + 1]) << 8 | d[row + 2];
+            if (d[row] != static_cast<std::uint8_t>(ddcs[n].adcIndex)
+                || rate != ddcs[n].rateKsps
+                || d[row + 3] != 0 || d[row + 4] != 0   // CIC1/CIC2 "For Future use"
+                || d[row + 5] != 24) {
+                rowsOk = false;
+                std::fprintf(stderr,
+                    "  DDC%zu row at %zu: adc=%u rate=%d cic=%u,%u size=%u "
+                    "(expected adc=%d rate=%d cic=0,0 size=24)\n",
+                    n, row, d[row], rate, d[row + 3], d[row + 4], d[row + 5],
+                    ddcs[n].adcIndex, ddcs[n].rateKsps);
+            }
+        }
+        check(rowsOk, "each DDC's 6-byte row at 17+6n carries its own ADC/rate/size, "
+                      "with CIC1/CIC2 left zero");
+
+        // Nothing beyond the last encoded row: DDC4-79 must stay disabled.
+        bool tailZero = true;
+        for (std::size_t i = 17 + 6 * ddcs.size(); i < 1444; ++i)
+            if (d[i] != 0) { tailZero = false; break; }
+        check(tailZero, "DDC4-79 rows stay zero/disabled");
+
+        // High Priority: one 4-byte phase word per DDC at 9+4n.
+        const std::array<std::uint32_t, 4> words{
+            phaseWord(3'500'000.0), phaseWord(7'100'000.0),
+            phaseWord(14'200'000.0), phaseWord(28'400'000.0)};
+        const auto hp = buildHighPriority(true, words);
+        bool wordsOk = true;
+        for (std::size_t n = 0; n < words.size(); ++n) {
+            const std::size_t at = 9 + 4 * n;
+            const std::uint32_t got =
+                static_cast<std::uint32_t>(hp[at]) << 24
+              | static_cast<std::uint32_t>(hp[at + 1]) << 16
+              | static_cast<std::uint32_t>(hp[at + 2]) << 8
+              | hp[at + 3];
+            if (got != words[n]) {
+                wordsOk = false;
+                std::fprintf(stderr, "  DDC%zu phase word at %zu: got %u expected %u\n",
+                             n, at, got, words[n]);
+            }
+        }
+        check(wordsOk, "each DDC's frequency/phase word round-trips at 9+4n");
+
+        // Principle VI is structural, not incidental: adding DDCs must not
+        // add a way to key. No parameter here can set the PTT bits.
+        check((hp[4] & 0x1E) == 0,
+              "multi-DDC High Priority still never sets the PTT bits (byte4 bits 1-4)");
+    }
+
+    // ---- Sender-port demux (the ONLY thing separating DDC streams) ----
+    {
+        // Base + n, verified against p2app's generalpacket.c and its
+        // DefaultPorts[] table (both give 1035..1044 for DDC0..9).
+        check(kDdc0DefaultPort == 1035, "DDC0's default source port is 1035");
+
+        // In range: each port maps to its own index.
+        bool mapped = true;
+        for (int n = 0; n < 4; ++n) {
+            const auto idx = ddcIndexForSenderPort(
+                static_cast<std::uint16_t>(1035 + n), 4);
+            if (!idx || *idx != n) {
+                mapped = false;
+                std::fprintf(stderr, "  port %d -> %s (expected %d)\n", 1035 + n,
+                             idx ? std::to_string(*idx).c_str() : "nullopt", n);
+            }
+        }
+        check(mapped, "ports 1035..1038 map to DDC 0..3");
+
+        // Below the base, and at/above the active count: both rejected.
+        check(!ddcIndexForSenderPort(1034, 4).has_value(),
+              "a port below the base is not a DDC stream");
+        check(!ddcIndexForSenderPort(1039, 4).has_value(),
+              "a port past the active DDC count is rejected (DDC4 with only 4 active)");
+        check(ddcIndexForSenderPort(1038, 4).has_value(),
+              "the last active DDC's port IS accepted (boundary, not off-by-one)");
+
+        // A single-DDC session must reject DDC1's port -- this is the case
+        // that keeps a leftover stream from a previous multi-DDC session
+        // from being fed to DDC0.
+        check(ddcIndexForSenderPort(1035, 1).has_value(),
+              "single-DDC session accepts DDC0's port");
+        check(!ddcIndexForSenderPort(1036, 1).has_value(),
+              "single-DDC session rejects DDC1's port");
+
+        // Degenerate counts: no DDCs active means nothing is a DDC stream.
+        check(!ddcIndexForSenderPort(1035, 0).has_value(),
+              "numDdc=0 accepts nothing");
+        check(!ddcIndexForSenderPort(1035, -1).has_value(),
+              "a negative DDC count accepts nothing rather than underflowing");
+
+        // The shared-socket traffic this must not misclassify: Mic Data and
+        // High Priority Status arrive on the same PC-side socket.
+        check(!ddcIndexForSenderPort(kRadioPort, 4).has_value(),
+              "the radio's command port is never mistaken for a DDC stream");
+
+        // An explicit non-default base still works, for a session that ever
+        // negotiates ports via the General packet's bytes 17-18.
+        const auto negotiated = ddcIndexForSenderPort(2003, 4, 2000);
+        check(negotiated && *negotiated == 3,
+              "an explicitly negotiated base port is honoured");
+    }
+
+    {
+        // Empty list: a legitimate all-disabled packet, not a malformed one.
+        const auto none = buildDdcSpecific(std::span<const DdcConfig>{});
+        check(none[7] == 0x00, "empty DDC list disables every DDC (byte7 = 0)");
+        check(none[4] == 2, "empty DDC list still carries the ADC-count field");
+
+        // Over the cap: extras are ignored rather than encoded or truncating
+        // the packet. kMaxDdcs is the codec's own bound (Principle VII).
+        const std::array<DdcConfig, 5> tooMany{
+            DdcConfig{48, 0}, DdcConfig{48, 0}, DdcConfig{48, 0},
+            DdcConfig{48, 0}, DdcConfig{1536, 1}};
+        const auto capped = buildDdcSpecific(tooMany);
+        check(capped[7] == 0x0F, "more DDCs than kMaxDdcs: only the first 4 are enabled");
+        const std::size_t fifthRow = 17 + 6 * 4;
+        check(capped[fifthRow] == 0 && capped[fifthRow + 1] == 0
+              && capped[fifthRow + 2] == 0 && capped[fifthRow + 5] == 0,
+              "the 5th DDC's row is left untouched, not encoded");
+
+        const std::array<std::uint32_t, 5> tooManyWords{1, 2, 3, 4, 0xFFFFFFFFu};
+        const auto hpCapped = buildHighPriority(true, tooManyWords);
+        const std::size_t fifthWord = 9 + 4 * 4;
+        check(hpCapped[fifthWord] == 0 && hpCapped[fifthWord + 1] == 0
+              && hpCapped[fifthWord + 2] == 0 && hpCapped[fifthWord + 3] == 0,
+              "more phase words than kMaxDdcs: the 5th is ignored, not written");
     }
 
     // ---- DDC frame: strict shape validation ----


### PR DESCRIPTION
## Summary

Two ANAN-G2 wire-layer changes under RFC #4970, submitted together because they
touch the same two files for the same reason.

**Live DDC rate change.** Zooming rebuilt the whole P2 session — mute, stop,
2000 ms settle, restart, then a 6000 ms connect-timeout window — for what the
operator experienced as one scroll-wheel notch. `p2app` shows none of it was
needed: `IncomingDDCSpecific.c` services DDC-Specific packets in a continuous
thread loop, calls `WriteP2DDCRateRegister()` directly, and its "something
changed" hook `HandlerCheckDDCSettings()` is empty. The radio writes the new
rate and keeps streaming. `setDdcRateLive()` resends the DDC-Specific packet on
the running session; `finishRateChange()` mutes, sends, waits 250 ms, unmutes.

**Multi-DDC encode/demux.** `buildDdcSpecific()`/`buildHighPriority()` gain span
overloads for up to `kMaxDdcs` (4, what a G2 reports via Discovery), and
`ddcIndexForSenderPort()` demultiplexes inbound IQ by sender port — the DDC I&Q
packet carries no index field (spec pp. 53–54), and `1035 + n` is confirmed
against `p2app`'s `generalpacket.c` and its `DefaultPorts[]` fallback.
Sequence-gap detection becomes per-DDC, because one shared counter would report
a gap on every alternating frame once a second DDC streams.

## This lands code with no caller yet

`ddcIqReady()` has no consumer and `AnanBackend` still drives one DDC. This
makes the codec capable, not the backend multi-receiver; the `AnanRxDsp` fan-out
is the next phase.

Flagging it rather than leaving it to be found. It ships here because the
single-DDC builders now **delegate** to the span forms, so the packet row layout
has one implementation and cannot drift — splitting means duplicating that
layout or landing the delegation without its target. They are separate commits,
so if you would rather not carry an unused seam, say so and I will resubmit the
rate change alone.

## Constitution principle honored

**Principle IV — clean-room.** Spec v4.4 and `p2app`/Saturn source only, cited
inline at each non-obvious field. **Principle VI — nothing keys:** no PTT
parameter is added, pinned by an assertion.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Existing tests pass
- [x] Behavior verified on a real radio — bench tested with the ANAN-G2.
- [x] `tests/anan_p2_protocol_test.cpp` gains 157 lines: multi-DDC row and
      phase-word layout, delegation pinned byte-identical to the single-DDC
      packets, `ddcIndexForSenderPort()` in and out of range, and the no-PTT
      assertion. Socket-free.

## Scope

Does not make zoom continuous — it still snaps to the six DDC rates, which is
#5223. No file outside `src/core/backends/anan/` and its test is touched; Flex,
Icom, HL2 and RTL are unaffected.