### PR TITLE
gui: honest FFT trace width on the GPU path, 1.0 px default, WAVE scope floor 0.5 (RFC #5561)

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ AETHER_NO_GPU=1 ./AetherSDR-*.AppImage
 
 That is the escape hatch if a GPU or driver renders the spectrum incorrectly — worth trying first on Raspberry Pi and other systems whose Mesa driver is newer than its hardware.
 
+Trace thickness is the **FFT Line** slider under the spectrum's right-click **Display** panel (Off to 5.0 px, per panadapter).
+
 ### Wayland and XWayland
 
 On a Wayland session AetherSDR chooses the Qt platform based on whether a

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -1211,7 +1211,7 @@ comparing screenshots.
    "panIndex":1,"objectName":"",
    "fftAverage":0,"fftFps":25,"fftWeightedAvg":false,
    "fftHeatMap":true,"showGrid":true,
-   "fftLineWidth":2.0,"fftLineColor":"#00e5ff",
+   "fftLineWidth":1.0,"fftLineColor":"#00e5ff",
    "fftFillAlpha":0.7,"fftFillColor":"#00e5ff",
    "noiseFloorEnable":false,"noiseFloorPosition":75,
    "wfBlankerEnabled":false,"wfBlankerThreshold":1.15,"wfBlankerMode":0,

--- a/src/gui/FftLineWidth.h
+++ b/src/gui/FftLineWidth.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace AetherSDR {
+
+// FFT Line is a full width in device pixels. The panscope shader consumes
+// a half-width; keeping the conversion here makes RFC #5561 regression-testable.
+constexpr float fftLineHalfWidth(float fullWidth)
+{
+    return fullWidth * 0.5f;
+}
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -4794,7 +4794,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         sw->setFftFillAlpha(0.70f);
         sw->setFftFillColor(QColor(0x00, 0xe5, 0xff));
         sw->setFftLineColor(QColor(0x00, 0xe5, 0xff));
-        sw->setFftLineWidth(2.0f);
+        sw->setFftLineWidth(1.0f);
         sw->setFftWeightedAvg(false);
         sw->setFftHeatMap(true);
         sw->setWfColorScheme(0);
@@ -4845,7 +4845,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         s.setValue(sw->settingsKey("DisplayFftFillAlpha"),        "0.70");
         s.setValue(sw->settingsKey("DisplayFftFillColor"),        "#00e5ff");
         s.setValue(sw->settingsKey("DisplayFftLineColor"),        "#00e5ff");
-        s.setValue(sw->settingsKey("DisplayFftLineWidth"),        "2.0");
+        s.setValue(sw->settingsKey("DisplayFftLineWidth"),        "1.0");
         s.setValue(sw->settingsKey("DisplayFftHeatMap"),          "True");
         s.setValue(sw->settingsKey("DisplayWfColorScheme"),       "0");
         s.setValue(sw->settingsKey("DisplayWfColorGain"),         "50");

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -1783,7 +1783,7 @@ void SpectrumOverlayMenu::buildDisplayPanel()
 
         auto* lineWidthSlider = new GuardedSlider(Qt::Horizontal);
         lineWidthSlider->setRange(0, 10);
-        lineWidthSlider->setValue(4);
+        lineWidthSlider->setValue(2);
         lineWidthSlider->setSingleStep(1);
         lineWidthSlider->setPageStep(1);
         lineWidthSlider->setObjectName("displayFftLineWidthSlider");
@@ -1796,7 +1796,7 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         applyPrimarySliderStyle(m_lineWidthSlider);
         grid->addWidget(m_lineWidthSlider, row, 2);
 
-        m_lineWidthLabel = new QLabel("2.0");
+        m_lineWidthLabel = new QLabel("1.0");
         m_lineWidthLabel->setStyleSheet(valStyle);
         reserveValueColumnLabel(m_lineWidthLabel);
         m_lineWidthLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2,6 +2,7 @@
 
 #include "SliceToneCues.h"
 #include "gui/FftHeatMap.h"
+#include "gui/FftLineWidth.h"
 #include "gui/SpectrumGrid.h"
 #include "DbmRangeTransition.h"
 #include "DssDcEdgeMath.h"
@@ -14760,7 +14761,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                     // the full value as the half drew every trace at twice its
                     // labelled width on the GPU path (RFC #5561 §A). Device
                     // pixels, no dpr scaling, as the old vertex bake did.
-                    m_fftLineWidth * 0.5f,                          // coreHalfWidthPx
+                    AetherSDR::fftLineHalfWidth(m_fftLineWidth),      // coreHalfWidthPx
                     kFftLineFeatherPx,                              // featherPx
                     kFftLineCoreAlpha,
                     kFftLineFeatherAlpha,

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2558,7 +2558,7 @@ void SpectrumWidget::loadSettings()
     m_freqGridSpacingKhz = s.value(settingsKey("DisplayFreqGridSpacing"), "0").toInt();
     m_freqScaleFontPt = std::clamp(
         s.value(settingsKey("DisplayFreqScaleFontPt"), "8").toInt(), 8, 14);
-    m_fftLineWidth   = s.value(settingsKey("DisplayFftLineWidth"), "2.0").toFloat();
+    m_fftLineWidth   = s.value(settingsKey("DisplayFftLineWidth"), "1.0").toFloat();
     m_noiseFloorEnable = s.value(settingsKey("DisplayNoiseFloorEnable"), "False").toString() == "True";
     const int legacyNoiseFloorPosition = std::clamp(
         s.value(settingsKey("DisplayNoiseFloorPosition"), "75").toInt(), 1, 99);
@@ -14754,9 +14754,13 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                     static_cast<float>(specH) * fbDpr,              // hPx
                     static_cast<float>(n),                          // columnCount
                     1.0f,                                           // hasData
-                    // Match the old vertex bake: stroke half-widths were
-                    // DEVICE-pixel offsets with no dpr scaling.
-                    m_fftLineWidth,                                 // coreHalfWidthPx
+                    // The slider is a FULL width in device px (the QPainter
+                    // path sets a cosmetic pen of exactly m_fftLineWidth), and
+                    // the shader takes a HALF width, so halve it here. Passing
+                    // the full value as the half drew every trace at twice its
+                    // labelled width on the GPU path (RFC #5561 §A). Device
+                    // pixels, no dpr scaling, as the old vertex bake did.
+                    m_fftLineWidth * 0.5f,                          // coreHalfWidthPx
                     kFftLineFeatherPx,                              // featherPx
                     kFftLineCoreAlpha,
                     kFftLineFeatherAlpha,

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -1528,7 +1528,7 @@ private:
     bool m_showGrid{true};          // false = hide grid lines
     int  m_freqGridSpacingKhz{0};   // 0=Auto, or 1/2/5/10/25/50/100 kHz (#1390)
     int  m_freqScaleFontPt{8};      // freq-scale label size, 8..14 pt (#3501)
-    float m_fftLineWidth{2.0f};     // spectrum trace width in pixels
+    float m_fftLineWidth{1.0f};     // spectrum trace width in pixels (RFC #5561)
 
     // ── Waterfall display controls (radio-side via "display panafall set") ─
     int   m_wfColorGain{50};         // 0-100, maps intensity to color range

--- a/src/gui/WaveformWidget.cpp
+++ b/src/gui/WaveformWidget.cpp
@@ -68,8 +68,11 @@ QColor waveformColor()
 
 float waveformLineWidth()
 {
-    const float w = AppSettings::instance().value("DisplayFftLineWidth", "2.0").toFloat();
-    return std::clamp(w, 1.0f, 3.0f);
+    // Shares the panadapter's key, so it must accept every width the FFT Line
+    // slider can set: the floor is the slider's lowest non-Off step (RFC
+    // #5561 §E). The 3.0 ceiling is the scope's own.
+    const float w = AppSettings::instance().value("DisplayFftLineWidth", "1.0").toFloat();
+    return std::clamp(w, 0.5f, 3.0f);
 }
 
 bool showGrid()

--- a/tests/fft_line_width_test.cpp
+++ b/tests/fft_line_width_test.cpp
@@ -1,0 +1,24 @@
+#include "gui/FftLineWidth.h"
+
+#include <array>
+#include <cstdio>
+
+int main()
+{
+    // The shader draws on both sides of the centerline. Pin the entire UI
+    // range, including Off and subpixel widths, to device-pixel half-widths.
+    constexpr std::array<float, 11> expectedHalfWidths{
+        0.0f, 0.25f, 0.5f, 0.75f, 1.0f, 1.25f,
+        1.5f, 1.75f, 2.0f, 2.25f, 2.5f};
+    int failures = 0;
+    for (int step = 0; step <= 10; ++step) {
+        const float fullWidth = static_cast<float>(step) * 0.5f;
+        const float actual = AetherSDR::fftLineHalfWidth(fullWidth);
+        if (actual != expectedHalfWidths[step]) {
+            std::fprintf(stderr, "FAIL: %.1f px trace: expected half-width %.2f, got %.2f\n",
+                         fullWidth, expectedHalfWidths[step], actual);
+            ++failures;
+        }
+    }
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -2060,6 +2060,11 @@ target_include_directories(dss_renderer_test PRIVATE src)
 target_link_libraries(dss_renderer_test PRIVATE Qt6::Core Qt6::Gui)
 add_test(NAME dss_renderer_test COMMAND dss_renderer_test)
 
+# Socket-free full-width to GPU half-width contract (RFC #5561).
+add_executable(fft_line_width_test tests/fft_line_width_test.cpp)
+target_include_directories(fft_line_width_test PRIVATE src)
+add_test(NAME fft_line_width_test COMMAND fft_line_width_test)
+
 add_executable(spectrum_preview_logic_test
     tests/spectrum_preview_logic_test.cpp
 )


### PR DESCRIPTION
Implements **RFC #5561** as ruled on 2026-09-11. Supersedes the earlier three commits on this branch (0.5 default + migration), which are withdrawn.

## What changed

| RFC | Change | Where |
|---|---|---|
| §A | **Honest width on the GPU path.** The shader takes a half width; it was handed the slider's full value, so every trace drew at 2× its label (the shipped 2.0 was a 4 px core + feather; the QPainter path drew a true 2 px pen). The uniform now carries `value / 2`. | `SpectrumWidget.cpp` (uniform write) |
| §B | **Default 1.0 px** at every site that encodes it. | `SpectrumWidget.h` initialiser, `SpectrumWidget.cpp` fallback, `MainWindow_Wiring.cpp` reset path (setter + stored default), `SpectrumOverlayMenu.cpp` slider position 2 + label, `WaveformWidget.cpp` fallback, `docs/automation-bridge.md` sample |
| §C | **No migration.** Stored values are untouched; §A already thins a stored 2.0. | — |
| §D | **Docs line only.** README's GPU Spectrum Rendering section names the Display panel's FFT Line slider and its range. | `README.md` |
| §E | **WAVE scope floor 0.5.** It shares the key and clamped to 1.0, so a 0.5 panadapter trace paired with a 1.0 waveform trace. Its own 3.0 ceiling stays. | `WaveformWidget.cpp` |

## What operators see

- Fresh install: 1.0 px trace, which looks like today's 0.5 on the GPU path.
- Existing stored width `w`: renders at `w` px on the GPU path instead of `2w`. No settings are rewritten.
- The slider's px label is now true on both render paths.

## Review response (earlier automated review on this PR)

All five blockers addressed: RFC filed and approved; migration dropped (so no contradiction, no third value, no namespace scan); WaveformWidget clamp lowered deliberately rather than left as a dead fallback. The render-path parity nit was the root cause and is §A.

## Verification

- `AetherSDR` Release build clean in a fresh worktree.
- Tests pass: `client_display_settings_test`, `panadapter_message_overlay_test`, `spectrum_overlay_band_highlight_test`, `spectrum_overlay_wheel_guard_test`, `spectrum_pattern_test`, `spectrum_preview_logic_test`, `waveform_scope_model_test`, `hl2_spectrum_test`.
- `check_engine_boundary.py` clean; touchpoint manifest unchanged.
- No CHANGELOG entry per project policy.
- Independent native Metal demo review: fresh width 1.0; Off and 0.5/1.0/2.0/5.0 readbacks and screenshots; Display reopen retained 2.0; process restart retained 2.0; Reset to Defaults restored 1.0. Isolated DEMO-0001, TX disabled. Exact software/GPU pixel parity and WAVE visual parity were not measured.
- Added socket-free `fft_line_width_test`, using the production full-to-half-width conversion across all 11 slider positions. Mutation check: restoring the old full-width behavior fails all ten nonzero positions; restored fix passes. Run with `cmake --build <build-dir> --target fft_line_width_test` and `ctest --test-dir <build-dir> -R '^fft_line_width_test$' --output-on-failure --no-tests=error`. Registered in the default suite; the frozen per-PR test allow-list is unchanged.

Closes #5561

🤖 Generated with [Claude Code](https://claude.com/claude-code)
