### PR TITLE
ci: pin py7zr for the aqt venvs; turn off CodeQL TRAP caching (#5548)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,15 @@ permissions:
 env:
   QT_VERSION: '6.8.3'
   AQTINSTALL_VERSION: '3.3.0'
+  # py7zr is aqt's 7z extractor and is pinned separately, to the same series
+  # jurplel/install-qt-action pins (py7zrversion default ==1.0.*). Left to
+  # pip, aqtinstall==3.3.0 resolves py7zr>=0.22.0 to the newest 1.1.x, whose
+  # symlink sanitising throws `Bad7zFile: Specified path is bad: lib/cmake/…`
+  # part-way through the Windows extraction, at random (aqtinstall #995 —
+  # the reporter measured ~50%). It passed on two PR runs of #5552 and then
+  # failed the first main run, which is exactly the shape of that bug.
+  # Not in the Qt cache key: the extractor does not change what is laid down.
+  PY7ZR_VERSION: '1.0.0'
 
 jobs:
   build:
@@ -415,7 +424,7 @@ jobs:
           # change to the Qt this job builds against.
           python -m venv "$env:RUNNER_TEMP\aqtvenv"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          & "$env:RUNNER_TEMP\aqtvenv\Scripts\pip.exe" install -q "aqtinstall==$env:AQTINSTALL_VERSION"
+          & "$env:RUNNER_TEMP\aqtvenv\Scripts\pip.exe" install -q "aqtinstall==$env:AQTINSTALL_VERSION" "py7zr==$env:PY7ZR_VERSION"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           & "$env:RUNNER_TEMP\aqtvenv\Scripts\aqt.exe" install-qt windows desktop $env:QT_VERSION $env:QT_ARCH `
             -m qtmultimedia qtwebsockets qtserialport qtshadertools `
@@ -767,7 +776,7 @@ jobs:
           # this job exists to make about Qt itself. Matches
           # .github/docker/Dockerfile, which pins for that reason.
           python3 -m venv "$RUNNER_TEMP/aqtvenv"
-          "$RUNNER_TEMP/aqtvenv/bin/pip" install -q "aqtinstall==${AQTINSTALL_VERSION}"
+          "$RUNNER_TEMP/aqtvenv/bin/pip" install -q "aqtinstall==${AQTINSTALL_VERSION}" "py7zr==${PY7ZR_VERSION}"
           "$RUNNER_TEMP/aqtvenv/bin/aqt" install-qt mac desktop "$QT_VERSION" clang_64 \
             -m qtmultimedia qtwebsockets qtserialport qtshadertools \
             --outputdir "${{ github.workspace }}/Qt"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -90,6 +90,19 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
+          # TRAP caching is OFF. It only ever speeds up PR analyses: on the
+          # default branch the action logs "Analyzing default branch.
+          # Skipping downloading of TRAP caches", and this workflow has no
+          # pull_request trigger, so nothing ever restores one. What it DID
+          # do is upload a ~2.9 GiB entry keyed on the commit sha from every
+          # push:main run (5-23/day) into the repo's 10 GiB Actions cache
+          # allowance. The action's own cleanup needs actions:write, which
+          # this workflow deliberately does not grant, so it 403s silently
+          # and LRU eviction was the only thing removing them — taking
+          # ci.yml's compiler caches with it (#5548). Turning it on again
+          # needs a pull_request trigger to make it worth its budget, and a
+          # line in ci.yml's CCACHE_MAXSIZE budget table.
+          trap-caching: false
 
       - name: Configure
         run: cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo


### PR DESCRIPTION
## What

Two CI-budget fixes in `ci.yml` and `codeql.yml`:

1. **Pin `py7zr==1.0.0`** in both aqt venvs (check-windows, check-macos), as a workflow-level `PY7ZR_VERSION` next to `AQTINSTALL_VERSION`. Fixes red main after #5552.
2. **`trap-caching: false`** on the CodeQL init step. Removes a 2.9 GiB cache entry that is written on every source-touching push to main and never read.

## Why — py7zr

The first main run after #5552 ([34528490345](https://github.com/aethersdr/AetherSDR/actions/runs/34528490345)) failed in check-windows during `Install Qt LTS via aqtinstall`:

```
WARNING : Caught Bad7zFile, terminating installer workers
ERROR   : Specified path is bad: lib/cmake/Qt6ShaderToolsTools
py7zr.exceptions.Bad7zFile: Specified path is bad: lib/cmake/Qt6ShaderToolsTools
```

This is [aqtinstall #995](https://github.com/miurahr/aqtinstall/issues/995): py7zr 1.1.x added symlink sanitising that intermittently rejects Qt's archives on Windows (~50% of runs per the reporter; maintainer confirmed the source; pinning py7zr 1.0/1.1.0 is the reported workaround). `jurplel/install-qt-action` never hit it because it pins `py7zr==1.0.*` alongside `aqtinstall==3.3.*`. The venv #5552 introduced installs `aqtinstall==3.3.0` alone, and its `py7zr>=0.22.0` requirement resolves to 1.1.3. It passed both PR runs of #5552 and then failed the first main run — the shape of an intermittent bug, not a main-specific one.

The Qt cache key is deliberately unchanged: the extractor does not change what it lays down. Not touched: the aqt installs in `.github/docker/Dockerfile`, `appimage.yml`, `macos-dmg.yml` (Linux/macOS, no reports there).

## Why — CodeQL TRAP caching

`codeql-action` uploads a TRAP cache keyed on the commit sha from every default-branch run (`trap-caching.ts`, `uploadTrapCaches`), and `codeql.yml` runs on every source-touching push to main — 5 to 23 times a day over the last two weeks. TRAP caches only speed up PR analyses: on the default branch the action logs `Analyzing default branch. Skipping downloading of TRAP caches`, and this workflow has no `pull_request` trigger, so **no run has ever restored one**. The action's own `cleanupTrapCaches` needs `actions: write`, which `codeql.yml` deliberately does not grant, so it 403s silently; LRU eviction was the only thing removing the entries, and each eviction round could take `ci.yml`'s compiler caches with it.

Measured 2026-09-10: one `codeql-trap-1-2.27.0-cpp-<sha>` entry on main at **2,939 MiB** — the largest single cache in the repository, absent from every budget table in #5008 / #5551. Sept 6, the day the cold Linux builds began, had 23 CodeQL runs on main. With this off, main's steady state drops from ~9.5 GiB to ~6.6 GiB and the transient peak from over 10 to ~8.2 GiB.

Analysis results are unaffected; only the extractor's cache of parsed files is not persisted.

## Verification

- A PR run exercises the Windows aqt path cold (no `qt-6.8.3-windows-…` entry on main yet, since main's save never ran). One green run does not prove an intermittent bug fixed; the pin matching install-qt-action's known-good configuration is the evidence.
- CodeQL does not run on PRs, so the `trap-caching` change is exercised by the first source-touching push to main: its log should show no `Uploading TRAP cache` line, and no new `codeql-trap-*` entry should appear.
- After merge: the first main run should show `Save Qt` executed on check-windows and the entry on `refs/heads/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
