### PR TITLE
ci: dep caches save on main, Windows Qt via aqt, tag sweep (#5548)

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -34,15 +34,17 @@ name: Cache cleanup
 # pins the repo at its allowance on its own, holding well under a day of caches
 # nothing will ever read.
 #
-# The other cause is caches on refs/pull/N/merge, which become unreadable the
-# moment the PR closes — handled by sweep-closed-prs below, on a schedule rather
-# than on the close event. See that job for why the trigger is what it is.
+# The other causes are caches on refs that nothing will run against again:
+# refs/pull/N/merge once the PR closes, and refs/tags/v* once the release
+# workflows that ran on that tag have finished. Both are handled by
+# sweep-dead-refs below, on a schedule rather than on an event. See that job
+# for why the trigger is what it is.
 
 on:
   workflow_run:
     workflows: [CI]
     types: [completed]
-  # Daily, plus on demand. See sweep-closed-prs for why this is scheduled
+  # Daily, plus on demand. See sweep-dead-refs for why this is scheduled
   # rather than fired from `pull_request: closed`.
   schedule:
     - cron: "17 4 * * *"
@@ -53,7 +55,7 @@ on:
 # specifically so ci.yml keeps `contents: read` — nothing that compiles
 # PR-authored code ever holds a write scope.
 #
-# pull-requests:read is a read scope, needed only by sweep-closed-prs to ask
+# pull-requests:read is a read scope, needed only by sweep-dead-refs to ask
 # whether a PR is still open. Listing it is not optional: naming ANY scope in a
 # `permissions:` block sets every unnamed one to `none`, and the job's lookup
 # would then fail on every ref while the job stayed green.
@@ -175,16 +177,18 @@ jobs:
   # closes nothing can ever read them again, but they hold budget for up to the
   # full 7-day retention.
   #
-  # ci.yml's save-on-main split already stops PRs writing the big COMPILER
-  # caches. What still lands on a PR ref is a content-hash-keyed DEPENDENCY
-  # cache (Qt, FFTW3, DeepFilterNet3, qtkeychain, install-qt-action). In theory a
-  # PR only writes one when the key is not readable from main; in practice the
-  # repo sits at its allowance, LRU evicts main's copy between runs, and the
-  # next PR run re-saves its own — measured 2026-09-10: four open PRs each
-  # holding the same 1,297 MiB Qt entry main holds, plus a merged PR holding
-  # 1,720 MiB nothing could read. That loop is a ci.yml problem (the dependency
-  # caches want the same restore-on-PR / save-on-main split the compiler caches
-  # got); this job only reclaims the closed-PR leg of it.
+  # ci.yml saves nothing from a PR ref any more: #5008 gave the COMPILER
+  # caches a restore-on-PR / save-on-main split, and #5548 gave the
+  # content-hash-keyed DEPENDENCY caches (Qt, FFTW3, DeepFilterNet3,
+  # qtkeychain) the same. Before that second step, a PR wrote a dependency
+  # entry whenever main's copy was unreadable — and with the repo at its
+  # allowance, LRU evicted main's copy between runs, so on 2026-09-10 four
+  # open PRs each held the same 1,297 MiB Qt entry main holds, plus a merged
+  # PR holding 1,720 MiB nothing could read. This step is now the backstop for
+  # whatever other PR-triggered workflows still write (setup-python and the
+  # like — small) and for anything that regresses to a bidirectional
+  # `actions/cache` step in ci.yml. If it starts reporting large sweeps
+  # again, look for that regression before anything else.
   #
   # WHY SCHEDULED, not `pull_request: closed`
   #
@@ -208,7 +212,25 @@ jobs:
   # A PR that is closed and later REOPENED can read its ref again, but this job
   # will already have deleted it; the reopened PR's first run re-saves its
   # dependency caches (~1.7 GiB across platforms). Accepted, not a bug.
-  sweep-closed-prs:
+  #
+  # ── Dead cause 3: the tag's release run is over ─────────────────────────────
+  # appimage.yml, macos-dmg.yml and windows-installer.yml run on push:tags only.
+  # main never runs them, so the keys they cache (Opus, FFTW3, hidapi, Vulkan
+  # SDK, macos-deps, the DMG legs' ccache) exist ONLY on tag refs — and a run
+  # on refs/tags/v26.9.2 can read its own ref and main, never v26.9.1's. Every
+  # release therefore writes a full set that no later release can read: ~6
+  # entries from windows-installer, ~4 per DMG leg, one from appimage, held
+  # for the 7-day retention. The sharpest is macos-dmg's ccache-action, which
+  # append-timestamps its key and so writes a fresh ~0.5 GiB entry per leg per
+  # release under a prefix prune-main does not match.
+  #
+  # The one thing that CAN read a tag's caches is a re-run of the same tag's
+  # workflow — a retry after a flaky release step, typically within hours — so
+  # the rule is last-access age, not "not the newest tag": a tag-ref entry that
+  # nothing has touched for TAG_IDLE_HOURS is dead. 48 h is long enough for a
+  # next-morning retry and short enough that a release's set is gone before
+  # it can crowd main's compiler caches for the rest of the week.
+  sweep-dead-refs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     # A dispatch overlapping the cron would run two sweeps over the same refs;
@@ -236,10 +258,9 @@ jobs:
           total=$(printf '%s' "$caches" | jq 'length')
           [ "$total" -lt "$LIMIT" ] || echo "::warning::cache list hit the $LIMIT limit; some entries not examined this run"
 
-          # Only refs/pull/N/merge entries are candidates. main and tag refs are
-          # not swept here: main's are handled by prune-main, and tag caches
-          # belong to release workflows that run rarely enough not to matter.
-          # One jq pass emits, per PR ref: number, total bytes, and the ids.
+          # refs/pull/N/merge entries first; tag refs are the next step and
+          # main's are prune-main's. One jq pass emits, per PR ref: number,
+          # total bytes, and the ids.
           candidates=$(printf '%s' "$caches" | jq -r '
             [.[] | select(.ref | test("^refs/pull/[0-9]+/merge$"))]
             | group_by(.ref) | .[]
@@ -299,6 +320,56 @@ jobs:
             echo "::warning::$unresolved PR state lookup(s) failed; their caches were left alone. gh stderr:"
             cat "$errlog"
           fi
+
+      - name: Delete caches on idle tag refs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG_IDLE_HOURS: "48"
+        run: |
+          set -euo pipefail
+
+          # Same listing shape and the same cap warning as the PR step above.
+          LIMIT=500
+          caches=$(gh cache list --limit "$LIMIT" --json id,ref,key,sizeInBytes,lastAccessedAt)
+          total=$(printf '%s' "$caches" | jq 'length')
+          [ "$total" -lt "$LIMIT" ] || echo "::warning::cache list hit the $LIMIT limit; some entries not examined this run"
+
+          # last_accessed_at, deliberately — the opposite of prune-main's
+          # created_at. There "newest written" is the entry to keep; here the
+          # question is whether anything is still READING the entry, and a
+          # re-run of the tag's workflow is the only thing that could be.
+          cutoff=$(date -u -d "-${TAG_IDLE_HOURS} hours" +%Y-%m-%dT%H:%M:%SZ)
+          candidates=$(printf '%s' "$caches" | jq -r --arg cutoff "$cutoff" '
+            [.[] | select(.ref | startswith("refs/tags/")) | select(.lastAccessedAt < $cutoff)]
+            | group_by(.ref) | .[]
+            | "\(.[0].ref)\t\(map(.sizeInBytes) | add)\t\(map(.id) | join(","))"')
+
+          if [ -z "$candidates" ]; then
+            echo "No tag-ref caches idle for ${TAG_IDLE_HOURS}h — nothing to sweep."
+            exit 0
+          fi
+
+          freed=0
+          swept=0
+          while IFS=$'\t' read -r ref bytes ids; do
+            mib=$(( bytes / 1048576 ))
+            echo "$ref: sweeping ${mib} MiB (idle > ${TAG_IDLE_HOURS}h)"
+            ref_freed=0
+            for id in ${ids//,/ }; do
+              size=$(printf '%s' "$caches" | jq --argjson i "$id" '.[] | select(.id == $i) | .sizeInBytes')
+              if gh cache delete "$id"; then
+                ref_freed=$(( ref_freed + size ))
+              else
+                echo "  $ref: delete of $id failed or already gone"
+              fi
+            done
+            if [ "$ref_freed" -gt 0 ]; then
+              freed=$(( freed + ref_freed / 1048576 ))
+              swept=$(( swept + 1 ))
+            fi
+          done <<< "$candidates"
+          echo "Swept $swept idle tag ref(s), freeing ~${freed} MiB."
 
       # Same line prune-main prints, kept as a copy: a shared always() job was
       # tried and rejected (see prune-main). If you change one, change both.

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -267,89 +267,7 @@ jobs:
       group: cache-cleanup-sweep
       cancel-in-progress: false
     steps:
-      - name: Delete caches belonging to closed PRs
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-
-          # gh paginates, so a high cap is free. It matters which end gets cut
-          # if the cap is ever hit: the default order is last-accessed first,
-          # and a closed PR's entries are by definition the least recently
-          # accessed, so a low cap would drop exactly the candidates. 36 entries
-          # on 2026-09-10 (usage API counts 23 active; the two endpoints differ),
-          # ~5 per open PR. Logged below if the cap is hit, because a silent
-          # truncation here would look exactly like "nothing to clean".
-          LIMIT=500
-          caches=$(gh cache list --limit "$LIMIT" --json id,ref,sizeInBytes)
-          total=$(printf '%s' "$caches" | jq 'length')
-          [ "$total" -lt "$LIMIT" ] || echo "::warning::cache list hit the $LIMIT limit; some entries not examined this run"
-
-          # refs/pull/N/merge entries first; tag refs are the next step and
-          # main's are prune-main's. One jq pass emits, per PR ref: number,
-          # total bytes, and the ids.
-          candidates=$(printf '%s' "$caches" | jq -r '
-            [.[] | select(.ref | test("^refs/pull/[0-9]+/merge$"))]
-            | group_by(.ref) | .[]
-            | "\(.[0].ref | capture("^refs/pull/(?<n>[0-9]+)/merge$").n)\t\(map(.sizeInBytes) | add)\t\(map(.id) | join(","))"')
-
-          if [ -z "$candidates" ]; then
-            echo "No PR-scoped caches at all — nothing to sweep."
-            exit 0
-          fi
-
-          freed=0
-          swept=0
-          unresolved=0
-          errlog="$RUNNER_TEMP/pr-view.err"
-          : > "$errlog"
-          while IFS=$'\t' read -r num bytes ids; do
-            mib=$(( bytes / 1048576 ))
-
-            # An OPEN PR's caches are still live — leave them. Anything else
-            # (CLOSED or MERGED) can never be read again.
-            state=$(gh pr view "$num" --json state --jq .state 2>>"$errlog" || echo UNKNOWN)
-            if [ "$state" = "OPEN" ]; then
-              continue
-            fi
-            if [ "$state" = "UNKNOWN" ]; then
-              # A cache ref with no resolvable PR. Left alone deliberately:
-              # deleting on a failed lookup would turn a transient API error
-              # into data loss, and the next run retries for free. Counted and
-              # surfaced below so a PERSISTENT cause (a missing scope, a rate
-              # limit) cannot hide behind the same message run after run.
-              echo "  #$num: state unresolved, skipping this run"
-              unresolved=$(( unresolved + 1 ))
-              continue
-            fi
-
-            echo "#$num ($state): sweeping ${mib} MiB"
-            # Delete by id, the same idiom as prune-main: unambiguous, and a
-            # single 404 (LRU took the entry between the list and now) neither
-            # aborts the loop nor counts toward `freed`.
-            ref_freed=0
-            for id in ${ids//,/ }; do
-              size=$(printf '%s' "$caches" | jq --argjson i "$id" '.[] | select(.id == $i) | .sizeInBytes')
-              if gh cache delete "$id"; then
-                ref_freed=$(( ref_freed + size ))
-              else
-                echo "  #$num: delete of $id failed or already gone"
-              fi
-            done
-            if [ "$ref_freed" -gt 0 ]; then
-              freed=$(( freed + ref_freed / 1048576 ))
-              swept=$(( swept + 1 ))
-            fi
-          done <<< "$candidates"
-
-          echo "Swept $swept closed PR(s), freeing ~${freed} MiB."
-          if [ "$unresolved" -gt 0 ]; then
-            echo "::warning::$unresolved PR state lookup(s) failed; their caches were left alone. gh stderr:"
-            cat "$errlog"
-          fi
-
-      - name: Delete caches on idle tag refs
+      - name: Delete caches on dead refs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -357,9 +275,19 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Same listing shape and the same cap warning as the PR step above.
+          # ONE listing serves both sweeps. gh paginates, so a high cap is
+          # free; what matters is which END gets cut if the cap is ever hit.
+          # Both predicates below select the LEAST recently accessed entries
+          # (a closed PR's are idle by definition; the tag rule IS idle time),
+          # so list oldest-access first: a truncation then drops entries we
+          # would have kept anyway. gh's default is newest first, which would
+          # drop exactly the candidates. 36 entries on 2026-09-10 (the usage
+          # API counted 23 active; the two endpoints differ), ~5 per open PR.
+          # Logged below if the cap is hit, because a silent truncation would
+          # look exactly like "nothing to clean".
           LIMIT=500
-          caches=$(gh cache list --limit "$LIMIT" --json id,ref,key,sizeInBytes,lastAccessedAt)
+          caches=$(gh cache list --limit "$LIMIT" --sort last_accessed_at --order asc \
+                     --json id,ref,sizeInBytes,lastAccessedAt)
           total=$(printf '%s' "$caches" | jq 'length')
           [ "$total" -lt "$LIMIT" ] || echo "::warning::cache list hit the $LIMIT limit; some entries not examined this run"
 
@@ -368,36 +296,96 @@ jobs:
           # question is whether anything is still READING the entry, and a
           # re-run of the tag's workflow is the only thing that could be.
           cutoff=$(date -u -d "-${TAG_IDLE_HOURS} hours" +%Y-%m-%dT%H:%M:%SZ)
+
+          # One jq pass emits, per candidate ref: kind, ref, total bytes, and
+          # id:size pairs — the sizes travel with the ids so the delete loop
+          # never re-scans the listing. Only refs/pull/N/merge and refs/tags/*
+          # are candidates; main's entries are prune-main's. The idle test is
+          # a string compare on RFC3339 UTC text, correct for the Z-suffixed
+          # form the API returns; jq orders null BELOW every string, so a
+          # missing lastAccessedAt is excluded explicitly rather than read as
+          # infinitely old (which would sweep a release's set while it is
+          # still retry-able).
           candidates=$(printf '%s' "$caches" | jq -r --arg cutoff "$cutoff" '
-            [.[] | select(.ref | startswith("refs/tags/")) | select(.lastAccessedAt < $cutoff)]
+            [ .[] | select(.ref | test("^refs/pull/[0-9]+/merge$")) | . + {kind: "pr"} ]
+            + [ .[] | select(.ref | startswith("refs/tags/"))
+                    | select(.lastAccessedAt != null and .lastAccessedAt < $cutoff)
+                    | . + {kind: "tag"} ]
             | group_by(.ref) | .[]
-            | "\(.[0].ref)\t\(map(.sizeInBytes) | add)\t\(map(.id) | join(","))"')
+            | "\(.[0].kind)\t\(.[0].ref)\t\(map(.sizeInBytes) | add)\t\(map("\(.id):\(.sizeInBytes)") | join(","))"')
 
           if [ -z "$candidates" ]; then
-            echo "No tag-ref caches idle for ${TAG_IDLE_HOURS}h — nothing to sweep."
+            echo "No PR-scoped caches and no tag-ref caches idle for ${TAG_IDLE_HOURS}h — nothing to sweep."
             exit 0
           fi
 
-          freed=0
-          swept=0
-          while IFS=$'\t' read -r ref bytes ids; do
-            mib=$(( bytes / 1048576 ))
-            echo "$ref: sweeping ${mib} MiB (idle > ${TAG_IDLE_HOURS}h)"
+          # Delete every id in one ref's group. By id, which is unambiguous;
+          # deleting by key would need --ref and could match another ref's
+          # identically-keyed entry. A single 404 (LRU took the entry between
+          # the list and now) neither aborts the loop nor counts toward the
+          # total. Leaves the bytes actually freed in ref_freed.
+          sweep_group() {
+            local pairs=$1 label=$2 pair id size
             ref_freed=0
-            for id in ${ids//,/ }; do
-              size=$(printf '%s' "$caches" | jq --argjson i "$id" '.[] | select(.id == $i) | .sizeInBytes')
+            for pair in ${pairs//,/ }; do
+              id=${pair%%:*}
+              size=${pair##*:}
               if gh cache delete "$id"; then
                 ref_freed=$(( ref_freed + size ))
               else
-                echo "  $ref: delete of $id failed or already gone"
+                echo "  $label: delete of $id failed or already gone"
               fi
             done
+          }
+
+          freed_bytes=0
+          swept=0
+          unresolved=0
+          errlog="$RUNNER_TEMP/pr-view.err"
+          : > "$errlog"
+          while IFS=$'\t' read -r kind ref bytes pairs; do
+            mib=$(( bytes / 1048576 ))
+            case "$kind" in
+              pr)
+                num=${ref#refs/pull/}
+                num=${num%/merge}
+                # An OPEN PR's caches are still live — leave them. Anything
+                # else (CLOSED or MERGED) can never be read again.
+                state=$(gh pr view "$num" --json state --jq .state 2>>"$errlog" || echo UNKNOWN)
+                if [ "$state" = "OPEN" ]; then
+                  continue
+                fi
+                if [ "$state" = "UNKNOWN" ]; then
+                  # A cache ref with no resolvable PR. Left alone deliberately:
+                  # deleting on a failed lookup would turn a transient API
+                  # error into data loss, and the next run retries for free.
+                  # Counted and surfaced below so a PERSISTENT cause (a
+                  # missing scope, a rate limit) cannot hide behind the same
+                  # message run after run.
+                  echo "  #$num: state unresolved, skipping this run"
+                  unresolved=$(( unresolved + 1 ))
+                  continue
+                fi
+                echo "#$num ($state): sweeping ${mib} MiB"
+                label="#$num"
+                ;;
+              tag)
+                echo "$ref: sweeping ${mib} MiB (idle > ${TAG_IDLE_HOURS}h)"
+                label=$ref
+                ;;
+            esac
+            sweep_group "$pairs" "$label"
             if [ "$ref_freed" -gt 0 ]; then
-              freed=$(( freed + ref_freed / 1048576 ))
+              freed_bytes=$(( freed_bytes + ref_freed ))
               swept=$(( swept + 1 ))
             fi
           done <<< "$candidates"
-          echo "Swept $swept idle tag ref(s), freeing ~${freed} MiB."
+
+          echo "Swept $swept dead ref(s), freeing ~$(( freed_bytes / 1048576 )) MiB."
+          if [ "$unresolved" -gt 0 ]; then
+            echo "::warning::$unresolved PR state lookup(s) failed; their caches were left alone. gh stderr:"
+            cat "$errlog"
+          fi
 
       # Same line prune-main prints, kept as a copy: a shared always() job was
       # tried and rejected (see prune-main). If you change one, change both.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,8 +130,36 @@ jobs:
           restore-keys: |
             ccache-linux-build-
 
-      - name: Cache DeepFilterNet3
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      # DEPENDENCY caches: restore on every run, save only on main — the same
+      # split the compiler caches got in #5008, applied here in #5548. These
+      # keys are content hashes, so unlike the compiler caches they need no
+      # run_id: the save is gated on the MISS (cache-hit != 'true') as well as
+      # the ref, because actions/cache/save against a key that already exists
+      # only warns, and that warning on every main run would hide a real one.
+      #
+      # Why it matters: a plain `actions/cache` step saves on a miss from ANY
+      # ref, and a PR's entry lands on refs/pull/N/merge where nothing else can
+      # read it. In theory a PR only misses when main's copy is gone; in
+      # practice (2026-09-10) the repo sat at its 10 GiB allowance, LRU evicted
+      # main's Qt entry between runs, and four open PRs each held their own
+      # 1.3 GiB copy — which kept the repo at the allowance, which evicted
+      # main's compiler caches, which is a 30-minute cold build. Saving from
+      # main only breaks that loop; cache-cleanup.yml sweeps what remains.
+      #
+      # THE COST, accepted deliberately: a PR that changes one of these keys —
+      # bumps QT_VERSION, edits setup-deepfilter.sh / setup-fftw.ps1 /
+      # setup-qtkeychain.sh — misses on EVERY push until it merges, because
+      # the new entry only appears once main has built it. For the macOS Qt
+      # tree that is the ~6 min -> ~18 min this file already records below.
+      # Rare, self-limiting, and the right trade against a permanent
+      # 1.7 GiB × open-PRs tax; it is written here so the next Qt bump is not
+      # a surprise.
+      #
+      # `cache-hit` from actions/cache/restore is 'true' only on an exact key
+      # match. None of these steps use restore-keys, so the setup-step gating
+      # below is unchanged from the bidirectional form.
+      - name: Restore DeepFilterNet3
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         id: cache-deepfilter
         with:
           path: third_party/deepfilter
@@ -140,6 +168,13 @@ jobs:
       - name: Setup DeepFilterNet3 (DFNR)
         if: steps.cache-deepfilter.outputs.cache-hit != 'true'
         run: bash scripts/setup/setup-deepfilter.sh
+
+      - name: Save DeepFilterNet3
+        if: github.ref == 'refs/heads/main' && steps.cache-deepfilter.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: third_party/deepfilter
+          key: ${{ steps.cache-deepfilter.outputs.cache-primary-key }}
 
       - name: Zero ccache stats
         run: ccache --zero-stats
@@ -239,9 +274,13 @@ jobs:
   # of regression we kept paying for.
   #
   # Caching strategy:
-  #   * Qt install        — handled by jurplel/install-qt-action's cache: true
+  #   * Qt install        — aqtinstall into an explicitly cached tree, the
+  #                         same shape as check-macos (was install-qt-action's
+  #                         cache: true until #5548 — see the Qt step)
   #   * FFTW3 third_party — actions/cache, keyed on the setup script + version
   #   * MSVC object files — sccache over a LOCAL dir, persisted by actions/cache
+  #   All of the above restore on every run and save only from main; the
+  #   reasoning is on the Linux job's DeepFilterNet3 step.
   #
   # sccache used to run on the GitHub Actions cache backend
   # (SCCACHE_GHA_ENABLED), which stores each object as its own cache entry
@@ -286,31 +325,105 @@ jobs:
       # on every restore. Do not raise the three caps together on symmetry
       # grounds — check the stats step first.
       SCCACHE_CACHE_SIZE: 1G
+      # 6.8.3 matches what community Windows builders are running and exposes
+      # Qt 6.8.x MOC volume so we catch issues like #1910 (MSVC COFF section
+      # limit, fixed by /bigobj) before they reach users. Exact, and the same
+      # spelling as windows-installer.yml, so the per-PR build and the release
+      # build agree by construction. QT_ARCH likewise: Qt 6.8 LTS dropped the
+      # MSVC 2019 builds.
+      QT_VERSION: '6.8.3'
+      QT_ARCH: 'win64_msvc2022_64'
+      AQTINSTALL_VERSION: '3.3.0'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      - name: Install Qt
-        uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730
+      # Qt via aqtinstall into an explicitly cached tree — the shape check-macos
+      # already uses, ported here in #5548. Until then this step was
+      # jurplel/install-qt-action with `cache: true`, which is aqt plus a
+      # bidirectional cache with no restore-only mode: every PR that missed
+      # wrote a 396 MiB entry onto its own refs/pull/N/merge, where nothing
+      # else could read it. Keyed on everything that changes the tree — Qt
+      # version, arch, module set, and the aqt version that resolved them.
+      - name: Restore Qt
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        id: cache-qt-win
         with:
-          # 6.8.3 matches what community Windows builders are running and
-          # exposes Qt 6.8.x MOC volume so we catch issues like #1910 (MSVC
-          # COFF section limit, fixed by /bigobj) before they reach users.
-          version: '6.8.3'
-          modules: 'qtmultimedia qtwebsockets qtserialport qtshadertools'
-          cache: true
+          path: ${{ github.workspace }}\Qt
+          key: qt-${{ env.QT_VERSION }}-windows-${{ env.QT_ARCH }}-aqt${{ env.AQTINSTALL_VERSION }}-mm.ws.sp.st
 
-      - name: Cache FFTW3
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      - name: Install Qt LTS via aqtinstall
+        if: steps.cache-qt-win.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          # aqt goes in a venv and is pinned, for the reason check-macos and
+          # .github/docker/Dockerfile give: it is the tool that decides what
+          # Qt lands here, so an unreviewed aqt upgrade is an unreviewed
+          # change to the Qt this job builds against.
+          python -m venv "$env:RUNNER_TEMP\aqtvenv"
+          & "$env:RUNNER_TEMP\aqtvenv\Scripts\pip.exe" install -q "aqtinstall==$env:AQTINSTALL_VERSION"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          & "$env:RUNNER_TEMP\aqtvenv\Scripts\aqt.exe" install-qt windows desktop $env:QT_VERSION $env:QT_ARCH `
+            -m qtmultimedia qtwebsockets qtserialport qtshadertools `
+            --outputdir "$env:GITHUB_WORKSPACE\Qt"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Save Qt
+        if: github.ref == 'refs/heads/main' && steps.cache-qt-win.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ${{ github.workspace }}\Qt
+          key: ${{ steps.cache-qt-win.outputs.cache-primary-key }}
+
+      # Separate from the install so it also runs on a cache hit. Exports the
+      # same variables install-qt-action did (QT_ROOT_DIR, QT_PLUGIN_PATH,
+      # QML2_IMPORT_PATH, bin on PATH) plus Qt6_DIR and CMAKE_PREFIX_PATH so
+      # find_package(Qt6) resolves without a -D on the configure line. PATH
+      # goes through GITHUB_PATH so it prepends; the test steps below run Qt
+      # executables and need the DLLs resolvable.
+      - name: Export Qt environment
+        shell: pwsh
+        run: |
+          # aqt lays the tree down under <version>/<arch minus the win64_ host
+          # prefix>: win64_msvc2022_64 -> msvc2022_64.
+          $qtRoot = "$env:GITHUB_WORKSPACE\Qt\$env:QT_VERSION\" + ($env:QT_ARCH -replace '^win64_', '')
+          if (-not (Test-Path "$qtRoot\bin\qmake.exe")) {
+            Write-Host "ERROR: no qmake at $qtRoot — aqt layout changed, or a stale cache entry"
+            Get-ChildItem "$env:GITHUB_WORKSPACE\Qt\$env:QT_VERSION" -ErrorAction SilentlyContinue
+            exit 1
+          }
+          @(
+            "QT_ROOT_DIR=$qtRoot",
+            "Qt6_DIR=$qtRoot\lib\cmake\Qt6",
+            "CMAKE_PREFIX_PATH=$qtRoot",
+            "QT_PLUGIN_PATH=$qtRoot\plugins",
+            "QML2_IMPORT_PATH=$qtRoot\qml"
+          ) | Out-File -FilePath $env:GITHUB_ENV -Append
+          "$qtRoot\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+          & "$qtRoot\bin\qmake.exe" -query QT_VERSION
+
+      - name: Restore FFTW3
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        id: cache-fftw
         with:
           path: third_party/fftw3
           key: ${{ runner.os }}-fftw3-3.3.5-${{ hashFiles('scripts/setup/setup-fftw.ps1') }}
 
+      # Gated on the miss, as windows-installer.yml's copy of this step already
+      # is; the script's output is entirely inside the cached directory.
       - name: Install FFTW3
+        if: steps.cache-fftw.outputs.cache-hit != 'true'
         shell: pwsh
         run: .\scripts\setup\setup-fftw.ps1
 
-      - name: Cache DeepFilterNet3
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      - name: Save FFTW3
+        if: github.ref == 'refs/heads/main' && steps.cache-fftw.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: third_party/fftw3
+          key: ${{ steps.cache-fftw.outputs.cache-primary-key }}
+
+      - name: Restore DeepFilterNet3
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         id: cache-deepfilter
         with:
           path: third_party/deepfilter
@@ -320,6 +433,13 @@ jobs:
         if: steps.cache-deepfilter.outputs.cache-hit != 'true'
         shell: pwsh
         run: .\scripts\setup\setup-deepfilter.ps1
+
+      - name: Save DeepFilterNet3
+        if: github.ref == 'refs/heads/main' && steps.cache-deepfilter.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: third_party/deepfilter
+          key: ${{ steps.cache-deepfilter.outputs.cache-primary-key }}
 
       # Restored BEFORE sccache first runs, so the server sees a populated
       # SCCACHE_DIR when it starts. The prefix fallback is the entire point,
@@ -564,15 +684,14 @@ jobs:
             autoconf automake libtool
 
       # ~1.3 GB downloaded on every PR otherwise, and it showed: this job went
-      # from ~6 min to ~18 min the first time it took Qt from aqt.
-      # check-windows gets caching for free from jurplel/install-qt-action; aqt
-      # has no such wrapper, so cache the tree explicitly. Keyed on everything
-      # that changes its contents — the Qt version, the module set, and the aqt
-      # version that resolved them — so the entry is written once and then just
-      # restored, which is what keeps it from churning the repo's 10 GB cache
-      # budget the way a per-run key would.
-      - name: Cache Qt
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      # from ~6 min to ~18 min the first time it took Qt from aqt. aqt has no
+      # caching wrapper, so cache the tree explicitly (check-windows now does
+      # the same). Keyed on everything that changes its contents — the Qt
+      # version, the module set, and the aqt version that resolved them — so
+      # the entry is written once and then just restored. Saved from main only;
+      # see the Linux job's DeepFilterNet3 step for why.
+      - name: Restore Qt
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         id: cache-qt-mac
         with:
           path: ${{ github.workspace }}/Qt
@@ -592,6 +711,13 @@ jobs:
           "$RUNNER_TEMP/aqtvenv/bin/aqt" install-qt mac desktop "$QT_VERSION" clang_64 \
             -m qtmultimedia qtwebsockets qtserialport qtshadertools \
             --outputdir "${{ github.workspace }}/Qt"
+
+      - name: Save Qt
+        if: github.ref == 'refs/heads/main' && steps.cache-qt-mac.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ${{ github.workspace }}/Qt
+          key: ${{ steps.cache-qt-mac.outputs.cache-primary-key }}
 
       # Separate from the install so it also runs on a cache hit.
       - name: Export Qt environment
@@ -637,8 +763,8 @@ jobs:
           fi
           echo "No Homebrew Qt present; the aqt tree at $QT_ROOT is the only one."
 
-      - name: Cache DeepFilterNet3
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      - name: Restore DeepFilterNet3
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         id: cache-deepfilter
         with:
           path: third_party/deepfilter
@@ -648,8 +774,15 @@ jobs:
         if: steps.cache-deepfilter.outputs.cache-hit != 'true'
         run: bash scripts/setup/setup-deepfilter.sh
 
-      - name: Cache qtkeychain
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      - name: Save DeepFilterNet3
+        if: github.ref == 'refs/heads/main' && steps.cache-deepfilter.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: third_party/deepfilter
+          key: ${{ steps.cache-deepfilter.outputs.cache-primary-key }}
+
+      - name: Restore qtkeychain
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         id: cache-qtkeychain-mac
         with:
           path: third_party/qtkeychain
@@ -670,6 +803,16 @@ jobs:
       - name: Setup qtkeychain (SmartLink credential persistence)
         if: steps.cache-qtkeychain-mac.outputs.cache-hit != 'true'
         run: bash scripts/setup/setup-qtkeychain.sh
+
+      # Saved from main only, like the rest. macos-dmg.yml restores this same
+      # key on a tag ref and cannot read a PR's copy anyway; the entry it
+      # normally finds is the one this job wrote from main.
+      - name: Save qtkeychain
+        if: github.ref == 'refs/heads/main' && steps.cache-qtkeychain-mac.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: third_party/qtkeychain
+          key: ${{ steps.cache-qtkeychain-mac.outputs.cache-primary-key }}
 
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@f09c25b45002a07be2955cbe52e8cee55643f89d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,11 +344,19 @@ jobs:
       # wrote a 396 MiB entry onto its own refs/pull/N/merge, where nothing
       # else could read it. Keyed on everything that changes the tree — Qt
       # version, arch, module set, and the aqt version that resolved them.
+      #
+      # runner.workspace (D:\a\AetherSDR\Qt), NOT github.workspace as
+      # check-macos uses: that is where install-qt-action put it, and the path
+      # is in every Qt-including compile's -I flags, which sccache hashes.
+      # The first cut of this port moved the tree one directory down and the
+      # sccache hit rate on an otherwise-identical PR went from 99.26% to
+      # 19.09% (657 of 812 objects missed, Build 26 min instead of 6). Keeping
+      # the path keeps main's ~1 GiB sccache entry valid across the port.
       - name: Restore Qt
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         id: cache-qt-win
         with:
-          path: ${{ github.workspace }}\Qt
+          path: ${{ runner.workspace }}\Qt
           key: qt-${{ env.QT_VERSION }}-windows-${{ env.QT_ARCH }}-aqt${{ env.AQTINSTALL_VERSION }}-mm.ws.sp.st
 
       - name: Install Qt LTS via aqtinstall
@@ -364,14 +372,14 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           & "$env:RUNNER_TEMP\aqtvenv\Scripts\aqt.exe" install-qt windows desktop $env:QT_VERSION $env:QT_ARCH `
             -m qtmultimedia qtwebsockets qtserialport qtshadertools `
-            --outputdir "$env:GITHUB_WORKSPACE\Qt"
+            --outputdir "$env:RUNNER_WORKSPACE\Qt"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Save Qt
         if: github.ref == 'refs/heads/main' && steps.cache-qt-win.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
-          path: ${{ github.workspace }}\Qt
+          path: ${{ runner.workspace }}\Qt
           key: ${{ steps.cache-qt-win.outputs.cache-primary-key }}
 
       # Separate from the install so it also runs on a cache hit. Exports the
@@ -385,10 +393,10 @@ jobs:
         run: |
           # aqt lays the tree down under <version>/<arch minus the win64_ host
           # prefix>: win64_msvc2022_64 -> msvc2022_64.
-          $qtRoot = "$env:GITHUB_WORKSPACE\Qt\$env:QT_VERSION\" + ($env:QT_ARCH -replace '^win64_', '')
+          $qtRoot = "$env:RUNNER_WORKSPACE\Qt\$env:QT_VERSION\" + ($env:QT_ARCH -replace '^win64_', '')
           if (-not (Test-Path "$qtRoot\bin\qmake.exe")) {
             Write-Host "ERROR: no qmake at $qtRoot — aqt layout changed, or a stale cache entry"
-            Get-ChildItem "$env:GITHUB_WORKSPACE\Qt\$env:QT_VERSION" -ErrorAction SilentlyContinue
+            Get-ChildItem "$env:RUNNER_WORKSPACE\Qt\$env:QT_VERSION" -ErrorAction SilentlyContinue
             exit 1
           }
           @(

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,18 @@ concurrency:
 permissions:
   contents: read
 
+# Qt inputs shared by check-windows and check-macos. Declared once so the two
+# per-PR legs cannot drift apart: both aqt invocations and both cache keys
+# read these. 6.8.3 matches what community builders run and what
+# windows-installer.yml / macos-dmg.yml ship, so the per-PR build and the
+# release build agree by construction. aqt is pinned because it is the tool
+# that decides what Qt lands here — an unreviewed aqt upgrade is an
+# unreviewed change to the Qt CI builds against (same argument as
+# .github/docker/Dockerfile).
+env:
+  QT_VERSION: '6.8.3'
+  AQTINSTALL_VERSION: '3.3.0'
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -114,13 +126,12 @@ jobs:
       # The canary line is system-libs-canary.yml's cache; it was missed by an
       # earlier revision of this table and by cache-cleanup.yml's PREFIXES
       # alike, so if you add a compiler cache in ANY workflow, add it to both.
-      # Dependency caches are still written on PR refs until #5548 item 1
-      # lands; that adds up to ~1.7 GiB per open PR that missed, on top of
-      # the figure above — with the four open PRs measured on 2026-09-10 that
-      # is ~12 GiB, still over the line. This change makes main's OWN
-      # footprint survivable; the Linux entry can still be evicted by PR-ref
-      # churn until item 1 stops PRs writing dependency caches, so usage
-      # pinned at the allowance next week does not mean this did not work.
+      # Dependency caches were also written on PR refs until #5548 item 1
+      # (~1.7 GiB per open PR that missed — ~12 GiB with the four open PRs
+      # measured on 2026-09-10, still over the line even after the prune
+      # change). Since item 1 they restore on PR and save on main only, so
+      # the figure above is the whole steady state; anything on refs/pull or
+      # refs/tags is transient and cache-cleanup.yml's sweep reclaims it.
       # See "Compiler-cache strategy" at the bottom of this file for why only
       # main writes an entry, and cache-cleanup.yml for what prunes the rest.
       CCACHE_MAXSIZE: 1500M
@@ -157,9 +168,9 @@ jobs:
       # DEPENDENCY caches: restore on every run, save only on main — the same
       # split the compiler caches got in #5008, applied here in #5548. These
       # keys are content hashes, so unlike the compiler caches they need no
-      # run_id: the save is gated on the MISS (cache-hit != 'true') as well as
-      # the ref, because actions/cache/save against a key that already exists
-      # only warns, and that warning on every main run would hide a real one.
+      # run_id. The Save steps sit at the END of each job, gated on the ref,
+      # on `success()`, and on the MISS (cache-hit != 'true') — see the Save
+      # DeepFilterNet3 step at the bottom of this job for why all three.
       #
       # Why it matters: a plain `actions/cache` step saves on a miss from ANY
       # ref, and a PR's entry lands on refs/pull/N/merge where nothing else can
@@ -192,13 +203,6 @@ jobs:
       - name: Setup DeepFilterNet3 (DFNR)
         if: steps.cache-deepfilter.outputs.cache-hit != 'true'
         run: bash scripts/setup/setup-deepfilter.sh
-
-      - name: Save DeepFilterNet3
-        if: github.ref == 'refs/heads/main' && steps.cache-deepfilter.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: third_party/deepfilter
-          key: ${{ steps.cache-deepfilter.outputs.cache-primary-key }}
 
       - name: Zero ccache stats
         run: ccache --zero-stats
@@ -263,6 +267,25 @@ jobs:
         if: always()
         run: ccache --show-stats
 
+      # Dependency caches are saved LAST, after the build and tests, and only
+      # from a green main run — the same rule as the compiler-cache save
+      # below, and the one the bidirectional actions/cache step these replaced
+      # already gave for free (it saved from a post step with
+      # `post-if: success()`). A save placed right after the setup script
+      # would persist a tree the build never validated, under a content-hash
+      # key that no later run can overwrite and no sweeper matches on main;
+      # the only recovery would be a manual `gh cache delete`. The
+      # cache-hit != 'true' half is still needed: a save against a key that
+      # already exists only warns, and that warning on every main run would
+      # hide a real one. See the Restore DeepFilterNet3 step for the
+      # restore-on-PR / save-on-main reasoning.
+      - name: Save DeepFilterNet3
+        if: github.ref == 'refs/heads/main' && success() && steps.cache-deepfilter.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: third_party/deepfilter
+          key: ${{ steps.cache-deepfilter.outputs.cache-primary-key }}
+
       # Save LAST, and only from a green main build.
       #
       # `success()` is not about correctness — ccache keys each object on a hash
@@ -301,7 +324,8 @@ jobs:
   #   * Qt install        — aqtinstall into an explicitly cached tree, the
   #                         same shape as check-macos (was install-qt-action's
   #                         cache: true until #5548 — see the Qt step)
-  #   * FFTW3 third_party — actions/cache, keyed on the setup script + version
+  #   * FFTW3 third_party — actions/cache restore/save, keyed on the setup
+  #                         script + version
   #   * MSVC object files — sccache over a LOCAL dir, persisted by actions/cache
   #   All of the above restore on every run and save only from main; the
   #   reasoning is on the Linux job's DeepFilterNet3 step.
@@ -350,15 +374,12 @@ jobs:
       # raising it, check the "sccache stats" hit rate, and re-do that budget.
       # Do not move the caps together on symmetry grounds.
       SCCACHE_CACHE_SIZE: 1G
-      # 6.8.3 matches what community Windows builders are running and exposes
-      # Qt 6.8.x MOC volume so we catch issues like #1910 (MSVC COFF section
-      # limit, fixed by /bigobj) before they reach users. Exact, and the same
-      # spelling as windows-installer.yml, so the per-PR build and the release
-      # build agree by construction. QT_ARCH likewise: Qt 6.8 LTS dropped the
-      # MSVC 2019 builds.
-      QT_VERSION: '6.8.3'
+      # QT_VERSION / AQTINSTALL_VERSION are workflow-level env (top of file).
+      # 6.8.3 exposes Qt 6.8.x MOC volume so we catch issues like #1910 (MSVC
+      # COFF section limit, fixed by /bigobj) before they reach users. QT_ARCH
+      # is spelled exactly as windows-installer.yml spells it: Qt 6.8 LTS
+      # dropped the MSVC 2019 builds.
       QT_ARCH: 'win64_msvc2022_64'
-      AQTINSTALL_VERSION: '3.3.0'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
@@ -393,19 +414,13 @@ jobs:
           # Qt lands here, so an unreviewed aqt upgrade is an unreviewed
           # change to the Qt this job builds against.
           python -m venv "$env:RUNNER_TEMP\aqtvenv"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           & "$env:RUNNER_TEMP\aqtvenv\Scripts\pip.exe" install -q "aqtinstall==$env:AQTINSTALL_VERSION"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           & "$env:RUNNER_TEMP\aqtvenv\Scripts\aqt.exe" install-qt windows desktop $env:QT_VERSION $env:QT_ARCH `
             -m qtmultimedia qtwebsockets qtserialport qtshadertools `
             --outputdir "$env:RUNNER_WORKSPACE\Qt"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: Save Qt
-        if: github.ref == 'refs/heads/main' && steps.cache-qt-win.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: ${{ runner.workspace }}\Qt
-          key: ${{ steps.cache-qt-win.outputs.cache-primary-key }}
 
       # Separate from the install so it also runs on a cache hit. Exports the
       # same variables install-qt-action did (QT_ROOT_DIR, QT_PLUGIN_PATH,
@@ -420,7 +435,10 @@ jobs:
           # prefix>: win64_msvc2022_64 -> msvc2022_64.
           $qtRoot = "$env:RUNNER_WORKSPACE\Qt\$env:QT_VERSION\" + ($env:QT_ARCH -replace '^win64_', '')
           if (-not (Test-Path "$qtRoot\bin\qmake.exe")) {
+            # A bad entry on main is only clearable by hand: the key is a
+            # content hash nothing re-saves, and no sweeper matches qt-* there.
             Write-Host "ERROR: no qmake at $qtRoot — aqt layout changed, or a stale cache entry"
+            Write-Host "       (clear a stale entry: gh cache delete --key <the Restore Qt key> --ref refs/heads/main)"
             Get-ChildItem "$env:RUNNER_WORKSPACE\Qt\$env:QT_VERSION" -ErrorAction SilentlyContinue
             exit 1
           }
@@ -448,13 +466,6 @@ jobs:
         shell: pwsh
         run: .\scripts\setup\setup-fftw.ps1
 
-      - name: Save FFTW3
-        if: github.ref == 'refs/heads/main' && steps.cache-fftw.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: third_party/fftw3
-          key: ${{ steps.cache-fftw.outputs.cache-primary-key }}
-
       - name: Restore DeepFilterNet3
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         id: cache-deepfilter
@@ -466,13 +477,6 @@ jobs:
         if: steps.cache-deepfilter.outputs.cache-hit != 'true'
         shell: pwsh
         run: .\scripts\setup\setup-deepfilter.ps1
-
-      - name: Save DeepFilterNet3
-        if: github.ref == 'refs/heads/main' && steps.cache-deepfilter.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: third_party/deepfilter
-          key: ${{ steps.cache-deepfilter.outputs.cache-primary-key }}
 
       # Restored BEFORE sccache first runs, so the server sees a populated
       # SCCACHE_DIR when it starts. The prefix fallback is the entire point,
@@ -664,6 +668,30 @@ jobs:
           QT_QPA_PLATFORM: offscreen
         run: ctest --test-dir build -R "cross_needle_meter_test" --no-tests=error --output-on-failure
 
+      # Dependency caches: saved LAST and only from a green main run — see the
+      # Linux job's Save DeepFilterNet3 step for why the save is not placed
+      # next to the setup step.
+      - name: Save Qt
+        if: github.ref == 'refs/heads/main' && success() && steps.cache-qt-win.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ${{ runner.workspace }}\Qt
+          key: ${{ steps.cache-qt-win.outputs.cache-primary-key }}
+
+      - name: Save FFTW3
+        if: github.ref == 'refs/heads/main' && success() && steps.cache-fftw.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: third_party/fftw3
+          key: ${{ steps.cache-fftw.outputs.cache-primary-key }}
+
+      - name: Save DeepFilterNet3
+        if: github.ref == 'refs/heads/main' && success() && steps.cache-deepfilter.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: third_party/deepfilter
+          key: ${{ steps.cache-deepfilter.outputs.cache-primary-key }}
+
       - name: sccache stats
         if: always()
         # Stop the server after reporting: it holds the cache files open, and
@@ -700,8 +728,7 @@ jobs:
     # other ships, and a mismatch would put a minos-15 library inside a bundle
     # that advertises 14.0.
     env:
-      QT_VERSION: '6.8.3'
-      AQTINSTALL_VERSION: '3.3.0'
+      # QT_VERSION / AQTINSTALL_VERSION are workflow-level env (top of file).
       MACOS_DEPLOYMENT_TARGET: '14.0'
 
     steps:
@@ -745,20 +772,16 @@ jobs:
             -m qtmultimedia qtwebsockets qtserialport qtshadertools \
             --outputdir "${{ github.workspace }}/Qt"
 
-      - name: Save Qt
-        if: github.ref == 'refs/heads/main' && steps.cache-qt-mac.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: ${{ github.workspace }}/Qt
-          key: ${{ steps.cache-qt-mac.outputs.cache-primary-key }}
-
       # Separate from the install so it also runs on a cache hit.
       - name: Export Qt environment
         run: |
           set -o pipefail
           QT_ROOT="${{ github.workspace }}/Qt/$QT_VERSION/macos"
           if [ ! -x "$QT_ROOT/bin/qmake" ]; then
+            # A bad entry on main is only clearable by hand: the key is a
+            # content hash nothing re-saves, and no sweeper matches qt-* there.
             echo "ERROR: no qmake at $QT_ROOT — aqt layout changed, or a stale cache entry"
+            echo "       (clear a stale entry: gh cache delete --key <the Restore Qt key> --ref refs/heads/main)"
             ls -la "${{ github.workspace }}/Qt/$QT_VERSION/" || true
             exit 1
           fi
@@ -807,13 +830,6 @@ jobs:
         if: steps.cache-deepfilter.outputs.cache-hit != 'true'
         run: bash scripts/setup/setup-deepfilter.sh
 
-      - name: Save DeepFilterNet3
-        if: github.ref == 'refs/heads/main' && steps.cache-deepfilter.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: third_party/deepfilter
-          key: ${{ steps.cache-deepfilter.outputs.cache-primary-key }}
-
       - name: Restore qtkeychain
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         id: cache-qtkeychain-mac
@@ -836,16 +852,6 @@ jobs:
       - name: Setup qtkeychain (SmartLink credential persistence)
         if: steps.cache-qtkeychain-mac.outputs.cache-hit != 'true'
         run: bash scripts/setup/setup-qtkeychain.sh
-
-      # Saved from main only, like the rest. macos-dmg.yml restores this same
-      # key on a tag ref and cannot read a PR's copy anyway; the entry it
-      # normally finds is the one this job wrote from main.
-      - name: Save qtkeychain
-        if: github.ref == 'refs/heads/main' && steps.cache-qtkeychain-mac.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: third_party/qtkeychain
-          key: ${{ steps.cache-qtkeychain-mac.outputs.cache-primary-key }}
 
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@f09c25b45002a07be2955cbe52e8cee55643f89d
@@ -956,6 +962,36 @@ jobs:
             xcrun -sdk macosx metallib - -o "$RUNNER_TEMP/ggml-metal-intel-dmg.metallib"
           ls -l "$RUNNER_TEMP/ggml-metal-intel-dmg.metallib"
 
+      # Dependency caches: saved LAST and only from a green main run — see the
+      # Linux job's Save DeepFilterNet3 step for why the save is not placed
+      # next to the setup step. The ccache-action above saves from its own
+      # post-job hook (with the KNOWN GAP its comment describes); these three
+      # are ordinary steps and do get the `success()` half.
+      #
+      # qtkeychain: macos-dmg.yml restores this same key on a tag ref and
+      # cannot read a PR's copy anyway; the entry it normally finds is the one
+      # this job wrote from main.
+      - name: Save Qt
+        if: github.ref == 'refs/heads/main' && success() && steps.cache-qt-mac.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ${{ github.workspace }}/Qt
+          key: ${{ steps.cache-qt-mac.outputs.cache-primary-key }}
+
+      - name: Save DeepFilterNet3
+        if: github.ref == 'refs/heads/main' && success() && steps.cache-deepfilter.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: third_party/deepfilter
+          key: ${{ steps.cache-deepfilter.outputs.cache-primary-key }}
+
+      - name: Save qtkeychain
+        if: github.ref == 'refs/heads/main' && success() && steps.cache-qtkeychain-mac.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: third_party/qtkeychain
+          key: ${{ steps.cache-qtkeychain-mac.outputs.cache-primary-key }}
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Compiler-cache strategy: restore everywhere, save only on main
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1049,6 +1085,9 @@ jobs:
 # - PR-scoped caches (Qt, FFTW, DeepFilterNet, qtkeychain on refs/pull/N/merge)
 #   are swept by cache-cleanup.yml's scheduled job once the PR closes (#5009;
 #   a `pull_request: closed` trigger gets a read-only token on fork PRs, so it
-#   runs daily instead). Open PRs still write them whenever main's copy is not
-#   readable, which at the allowance is often — #5548 item 1 gives the
-#   dependency caches the same restore-on-PR / save-on-main split as above.
+#   runs daily instead), along with tag-ref caches idle for two days. Open
+#   PRs no longer write them at all: #5548 item 1 gave the dependency caches
+#   the same restore-on-PR / save-on-main split as above, so an entry on
+#   refs/pull/N/merge now means a step regressed to bidirectional
+#   `actions/cache` — that is the first thing to look for if the sweep
+#   starts reporting large numbers.

--- a/README.md
+++ b/README.md
@@ -258,8 +258,8 @@ the release binaries use 6.8.3 LTS).
 :: 2. Point at your Qt kit once, with forward slashes (CMake reads the path
 ::    literally, so backslashes would be taken as escape sequences). Change the
 ::    version/edition here to match your install; both steps below reuse it.
-::    setup-qtkeychain.ps1 (step 4) reads QT_ROOT_DIR; on CI ci.yml exports it
-::    right after installing Qt, so a local build has to set it explicitly
+::    setup-qtkeychain.ps1 (step 4) reads QT_ROOT_DIR; on CI that variable is
+::    exported by install-qt-action, so a local build has to set it explicitly
 ::    or the script exits with "Qt not found".
 set "QT_KIT=C:/Qt/6.8.3/msvc2022_64"
 set "QT_ROOT_DIR=%QT_KIT%"

--- a/README.md
+++ b/README.md
@@ -258,8 +258,8 @@ the release binaries use 6.8.3 LTS).
 :: 2. Point at your Qt kit once, with forward slashes (CMake reads the path
 ::    literally, so backslashes would be taken as escape sequences). Change the
 ::    version/edition here to match your install; both steps below reuse it.
-::    setup-qtkeychain.ps1 (step 4) reads QT_ROOT_DIR; on CI that variable is
-::    exported by install-qt-action, so a local build has to set it explicitly
+::    setup-qtkeychain.ps1 (step 4) reads QT_ROOT_DIR; on CI ci.yml exports it
+::    right after installing Qt, so a local build has to set it explicitly
 ::    or the script exits with "Qt not found".
 set "QT_KIT=C:/Qt/6.8.3/msvc2022_64"
 set "QT_ROOT_DIR=%QT_KIT%"


### PR DESCRIPTION
## What

Items **1** and **3** of #5548. Independent of #5551 (items 4/5a/5b); the two can land in either order.

### Item 1 — dependency caches restore on PR, save only on main (`ci.yml`)

Every dependency cache was a bidirectional `actions/cache` step:

| job | step | key | size |
|---|---|---|---|
| build (Linux) | DeepFilterNet3 | `deepfilter-Linux-X64-…` | 17 MiB |
| check-windows | Qt (via `install-qt-action`, `cache: true`) | `install-qt-action-windows-…` | 396 MiB |
| check-windows | FFTW3 | `Windows-fftw3-3.3.5-…` | 2 MiB |
| check-windows | DeepFilterNet3 | `deepfilter-Windows-X64-…` | 31 MiB |
| check-macos | Qt | `qt-6.8.3-macos-clang64-…` | **1,297 MiB** |
| check-macos | DeepFilterNet3 | `deepfilter-macOS-ARM64-…` | 24 MiB |
| check-macos | qtkeychain | `qtkeychain-macos-arm64-…` | ~0 |

A PR that missed wrote its own copy onto `refs/pull/N/merge`, readable by nothing else. With the repo at its allowance, LRU evicted main's copy between runs and the next PR re-saved it — four open PRs each holding the same 1.3 GiB Qt entry on 2026-09-10.

Each step is now `actions/cache/restore` next to its setup script, plus an `actions/cache/save` **at the end of the job, after the tests**, gated on `github.ref == 'refs/heads/main' && success() && steps.<id>.outputs.cache-hit != 'true'`. All three halves matter: the bidirectional step these replace saved from a post step with `post-if: success()`, so a tree only reached main once the whole job had passed with it, and an inline save would persist a tree the build never validated under a content-hash key nothing re-saves; the keys are content hashes, so a save against an existing key would only warn on every main run. `cache-hit` semantics are unchanged (no step uses `restore-keys`), so the existing setup-step gating is untouched. The reasoning and the accepted cost — a PR that bumps Qt or edits a setup script misses on every push until it merges — are written once on the Linux job's steps.

`QT_VERSION` and `AQTINSTALL_VERSION` move to workflow-level `env:` so check-windows and check-macos read one value; `QT_ARCH` stays on check-windows.

**Behaviour change beyond the split:** the Windows `Install FFTW3` step is now gated on the cache hit (it ran on every run before). `setup-fftw.ps1` writes only under `third_party/fftw3` and exports nothing, so a hit needs no script run; this matches `windows-installer.yml`'s copy of the step.

**Windows Qt port.** `jurplel/install-qt-action` has no restore-only mode, so check-windows now installs Qt the way check-macos does: pinned `aqtinstall==3.3.0` in a venv, `aqt install-qt windows desktop 6.8.3 win64_msvc2022_64 -m qtmultimedia qtwebsockets qtserialport qtshadertools`, explicit restore/save on `qt-6.8.3-windows-win64_msvc2022_64-aqt3.3.0-mm.ws.sp.st`. A separate "Export Qt environment" step (runs on hit and miss) sets what the action set — `QT_ROOT_DIR`, `QT_PLUGIN_PATH`, `QML2_IMPORT_PATH`, `bin` on PATH — plus `Qt6_DIR` and `CMAKE_PREFIX_PATH`, and fails if `qmake.exe` is not at the expected layout path. Version and arch are spelled exactly as in `windows-installer.yml`. The Configure step is unchanged; `find_package(Qt6)` resolves through the exported variables as before.

### Item 3 — sweep tag-ref caches (`cache-cleanup.yml`)

`appimage.yml`, `macos-dmg.yml` and `windows-installer.yml` run on `push: tags` only, and main never runs them, so their caches (Opus, FFTW3, hidapi, Vulkan SDK, macos-deps, DMG-leg ccache, install-qt) exist only on `refs/tags/v*`. A run on `v26.9.2` can read its own ref and main, never `v26.9.1`'s, so every release writes a full set nothing later reads; neither `prune-main` nor the closed-PR sweep looked there, and `macos-dmg`'s `ccache-action` append-timestamps its key (~0.5 GiB per leg per release).

`sweep-closed-prs` → `sweep-dead-refs`, one step that handles both closed-PR refs and tag-ref entries whose `lastAccessedAt` is older than 48 h. Last-access rather than "not the newest tag" because the one legitimate reader is a re-run of the same tag's workflow after a flaky release step; 48 h keeps a next-morning retry warm. One `gh cache list` (sorted oldest-access first, so hitting the 500 cap drops entries we would keep rather than the candidates), one jq pass emitting `id:size` pairs, a null-safe idle test, and a shared delete-by-id loop with 404 tolerance.

### Also

- `cache-cleanup.yml`'s closed-PR comment described the dependency-cache loop as an open ci.yml problem; it now records that ci.yml saves nothing from PR refs and that this sweep is the backstop for a regression to a bidirectional step.
- The two sentences #5551 left in `ci.yml` describing item 1 as pending are flipped.
- Both "no qmake" errors now say how to clear a poisoned main entry (`gh cache delete --key … --ref refs/heads/main`), since no sweeper matches `qt-*` on main.

## Verification

- Both workflows parse; every bash `run:` block passes `shellcheck -S warning` (the only hits are pre-existing `${{ }}` false positives).
- **Cannot be fully exercised on this PR:** the `Save` steps only fire from main, and the sweep only from schedule/dispatch on the default branch. What this PR's own CI does prove: the Windows aqt install + export path (a cold miss, since no `qt-6.8.3-windows-…` entry exists yet), the FFTW3 miss gating, and that all three jobs still configure and build. Expect check-windows to be slower on this PR only — it is downloading Qt with no cache to restore.
- The sweep script was dry-run locally against the live listing with `gh cache delete` stubbed: no candidates today (no PR-ref or tag-ref caches exist), and the pair parser / 404 path verified with synthetic input.
- **After merge, by hand:** `gh cache delete` main's now-orphaned `install-qt-action-windows-…` entry (396 MiB; nothing reads it after this PR and no sweeper matches it on main). Then read the first main run's log to confirm all seven `Save` steps executed (not skipped) and note the Windows Qt entry's size against the 396 MiB the action's entry was.
- After merge: first main run writes the Windows Qt entry; subsequent PRs restore it. Over the following week `gh cache list --json key,ref` should show no `qt-`/`deepfilter-`/`fftw3`/`qtkeychain-` keys on `refs/pull/*/merge`, main's dependency entries should keep a stable `createdAt`, and after the next release `sweep-dead-refs` should report the tag's set swept two days later. Trigger it once via `workflow_dispatch` after merge and read the log.

Item 2 (sweep on `workflow_run`) stays deferred per the issue: with this in, there is little left on PR refs for it to reclaim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
