### PR TITLE
aetherd: add guarded local slice frequency control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -489,7 +489,7 @@ directories are excluded. Catalogue fields and lifecycle are specified in
 Sessions require explicit trusted authorization; the local transport defaults
 to observe permission, and reads/subscriptions enforce it. The daemon's explicit
 `--allow-local-control` flag additionally grants non-TX control to current-user
-local clients. Only typed catalogue-selected `radio.connect` / `radio.disconnect`
+local clients. Typed catalogue-selected `radio.connect` / `radio.disconnect`
 are implemented; see `docs/aetherd-local-connection-control.md` for lifecycle,
 revision checks and limits. Clients cannot supply arbitrary endpoints or
 credentials. Every negotiated session, observer or controller, now shares a
@@ -498,7 +498,11 @@ it is terminal for that connection. The revocation hook
 discards pending observations and terminates local delivery; no wire or daemon
 path invokes it yet. Remote credential verification/provisioning and transmit
 grants are not implemented yet.
-Meters, read-only transmit state, typed slice/pan receive controls, and the desktop
+`slice.setFrequency` now dispatches a bounded, revision-checked intent for an
+existing owned slice, with explicit backend observation provenance and fail-closed
+TX-idle admission; see `docs/aetherd-local-slice-frequency-control.md`. It does
+not optimistically update the model. Unknown coverage/readback remains unavailable.
+Meters, read-only transmit state, other typed slice/pan receive controls, and the desktop
 adapter have not landed; UI code still consumes models directly, and that
 remains correct. New resource fields belong in the adapter and the versioned
 catalogue, never in a transport or via QObject reflection. No protocol TX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -699,6 +699,7 @@ set(CORE_SOURCES
     src/core/control/RadioConnectionTarget.h  # socket-free connection intent seam
     src/core/backends/ModelRadioConnectionTarget.cpp # native translation and lifecycle
     src/core/control/RadioResourceAdapter.cpp # normalized model resources
+    src/core/control/ModelSliceFrequencyTarget.cpp # validated non-keying intents
     src/core/control/RadioCatalogue.cpp       # bounded normalized discovery resource
     src/core/control/LocalControlServer.cpp   # current-user local transport
     src/core/discovery/RadioDiscoverySource.h  # socket-free discovery interface (AUTOMOC)

--- a/docs/aetherd-control-protocol-v1-design.md
+++ b/docs/aetherd-control-protocol-v1-design.md
@@ -111,11 +111,15 @@ After negotiation every request carries the assigned session:
   "id": "req-42",
   "sessionId": "019d2d95-2c8b-7f2a-a17d-cc77031b3040",
   "method": "slice.setFrequency",
-  "params": {"radioSession": "radio-1", "slice": "0", "hz": 14225000}
+  "params": {"radioSession": "radio-1", "slice": "0", "expectedRevision": 42, "hz": 14225000}
 }
 ```
 
 Success returns exactly one `result`; failure returns exactly one `error`:
+
+The implemented local frequency method's bounds, revision freshness (not CAS),
+readback provenance and acceptance semantics are specified in
+[`aetherd-local-slice-frequency-control.md`](aetherd-local-slice-frequency-control.md).
 
 ```json
 {"v":1,"id":"req-42","result":{"accepted":true}}

--- a/docs/aetherd-control-resource-v1-catalogue.md
+++ b/docs/aetherd-control-resource-v1-catalogue.md
@@ -210,6 +210,8 @@ commands. Create a new instance to restart discovery.
   - `maxSlices`, `maxPanadapters`, `sampleRatesHz`;
   - `tuningRangeHz` with `minimum` and `maximum`;
   - `declaredBands`, each with `name`, `lowHz`, and `highHz`;
+  - `sliceFrequencyControl` with `authority` (`radio`, `engine`, `unknown`),
+    `minimumHz` and `maximumHz`; zero bounds mean unavailable, not unlimited;
   - `canTransmit`, `maximumTransmitWatts`, `hasTuner`, `hasAmplifier`;
   - `extensions`, containing namespace names only, never extension payloads.
 
@@ -225,6 +227,9 @@ control methods are specified in
 
 - `id`, `letter`, `panadapterId`, `owned`.
 - `frequencyHz`, `mode`, `filter.lowHz`, `filter.highHz`.
+- `frequencyObservation.known`, `.hz`, `.authority`: last backend publication,
+  with `hz:null` while unknown. Authority is `radio`, `engine` or `unknown`;
+  engine configuration is not a hardware acknowledgement or DSP completion.
 - `active`, `txSlice`, `locked`.
 - `audio.gain`, `audio.pan`, `audio.muted`.
 - `receive.antenna`, `receive.rfGain`.
@@ -232,6 +237,11 @@ control methods are specified in
 - `receive.squelch.enabled`, `receive.squelch.level`.
 
 Values come from `SliceModel`; radio/backend status remains authoritative.
+`frequencyHz` retains the existing effective (potentially optimistic desktop)
+value. The separate observation is invalidated across disconnect/reconnect and
+updates even when a backend echo equals that effective value. See
+[`aetherd-local-slice-frequency-control.md`](aetherd-local-slice-frequency-control.md)
+for control admission, observation and concurrent-intent semantics.
 
 ### `panadapter`
 

--- a/docs/aetherd-local-connection-control.md
+++ b/docs/aetherd-local-connection-control.md
@@ -1,8 +1,10 @@
 # AetherD v1 — local connection control
 
 This Stage 3 sub-slice of RFC #3849 adds only non-TX connection intents.
-Receive setters, transmit, remote transport, credentials and desktop migration
-remain excluded. The default daemon remains observe-only.
+Transmit, remote transport, credentials and desktop migration remain excluded.
+The subsequent [slice frequency slice](aetherd-local-slice-frequency-control.md)
+adds one receive setter under the same explicit opt-in. The default daemon
+remains observe-only.
 
 ## Authorization and startup
 
@@ -94,7 +96,8 @@ it never attaches to the desktop session or starts TCI/CAT servers.
 Grants describe authorization, not current state. Controllers see
 `radio.connect` only with an idle target and an available supported entry;
 `radio.disconnect` appears while the target is non-idle. Refresh capabilities
-after lifecycle/catalogue events. No receive setters or TX verbs appear.
+after lifecycle/catalogue events. The separately bound frequency target can
+add `slice.setFrequency` for an eligible existing slice; no TX verbs appear.
 
 Every post-negotiation frame (including malformed/rejected requests and repeated
 `hello`) shares a per-client monotonic token bucket of 100/s, burst 200,

--- a/docs/aetherd-local-slice-frequency-control.md
+++ b/docs/aetherd-local-slice-frequency-control.md
@@ -1,0 +1,130 @@
+# AetherD v1 — local slice frequency control
+
+This Stage 3 slice of #3849 adds `slice.setFrequency` for an **existing owned
+slice**. It does not create slices, connect radios, migrate the desktop client,
+implement other receive setters, or expose transmit. The daemon still defaults
+to observe-only. The existing `--allow-local-control` flag explicitly grants
+observe and non-TX control to every client admitted by its current-user local
+endpoint; it is not per-application consent. No remote transport, credentials,
+new grant, implicit discovery or automatic retry is introduced.
+
+## Request and response
+
+After `hello`, use the negotiated connection's `sessionId`:
+
+```json
+{"v":1,"id":"tune-1","sessionId":"<negotiated session>","method":"slice.setFrequency","params":{"radioSession":"radio-1","slice":"0","expectedRevision":42,"hz":14230000}}
+```
+
+All four parameters are required; unknown fields are rejected. `slice` is a
+canonical non-negative decimal string fitting a signed 32-bit integer (no
+sign, whitespace or leading zeros). `expectedRevision` is the slice resource's
+revision, not the radio-session revision. It and `hz` must be positive exact
+JSON integers at most 2^53-1. Hz are never silently rounded or clamped.
+
+Success is `{"v":1,"id":"tune-1","result":{"accepted":true}}`.
+It means exactly one typed backend intent was dispatched, **not** that the
+radio acknowledged it, the requested frequency took effect, or DSP settled.
+No raw command, endpoint, family override, force option or TX flag is accepted.
+The target deliberately bypasses the optimistic desktop/CAT setters.
+
+Authorization is checked before parameter validation and resource lookup. The
+service then checks the exact session/slice resource and revision. Immediately
+before dispatch, on the engine owning thread without yielding, the model target
+checks connection readiness, current slice ownership, lock state, fresh frequency
+observation, backend coverage and transmit safety. The trusted target binds once
+before dispatch to an otherwise idle engine; it does not attach to a running
+desktop session. Destroyed dependencies or a wrong-thread call fail closed.
+
+| Error | Meaning |
+|---|---|
+| `auth.grant_denied` | No control grant; observing does not authorize tuning |
+| `request.invalid_params` | Missing, unknown, non-integral or noncanonical parameters |
+| `resource.not_found` | Unknown session, absent slice, or slice not owned by this engine |
+| `request.conflict` | Stale revision, connection transition, lock, or active/unconfirmed TX |
+| `capability.unavailable` | No target, unknown coverage/authority, or no valid observation |
+| `request.out_of_range` | Outside the backend's positive bounded range or declared band union |
+
+Existing envelope, session, revocation and terminal rate-limit errors still
+apply. This method shares the existing per-client 100/s, burst-200 budget;
+it adds no queue, reservation or independent retry budget.
+
+## Observations and concurrency
+
+`slice.value.frequencyHz` retains its existing effective model semantics,
+including optimistic desktop changes. The additive `frequencyObservation`
+object separates the last backend publication:
+
+```json
+{"known":true,"hz":14230000,"authority":"radio"}
+```
+
+`known:false` carries `hz:null`, never a default masquerading as a report.
+`authority` is `radio`, `engine` or `unknown`, declared by the backend.
+`radio` denotes normalized radio readback; `engine` denotes backend-owned
+receive configuration, **not a hardware acknowledgement or DSP-completion
+signal**. In-process backends may publish before asynchronous hardware/DSP work
+settles. Invalid/non-positive reports clear knowledge. Disconnect/reconnect
+invalidates the old observation, even if a SliceModel is reused. A new same-value
+report establishes knowledge again. An echo matching an optimistic desktop
+value still updates the separate observation. Identical snapshots are deduplicated.
+
+Observe this field through existing `resource.get` / atomic
+`resource.subscribe` snapshots and events. A differing backend value wins;
+neither timeout nor acceptance fabricates the requested value. A backend can
+publish synchronously, so its event need not follow the response. An accepted
+same-value command need not produce an event at all. There is no per-command
+completion event, error callback, convergence timeout or exactly-once guarantee.
+
+`expectedRevision` is a **freshness check, not compare-and-swap or exclusive
+ownership**. Two controllers may submit different intents against the same
+observed revision before a backend publication; both can be accepted in engine
+dispatch order. No pending intent changes the revision by itself. A publication,
+including a non-frequency slice change, invalidates old selections. Removed and
+recreated resources get new revisions, including across reconnect. Refresh and
+make a new decision on conflict or an uncertain response; never automatically
+retry the old intent. Losing a grant blocks subsequent dispatch but does not
+undo an already accepted command. No TX lease is created or implied.
+
+## Capability and safety gates
+
+`radioSession.value.capabilities.sliceFrequencyControl` declares `authority`,
+`minimumHz` and `maximumHz`. Zero bounds or unknown authority disable the method;
+the older UI `tuningRangeHz` convention (zero means unconstrained) is not reused.
+A nonempty `declaredBands` list further restricts requests to its inclusive union.
+Malformed bounds fail closed. The simulator declares a 1 Hz–1 THz API domain,
+not physical RF coverage. All six backends explicitly declare this metadata;
+see the [capability map](architecture/radio-capabilities-map.md#local-slice-frequency-control).
+
+`capabilities.get` advertises `slice.setFrequency` only to controllers and only
+while at least one owned unlocked slice is eligible. Every request rechecks the
+selected slice. Refresh capabilities after connection, capability or slice
+changes; advertisement is not a reservation or a guarantee of later acceptance.
+
+For a TX-capable backend, initial/default false TX state is insufficient. The
+target requires explicit idle readback and refuses while the radio or local
+transmit/MOX/TUNE state is active. Active TX, backend replacement and connection
+transitions invalidate idle knowledge. A falling command edge alone cannot
+restore it. This is conservative receive admission, **not the Stage 4 transmit
+arbiter**: asynchronous external PTT can always change after the last report.
+
+The production simulator is the fully exercised integration path for this
+slice. RTL-SDR is eligible when built and connected but is not hardware-certified
+by simulator tests. Ordinary TX-enabled HL2 lacks normalized idle readback and
+remains unavailable; explicitly TX-disabled HL2 can qualify. Flex and ANAN
+currently lack verified command coverage and remain unavailable. Icom's
+profile-driven bounds/readback can satisfy the model seam, but the current daemon
+catalogue intentionally does not offer Icom/manual connections. None of these
+limitations changes existing desktop tuning behavior.
+
+## Verification
+
+`control_slice_frequency_test` exercises the production target/service/adapter
+with an injected socket-free command recorder and normalized observations. It
+does not open a listener, simulate firmware, discover hardware or key a radio.
+It covers grants, schemas, revisions, competing controllers, delayed/differing
+reports, optimistic desktop separation, reconnect, coverage, locks, unknown/active
+TX, target lifetime, owning-thread dispatch and terminal budgets.
+The manual daemon smoke uses our real local server and production simulator;
+native Mac automation-bridge regression uses a separate no-TX simulator profile.
+Neither substitutes for hardware convergence evidence.

--- a/docs/aetherd-local-slice-frequency-control.md
+++ b/docs/aetherd-local-slice-frequency-control.md
@@ -22,6 +22,13 @@ sign, whitespace or leading zeros). `expectedRevision` is the slice resource's
 revision, not the radio-session revision. It and `hz` must be positive exact
 JSON integers at most 2^53-1. Hz are never silently rounded or clamped.
 
+That is the general wire-integer limit, not the frequency-observation domain.
+Coverage maxima and observations share the conservative whole-MHz ceiling
+9,007,199,254 MHz (9,007,199,254,000,000 Hz), below the wire ceiling by 740,991 Hz.
+This avoids advertising a command domain the MHz model cannot report as known.
+A backend maximum above this ceiling disables its frequency-control capability;
+an observation above it is unknown. Current backend maxima are much smaller.
+
 Success is `{"v":1,"id":"tune-1","result":{"accepted":true}}`.
 It means exactly one typed backend intent was dispatched, **not** that the
 radio acknowledged it, the requested frequency took effect, or DSP settled.
@@ -107,6 +114,12 @@ transmit/MOX/TUNE state is active. Active TX, backend replacement and connection
 transitions invalidate idle knowledge. A falling command edge alone cannot
 restore it. This is conservative receive admission, **not the Stage 4 transmit
 arbiter**: asynchronous external PTT can always change after the last report.
+
+The `txSlice` designation is not itself a refusal condition. An explicit receive
+tune while confirmed idle may change the frequency that a subsequent transmission
+would use; this method does not grant permission to key. Lease/inhibit policy for
+that coupling belongs to the Stage 4 arbiter and must be reviewed before enabling
+TX-capable daemon paths, not inferred from this receive-only method.
 
 The production simulator is the fully exercised integration path for this
 slice. RTL-SDR is eligible when built and connected but is not hardware-certified

--- a/docs/architecture/radio-capabilities-map.md
+++ b/docs/architecture/radio-capabilities-map.md
@@ -31,6 +31,28 @@ Two rules that fall out of that, both of which have already caused bugs:
 See [`HERMES.md`](../HERMES.md) §18 for the worked narrative, including the
 traps and why the DAX crash guard is deliberately *not* the DAX capability.
 
+## Local slice frequency control
+
+`sliceFrequencyControl` is read by `ModelSliceFrequencyTarget` for admission
+and `RadioResourceAdapter` for explicit command-domain/provenance observations.
+It does not alter the existing GUI tuning range or desktop commands. Unlike
+the permissive UI disconnect convention above, local protocol mutations always
+require a live eligible slice; zero bounds or unknown authority fail closed.
+
+| Backend | Authority | Inclusive command domain (Hz) | Additional gate |
+|---|---|---|---|
+| Flex | radio | 0 / 0 (unknown) | Unavailable; no guessed legacy/transverter bounds |
+| HL2 | engine | 100,000–38,400,000 | TX-enabled sessions need normalized idle readback, currently absent |
+| Sim | engine | 1–1,000,000,000,000 | Explicit simulator API domain, not RF coverage |
+| Icom | radio | Profile `tuningMinHz` / `tuningMaxHz` | Declared band union and confirmed idle; no current daemon catalogue connection |
+| ANAN | engine | 0 / 0 (unknown) | Unavailable pending verified coverage |
+| RTL-SDR | engine | 24,000–1,766,000,000 | Backend/build availability; no TX capability |
+
+The default struct declares unknown authority and zero bounds. Every backend
+sets all three fields explicitly. Engine authority means backend-owned receive
+configuration, not physical acknowledgement or DSP convergence. For full
+semantics see [local frequency control](../aetherd-local-slice-frequency-control.md).
+
 ## Wired and consumed
 
 | Field | Flex | HL2 | Sim | Read at | Effect |

--- a/src/aetherd/main.cpp
+++ b/src/aetherd/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char* argv[])
     parser.addOption(simDiscoveryOption);
     const QCommandLineOption controlOption(
         QStringLiteral("allow-local-control"),
-        QStringLiteral("Grant current-user local clients non-TX connect/disconnect permission."));
+        QStringLiteral("Grant current-user local clients non-TX connection and receive-frequency control."));
     parser.addOption(controlOption);
     parser.process(app);
 
@@ -62,10 +62,17 @@ int main(int argc, char* argv[])
     AetherSDR::RadioSession radioSession;
     radioSession.setSessionId(1);
     std::unique_ptr<AetherSDR::control::RadioConnectionTarget> connectionTarget;
+    std::unique_ptr<AetherSDR::control::SliceFrequencyTarget> frequencyTarget;
     if (parser.isSet(controlOption)) {
         connectionTarget = AetherSDR::control::makeModelRadioConnectionTarget(&radioSession.radioModel());
         if (!connectionTarget || !server.bindConnectionTarget(connectionTarget.get())) {
             QTextStream(stderr) << "aetherd: cannot initialize connection control\n";
+            return 1;
+        }
+        frequencyTarget = AetherSDR::control::makeModelSliceFrequencyTarget(
+            &radioSession.radioModel(), connectionTarget.get());
+        if (!frequencyTarget || !server.bindFrequencyTarget(frequencyTarget.get())) {
+            QTextStream(stderr) << "aetherd: cannot initialize frequency control\n";
             return 1;
         }
     }

--- a/src/core/backends/RadioCapabilities.h
+++ b/src/core/backends/RadioCapabilities.h
@@ -26,6 +26,16 @@ struct DeclaredBandRange {
     bool operator==(const DeclaredBandRange&) const = default;
 };
 
+// Frequency observations describe the state owned by the backend, not a
+// promise that a queued hardware/DSP write has completed. Zero bounds mean
+// this backend has not established a range for the headless control method.
+struct SliceFrequencyControl {
+    enum class Authority { Unknown, Radio, Engine };
+    Authority authority{Authority::Unknown};
+    qint64 minimumHz{0};
+    qint64 maximumHz{0};
+};
+
 // A stable, radio-owned receive-filter preset. `id` is the identity used on
 // the wire (for example Icom FIL1/FIL2/FIL3); widthHz is mutable content of
 // that preset and must never be used as its identity.
@@ -134,6 +144,7 @@ struct RadioCapabilities {
     // that told them it was not available.
     double tuningMinHz = 0.0;
     double tuningMaxHz = 0.0;
+    SliceFrequencyControl sliceFrequencyControl;
 
     // Optional per-band native coverage. Empty means "not reported" and keeps
     // canonical band labels. This is distinct from txPowerBands: receive-only

--- a/src/core/backends/anan/AnanBackend.cpp
+++ b/src/core/backends/anan/AnanBackend.cpp
@@ -344,6 +344,8 @@ RadioCapabilities AnanBackend::capabilities() const
     // both zero means "not reported", not a guess.
     c.tuningMinHz = 0.0;
     c.tuningMaxHz = 0.0;
+    // State is engine-owned, but verified coverage is still unavailable.
+    c.sliceFrequencyControl = {SliceFrequencyControl::Authority::Engine, 0, 0};
     c.canTransmit = false;         // P2Client has no PTT capability -- see class comment
     c.txPowerMaxWatts = 0.0;
     c.hostModulates = true;        // client-side WDSP, like the HL2

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -131,6 +131,9 @@ void FlexBackend::setModelProvider(std::function<QString()> provider)
 RadioCapabilities FlexBackend::capabilities() const
 {
     RadioCapabilities caps;
+    // FlexLib 4.2.18 Slice.Freq delegates range refusal to firmware; its old
+    // bounds are commented out. Do not guess coverage (including transverters).
+    caps.sliceFrequencyControl = {SliceFrequencyControl::Authority::Radio, 0, 0};
     caps.txPowerBands = {};
     caps.declaredBandRanges = {};
     caps.family = QStringLiteral("flex");

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -1447,6 +1447,8 @@ RadioCapabilities Hl2Backend::capabilities() const
     // rolls off and there is nothing to hear.
     c.tuningMinHz = 100'000.0;
     c.tuningMaxHz = 38'400'000.0;
+    c.sliceFrequencyControl = {SliceFrequencyControl::Authority::Engine,
+                               100'000, 38'400'000};
     // THE RADIO'S POWER CLASS, which is what every forward-power gauge scales
     // its arc from. Declared as a band table because that is the seam the
     // clients already read: RadioModel::refreshTxPowerLimit turns it into

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -282,6 +282,9 @@ RadioCapabilities IcomCivBackend::capabilities() const
     c.maxPanadapters = m.hasScope ? m.receivers : 0;
     c.tuningMinHz = static_cast<double>(m.tuningMinHz);
     c.tuningMaxHz = static_cast<double>(m.tuningMaxHz);
+    c.sliceFrequencyControl = {SliceFrequencyControl::Authority::Radio,
+                               static_cast<qint64>(m.tuningMinHz),
+                               static_cast<qint64>(m.tuningMaxHz)};
 
     const std::span<const IcomBand> bands = bandsFor(m);
     c.declaredBandRanges.reserve(static_cast<int>(bands.size()));

--- a/src/core/backends/rtl/RtlSdrBackend.cpp
+++ b/src/core/backends/rtl/RtlSdrBackend.cpp
@@ -126,6 +126,8 @@ RadioCapabilities RtlSdrBackend::capabilities() const
     // Tuning range — R820T: 24 MHz – 1.766 GHz (HF via direct sampling)
     c.tuningMinHz = 24'000;
     c.tuningMaxHz = 1'766'000'000;
+    c.sliceFrequencyControl = {SliceFrequencyControl::Authority::Engine,
+                               24'000, 1'766'000'000};
 
     // Sample rates — non-contiguous legal windows for R820T
     c.sampleRatesHz = {

--- a/src/core/backends/sim/SimBackend.cpp
+++ b/src/core/backends/sim/SimBackend.cpp
@@ -254,6 +254,10 @@ QString SimBackend::familyName()    { return QStringLiteral("sim"); }
 RadioCapabilities SimBackend::capabilities() const
 {
     RadioCapabilities caps;
+    // Synthetic receiver: this is the API's bounded numeric domain, not an
+    // advertised hardware tuning range. Off-scene signals simply become silent.
+    caps.sliceFrequencyControl = {SliceFrequencyControl::Authority::Engine,
+                                  1, 1'000'000'000'000};
     caps.canReboot = false;
     caps.hasRemoteOnControl = false;
     caps.canUpgradeFirmware = false;

--- a/src/core/control/ControlService.cpp
+++ b/src/core/control/ControlService.cpp
@@ -112,9 +112,11 @@ DiscoveredRadio catalogueRadio(const QJsonObject& entry)
 } // namespace
 
 ControlService::ControlService(ControlResourceStore* resources,
-                               RadioConnectionTarget* connectionTarget)
+                               RadioConnectionTarget* connectionTarget,
+                               SliceFrequencyTarget* frequencyTarget)
     : m_resources(resources), m_connectionTarget(connectionTarget),
-      m_targetBound(connectionTarget != nullptr)
+      m_targetBound(connectionTarget != nullptr), m_frequencyTarget(frequencyTarget),
+      m_frequencyTargetBound(frequencyTarget != nullptr)
 {
     Q_ASSERT(m_resources);
 }
@@ -133,12 +135,25 @@ bool ControlService::bindConnectionTarget(RadioConnectionTarget* target)
     return true;
 }
 
+bool ControlService::bindFrequencyTarget(SliceFrequencyTarget* target)
+{
+    if (m_resources->thread() != QThread::currentThread()
+        || !target || target->thread() != QThread::currentThread()
+        || m_frequencyTargetBound || m_dispatchStarted) {
+        return false;
+    }
+    m_frequencyTarget = target;
+    m_frequencyTargetBound = true;
+    return true;
+}
+
 ServiceReply ControlService::handle(
     const QByteArray& bytes, ControlSession* session) const
 {
     if (!session || session->thread() != QThread::currentThread()
         || m_resources->thread() != QThread::currentThread()
-        || (m_connectionTarget && m_connectionTarget->thread() != QThread::currentThread())) {
+        || (m_connectionTarget && m_connectionTarget->thread() != QThread::currentThread())
+        || (m_frequencyTarget && m_frequencyTarget->thread() != QThread::currentThread())) {
         return failure({}, {QStringLiteral("engine.failed"),
                             QStringLiteral("service owning thread required"), {}, false}, true);
     }
@@ -218,6 +233,9 @@ ServiceReply ControlService::handle(
     if (request.method == QStringLiteral("radio.connect")
         || request.method == QStringLiteral("radio.disconnect")) {
         return handleConnection(request, *session);
+    }
+    if (request.method == QStringLiteral("slice.setFrequency")) {
+        return handleFrequency(request, *session);
     }
     if (request.method == QStringLiteral("resource.get")) {
         if (const std::optional<ProtocolError> error = session->observationError()) {
@@ -388,6 +406,61 @@ ServiceReply ControlService::handleConnection(
                 {{QStringLiteral("accepted"), true}}), false};
 }
 
+ServiceReply ControlService::handleFrequency(
+    const ProtocolRequest& request, const ControlSession& session) const
+{
+    const auto reject = [&request](const char* code, const char* message) {
+        return failure(request.id, {QString::fromLatin1(code),
+                                   QString::fromLatin1(message), {}, false});
+    };
+    if (!session.canControl()) {
+        return reject("auth.grant_denied", "control grant required");
+    }
+    if (!m_frequencyTarget) {
+        return reject("capability.unavailable", "slice frequency control unavailable");
+    }
+    if (const std::optional<ProtocolError> error = onlyKeys(
+            request.params, {QStringLiteral("radioSession"), QStringLiteral("slice"),
+                             QStringLiteral("expectedRevision"), QStringLiteral("hz")})) {
+        return failure(request.id, *error);
+    }
+    const QJsonValue radioSession = request.params.value(QStringLiteral("radioSession"));
+    const QJsonValue slice = request.params.value(QStringLiteral("slice"));
+    const QJsonValue revision = request.params.value(QStringLiteral("expectedRevision"));
+    const QJsonValue frequency = request.params.value(QStringLiteral("hz"));
+    const auto positiveInteger = [](const QJsonValue& value) {
+        const double number = value.toDouble();
+        return value.isDouble() && std::isfinite(number)
+            && number >= 1 && number <= 9'007'199'254'740'991.0
+            && std::floor(number) == number;
+    };
+    bool idOk = false;
+    const int sliceId = slice.toString().toInt(&idOk);
+    if (!radioSession.isString() || !slice.isString()
+        || !idOk || sliceId < 0 || QString::number(sliceId) != slice.toString()
+        || !positiveInteger(revision) || !positiveInteger(frequency)) {
+        return reject("request.invalid_params", "session, canonical slice id, integer revision and hz required");
+    }
+    if (radioSession.toString() != QStringLiteral("radio-1")
+        || !m_resources->get({QStringLiteral("radioSession"), {}, radioSession.toString()})) {
+        return reject("resource.not_found", "radio session unavailable");
+    }
+    const std::optional<ResourceSnapshot> snapshot = m_resources->get(
+        {QStringLiteral("slice"), radioSession.toString(), slice.toString()});
+    if (!snapshot) {
+        return reject("resource.not_found", "slice unavailable");
+    }
+    if (snapshot->revision != static_cast<quint64>(revision.toDouble())) {
+        return reject("request.conflict", "slice changed; refresh before deciding whether to retry");
+    }
+    if (const std::optional<ProtocolError> error = m_frequencyTarget->setFrequency(
+            sliceId, static_cast<qint64>(frequency.toDouble()))) {
+        return failure(request.id, *error);
+    }
+    return {ControlProtocolCodec::successResponse(request.id,
+                {{QStringLiteral("accepted"), true}}), false};
+}
+
 QJsonObject ControlService::capabilities(const ControlSession& session) const
 {
     const bool observe = session.canObserve();
@@ -423,6 +496,9 @@ QJsonObject ControlService::capabilities(const ControlSession& session) const
         } else {
             available.append(QStringLiteral("radio.disconnect"));
         }
+    }
+    if (session.canControl() && m_frequencyTarget && m_frequencyTarget->available()) {
+        available.append(QStringLiteral("slice.setFrequency"));
     }
     return {
         {QStringLiteral("sessionId"), session.sessionId()},

--- a/src/core/control/ControlService.h
+++ b/src/core/control/ControlService.h
@@ -4,6 +4,7 @@
 #include "ControlResourceStore.h"
 #include "ControlSession.h"
 #include "RadioConnectionTarget.h"
+#include "SliceFrequencyTarget.h"
 
 #include <QJsonObject>
 #include <QString>
@@ -22,11 +23,13 @@ struct ServiceReply {
 class ControlService final {
 public:
     explicit ControlService(ControlResourceStore* resources,
-                            RadioConnectionTarget* connectionTarget = nullptr);
+                            RadioConnectionTarget* connectionTarget = nullptr,
+                            SliceFrequencyTarget* frequencyTarget = nullptr);
 
     // Trusted startup only: bind once, on the owning thread, before dispatch.
     // This lets the daemon claim its endpoint before constructing any models.
     [[nodiscard]] bool bindConnectionTarget(RadioConnectionTarget* target);
+    [[nodiscard]] bool bindFrequencyTarget(SliceFrequencyTarget* target);
 
     [[nodiscard]] ServiceReply handle(
         const QByteArray& bytes, ControlSession* session) const;
@@ -41,10 +44,14 @@ private:
     [[nodiscard]] static bool acceptsVersionOne(const QJsonObject& params);
     [[nodiscard]] ServiceReply handleConnection(
         const ProtocolRequest& request, const ControlSession& session) const;
+    [[nodiscard]] ServiceReply handleFrequency(
+        const ProtocolRequest& request, const ControlSession& session) const;
 
     ControlResourceStore* m_resources{nullptr};
     QPointer<RadioConnectionTarget> m_connectionTarget;
     bool m_targetBound{false};
+    QPointer<SliceFrequencyTarget> m_frequencyTarget;
+    bool m_frequencyTargetBound{false};
     mutable bool m_dispatchStarted{false};
 };
 

--- a/src/core/control/LocalControlServer.cpp
+++ b/src/core/control/LocalControlServer.cpp
@@ -80,6 +80,13 @@ bool LocalControlServer::bindConnectionTarget(RadioConnectionTarget* target)
         && m_service.bindConnectionTarget(target);
 }
 
+bool LocalControlServer::bindFrequencyTarget(SliceFrequencyTarget* target)
+{
+    return thread() == QThread::currentThread() && m_clients.empty()
+        && m_localAuthorization == SessionAuthorization::ObserverController
+        && m_service.bindFrequencyTarget(target);
+}
+
 bool LocalControlServer::listen(const QString& name)
 {
     if (m_server.isListening() || m_lock || m_limits.maxClients < 1

--- a/src/core/control/LocalControlServer.h
+++ b/src/core/control/LocalControlServer.h
@@ -38,6 +38,7 @@ public:
     [[nodiscard]] bool listen(const QString& name);
     // Startup-only binding; never changes grants or replaces a lost target.
     [[nodiscard]] bool bindConnectionTarget(RadioConnectionTarget* target);
+    [[nodiscard]] bool bindFrequencyTarget(SliceFrequencyTarget* target);
     void close();
     [[nodiscard]] bool isListening() const { return m_server.isListening(); }
     [[nodiscard]] QString fullServerName() const { return m_server.fullServerName(); }

--- a/src/core/control/ModelSliceFrequencyTarget.cpp
+++ b/src/core/control/ModelSliceFrequencyTarget.cpp
@@ -1,0 +1,173 @@
+#include "SliceFrequencyTarget.h"
+
+#include "RadioConnectionTarget.h"
+#include "core/backends/IRadioBackend.h"
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+
+#include <QPointer>
+#include <QThread>
+
+#include <cmath>
+
+namespace AetherSDR::control {
+namespace {
+
+ProtocolError refusal(const char* code, const char* message)
+{
+    return {QString::fromLatin1(code), QString::fromLatin1(message), {}, false};
+}
+
+bool validCoverage(const RadioCapabilities& caps)
+{
+    const SliceFrequencyControl& control = caps.sliceFrequencyControl;
+    if (control.authority == SliceFrequencyControl::Authority::Unknown
+        || control.minimumHz <= 0 || control.maximumHz < control.minimumHz
+        || control.maximumHz > 9'007'199'254'000'000) {
+        return false;
+    }
+    for (const DeclaredBandRange& band : caps.declaredBandRanges) {
+        if (!std::isfinite(band.lowHz) || !std::isfinite(band.highHz)
+            || band.lowHz <= 0 || band.highHz < band.lowHz) {
+            return false;
+        }
+    }
+    return true;
+}
+
+class ModelSliceFrequencyTarget final : public SliceFrequencyTarget {
+public:
+    ModelSliceFrequencyTarget(RadioModel* radio, RadioConnectionTarget* connection)
+        : m_radio(radio), m_connection(connection)
+    {
+        // A command edge or construction default is NOT an idle observation.
+        connect(radio, &RadioModel::radioTransmitConfirmed, this, [this](bool tx) {
+            m_confirmedIdle = !tx;
+        });
+        connect(radio, &RadioModel::radioTransmittingChanged, this, [this](bool tx) {
+            if (tx) {
+                m_confirmedIdle = false;
+            }
+        });
+        // A locally initiated keying interval can precede radio readback.
+        // Do not reuse an idle observation from before that interval ends.
+        const auto invalidateOnActive = [this](bool active) {
+            if (active) {
+                m_confirmedIdle = false;
+            }
+        };
+        TransmitModel* transmit = &radio->transmitModel();
+        connect(transmit, &TransmitModel::transmittingChanged, this, invalidateOnActive);
+        connect(transmit, &TransmitModel::moxChanged, this, invalidateOnActive);
+        connect(transmit, &TransmitModel::tuneChanged, this, invalidateOnActive);
+        connect(radio, &RadioModel::connectionStateChanged, this, [this](bool connected) {
+            if (!connected) {
+                m_confirmedIdle = false;
+            }
+        });
+        connect(radio, &RadioModel::backendRebuilt, this, [this] {
+            m_confirmedIdle = false;
+        });
+        connect(connection, &RadioConnectionTarget::stateChanged, this, [this] {
+            if (!m_connection || m_connection->state() != RadioConnectionTarget::State::Connected) {
+                m_confirmedIdle = false;
+            }
+        });
+    }
+
+    bool available() const override
+    {
+        if (!ready()) {
+            return false;
+        }
+        for (SliceModel* slice : m_radio->slices()) {
+            if (slice && !checkSlice(slice->sliceId())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    std::optional<ProtocolError> setFrequency(int sliceId, qint64 hz) override
+    {
+        if (const std::optional<ProtocolError> error = checkSlice(sliceId)) {
+            return error;
+        }
+        const RadioCapabilities caps = m_radio->backendCapabilities();
+        const SliceFrequencyControl& control = caps.sliceFrequencyControl;
+        bool inRange = hz >= control.minimumHz && hz <= control.maximumHz;
+        if (inRange && !caps.declaredBandRanges.isEmpty()) {
+            inRange = false;
+            for (const DeclaredBandRange& band : caps.declaredBandRanges) {
+                if (hz >= band.lowHz && hz <= band.highHz) {
+                    inRange = true;
+                    break;
+                }
+            }
+        }
+        if (!inRange) {
+            return refusal("request.out_of_range", "hz is outside the supported receive coverage");
+        }
+        // Do not call the optimistic desktop/CAT setters. No event-loop
+        // yielding or saved pointer crosses validation and this typed dispatch.
+        m_radio->backend()->setSliceFrequency(sliceId, static_cast<double>(hz));
+        return std::nullopt;
+    }
+
+private:
+    bool ready() const
+    {
+        return thread() == QThread::currentThread()
+            && m_radio && m_radio->thread() == thread()
+            && m_connection && m_connection->thread() == thread()
+            && m_connection->state() == RadioConnectionTarget::State::Connected
+            && m_radio->isConnected() && m_radio->backend()
+            && m_radio->backend()->thread() == thread();
+    }
+
+    std::optional<ProtocolError> checkSlice(int sliceId) const
+    {
+        if (!ready()) {
+            return refusal("request.conflict", "radio connection is not ready");
+        }
+        SliceModel* slice = m_radio->slice(sliceId);
+        if (!slice || !m_radio->isSlotOurs(sliceId) || m_radio->isSlotForeign(sliceId)) {
+            return refusal("resource.not_found", "owned slice unavailable");
+        }
+        if (slice->isLocked()) {
+            return refusal("request.conflict", "slice is locked");
+        }
+        const RadioCapabilities caps = m_radio->backendCapabilities();
+        if (!validCoverage(caps) || !slice->frequencyReportedKnown()) {
+            return refusal("capability.unavailable", "frequency coverage or observation unavailable");
+        }
+        if (caps.canTransmit
+            && (!m_confirmedIdle || m_radio->isRadioTransmitting()
+                || m_radio->transmitModel().isTransmitting()
+                || m_radio->transmitModel().isMox()
+                || m_radio->transmitModel().isTuning())) {
+            return refusal("request.conflict", "transmitter is active or idle state is unconfirmed");
+        }
+        return std::nullopt;
+    }
+
+    QPointer<RadioModel> m_radio;
+    QPointer<RadioConnectionTarget> m_connection;
+    bool m_confirmedIdle{false};
+};
+
+} // namespace
+
+std::unique_ptr<SliceFrequencyTarget> makeModelSliceFrequencyTarget(
+    RadioModel* radio, RadioConnectionTarget* connection)
+{
+    if (!radio || !connection || radio->thread() != QThread::currentThread()
+        || connection->thread() != QThread::currentThread()
+        || radio->isConnected() || radio->isConnectAttemptInFlight()
+        || connection->state() != RadioConnectionTarget::State::Idle) {
+        return {};
+    }
+    return std::make_unique<ModelSliceFrequencyTarget>(radio, connection);
+}
+
+} // namespace AetherSDR::control

--- a/src/core/control/ModelSliceFrequencyTarget.cpp
+++ b/src/core/control/ModelSliceFrequencyTarget.cpp
@@ -23,7 +23,7 @@ bool validCoverage(const RadioCapabilities& caps)
     const SliceFrequencyControl& control = caps.sliceFrequencyControl;
     if (control.authority == SliceFrequencyControl::Authority::Unknown
         || control.minimumHz <= 0 || control.maximumHz < control.minimumHz
-        || control.maximumHz > 9'007'199'254'000'000) {
+        || control.maximumHz > SliceModel::kMaximumReportedFrequencyHz) {
         return false;
     }
     for (const DeclaredBandRange& band : caps.declaredBandRanges) {
@@ -141,6 +141,9 @@ private:
         if (!validCoverage(caps) || !slice->frequencyReportedKnown()) {
             return refusal("capability.unavailable", "frequency coverage or observation unavailable");
         }
+        // TX-slice designation alone is not keying: this receive intent may
+        // retune it while confirmed idle. Any lease/inhibit policy coupling
+        // belongs to the Stage 4 arbiter before TX-capable daemon enablement.
         if (caps.canTransmit
             && (!m_confirmedIdle || m_radio->isRadioTransmitting()
                 || m_radio->transmitModel().isTransmitting()

--- a/src/core/control/RadioResourceAdapter.cpp
+++ b/src/core/control/RadioResourceAdapter.cpp
@@ -22,6 +22,16 @@ QJsonArray strings(const auto& values)
     return result;
 }
 
+QString frequencyAuthority(SliceFrequencyControl::Authority authority)
+{
+    switch (authority) {
+    case SliceFrequencyControl::Authority::Radio: return QStringLiteral("radio");
+    case SliceFrequencyControl::Authority::Engine: return QStringLiteral("engine");
+    case SliceFrequencyControl::Authority::Unknown: return QStringLiteral("unknown");
+    }
+    return QStringLiteral("unknown");
+}
+
 QJsonObject capabilityValue(const RadioCapabilities& capabilities)
 {
     QJsonArray sampleRates;
@@ -42,6 +52,10 @@ QJsonObject capabilityValue(const RadioCapabilities& capabilities)
              {QStringLiteral("minimum"), capabilities.tuningMinHz},
              {QStringLiteral("maximum"), capabilities.tuningMaxHz}}},
         {QStringLiteral("declaredBands"), bands},
+        {QStringLiteral("sliceFrequencyControl"), QJsonObject{
+             {QStringLiteral("authority"), frequencyAuthority(capabilities.sliceFrequencyControl.authority)},
+             {QStringLiteral("minimumHz"), capabilities.sliceFrequencyControl.minimumHz},
+             {QStringLiteral("maximumHz"), capabilities.sliceFrequencyControl.maximumHz}}},
         {QStringLiteral("canTransmit"), capabilities.canTransmit},
         {QStringLiteral("maximumTransmitWatts"), capabilities.txPowerMaxWatts},
         {QStringLiteral("hasTuner"), capabilities.hasTuner},
@@ -157,6 +171,7 @@ void RadioResourceAdapter::attachSlice(SliceModel* slice)
     const auto refresh = [this, slice] { publishSlice(slice); };
     connect(slice, &SliceModel::letterChanged, this, refresh);
     connect(slice, &SliceModel::frequencyChanged, this, refresh);
+    connect(slice, &SliceModel::frequencyReported, this, refresh);
     connect(slice, &SliceModel::panIdChanged, this, refresh);
     connect(slice, &SliceModel::modeChanged, this, refresh);
     connect(slice, &SliceModel::filterChanged, this, refresh);
@@ -307,6 +322,13 @@ void RadioResourceAdapter::publishSlice(SliceModel* slice)
         {QStringLiteral("panadapterId"), slice->panId()},
         {QStringLiteral("owned"), m_radio->isSlotOurs(slice->sliceId())},
         {QStringLiteral("frequencyHz"), qRound64(slice->frequency() * 1'000'000.0)},
+        {QStringLiteral("frequencyObservation"), QJsonObject{
+             {QStringLiteral("known"), slice->frequencyReportedKnown()},
+             {QStringLiteral("hz"), slice->frequencyReportedKnown()
+                  ? QJsonValue(qRound64(slice->reportedFrequency() * 1'000'000.0))
+                  : QJsonValue(QJsonValue::Null)},
+             {QStringLiteral("authority"), frequencyAuthority(
+                  m_radio->backendCapabilities().sliceFrequencyControl.authority)}}},
         {QStringLiteral("mode"), slice->mode()},
         {QStringLiteral("filter"), QJsonObject{
              {QStringLiteral("lowHz"), slice->filterLow()},

--- a/src/core/control/RadioResourceAdapter.cpp
+++ b/src/core/control/RadioResourceAdapter.cpp
@@ -88,6 +88,7 @@ RadioResourceAdapter::RadioResourceAdapter(
             this, &RadioResourceAdapter::publishRadioSession);
     connect(m_radio, &RadioModel::connectionStateChanged,
             this, [this](bool connected) {
+                m_frequencyAuthority.clear();
                 publishRadioSession();
                 if (connected) {
                     publishAll();
@@ -285,6 +286,7 @@ void RadioResourceAdapter::clearDynamicResources()
 void RadioResourceAdapter::publishRadioSession()
 {
     const RadioCapabilities capabilities = m_radio->backendCapabilities();
+    m_frequencyAuthority = frequencyAuthority(capabilities.sliceFrequencyControl.authority);
     QJsonObject value{
         {QStringLiteral("id"), m_radioSessionId},
         {QStringLiteral("connected"), m_radio->isConnected()},
@@ -316,6 +318,10 @@ void RadioResourceAdapter::publishSlice(SliceModel* slice)
     if (!slice || !m_slices.contains(slice)) {
         return;
     }
+    if (m_frequencyAuthority.isEmpty()) {
+        m_frequencyAuthority = frequencyAuthority(
+            m_radio->backendCapabilities().sliceFrequencyControl.authority);
+    }
     const QJsonObject value{
         {QStringLiteral("id"), QString::number(slice->sliceId())},
         {QStringLiteral("letter"), slice->letter()},
@@ -327,8 +333,7 @@ void RadioResourceAdapter::publishSlice(SliceModel* slice)
              {QStringLiteral("hz"), slice->frequencyReportedKnown()
                   ? QJsonValue(qRound64(slice->reportedFrequency() * 1'000'000.0))
                   : QJsonValue(QJsonValue::Null)},
-             {QStringLiteral("authority"), frequencyAuthority(
-                  m_radio->backendCapabilities().sliceFrequencyControl.authority)}}},
+             {QStringLiteral("authority"), m_frequencyAuthority}}},
         {QStringLiteral("mode"), slice->mode()},
         {QStringLiteral("filter"), QJsonObject{
              {QStringLiteral("lowHz"), slice->filterLow()},

--- a/src/core/control/RadioResourceAdapter.h
+++ b/src/core/control/RadioResourceAdapter.h
@@ -47,6 +47,11 @@ private:
     QString m_radioSessionId;
     QPointer<RadioConnectionTarget> m_connectionTarget;
     QSet<SliceModel*> m_slices;
+    // Backend capabilities are rebuilt on every RadioModel::backendCapabilities()
+    // call; cache the slice-frequency authority string and refill it on the
+    // same edges that republish the radio session (capabilities, rebuild,
+    // connection). Empty means "read it on the next publish".
+    QString m_frequencyAuthority;
     QSet<PanadapterModel*> m_panadapters;
 };
 

--- a/src/core/control/SliceFrequencyTarget.h
+++ b/src/core/control/SliceFrequencyTarget.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "ControlProtocolCodec.h"
+
+#include <QObject>
+
+#include <memory>
+#include <optional>
+
+namespace AetherSDR {
+class RadioModel;
+
+namespace control {
+class RadioConnectionTarget;
+
+// Trusted, owning-thread, non-keying intent seam. Implementations revalidate
+// live identities and state before dispatch; success is acceptance, not an ACK.
+class SliceFrequencyTarget : public QObject {
+public:
+    using QObject::QObject;
+    ~SliceFrequencyTarget() override = default;
+    [[nodiscard]] virtual bool available() const = 0;
+    [[nodiscard]] virtual std::optional<ProtocolError> setFrequency(
+        int sliceId, qint64 hz) = 0;
+};
+
+// Both dependencies must outlive the target and remain on its owning thread.
+[[nodiscard]] std::unique_ptr<SliceFrequencyTarget> makeModelSliceFrequencyTarget(
+    RadioModel* radio, RadioConnectionTarget* connection);
+
+} // namespace control
+} // namespace AetherSDR

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -7267,11 +7267,6 @@ void RadioModel::onDisconnected()
     }
     m_radioTransmitting = false;
     emit radioTransmittingChanged(false);
-    for (SliceModel* slice : std::as_const(m_slices)) {
-        if (slice) {
-            slice->invalidateFrequencyObservation();
-        }
-    }
     if (m_profileDatabaseImporting) {
         m_profileDatabaseImporting = false;
         emit profileDatabaseImportingChanged(false);
@@ -7463,6 +7458,14 @@ void RadioModel::onDisconnected()
     emit otherClientsChanged(0, {});
     emit infoChanged();
     emit connectionStateChanged(false);
+    // After connectionStateChanged(false): protocol adapters detach and remove
+    // their slice resources on that edge, so invalidating here costs no
+    // republish of a resource that is about to be removed anyway.
+    for (SliceModel* slice : std::as_const(m_slices)) {
+        if (slice) {
+            slice->invalidateFrequencyObservation();
+        }
+    }
     m_forcedDisconnectInProgress = false;
 
     if (m_wanConn) {

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -6311,6 +6311,7 @@ void RadioModel::stageSessionModelsForReconnect()
     for (SliceModel* slice : m_slices) {
         if (slice) {
             slice->invalidateSquelchState();
+            slice->invalidateFrequencyObservation();
             m_staleSlices.insert(slice->sliceId(), slice);
         }
     }
@@ -7266,6 +7267,11 @@ void RadioModel::onDisconnected()
     }
     m_radioTransmitting = false;
     emit radioTransmittingChanged(false);
+    for (SliceModel* slice : std::as_const(m_slices)) {
+        if (slice) {
+            slice->invalidateFrequencyObservation();
+        }
+    }
     if (m_profileDatabaseImporting) {
         m_profileDatabaseImporting = false;
         emit profileDatabaseImportingChanged(false);

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -1199,7 +1199,7 @@ void SliceModel::applyChanges(const SliceDelta& d)
     if (d.frequency.has_value()) {
         const double f = *d.frequency;
         m_frequencyReportedKnown = std::isfinite(f)
-            && f > 0.0 && f <= 9'007'199'254.0;
+            && f > 0.0 && f <= kMaximumReportedFrequencyMhz;
         m_reportedFrequency = m_frequencyReportedKnown ? f : 0.0;
         // qFuzzyCompare fails when either value is 0.0 — use explicit epsilon
         if (std::abs(m_frequency - f) > 1e-9) {
@@ -1714,8 +1714,9 @@ void SliceModel::applyChanges(const SliceDelta& d)
         if (changed) emit stepChanged(m_stepHz, m_stepList);
     }
 
-    if (d.frequency.has_value()) {
+    if (d.frequency.has_value() && !freqChanged) {
         // Also report a same-value echo following an optimistic desktop tune.
+        // A changed value already notifies observation consumers below.
         emit frequencyReported();
     }
     if (freqChanged)

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -1198,6 +1198,9 @@ void SliceModel::applyChanges(const SliceDelta& d)
 
     if (d.frequency.has_value()) {
         const double f = *d.frequency;
+        m_frequencyReportedKnown = std::isfinite(f)
+            && f > 0.0 && f <= 9'007'199'254.0;
+        m_reportedFrequency = m_frequencyReportedKnown ? f : 0.0;
         // qFuzzyCompare fails when either value is 0.0 — use explicit epsilon
         if (std::abs(m_frequency - f) > 1e-9) {
             m_frequency = f;
@@ -1711,10 +1714,23 @@ void SliceModel::applyChanges(const SliceDelta& d)
         if (changed) emit stepChanged(m_stepHz, m_stepList);
     }
 
+    if (d.frequency.has_value()) {
+        // Also report a same-value echo following an optimistic desktop tune.
+        emit frequencyReported();
+    }
     if (freqChanged)
         emit frequencyChanged(m_frequency);
     if (modeChanged_)   emit modeChanged(m_mode);
     if (filterChanged_) emit filterChanged(m_filterLow, m_filterHigh);
+}
+
+void SliceModel::invalidateFrequencyObservation()
+{
+    if (m_frequencyReportedKnown) {
+        m_frequencyReportedKnown = false;
+        m_reportedFrequency = 0.0;
+        emit frequencyReported();
+    }
 }
 
 void SliceModel::applyRecalledStepHz(int hz)

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -39,6 +39,11 @@ public:
                                      : m_letter; }
     QString panId()      const { return m_panId; }       // e.g. "0x40000000"
     double  frequency()  const { return m_frequency; }   // MHz
+    // Separate from the optimistic desktop value. Only applyChanges writes
+    // this observation; a reused slice must wait for a fresh session report.
+    double reportedFrequency() const { return m_reportedFrequency; } // MHz
+    bool frequencyReportedKnown() const { return m_frequencyReportedKnown; }
+    void invalidateFrequencyObservation();
     QString mode()       const { return m_mode; }
     QStringList modeList() const { return m_modeList; }
     int     filterLow()  const { return m_filterLow; }   // Hz offset
@@ -365,6 +370,7 @@ public:
 signals:
     void letterChanged(const QString& newLetter);
     void frequencyChanged(double mhz);
+    void frequencyReported();
     // Emitted after a local setter has issued a frequency command. Unlike
     // frequencyChanged, radio-status application does not emit this signal.
     void frequencyCommandIssued(double mhz);
@@ -542,6 +548,8 @@ private:
     QString m_letter;          // per-client display letter from `index_letter`
     QString m_panId;           // panadapter assignment (e.g. "0x40000000")
     double  m_frequency{0.0};
+    double  m_reportedFrequency{0.0};
+    bool    m_frequencyReportedKnown{false};
     QString m_mode{"USB"};
     QString m_modeBeforeDigitalVoice;
     QStringList m_modeList;

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -24,6 +24,13 @@ class SliceModel : public QObject {
     Q_PROPERTY(bool txSlice      READ isTxSlice  NOTIFY txSliceChanged)
 
 public:
+    // Conservative whole-MHz observation domain below JSON's 2^53-1 Hz
+    // integer limit. Keep target admission and MHz observation validation
+    // on this same bound; the general protocol integer domain is wider.
+    static constexpr qint64 kMaximumReportedFrequencyMhz = 9'007'199'254;
+    static constexpr qint64 kMaximumReportedFrequencyHz =
+        kMaximumReportedFrequencyMhz * 1'000'000;
+
     explicit SliceModel(int id, QObject* parent = nullptr);
     ~SliceModel() override;
 
@@ -370,6 +377,8 @@ public:
 signals:
     void letterChanged(const QString& newLetter);
     void frequencyChanged(double mhz);
+    // Supplemental observation notification when frequencyChanged does not
+    // fire (same-value reports, optimistic-value echoes, or invalidation).
     void frequencyReported();
     // Emitted after a local setter has issued a frequency command. Unlike
     // frequencyChanged, radio-status application does not emit this signal.

--- a/tests/control_authorization_test.cpp
+++ b/tests/control_authorization_test.cpp
@@ -121,8 +121,12 @@ bool testAuthenticationAndGrants()
                "an authorized observer must read the real resource")) {
         return false;
     }
-    for (const QString& method : {QStringLiteral("slice.setFrequency"),
-                                  QStringLiteral("transmit.acquire"),
+    if (!check(errorCode(invoke(service, observer, QStringLiteral("slice.setFrequency")))
+                   == QStringLiteral("auth.grant_denied"),
+               "observer cannot use frequency control")) {
+        return false;
+    }
+    for (const QString& method : {QStringLiteral("transmit.acquire"),
                                   QStringLiteral("transmit.setMox")}) {
         if (!check(errorCode(invoke(service, observer, method))
                        == QStringLiteral("request.unknown_method"),

--- a/tests/control_connection_test.cpp
+++ b/tests/control_connection_test.cpp
@@ -259,8 +259,10 @@ void validationAndLifecycle()
     f.catalogue.stop();
     check(error(invoke(f.service, f.controller, QStringLiteral("radio.connect"), valid))
               == QStringLiteral("capability.unavailable"), "stopped source cannot connect");
+    check(error(invoke(f.service, f.controller, QStringLiteral("slice.setFrequency")))
+              == QStringLiteral("capability.unavailable"), "absent frequency target cannot tune");
     for (const QString& method : {QStringLiteral("transmit.setMox"), QStringLiteral("tx.acquire"),
-                                 QStringLiteral("slice.setFrequency"), QStringLiteral("invoke")}) {
+                                 QStringLiteral("slice.setMode"), QStringLiteral("invoke")}) {
         check(error(invoke(f.service, f.controller, method)) == QStringLiteral("request.unknown_method"),
               "TX and out-of-scope control remain absent");
     }

--- a/tests/control_resource_service_test.cpp
+++ b/tests/control_resource_service_test.cpp
@@ -487,6 +487,11 @@ bool testPureSeamReconnectRepublishesSlice()
         return false;
     }
 
+    if (!check(waitUntil([&] { return originalSlice->frequencyReportedKnown(); }),
+               "reconnect fixture must wait for the simulator's typed frequency publication")) {
+        radio.disconnectFromRadio();
+        return false;
+    }
     radio.disconnectFromRadio();
     if (!check(waitUntil([&] {
                    return !radio.isConnected()
@@ -497,6 +502,10 @@ bool testPureSeamReconnectRepublishesSlice()
     }
 
     radio.stageSessionModelsForReconnectForTest();
+    if (!check(!originalSlice->frequencyReportedKnown(),
+               "reconnect must invalidate the retained frequency observation")) {
+        return false;
+    }
     radio.connectionStateChanged(true);
     int occupancySignals = 0;
     QObject::connect(&radio, &RadioModel::slotOccupancyChanged,
@@ -514,6 +523,8 @@ bool testPureSeamReconnectRepublishesSlice()
     const std::optional<ResourceSnapshot> reclaimed = store.get(sliceAddress);
     const bool result = check(radio.slice(0) == originalSlice,
                               "the normalized backend seam must reclaim the existing SliceModel")
+        && check(originalSlice->frequencyReportedKnown(),
+                 "same-value backend report restores frequency observation on reclaim")
         && check(occupancySignals == 1,
                  "non-Flex slice reclaim must publish an occupancy edge")
         && check(reclaimed.has_value()
@@ -694,10 +705,10 @@ bool testSimBackendEndToEnd()
                                      {"maxSlices", "maxPanadapters", "sampleRatesHz",
                                       "tuningRangeHz", "declaredBands", "canTransmit",
                                       "maximumTransmitWatts", "hasTuner", "hasAmplifier",
-                                      "extensions"})
+                                      "extensions", "sliceFrequencyControl"})
                    && hasExactlyKeys(sliceValue,
                                      {"id", "letter", "panadapterId", "owned",
-                                      "frequencyHz", "mode", "filter", "active",
+                                      "frequencyHz", "frequencyObservation", "mode", "filter", "active",
                                       "txSlice", "locked", "audio", "receive"})
                    && hasExactlyKeys(sliceValue.value(QStringLiteral("filter")).toObject(),
                                      {"lowHz", "highHz"})

--- a/tests/control_slice_frequency_test.cpp
+++ b/tests/control_slice_frequency_test.cpp
@@ -34,7 +34,8 @@ public:
     int keys{0};
     int lastSlice{-1};
     double lastHz{0};
-    RadioCapabilities capabilities() const override { return caps; }
+    mutable int capabilityReads{0};
+    RadioCapabilities capabilities() const override { ++capabilityReads; return caps; }
     bool isConnected() const override { return connected; }
     void connectRadio(const RadioConnectRequest&) override { connected = true; }
     void disconnectRadio() override { connected = false; }
@@ -203,7 +204,10 @@ void authoritativeObservations()
     check(call(f.service, second, "slice.setFrequency", competing).contains("result")
               && f.backend->tunes == 2 && f.backend->lastHz == 14'235'000,
           "same observed revision permits ordered pending intents, not compare-and-swap");
+    const int readsBeforeReport = f.backend->capabilityReads;
     f.report(14'232'000);
+    check(f.backend->capabilityReads <= readsBeforeReport + 1,
+          "a changed frequency avoids duplicate adapter capability reads");
     const ResourceSnapshot changed = *f.store.get(f.address);
     check(changed.revision > originalRevision
               && changed.value.value("frequencyObservation").toObject().value("hz").toInteger() == 14'232'000
@@ -254,6 +258,10 @@ void coverageAndSafety()
     f.radio.slice(0)->setLocked(true);
     f.rejected(f.params(), "request.conflict");
     f.radio.slice(0)->setLocked(false);
+    SliceDelta txSelection;
+    txSelection.txSlice = true;
+    f.radio.slice(0)->applyChanges(txSelection);
+    check(f.radio.slice(0)->isTxSlice(), "TX-slice designation is independent of active transmission");
     f.backend->caps.canTransmit = true;
     check(!f.target->available(), "TX-capable backend starts with unknown idle state");
     f.rejected(f.params(), "request.conflict");
@@ -286,6 +294,33 @@ void coverageAndSafety()
     f.connection.change(RadioConnectionTarget::State::Connected);
     f.rejected(f.params(), "request.conflict");
     check(f.backend->keys == 0, "safety cases issue no keying");
+}
+
+void numericDomainBoundary()
+{
+    Fixture f;
+    constexpr qint64 kWireMaximum = 9'007'199'254'740'991;
+    constexpr qint64 kObservationMaximum = SliceModel::kMaximumReportedFrequencyHz;
+    check(kWireMaximum - kObservationMaximum == 740'991,
+          "documented whole-MHz ceiling remains below the general wire limit");
+    f.backend->caps.sliceFrequencyControl.maximumHz = kObservationMaximum;
+    check(f.target->available() && f.tune(f.params(kObservationMaximum)).contains("result"),
+          "coverage ceiling is inclusive for typed intents");
+    f.report(kObservationMaximum);
+    check(f.radio.slice(0)->frequencyReportedKnown()
+              && f.store.get(f.address)->value.value("frequencyObservation").toObject()
+                     .value("hz").toInteger() == kObservationMaximum,
+          "coverage ceiling can be published as an exact known observation");
+    f.rejected(f.params(kObservationMaximum + 1), "request.out_of_range");
+    f.backend->caps.sliceFrequencyControl.maximumHz = kWireMaximum;
+    check(!f.target->available(), "wire-valid maximum beyond observation domain disables coverage");
+    f.rejected(f.params(), "capability.unavailable");
+    f.backend->caps.sliceFrequencyControl.maximumHz = kObservationMaximum;
+    f.report(kObservationMaximum + 1'000'000);
+    check(!f.radio.slice(0)->frequencyReportedKnown()
+              && f.store.get(f.address)->value.value("frequencyObservation").toObject()
+                     .value("hz").isNull(),
+          "report beyond the shared ceiling clears observation knowledge");
 }
 
 void lifetimeAndBinding()
@@ -361,6 +396,7 @@ int main(int argc, char** argv)
     authorizationAndSchema();
     authoritativeObservations();
     coverageAndSafety();
+    numericDomainBoundary();
     lifetimeAndBinding();
     requestBudget();
     return failures == 0 ? 0 : 1;

--- a/tests/control_slice_frequency_test.cpp
+++ b/tests/control_slice_frequency_test.cpp
@@ -1,0 +1,367 @@
+#include "TestSettingsProfile.h"
+#include "core/control/ControlService.h"
+#include "core/control/LocalControlServer.h"
+#include "core/control/RadioResourceAdapter.h"
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+
+#include <QCoreApplication>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QThread>
+
+#include <cstdio>
+#include <limits>
+
+using namespace AetherSDR;
+using namespace AetherSDR::control;
+
+namespace {
+int failures = 0;
+void check(bool ok, const char* message)
+{
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", message);
+    failures += !ok;
+}
+
+// Injected engine transport: no sockets, discovery, DSP, timers or peer.
+// It records DOWN intents; tests feed normalized observations separately.
+class RecordingBackend final : public IRadioBackend {
+public:
+    RadioCapabilities caps;
+    bool connected{false};
+    int tunes{0};
+    int keys{0};
+    int lastSlice{-1};
+    double lastHz{0};
+    RadioCapabilities capabilities() const override { return caps; }
+    bool isConnected() const override { return connected; }
+    void connectRadio(const RadioConnectRequest&) override { connected = true; }
+    void disconnectRadio() override { connected = false; }
+    void setSliceFrequency(int id, double hz) override { ++tunes; lastSlice = id; lastHz = hz; }
+    void setSliceMode(int, const QString&) override {}
+    void setSliceFilter(int, int, int) override {}
+    void setSliceAgc(int, const QString&, int) override {}
+    void setPanCenter(const QString&, double, PanCenterIntent) override {}
+    void setKeying(bool) override { ++keys; }
+    void invokeExtension(const QString&, const QString&, quint64, const QVariant&) override {}
+};
+
+class Connection final : public RadioConnectionTarget {
+public:
+    State current{State::Idle};
+    State state() const override { return current; }
+    QString errorCode() const override { return {}; }
+    bool supports(const DiscoveredRadio&) const override { return true; }
+    void connectRadio(const DiscoveredRadio&) override {}
+    void disconnectRadio() override { change(State::Disconnecting); }
+    void change(State next) { current = next; emit stateChanged(); }
+};
+
+QJsonObject call(ControlService& service, ControlSession& session, const QString& method,
+                 const QJsonObject& params = {}, const QString& sessionId = {})
+{
+    QJsonObject request{{"v", 1}, {"id", "request"}, {"method", method}, {"params", params}};
+    if (method != QStringLiteral("hello")) {
+        request.insert("sessionId", sessionId.isEmpty() ? session.sessionId() : sessionId);
+    }
+    return service.handle(QJsonDocument(request).toJson(QJsonDocument::Compact), &session).message;
+}
+
+QString error(const QJsonObject& response)
+{
+    return response.value("error").toObject().value("code").toString();
+}
+
+struct Fixture {
+    RadioModel radio;
+    Connection connection;
+    ControlResourceStore store;
+    std::unique_ptr<SliceFrequencyTarget> target;
+    ControlService service{&store};
+    ControlSession controller{&store, 65536, SessionAuthorization::ObserverController};
+    RadioResourceAdapter adapter{&radio, &store, QStringLiteral("radio-1"), nullptr, &connection};
+    RecordingBackend* backend{nullptr};
+    const ResourceAddress address{QStringLiteral("slice"), QStringLiteral("radio-1"), QStringLiteral("0")};
+
+    Fixture()
+    {
+        auto owned = std::make_unique<RecordingBackend>();
+        backend = owned.get();
+        backend->caps.sliceFrequencyControl = {SliceFrequencyControl::Authority::Radio,
+                                               100'000, 60'000'000};
+        radio.setBackendForTest(std::move(owned), QStringLiteral("frequency-test"));
+        check(radio.automationApplySliceFixture(0, QStringLiteral("A")),
+              "socket-free model slice fixture installed");
+        target = makeModelSliceFrequencyTarget(&radio, &connection);
+        check(target && service.bindFrequencyTarget(target.get()), "production target bound before dispatch");
+        backend->connected = true;
+        connection.change(RadioConnectionTarget::State::Connected);
+        report(14'225'000);
+        hello(controller);
+    }
+
+    void hello(ControlSession& session)
+    {
+        check(call(service, session, "hello", {{"versions", QJsonArray{1}}}).contains("result"),
+              "session negotiated");
+    }
+
+    void report(qint64 hz)
+    {
+        SliceDelta delta;
+        delta.frequency = static_cast<double>(hz) / 1'000'000.0;
+        radio.slice(0)->applyChanges(delta);
+    }
+
+    QJsonObject params(qint64 hz = 14'230'000) const
+    {
+        const std::optional<ResourceSnapshot> snapshot = store.get(address);
+        return {{"radioSession", "radio-1"}, {"slice", "0"},
+                {"expectedRevision", static_cast<qint64>(snapshot ? snapshot->revision : 0)}, {"hz", hz}};
+    }
+
+    QJsonObject tune(const QJsonObject& params) { return call(service, controller, "slice.setFrequency", params); }
+    void rejected(const QJsonObject& params, const char* code)
+    {
+        const int before = backend->tunes;
+        const QString actual = error(tune(params));
+        if (actual != QString::fromLatin1(code)) {
+            std::printf("Expected %s, got %s\n", code, qPrintable(actual));
+        }
+        check(actual == QString::fromLatin1(code) && backend->tunes == before,
+              "refusal has expected error and dispatches no intent");
+    }
+};
+
+void authorizationAndSchema()
+{
+    Fixture f;
+    for (SessionAuthorization authorization : {SessionAuthorization::Observer,
+                                               SessionAuthorization::AuthenticatedWithoutGrants}) {
+        ControlSession denied(&f.store, 65536, authorization);
+        f.hello(denied);
+        check(error(call(f.service, denied, "slice.setFrequency", {{"invalid", true}}))
+                  == "auth.grant_denied" && f.backend->tunes == 0,
+              "grant denial precedes target/schema access");
+        check(!f.service.capabilities(denied).value("capabilities").toArray()
+                   .contains("slice.setFrequency"), "observer never advertises mutation");
+    }
+    QJsonObject params = f.params();
+    params.insert("force", true);
+    f.rejected(params, "request.invalid_params");
+    for (const char* field : {"radioSession", "slice", "expectedRevision", "hz"}) {
+        params = f.params();
+        params.remove(field);
+        f.rejected(params, "request.invalid_params");
+    }
+    for (QJsonValue value : {QJsonValue(0), QJsonValue(-1), QJsonValue(1.25),
+                            QJsonValue(true), QJsonValue("14225000"),
+                            QJsonValue(QJsonValue::Null), QJsonValue(9007199254740992.0)}) {
+        params = f.params();
+        params.insert("hz", value);
+        f.rejected(params, "request.invalid_params");
+        params = f.params();
+        params.insert("expectedRevision", value);
+        f.rejected(params, "request.invalid_params");
+    }
+    for (const char* id : {"-1", "+0", "00", "0 ", "2147483648", "0\nraw command"}) {
+        params = f.params(); params.insert("slice", id);
+        f.rejected(params, "request.invalid_params");
+    }
+    params = f.params(); params.insert("slice", "1");
+    f.rejected(params, "resource.not_found");
+    params = f.params(); params.insert("radioSession", "radio-2");
+    f.rejected(params, "resource.not_found");
+    check(error(call(f.service, f.controller, "slice.setFrequency", f.params(), "another-session"))
+              == "session.invalid" && f.backend->tunes == 0, "foreign protocol session cannot tune");
+    f.controller.revokeAuthorization();
+    check(error(f.tune(f.params())) == "auth.invalid" && f.backend->tunes == 0,
+          "revocation prevents subsequent tuning");
+}
+
+void authoritativeObservations()
+{
+    Fixture f;
+    const quint64 originalRevision = f.store.get(f.address)->revision;
+    const QJsonObject request = f.params();
+    call(f.service, f.controller, "resource.subscribe",
+         {{"resources", QJsonArray{QJsonObject{{"type", "slice"}, {"radioSession", "radio-1"}}}}});
+    (void) f.controller.takePendingFrames();
+    check(f.tune(request).value("result").toObject().value("accepted").toBool()
+              && f.backend->tunes == 1 && f.backend->lastSlice == 0
+              && f.backend->lastHz == 14'230'000,
+          "production target dispatches exactly one typed Hz intent");
+    check(f.radio.slice(0)->frequency() == 14.225
+              && f.store.get(f.address)->revision == originalRevision
+              && f.controller.takePendingFrames().isEmpty(),
+          "acceptance never optimistically changes the model or observation");
+
+    ControlSession second(&f.store, 65536, SessionAuthorization::ObserverController);
+    f.hello(second);
+    QJsonObject competing = request; competing.insert("hz", 14'235'000);
+    check(call(f.service, second, "slice.setFrequency", competing).contains("result")
+              && f.backend->tunes == 2 && f.backend->lastHz == 14'235'000,
+          "same observed revision permits ordered pending intents, not compare-and-swap");
+    f.report(14'232'000);
+    const ResourceSnapshot changed = *f.store.get(f.address);
+    check(changed.revision > originalRevision
+              && changed.value.value("frequencyObservation").toObject().value("hz").toInteger() == 14'232'000
+              && !f.controller.takePendingFrames().isEmpty(),
+          "a differing backend report wins and reaches subscribers");
+    f.rejected(request, "request.conflict");
+    f.report(14'232'000);
+    check(f.store.get(f.address)->revision == changed.revision,
+          "unchanged reports do not fabricate resource revisions");
+    check(f.tune(f.params(14'232'000)).contains("result"), "same-current-frequency intent succeeds");
+
+    SliceModel* slice = f.radio.slice(0);
+    slice->setFrequency(14.240);
+    check(slice->frequency() == 14.240 && slice->reportedFrequency() == 14.232,
+          "legacy desktop optimistic value remains separate");
+    const quint64 optimisticRevision = f.store.get(f.address)->revision;
+    f.report(14'240'000);
+    check(f.store.get(f.address)->revision > optimisticRevision
+              && slice->reportedFrequency() == 14.240,
+          "echo equal to optimistic value still updates observed state");
+    slice->invalidateFrequencyObservation();
+    check(!f.target->available()
+              && f.store.get(f.address)->value.value("frequencyObservation").toObject().value("hz").isNull(),
+          "unknown observation is explicit and cannot enable tuning");
+    f.report(14'240'000);
+    check(f.target->available(), "fresh same-value observation restores eligibility");
+    check(f.backend->keys == 0, "all tuning and observation paths emit no keying intent");
+}
+
+void coverageAndSafety()
+{
+    Fixture f;
+    f.rejected(f.params(99'999), "request.out_of_range");
+    f.rejected(f.params(60'000'001), "request.out_of_range");
+    check(f.tune(f.params(100'000)).contains("result"), "lower coverage endpoint accepted");
+    check(f.tune(f.params(60'000'000)).contains("result"), "upper coverage endpoint accepted");
+    f.backend->caps.declaredBandRanges = {{"low", 100'000, 200'000}, {"high", 50'000'000, 60'000'000}};
+    f.rejected(f.params(), "request.out_of_range");
+    check(f.tune(f.params(50'000'000)).contains("result"), "discontinuous coverage endpoint accepted");
+    f.backend->caps.declaredBandRanges.clear();
+    f.backend->caps.sliceFrequencyControl.minimumHz = 0;
+    check(!f.target->available(), "unknown coverage is not advertised");
+    f.rejected(f.params(), "capability.unavailable");
+    f.backend->caps.sliceFrequencyControl.minimumHz = 100'000;
+    f.backend->caps.sliceFrequencyControl.authority = SliceFrequencyControl::Authority::Unknown;
+    f.rejected(f.params(), "capability.unavailable");
+    f.backend->caps.sliceFrequencyControl.authority = SliceFrequencyControl::Authority::Radio;
+    f.radio.slice(0)->setLocked(true);
+    f.rejected(f.params(), "request.conflict");
+    f.radio.slice(0)->setLocked(false);
+    f.backend->caps.canTransmit = true;
+    check(!f.target->available(), "TX-capable backend starts with unknown idle state");
+    f.rejected(f.params(), "request.conflict");
+    f.radio.radioTransmittingChanged(false);
+    f.rejected(f.params(), "request.conflict");
+    f.radio.radioTransmitConfirmed(false);
+    check(f.target->available() && f.tune(f.params()).contains("result"),
+          "explicit idle readback admits receive tuning");
+    f.radio.radioTransmittingChanged(true);
+    f.rejected(f.params(), "request.conflict");
+    f.radio.radioTransmittingChanged(false);
+    f.rejected(f.params(), "request.conflict");
+    f.radio.radioTransmitConfirmed(false);
+    f.radio.transmitModel().setTransmitting(true);
+    f.rejected(f.params(), "request.conflict");
+    f.radio.transmitModel().setTransmitting(false);
+    f.rejected(f.params(), "request.conflict");
+    for (auto signal : {&TransmitModel::moxChanged, &TransmitModel::tuneChanged}) {
+        f.radio.radioTransmitConfirmed(false);
+        (f.radio.transmitModel().*signal)(true);
+        (f.radio.transmitModel().*signal)(false);
+        f.rejected(f.params(), "request.conflict");
+    }
+    f.radio.radioTransmitConfirmed(false);
+    f.radio.backendRebuilt();
+    f.rejected(f.params(), "request.conflict");
+    f.radio.radioTransmitConfirmed(false);
+    f.connection.change(RadioConnectionTarget::State::Disconnecting);
+    f.rejected(f.params(), "request.conflict");
+    f.connection.change(RadioConnectionTarget::State::Connected);
+    f.rejected(f.params(), "request.conflict");
+    check(f.backend->keys == 0, "safety cases issue no keying");
+}
+
+void lifetimeAndBinding()
+{
+    Fixture f;
+    const QJsonObject oldSelection = f.params();
+    f.backend->connected = false;
+    f.radio.connectionStateChanged(false);
+    check(!f.store.get(f.address) && !f.target->available(),
+          "disconnect removes the selected resource and disables tuning");
+    check(f.radio.automationRemoveSliceFixture(0)
+              && f.radio.automationApplySliceFixture(0, QStringLiteral("A")),
+          "disconnected engine replaces the fixture slice");
+    f.backend->connected = true;
+    f.radio.connectionStateChanged(true);
+    f.report(14'225'000);
+    check(f.store.get(f.address).has_value(), "new connection republishes the replacement slice");
+    f.rejected(oldSelection, "request.conflict");
+    f.backend->connected = false;
+    f.rejected(f.params(), "request.conflict");
+    f.backend->connected = true;
+    bool offThreadAccepted = true;
+    std::unique_ptr<QThread> worker(QThread::create([&] {
+        offThreadAccepted = !f.target->setFrequency(0, 14'230'000).has_value();
+    }));
+    worker->start(); worker->wait();
+    check(!offThreadAccepted && f.backend->tunes == 0, "wrong-thread production dispatch fails closed");
+    check(!f.service.bindFrequencyTarget(f.target.get()), "target cannot be rebound after dispatch");
+    f.target.reset();
+    f.rejected(f.params(), "capability.unavailable");
+
+    Fixture fresh;
+    // Inert production transport objects: neither calls listen() or binds a socket.
+    LocalControlServer observer;
+    LocalControlServer controller(nullptr, {}, nullptr, true);
+    check(!observer.bindFrequencyTarget(fresh.target.get()), "observer transport refuses a target");
+    check(controller.bindFrequencyTarget(fresh.target.get()), "opt-in transport accepts initial target");
+    check(!controller.bindFrequencyTarget(fresh.target.get()), "transport target binding is one-shot");
+    check(!makeModelSliceFrequencyTarget(&fresh.radio, &fresh.connection),
+          "factory refuses attachment to an already-live engine");
+}
+
+void requestBudget()
+{
+    Fixture f;
+    qint64 now = 0;
+    ControlSession limited(&f.store, 65536, SessionAuthorization::Controller,
+                           nullptr, [&] { return now; });
+    f.hello(limited);
+    const QJsonObject params = f.params();
+    bool burstAccepted = true;
+    for (int i = 0; i < ControlSession::kRequestBurst; ++i) {
+        burstAccepted &= call(f.service, limited, "slice.setFrequency", params).contains("result");
+    }
+    check(burstAccepted && f.backend->tunes == ControlSession::kRequestBurst,
+          "control-only grant admits the advertised burst without optimistic revisions");
+    check(error(call(f.service, limited, "slice.setFrequency", params)) == "transport.limit_exceeded"
+              && f.backend->tunes == ControlSession::kRequestBurst,
+          "frequency method cannot bypass the request budget");
+    now += 10'000'000'000LL;
+    check(error(call(f.service, limited, "slice.setFrequency", params)) == "transport.limit_exceeded",
+          "terminal budget exhaustion prevents later dispatch");
+    check(f.tune(params).contains("result") && f.backend->tunes == ControlSession::kRequestBurst + 1,
+          "a second controller retains its independent budget");
+}
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile profile(QStringLiteral("control-slice-frequency"));
+    if (!profile.isValid()) { return 1; }
+    QCoreApplication app(argc, argv);
+    authorizationAndSchema();
+    authoritativeObservations();
+    coverageAndSafety();
+    lifetimeAndBinding();
+    requestBudget();
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/control_slice_frequency_test.cpp
+++ b/tests/control_slice_frequency_test.cpp
@@ -193,6 +193,9 @@ void authoritativeObservations()
               && f.backend->tunes == 1 && f.backend->lastSlice == 0
               && f.backend->lastHz == 14'230'000,
           "production target dispatches exactly one typed Hz intent");
+    check(f.store.get(f.address)->value.value("frequencyObservation").toObject()
+                  .value("authority").toString() == "radio",
+          "published observation authority reflects the bound backend");
     check(f.radio.slice(0)->frequency() == 14.225
               && f.store.get(f.address)->revision == originalRevision
               && f.controller.takePendingFrames().isEmpty(),
@@ -206,8 +209,8 @@ void authoritativeObservations()
           "same observed revision permits ordered pending intents, not compare-and-swap");
     const int readsBeforeReport = f.backend->capabilityReads;
     f.report(14'232'000);
-    check(f.backend->capabilityReads <= readsBeforeReport + 1,
-          "a changed frequency avoids duplicate adapter capability reads");
+    check(f.backend->capabilityReads == readsBeforeReport,
+          "a frequency report republishes without re-reading backend capabilities");
     const ResourceSnapshot changed = *f.store.get(f.address);
     check(changed.revision > originalRevision
               && changed.value.value("frequencyObservation").toObject().value("hz").toInteger() == 14'232'000

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -161,6 +161,14 @@ target_compile_definitions(control_connection_test PRIVATE AETHERSDR_VERSION="${
 target_link_libraries(control_connection_test PRIVATE Qt6::Core Qt6::Network)
 add_test(NAME control_connection_test COMMAND control_connection_test)
 
+# Socket-free frequency control: a recording engine backend and normalized
+# observations exercise the production target/service. LocalControlServer
+# instances only test startup binding; neither listens or opens an endpoint.
+add_executable(control_slice_frequency_test tests/control_slice_frequency_test.cpp)
+target_include_directories(control_slice_frequency_test PRIVATE src tests)
+target_link_libraries(control_slice_frequency_test PRIVATE aethercore Qt6::Core)
+add_test(NAME control_slice_frequency_test COMMAND control_slice_frequency_test)
+
 # Real factory wiring, with local=false: simulator metadata only, no sockets,
 # device scans, radio connections or third-party firmware stand-ins.
 add_executable(radio_discovery_source_test tests/radio_discovery_source_test.cpp)
@@ -4736,6 +4744,7 @@ set(AETHER_SETTINGS_CONSUMERS
     icom_identity_test
     icom_control_profile_test
     control_resource_service_test
+    control_slice_frequency_test
     aetherd_discovery_startup_test
     slice_label_test
     ulanzi_mapping_migration_test


### PR DESCRIPTION
## Summary

Continues #3849 after #5458 with one bounded receive-control method: `slice.setFrequency` for an existing owned slice. Coordination: https://github.com/aethersdr/AetherSDR/issues/3849#issuecomment-5622116087.

- Retains observe-only startup and the existing explicit `--allow-local-control` opt-in. No TX method, raw command, new credential path, discovery behavior or desktop migration.
- Validates the control grant, canonical session/slice identity, exact observed resource revision, integer Hz, live ownership/lock/connection state and backend coverage before one typed dispatch.
- Separates backend frequency observations from the existing optimistic desktop value. `accepted:true` is not a hardware ACK or convergence guarantee; revisions are freshness checks, not CAS or controller reservations.
- Refuses TX-capable sessions until explicit idle readback, invalidating that knowledge on local/radio TX activity and connection/backend transitions.
- Documents backend authority and coverage explicitly. Sim is the exercised path. RTL-SDR can qualify when built; TX-enabled HL2, Flex and ANAN remain unavailable where readback or verified bounds are missing. Icom stays outside the daemon's current catalogue connection scope. Existing desktop tuning remains unchanged.

See `docs/aetherd-local-slice-frequency-control.md` for the precise contract, errors, competing-controller behavior and limitations.

## Constitution principles

Principle II: accepted intent never fabricates observed frequency. Principle VI: no TX operation or grant is added. Principle VII: strict boundary validation and fail-closed coverage/idle checks. Principle XI: behavioral tests and deliberate guard mutations demonstrate the safety claims.

## Verification

- ARM64 `AetherSDR` and `aetherd` built with the dedicated Mac toolchain, RADE enabled; ARM64 processors/executables verified, no RNNoise x86 sources, no QtWidgets daemon dependency.
- Nine focused CTests passed: `control_protocol_codec_test`, `control_authorization_test`, `local_control_server_test`, `control_resource_service_test`, `radio_catalogue_test`, `control_connection_test`, `control_slice_frequency_test`, `radio_discovery_source_test`, `aetherd_discovery_startup_test`.
- New socket-free production-target tests cover grants, schema, ownership, limits, delayed/differing/same-value observations, optimistic desktop separation, revision conflicts/recreation, multiple controllers, TX-idle admission, lifetime, owning thread and request budgets.
- Mutation checks: removing revision validation and assuming idle at construction each failed the new test. A separate local-keying regression failed before the fix; all tests pass with guards restored.
- Real daemon/local-server smoke with production simulator: observe-only refusal, opt-in connection/tuning, subscription events, two controllers, stale revisions and disconnect.
- Native Cocoa desktop MCP proof on the exact rebuilt ARM64 artifact: authenticated identity, isolated settings, `txAllowed:false`, `DEMO-0001` tune/disconnect/reconnect/tune. The test instance was stopped afterward.
- Engine boundary, generated touchpoint manifest, test registration, frozen CI gate and whitespace checks pass. Existing engine-boundary legacy warnings remain unchanged.
- Git merge-tree confirms clean integration with refreshed upstream/main `df0520ad7725153a2802b1643d8c84edb01b450a`, preserving both subsequent upstream changes. Runtime evidence is for the reviewed branch on the #5458 merge base, not a rebuilt synthetic merge.

The new CTest does **not** bind sockets or simulate third-party firmware. Its `LocalControlServer` objects are inert binding-policy checks. The existing local-server test and manual daemon smoke bind our actual current-user local service; the server test required an unsandboxed run to bind on macOS. The daemon used `--discover-sim`, never `--discover-local`. Desktop startup retains its normal discovery listeners, but only `DEMO-0001` was selected: no hardware connection or TX testing occurred. RTL-SDR is not available in this local build; hardware convergence and Windows/Linux runtime validation remain untested. Per-PR CI is pending.

## Review

The functional review found and fixed a missing invalidation edge: a local transmitting/MOX/TUNE active interval must discard previously confirmed idle, and a subsequent local false edge must not restore it. The regression failed before the fix and passes afterward.

The independent architecture/control-path reviews and the security diff review found no remaining actionable findings. Security scan `eaf6de71-33fa-4562-9d92-597bb4b13a7e` reviewed the exact pre-commit working-tree patch on `981b7fe6593699ac8a5317c4cbe513ca1f56b6d7` and recorded zero findings. **Report artifact caveat:** its exporter retained two already-completed checkpoint items as deferred, so the sealed report labels coverage partial. The preserved final submitted checkpoint explicitly has complete coverage, no deferred items, and all five surfaces reviewed; the sealed report also includes those five completed surfaces. The sealed artifacts were preserved unchanged, and this is not presented as a clean automated coverage verdict. The hardware/platform limitations above still apply.

## Checklist

- [x] Signed commit `abd7d72f29faa567cc17255e7362ebe74769f214`; local SSH signature verification passed.
- [x] No new settings keys or dependencies; no `CHANGELOG.md` change.
- [x] Clean-room typed backend integration; Flex range uncertainty is left unavailable rather than using commented-out FlexLib limits.
- [x] Protocol/resource/capability documentation and test registration updated; no frozen PR test-gate expansion.
