### PR TITLE
feat(aetherd): add qualified receive controls and bounded telemetry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -519,8 +519,13 @@ grants are not implemented yet.
 existing owned slice, with explicit backend observation provenance and fail-closed
 TX-idle admission; see `docs/aetherd-local-slice-frequency-control.md`. It does
 not optimistically update the model. Unknown coverage/readback remains unavailable.
-Meters, read-only transmit state, other typed slice/pan receive controls, and the desktop
-adapter have not landed; UI code still consumes models directly, and that
+The receive-control milestone adds typed mode/filter/gain/mute and pan
+center/bandwidth intents for qualified existing owned resources, separate
+backend receive observations, bounded latest-value `meter` resources and a
+read-only `transmitState`; see `docs/aetherd-local-receive-control.md` for the
+per-backend support matrix and remaining no-op, geometry and TX-idle limits.
+This is not all-backend feature parity: unavailable operations remain absent.
+The desktop adapter has not landed; UI code still consumes models directly, and that
 remains correct. New resource fields belong in the adapter and the versioned
 catalogue, never in a transport or via QObject reflection. No protocol TX
 method is advertised before the step-4 arbiter exists.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -699,7 +699,9 @@ set(CORE_SOURCES
     src/core/control/RadioConnectionTarget.h  # socket-free connection intent seam
     src/core/backends/ModelRadioConnectionTarget.cpp # native translation and lifecycle
     src/core/control/RadioResourceAdapter.cpp # normalized model resources
+    src/core/control/RadioTelemetryAdapter.cpp # bounded read-only telemetry
     src/core/control/ModelSliceFrequencyTarget.cpp # validated non-keying intents
+    src/core/control/ModelReceiveControlTarget.cpp # typed receive operations
     src/core/control/RadioCatalogue.cpp       # bounded normalized discovery resource
     src/core/control/LocalControlServer.cpp   # current-user local transport
     src/core/discovery/RadioDiscoverySource.h  # socket-free discovery interface (AUTOMOC)

--- a/docs/aetherd-control-resource-v1-catalogue.md
+++ b/docs/aetherd-control-resource-v1-catalogue.md
@@ -6,9 +6,9 @@ slice of RFC #3849. It supplements
 the envelope, limits, errors, authentication, and TX rules in that document
 remain normative.
 
-Only the five resource types below exist in this slice. `meter` and
-`transmitState` remain unimplemented. No method in this catalogue mutates a
-model or can reach a radio backend intent.
+The seven resource types below are observational. No method in this catalogue
+mutates a model or can reach a backend intent. Typed receive intents are
+specified separately in [local receive control](aetherd-local-receive-control.md).
 
 ## Resource identities and selectors
 
@@ -20,14 +20,18 @@ An exact identity has one of these shapes:
 {"type":"radioSession","id":"radio-1"}
 {"type":"slice","radioSession":"radio-1","id":"0"}
 {"type":"panadapter","radioSession":"radio-1","id":"0x40000000"}
+{"type":"meter","radioSession":"radio-1","id":"0"}
+{"type":"transmitState","radioSession":"radio-1"}
 ```
 
 `resource.get` requires an exact identity. `resource.subscribe` also accepts
 an omitted `id` as an all-current-and-future selector for `radioSession`,
-`slice`, or `panadapter`; `slice` and `panadapter` still require
+`slice`, `panadapter`, or `meter`; these children still require
 `radioSession`. Unknown fields and unsupported resource types are rejected.
 `server` and `radioCatalogue` are singletons: neither accepts `id` or
 `radioSession`, including empty or null values.
+`transmitState` is one singleton per radio session: `radioSession` is required
+and `id` is forbidden.
 
 ## Methods
 
@@ -80,6 +84,10 @@ operation. Events still pending for existing subscriptions retain sequences
 greater than the returned boundary, and newly generated events advance beyond
 them, so an event delivered after the baseline cannot leave a snapshot/event
 gap or reuse the baseline sequence.
+
+A baseline exceeding the 256 KiB message limit (including reserved envelope
+space) returns `transport.limit_exceeded` before installing any subscription.
+Use narrower selectors; no partial baseline or silent truncation is returned.
 
 ### `resource.unsubscribe`
 
@@ -205,6 +213,9 @@ commands. Create a new instance to restart discovery.
 ### `radioSession`
 
 - `id`, `connected`, `family`.
+- `meterDelivery`: `maxEntries` (64), `publishIntervalMs` (100),
+  `staleAfterMs` (2000), and `limited`. The latter stays true until meter clear
+  or connection reset after an invalid/over-capacity definition is excluded.
 - `identity`: `name`, `model`, `serial`, `version`, `manufacturer`.
 - `capabilities`:
   - `maxSlices`, `maxPanadapters`, `sampleRatesHz`;
@@ -214,6 +225,12 @@ commands. Create a new instance to restart discovery.
     `minimumHz` and `maximumHz`; zero bounds mean unavailable, not unlimited;
   - `canTransmit`, `maximumTransmitWatts`, `hasTuner`, `hasAmplifier`;
   - `extensions`, containing namespace names only, never extension payloads.
+  - Optional `receiveModeControl`, `receiveFilterControl`, `receiveAudioControl`,
+    `receivePanCenterControl`, `receivePanBandwidthControl`: null when
+    unqualified. Records carry `authority` (`radio`, `engine`, `unknown`). Mode
+    carries `modes`; filter carries per-mode minimum/maximum low cut, high cut
+    and width; audio carries gain bounds 0–100; pan records carry inclusive
+    `minimumHz`/`maximumHz`. See the receive-control contract for eligibility.
 
 `canTransmit` is observation only. It does not advertise a protocol TX method
 or grant and cannot key a radio.
@@ -232,6 +249,13 @@ control methods are specified in
   engine configuration is not a hardware acknowledgement or DSP completion.
 - `active`, `txSlice`, `locked`.
 - `audio.gain`, `audio.pan`, `audio.muted`.
+- `receiveObservation.mode` and `receiveObservation.audio.gain` / `.muted`:
+  `{known, value, authority}` with null value when unknown. Mode is a string,
+  gain an integer 0–100, mute a boolean. `receiveObservation.filter` carries
+  `known`, nullable `lowHz`/`highHz`, and `authority`; both cuts and a mode are
+  required for a known ordered passband. These are backend publications,
+  separate from the legacy optimistic mode/filter/audio values above. A changed
+  mode invalidates previous cuts; partial fields do not invent missing partners.
 - `receive.antenna`, `receive.rfGain`.
 - `receive.agc.mode`, `receive.agc.threshold`, `receive.agc.offLevel`.
 - `receive.squelch.enabled`, `receive.squelch.level`.
@@ -245,7 +269,11 @@ for control admission, observation and concurrent-intent semantics.
 
 ### `panadapter`
 
-- `id`.
+- `id`, `owned` (exact current-session ownership, unknown is false).
+- `geometryObservation`: nullable `centerHz`/`bandwidthHz`, `centerKnown` /
+  `bandwidthKnown`, `centerAuthority` / `bandwidthAuthority`. Only normalized
+  backend geometry updates these fields. Reconnect or an ownership change
+  invalidates them, including when legacy visible geometry is retained.
 - `centerHz`, `centerKnown`, `bandwidthHz`.
 - `dbmRange.minimum`, `dbmRange.maximum`.
 - `bandwidthLimitsHz.minimum`, `bandwidthLimitsHz.maximum`; zero means the
@@ -261,5 +289,49 @@ for control admission, observation and concurrent-intent semantics.
 - `displayCadence.waterfallRate`; `-1` means the backend has not reported a
   value, otherwise this is the normalized 1–100 rate, not milliseconds.
 
-FFT bins, waterfall rows, audio, and other high-rate data never enter these
+### `meter`
+
+At most 64 valid observed definitions per session are projected; new identities
+at capacity are dropped and `radioSession.meterDelivery.limited` discloses the
+incomplete view. Existing identities continue updating. A removed slot can take
+a later new definition; previously dropped identities are not automatically
+backfilled. This is a latest-value diagnostic projection, not lossless metering.
+
+- `id`: decimal normalized meter index (0–65535).
+- `definition`: `source`, `sourceIndex`, `name`, `unit`, `minimum`, `maximum`,
+  `description`. Source/name are nonempty and bounded to 32 UTF-16 code units;
+  unit to 16 and description to 128. Text must be valid UTF-16 without NUL or
+  Unicode controls. Bounds must be finite and ordered. Invalid definitions are
+  excluded, not truncated. No raw frames or proprietary extension payloads.
+- `sample`: `known` (a sample was observed in this connection), `fresh` (at most
+  2000 ms old), `valid`, `ageMs`, `value`. Age is monotonic, -1 before a sample,
+  capped at 2001 once stale so an idle resource stops churning. `value` is a
+  finite converted physical number in the definition's units only when valid;
+  otherwise null. SWR additionally uses MeterModel's existing sample/power
+  validity gate; stale/inapplicable SWR is never a healthy-looking ratio.
+
+The adapter retains one latest sample per admitted meter, publishes at most
+every 100 ms, and refreshes liveness on unchanged samples. Metadata changes
+invalidate old samples (including units); identical definitions do not. Clear,
+disconnect and backend replacement remove resources and discard samples. A new
+connection needs new samples, even if a legacy model retained an old value.
+Meter updates never touch slice/pan command revisions. Existing per-client
+coalescing, resync and hard transport caps still apply.
+
+### `transmitState`
+
+- `connected`, `canTransmit`: backend/session observations only, never grants.
+- `state`: `unknown`, `unsupported` (connected RX-only backend), `idle`, or
+  `transmitting`. Only explicit normalized transmit readback establishes idle
+  or transmitting. Local command activity, backend/capability changes and
+  disconnect invalidate prior idle knowledge. False construction defaults or a
+  falling command edge cannot establish idle. Many backends currently have no
+  normalized readback and correctly remain unknown.
+- `localRequests`: `mox`, `tune`, `transmitting`. These are explicitly local
+  model/request values, not evidence of RF, physical PTT or idle state.
+
+This resource is readable with `observe`, including on an observe-only daemon.
+It introduces no TX verb, grant, lease, policy decision or safety guarantee.
+
+FFT bins, waterfall rows, audio, and other high-rate streams never enter these
 JSON resources; they belong to the later bounded binary data plane.

--- a/docs/aetherd-control-resource-v1-catalogue.md
+++ b/docs/aetherd-control-resource-v1-catalogue.md
@@ -293,15 +293,18 @@ for control admission, observation and concurrent-intent semantics.
 
 At most 64 valid observed definitions per session are projected; new identities
 at capacity are dropped and `radioSession.meterDelivery.limited` discloses the
-incomplete view. Existing identities continue updating. A removed slot can take
-a later new definition; previously dropped identities are not automatically
-backfilled. This is a latest-value diagnostic projection, not lossless metering.
+incomplete view. Existing identities continue updating. Removal or invalidation
+of a selected definition fills the vacancy from remaining valid definitions in
+index order, without importing retained samples. Initial admission skips invalid
+definitions before reaching the 64-entry bound. The limited flag remains latched
+until clear/reconnect. This is a latest-value diagnostic projection, not lossless metering.
 
 - `id`: decimal normalized meter index (0–65535).
 - `definition`: `source`, `sourceIndex`, `name`, `unit`, `minimum`, `maximum`,
   `description`. Source/name are nonempty and bounded to 32 UTF-16 code units;
   unit to 16 and description to 128. Text must be valid UTF-16 without NUL or
-  Unicode controls. Bounds must be finite and ordered. Invalid definitions are
+  Unicode control or format characters (including supplementary code points).
+  Bounds must be finite and ordered. Invalid definitions are
   excluded, not truncated. No raw frames or proprietary extension payloads.
 - `sample`: `known` (a sample was observed in this connection), `fresh` (at most
   2000 ms old), `valid`, `ageMs`, `value`. Age is monotonic, -1 before a sample,

--- a/docs/aetherd-local-connection-control.md
+++ b/docs/aetherd-local-connection-control.md
@@ -3,7 +3,8 @@
 This Stage 3 sub-slice of RFC #3849 adds only non-TX connection intents.
 Transmit, remote transport, credentials and desktop migration remain excluded.
 The subsequent [slice frequency slice](aetherd-local-slice-frequency-control.md)
-adds one receive setter under the same explicit opt-in. The default daemon
+adds frequency tuning, and the [receive-control milestone](aetherd-local-receive-control.md)
+adds qualified mode/filter/audio/geometry controls under the same explicit opt-in. The default daemon
 remains observe-only.
 
 ## Authorization and startup
@@ -23,6 +24,12 @@ The daemon binds its endpoint before either step, then binds the connection
 target once before request dispatch. A failed listen never constructs models
 or touches settings. Icom manual setup, SmartLink and external directories
 remain excluded.
+
+Endpoint reservation is not protocol readiness. During initialization, early
+connections are closed without admitting a session; clients may reconnect and
+retry `hello`. Serving begins only after all targets and initial resources are
+installed. Settings/model constructors may pump nested Qt event loops, but an
+early client must not cause startup binding to fail or observe partial state.
 
 ## Methods
 

--- a/docs/aetherd-local-connection-control.md
+++ b/docs/aetherd-local-connection-control.md
@@ -30,6 +30,9 @@ connections are closed without admitting a session; clients may reconnect and
 retry `hello`. Serving begins only after all targets and initial resources are
 installed. Settings/model constructors may pump nested Qt event loops, but an
 early client must not cause startup binding to fail or observe partial state.
+`local_control_server_test` pins this ordering against the production server:
+a client arriving on a reserved endpoint is closed without a reply, serving
+begins exactly once, and the default listen mode still admits sessions.
 
 ## Methods
 

--- a/docs/aetherd-local-receive-control.md
+++ b/docs/aetherd-local-receive-control.md
@@ -1,0 +1,145 @@
+# AetherD v1 — local receive-control milestone
+
+This Stage 3 milestone of #3849 extends the existing local opt-in with typed
+controls for existing owned receivers. It does not enable transmit, remote
+access, arbitrary commands, new slices/pans, or desktop migration. The default
+daemon remains observe-only. `--allow-local-control` grants all current-user
+local clients observe and non-TX control, not per-application consent.
+
+## Requests
+
+Every request uses the negotiated `sessionId` and requires `control` before
+schema validation or resource lookup. Unknown fields are rejected.
+
+| Method | Required parameters, in addition to `radioSession` and `expectedRevision` |
+|---|---|
+| `slice.setMode` | `slice`, `mode` |
+| `slice.setFilter` | `slice`, `lowHz`, `highHz` |
+| `slice.setAudioGain` | `slice`, `gain` |
+| `slice.setAudioMute` | `slice`, `muted` |
+| `panadapter.setCenter` | `panadapter`, `hz` |
+| `panadapter.setBandwidth` | `panadapter`, `hz` |
+
+`radioSession` must identify the current `radio-1`. Slice IDs are canonical
+nonnegative decimal strings fitting int32; pan IDs are exact opaque resource
+IDs, not backend IDs. `expectedRevision` is the addressed slice/pan revision,
+a positive exact JSON integer at most 2^53-1. Numeric strings, booleans used as
+numbers, fractional numbers, nulls and unknown fields are not coerced.
+
+`mode` is 1–32 uppercase ASCII letters/digits and must be in the backend's
+qualified mode list. Filter cuts are signed int32 **carrier-relative Hz**;
+both are required together. The requested lower/upper cut and width must fit
+the current observed mode's declared limits. No pitch-dependent CW, RTTY
+shift-dependent, FM preset, or digital-voice lease behavior is guessed.
+`gain` is an integer 0–100 (backend linear receive level, not RF gain or dB).
+`muted` is a JSON boolean. Pan `hz` is a positive exact JSON integer; coverage
+uses the same conservative whole-MHz observation ceiling as frequency control.
+Center and bandwidth must leave a positive-frequency viewport.
+
+```json
+{"v":1,"id":"mode-1","sessionId":"<negotiated>","method":"slice.setMode","params":{"radioSession":"radio-1","slice":"0","expectedRevision":42,"mode":"LSB"}}
+```
+
+Success is `{"accepted":true}`: one typed backend intent was dispatched, **not
+hardware acknowledgement, DSP completion, or a promise of the requested value**.
+The target does not call optimistic desktop setters. A synchronous publication
+may precede the response, and a same-value command need not create an event.
+Clients converge through resource snapshots/events, not by copying their request.
+
+## Admission, concurrency and safety
+
+The target binds once to an idle engine before serving requests. Every action
+rechecks the owning thread, dependency lifetime, ready connection, current
+capabilities and exact ownership. Slice locks, foreign slots, diversity child
+receivers and external receive replacement refuse slice control. Unknown pan
+ownership is not sufficient; wire-less pans must resolve through the current
+backend mapping. Pan center must not implicitly retune a slice; bandwidth must
+not create/remove/retune receivers. Backends with those couplings stay disabled.
+
+Receive mode, filter, gain/mute and geometry need their own backend observations;
+constructor defaults are not evidence. Mode readback changes invalidate old
+filter cuts, and both cuts must be observed again. A pending mode intent blocks
+another mode or filter intent until its matching mode publication, disconnect
+or backend replacement. It cannot accumulate a command queue. If a backend
+never reports the selected mode, clients must reconnect or wait for fresh
+matching state; timeout does not fabricate success or unlock old-mode filters.
+
+Revisions are freshness checks, not compare-and-swap or exclusive ownership.
+Other receive intents may be accepted against the same observed revision before
+a backend publishes; they dispatch in engine order. Meter revisions are separate
+and do not invalidate slice/pan selections. On conflict or an uncertain response,
+refresh and make a new decision; do not replay the old request automatically.
+
+The shared receive guard preserves the frequency-control TX policy. TX-capable
+backends need explicit normalized idle readback, and radio/local TX, MOX or TUNE
+activity invalidates that permission. Default false and a falling command edge
+are not idle evidence. This is **not** the Stage 4 TX arbiter or a guarantee
+against external PTT after the last observation. No TX method, lease or grant is
+introduced. Frequency tuning remains governed by its separate coverage contract.
+
+All methods share the existing 100/s, burst-200 session budget. Grant revocation
+is terminal and cannot undo an already dispatched intent. Error meanings match
+[frequency control](aetherd-local-slice-frequency-control.md): invalid schema,
+missing resource/ownership, conflict, unavailable capability/observation, or
+out-of-range request. Methods never accept raw commands, endpoint overrides,
+credentials, reflection paths, TX flags or `force`.
+
+## Qualified backend surface
+
+Optional per-operation records in `RadioCapabilities` are declarations, not
+grants. `capabilities.get` additionally checks current eligibility and advertises
+a method only while at least one resource can use it. Every request rechecks
+its own resource. Null records mean unavailable. Refresh after lifecycle,
+capability, ownership and resource changes; advertisement reserves nothing.
+
+| Backend | Mode | Filter | Gain/mute | Pan center | Pan bandwidth |
+|---|---|---|---|---|---|
+| Sim | USB, LSB | unavailable: echo-only | unavailable | unavailable: fixed VFO scene | unavailable: fixed span |
+| Flex | USB/LSB, DIGU/DIGL, AM/SAM/DSB, CW, FM/NFM | USB/LSB, DIGU/DIGL, AM/SAM/DSB | unavailable: legacy wire route | unavailable: unknown coverage | unavailable: coupled legacy geometry |
+| HL2 | USB/LSB, DIGU/DIGL, AM/SAM, CW | USB/LSB, DIGU/DIGL, AM/SAM | supported | 100 kHz–38.4 MHz | unavailable: radio-wide rate can retire receivers |
+| ANAN | not yet qualified | not yet qualified | not yet qualified | unavailable: also retunes slice | 48 kHz–1.536 MHz; backend selects actual rate |
+| RTL-SDR | AM/SAM, FM/FMN/WFM, USB/LSB, CW/CWR | unavailable: DSP does not consume cuts | supported | unavailable: also retunes slice | 225001 Hz–3 MHz; observe actual result |
+| Icom | not yet qualified | profile/preset contract needed | not yet qualified | not yet qualified | not yet qualified |
+
+Flex and ordinary TX-enabled HL2 still lack the normalized idle readback needed
+by this daemon path, so their declarations do **not** make those methods live.
+Explicitly TX-disabled HL2 can qualify. Icom is not offered by the daemon's
+catalogue. Optional RTL builds and hardware paths require their own validation;
+Demo evidence is not RF or hardware certification. Flex filter limits are grounded
+in FlexLib 4.2.18 `Slice.cs` (`FilterLow`/`FilterHigh`); in-process mode/filter
+records refer to the backend's actual DSP dispatch path, not a guessed radio API.
+
+Desktop routing/default requests are not migrated. HL2 now publishes its actual
+receive mixer gain/mute, including unity gain (100) before a user override; this
+can correct a previously default-looking display of 50 without changing audio.
+RTL publishes actual DDC gain/mute and resets observations to the new DDC's
+unity/unmuted initial state on reconnect.
+
+## Verification
+
+`control_receive_test` is socket-free: a recording intent seam plus separately
+injected normalized observations exercise the production service, target,
+ownership, thread/lifetime/TX gates, ranges, mode/filter ordering and revisions.
+Its backend declaration checks never connect hardware. `control_telemetry_test`
+uses an injected monotonic clock for bounded samples, freshness, redefinition,
+reconnect, independent command revisions, revocation and resync. Existing codec,
+authorization, connection, frequency and meter tests remain applicable.
+
+The optional `aetherd_receive_smoke` executable is **not in the default build or
+CTest graph**. It starts our actual daemon on a unique local socket / Windows
+named pipe with isolated settings, `--discover-sim`, and automation TX disabled.
+Two real clients negotiate, observe, change Demo mode/frequency, read the meter
+delivery contract and RX-only transmit state, disconnect and reconnect. Normal
+Demo RX has no meter samples; sample delivery/freshness is verified by the
+socket-free telemetry tests, not this diagnostic. It exits 77 on listen refusal, never scans LAN/USB,
+and never stands in for third-party firmware. Run it only when explicitly
+authorized:
+
+```sh
+cmake --build <native-build-dir> --target aetherd aetherd_receive_smoke
+<native-build-dir>/aetherd_receive_smoke <absolute-path-to-aetherd>
+```
+
+The native desktop automation bridge/MCP separately checks the exact rebuilt
+Demo app and legacy control convergence. Neither path certifies live radio
+behavior or the as-yet-unimplemented TX arbiter, binary data plane or thin UI.

--- a/docs/aetherd-local-receive-control.md
+++ b/docs/aetherd-local-receive-control.md
@@ -63,6 +63,8 @@ another mode or filter intent until its matching mode publication, disconnect
 or backend replacement. It cannot accumulate a command queue. If a backend
 never reports the selected mode, clients must reconnect or wait for fresh
 matching state; timeout does not fabricate success or unlock old-mode filters.
+An unrelated/old-mode publication cannot safely release this interlock: it may
+have been queued before the intent took effect and is not an explicit rejection.
 
 Revisions are freshness checks, not compare-and-swap or exclusive ownership.
 Other receive intents may be accepted against the same observed revision before
@@ -97,7 +99,7 @@ capability, ownership and resource changes; advertisement reserves nothing.
 | Sim | USB, LSB | unavailable: echo-only | unavailable | unavailable: fixed VFO scene | unavailable: fixed span |
 | Flex | USB/LSB, DIGU/DIGL, AM/SAM/DSB, CW, FM/NFM | USB/LSB, DIGU/DIGL, AM/SAM/DSB | unavailable: legacy wire route | unavailable: unknown coverage | unavailable: coupled legacy geometry |
 | HL2 | USB/LSB, DIGU/DIGL, AM/SAM, CW | USB/LSB, DIGU/DIGL, AM/SAM | supported | 100 kHz–38.4 MHz | unavailable: radio-wide rate can retire receivers |
-| ANAN | not yet qualified | not yet qualified | not yet qualified | unavailable: also retunes slice | 48 kHz–1.536 MHz; backend selects actual rate |
+| ANAN | not yet qualified | not yet qualified | not yet qualified | unavailable: also retunes slice | 48 kHz–1.536 MHz; backend selects actual rate; rate changes rebuild DSP and restart the P2 session, interrupting streams |
 | RTL-SDR | AM/SAM, FM/FMN/WFM, USB/LSB, CW/CWR | unavailable: DSP does not consume cuts | supported | unavailable: also retunes slice | 225001 Hz–3 MHz; observe actual result |
 | Icom | not yet qualified | profile/preset contract needed | not yet qualified | not yet qualified | not yet qualified |
 

--- a/docs/architecture/radio-capabilities-map.md
+++ b/docs/architecture/radio-capabilities-map.md
@@ -55,6 +55,19 @@ semantics see [local frequency control](../aetherd-local-slice-frequency-control
 
 ## Wired and consumed
 
+### Local receive-control records
+
+The optional `receiveModeControl`, `receiveFilterControl`, `receiveAudioControl`,
+`receivePanCenterControl`, and `receivePanBandwidthControl` records are read by
+`ModelReceiveControlTarget` at action time and by `RadioResourceAdapter` for
+versioned metadata/observation provenance. All six backends declare each record
+explicitly. They do not change UI visibility or migrate legacy command routes.
+Null or unknown authority fails closed. Their full per-backend support matrix,
+range contracts, TX-idle restrictions and remaining no-op/coupling limitations
+are in [local receive control](../aetherd-local-receive-control.md#qualified-backend-surface).
+`control_receive_test` pins declarations and action-time admission; the optional
+RTL declaration check runs only when the RTL backend is built.
+
 | Field | Flex | HL2 | Sim | Read at | Effect |
 |---|:--:|:--:|:--:|---|---|
 | `canCreateSlices` | ✅ | ❌ | ❌ | `RadioModel::addSliceOnPan`, only without a command plane | Admission to the neutral backend's independent slice-creation hook on an existing pan. Flex and Sim use their existing command adapters without consulting this field, so the values shown are declarations, not a UI availability rule; do not gate +RX on this field alone. Capacity remains `maxSlices`; paired/fixed receiver topologies do not gain independent creation. Icom, ANAN and RTL explicitly declare false; RTL remains one slice in RFC #5468 P01. |

--- a/src/aetherd/main.cpp
+++ b/src/aetherd/main.cpp
@@ -36,13 +36,14 @@ int main(int argc, char* argv[])
     parser.addOption(simDiscoveryOption);
     const QCommandLineOption controlOption(
         QStringLiteral("allow-local-control"),
-        QStringLiteral("Grant current-user local clients non-TX connection and receive-frequency control."));
+        QStringLiteral("Grant current-user local clients non-TX connection and receive control."));
     parser.addOption(controlOption);
     parser.process(app);
 
     AetherSDR::control::LocalControlServer server(
         nullptr, {}, nullptr, parser.isSet(controlOption));
-    if (!server.listen(parser.value(socketOption))) {
+    if (!server.listen(parser.value(socketOption),
+                       AetherSDR::control::LocalControlServer::ListenMode::ReserveEndpoint)) {
         QTextStream(stderr) << "aetherd: cannot listen on local socket '"
                             << parser.value(socketOption) << "'\n";
         return 1;
@@ -50,12 +51,9 @@ int main(int argc, char* argv[])
     // Claim the endpoint before settings or model construction: even the
     // AppSettings singleton constructor can create directories/migrate paths.
     // Native settings must then load before RadioModel snapshots its settings.
-    // bindConnectionTarget() below requires that no client was accepted in
-    // between. Nothing here runs the event loop except a first-run legacy XML
-    // import (AppSettings::load -> importLegacyXml -> persistVaultToKeychain
-    // pumps a bounded QEventLoop); a client arriving in that window makes the
-    // bind refuse and the daemon exit 1, which is fail-closed and one-shot.
-    // Keep any further settings work after the bind, never ahead of it.
+    // Constructors/settings imports can pump nested event loops. Reserving
+    // the endpoint closes early arrivals without admitting sessions, so no
+    // client can race the one-shot target binding or see partial resources.
     std::unique_ptr<AetherSDR::RadioDiscoverySource> discoverySource =
         AetherSDR::aetherd::makeDiscoverySource(
             {parser.isSet(localDiscoveryOption), parser.isSet(simDiscoveryOption)});
@@ -63,6 +61,7 @@ int main(int argc, char* argv[])
     radioSession.setSessionId(1);
     std::unique_ptr<AetherSDR::control::RadioConnectionTarget> connectionTarget;
     std::unique_ptr<AetherSDR::control::SliceFrequencyTarget> frequencyTarget;
+    std::unique_ptr<AetherSDR::control::ReceiveControlTarget> receiveTarget;
     if (parser.isSet(controlOption)) {
         connectionTarget = AetherSDR::control::makeModelRadioConnectionTarget(&radioSession.radioModel());
         if (!connectionTarget || !server.bindConnectionTarget(connectionTarget.get())) {
@@ -75,6 +74,12 @@ int main(int argc, char* argv[])
             QTextStream(stderr) << "aetherd: cannot initialize frequency control\n";
             return 1;
         }
+        receiveTarget = AetherSDR::control::makeModelReceiveControlTarget(
+            &radioSession.radioModel(), connectionTarget.get());
+        if (!receiveTarget || !server.bindReceiveTarget(receiveTarget.get())) {
+            QTextStream(stderr) << "aetherd: cannot initialize receive control\n";
+            return 1;
+        }
     }
     AetherSDR::control::RadioCatalogue catalogue(
         std::move(discoverySource), &server.resourceStore());
@@ -82,6 +87,10 @@ int main(int argc, char* argv[])
         &radioSession.radioModel(), &server.resourceStore(),
         QStringLiteral("radio-1"), nullptr, connectionTarget.get());
     catalogue.start();
+    if (!server.startServing()) {
+        QTextStream(stderr) << "aetherd: cannot start local client service\n";
+        return 1;
+    }
     const int result = app.exec();
     // The server was constructed first; stop delivery before target/model
     // teardown rather than relying on reverse local-variable destruction.

--- a/src/core/backends/RadioCapabilities.h
+++ b/src/core/backends/RadioCapabilities.h
@@ -6,6 +6,7 @@
 #include <QStringList>
 #include <QVector>
 #include <QVariantMap>
+#include <optional>
 
 namespace AetherSDR {
 
@@ -34,6 +35,38 @@ struct SliceFrequencyControl {
     Authority authority{Authority::Unknown};
     qint64 minimumHz{0};
     qint64 maximumHz{0};
+};
+
+// Optional per-feature records (#5262 M2). Absence means no headless verb;
+// neither UI ranges nor an inherited no-op establish support. Authority is
+// configuration provenance, never hardware acknowledgement/DSP completion.
+struct ReceiveModeControl {
+    SliceFrequencyControl::Authority authority{SliceFrequencyControl::Authority::Unknown};
+    QStringList modes;
+};
+struct ReceiveFilterMode {
+    QString mode;
+    int minimumLowHz{0};
+    int maximumLowHz{0};
+    int minimumHighHz{0};
+    int maximumHighHz{0};
+    int minimumWidthHz{0};
+    int maximumWidthHz{0};
+};
+struct ReceiveFilterControl {
+    SliceFrequencyControl::Authority authority{SliceFrequencyControl::Authority::Unknown};
+    QList<ReceiveFilterMode> modes;
+};
+struct ReceiveAudioControl {
+    SliceFrequencyControl::Authority authority{SliceFrequencyControl::Authority::Unknown};
+    // Both gain (0..100) and mute must act on the shared slice's RX audio.
+};
+struct ReceivePanRangeControl {
+    SliceFrequencyControl::Authority authority{SliceFrequencyControl::Authority::Unknown};
+    qint64 minimumHz{0};
+    qint64 maximumHz{0};
+    // Declaring center support promises no implicit slice retune. Declaring
+    // bandwidth support promises no slice creation/removal or retune.
 };
 
 // A stable, radio-owned receive-filter preset. `id` is the identity used on
@@ -151,6 +184,11 @@ struct RadioCapabilities {
     double tuningMinHz = 0.0;
     double tuningMaxHz = 0.0;
     SliceFrequencyControl sliceFrequencyControl;
+    std::optional<ReceiveModeControl> receiveModeControl;
+    std::optional<ReceiveFilterControl> receiveFilterControl;
+    std::optional<ReceiveAudioControl> receiveAudioControl;
+    std::optional<ReceivePanRangeControl> receivePanCenterControl;
+    std::optional<ReceivePanRangeControl> receivePanBandwidthControl;
 
     // Optional per-band native coverage. Empty means "not reported" and keeps
     // canonical band labels. This is distinct from txPowerBands: receive-only

--- a/src/core/backends/anan/AnanBackend.cpp
+++ b/src/core/backends/anan/AnanBackend.cpp
@@ -347,6 +347,12 @@ RadioCapabilities AnanBackend::capabilities() const
     c.tuningMaxHz = 0.0;
     // State is engine-owned, but verified coverage is still unavailable.
     c.sliceFrequencyControl = {SliceFrequencyControl::Authority::Engine, 0, 0};
+    c.receiveModeControl = std::nullopt; // mode/passband transition contract not yet qualified
+    c.receiveFilterControl = std::nullopt;
+    c.receiveAudioControl = std::nullopt;
+    c.receivePanCenterControl = std::nullopt; // center also retunes the slice
+    c.receivePanBandwidthControl = ReceivePanRangeControl{SliceFrequencyControl::Authority::Engine,
+                                                         48'000, 1'536'000};
     c.canTransmit = false;         // P2Client has no PTT capability -- see class comment
     c.txPowerMaxWatts = 0.0;
     c.hostModulates = true;        // client-side WDSP, like the HL2

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -134,6 +134,23 @@ RadioCapabilities FlexBackend::capabilities() const
     // FlexLib 4.2.18 Slice.Freq delegates range refusal to firmware; its old
     // bounds are commented out. Do not guess coverage (including transverters).
     caps.sliceFrequencyControl = {SliceFrequencyControl::Authority::Radio, 0, 0};
+    // FlexLib 4.2.18 Slice.DemodMode and FilterLow/High. Waveform modes and
+    // pitch/mark-dependent CW/RTTY filters require a separate runtime contract.
+    caps.receiveModeControl = ReceiveModeControl{SliceFrequencyControl::Authority::Radio,
+        {QStringLiteral("USB"), QStringLiteral("LSB"), QStringLiteral("DIGU"),
+         QStringLiteral("DIGL"), QStringLiteral("AM"), QStringLiteral("SAM"),
+         QStringLiteral("DSB"), QStringLiteral("CW"), QStringLiteral("FM"), QStringLiteral("NFM")}};
+    caps.receiveFilterControl = ReceiveFilterControl{SliceFrequencyControl::Authority::Radio, {
+        {QStringLiteral("USB"), 0, 11990, 10, 12000, 10, 12000},
+        {QStringLiteral("DIGU"), 0, 11990, 10, 12000, 10, 12000},
+        {QStringLiteral("LSB"), -12000, -10, -11990, 0, 10, 12000},
+        {QStringLiteral("DIGL"), -12000, -10, -11990, 0, 10, 12000},
+        {QStringLiteral("AM"), -12000, -10, 10, 12000, 20, 24000},
+        {QStringLiteral("SAM"), -12000, -10, 10, 12000, 20, 24000},
+        {QStringLiteral("DSB"), -12000, -10, 10, 12000, 20, 24000}}};
+    caps.receiveAudioControl = std::nullopt; // legacy wire mixer path has not migrated
+    caps.receivePanCenterControl = std::nullopt; // unknown coverage including transverters
+    caps.receivePanBandwidthControl = std::nullopt; // legacy coupled geometry path
     caps.txPowerBands = {};
     caps.declaredBandRanges = {};
     caps.family = QStringLiteral("flex");

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -1450,6 +1450,21 @@ RadioCapabilities Hl2Backend::capabilities() const
     c.tuningMaxHz = 38'400'000.0;
     c.sliceFrequencyControl = {SliceFrequencyControl::Authority::Engine,
                                100'000, 38'400'000};
+    c.receiveModeControl = ReceiveModeControl{SliceFrequencyControl::Authority::Engine,
+        {QStringLiteral("USB"), QStringLiteral("LSB"), QStringLiteral("DIGU"),
+         QStringLiteral("DIGL"), QStringLiteral("AM"), QStringLiteral("SAM"), QStringLiteral("CW")}};
+    // Conservative carrier-relative subdomains of the existing WDSP passband.
+    c.receiveFilterControl = ReceiveFilterControl{SliceFrequencyControl::Authority::Engine, {
+        {QStringLiteral("USB"), 0, 11990, 10, 12000, 10, 12000},
+        {QStringLiteral("DIGU"), 0, 11990, 10, 12000, 10, 12000},
+        {QStringLiteral("LSB"), -12000, -10, -11990, 0, 10, 12000},
+        {QStringLiteral("DIGL"), -12000, -10, -11990, 0, 10, 12000},
+        {QStringLiteral("AM"), -12000, -10, 10, 12000, 20, 24000},
+        {QStringLiteral("SAM"), -12000, -10, 10, 12000, 20, 24000}}};
+    c.receiveAudioControl = ReceiveAudioControl{SliceFrequencyControl::Authority::Engine};
+    c.receivePanCenterControl = ReceivePanRangeControl{SliceFrequencyControl::Authority::Engine,
+                                                      100'000, 38'400'000};
+    c.receivePanBandwidthControl = std::nullopt; // radio-wide rate can retire other receivers
     // THE RADIO'S POWER CLASS, which is what every forward-power gauge scales
     // its arc from. Declared as a band table because that is the seam the
     // clients already read: RadioModel::refreshTxPowerLimit turns it into
@@ -2671,6 +2686,7 @@ void Hl2Backend::setSliceAudioMute(int sliceId, bool mute)
     if (ddc >= 0 && static_cast<std::size_t>(ddc) < m_mixPending.size())
         m_mixPending[static_cast<std::size_t>(ddc)].clear();
     qCDebug(lcHl2) << "HL2: slice" << sliceId << (mute ? "muted" : "unmuted");
+    emitSliceState(ddc);
 }
 
 void Hl2Backend::setSliceAudioGain(int sliceId, int gainPercent)
@@ -2682,6 +2698,7 @@ void Hl2Backend::setSliceAudioGain(int sliceId, int gainPercent)
     // rather than inventing a dB curve here. Unity at 100 keeps a single
     // unmuted slice at exactly the level it has today.
     r->audioGain = std::clamp(gainPercent, 0, 100) / 100.0f;
+    emitSliceState(ddcForSlice(sliceId));
 }
 
 void Hl2Backend::setSliceAudioPan(int sliceId, int panPercent)
@@ -5633,6 +5650,8 @@ void Hl2Backend::emitSliceState(int ddc)
     d.mode = r->mode;
     d.filterLow = r->filterLowHz;
     d.filterHigh = r->filterHighHz;
+    d.audioGain = qRound(r->audioGain * 100.0f);
+    d.audioMute = r->audioMuted;
     // The AGC pair the DSP is actually running.
     //
     // Never published before, which is why a RESTORED AGC would have been

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -2697,7 +2697,11 @@ void Hl2Backend::setSliceAudioGain(int sliceId, int gainPercent)
     // 0..100 -> 0.0..1.0 LINEAR, matching what a Flex does with audio_level
     // rather than inventing a dB curve here. Unity at 100 keeps a single
     // unmuted slice at exactly the level it has today.
-    r->audioGain = std::clamp(gainPercent, 0, 100) / 100.0f;
+    const float scaled = std::clamp(gainPercent, 0, 100) / 100.0f;
+    if (r->audioGain == scaled) {
+        return;
+    }
+    r->audioGain = scaled;
     emitSliceState(ddcForSlice(sliceId));
 }
 

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -286,6 +286,13 @@ RadioCapabilities IcomCivBackend::capabilities() const
     c.sliceFrequencyControl = {SliceFrequencyControl::Authority::Radio,
                                static_cast<qint64>(m.tuningMinHz),
                                static_cast<qint64>(m.tuningMaxHz)};
+    // CI-V mode/filter presets and scope geometry need profile-specific
+    // contracts before the daemon can safely offer these generic intents.
+    c.receiveModeControl = std::nullopt;
+    c.receiveFilterControl = std::nullopt;
+    c.receiveAudioControl = std::nullopt;
+    c.receivePanCenterControl = std::nullopt;
+    c.receivePanBandwidthControl = std::nullopt;
 
     const std::span<const IcomBand> bands = bandsFor(m);
     c.declaredBandRanges.reserve(static_cast<int>(bands.size()));

--- a/src/core/backends/rtl/RtlSdrBackend.cpp
+++ b/src/core/backends/rtl/RtlSdrBackend.cpp
@@ -129,6 +129,15 @@ RadioCapabilities RtlSdrBackend::capabilities() const
     c.tuningMaxHz = 1'766'000'000;
     c.sliceFrequencyControl = {SliceFrequencyControl::Authority::Engine,
                                24'000, 1'766'000'000};
+    c.receiveModeControl = ReceiveModeControl{SliceFrequencyControl::Authority::Engine,
+        {QStringLiteral("AM"), QStringLiteral("SAM"), QStringLiteral("FM"),
+         QStringLiteral("FMN"), QStringLiteral("WFM"), QStringLiteral("USB"),
+         QStringLiteral("LSB"), QStringLiteral("CW"), QStringLiteral("CWR")}};
+    c.receiveFilterControl = std::nullopt; // DDC currently stores, but never consumes, filter edges
+    c.receiveAudioControl = ReceiveAudioControl{SliceFrequencyControl::Authority::Engine};
+    c.receivePanCenterControl = std::nullopt; // setPanCenter also retunes slice 0
+    c.receivePanBandwidthControl = ReceivePanRangeControl{SliceFrequencyControl::Authority::Engine,
+                                                         225'001, 3'000'000};
 
     // Sample rates — non-contiguous legal windows for R820T
     c.sampleRatesHz = {
@@ -353,6 +362,10 @@ void RtlSdrBackend::connectRadio(const RadioConnectRequest& request)
 
     // ── Instantiate Worker (owns RtlSdrDdc processing engine) ─────────────
     m_worker = std::make_unique<RtlSdrWorker>(m_device);
+    // A new DDC starts at unity/unmuted. Do not publish the old worker's
+    // mixer observation across a reconnect.
+    m_receiveGain = 100;
+    m_receiveMuted = false;
 
     if (RtlSdrDdc* ddcEngine = m_worker->ddc()) {
         ddcEngine->setSampleRate(m_sampleRateHz);
@@ -603,6 +616,10 @@ void RtlSdrBackend::setSliceAudioMute(int sliceId, bool mute)
     if (sliceId == 0) {
         if (RtlSdrDdc* ddcEngine = ddc()) {
             ddcEngine->setAudioMute(mute);
+            m_receiveMuted = mute;
+            SliceDelta delta;
+            delta.audioMute = mute;
+            emit sliceChanged(sliceId, delta);
         }
     }
 }
@@ -612,6 +629,10 @@ void RtlSdrBackend::setSliceAudioGain(int sliceId, int gainPercent)
     if (sliceId == 0) {
         if (RtlSdrDdc* ddcEngine = ddc()) {
             ddcEngine->setAudioGain(gainPercent);
+            m_receiveGain = std::clamp(gainPercent, 0, 100);
+            SliceDelta delta;
+            delta.audioGain = m_receiveGain;
+            emit sliceChanged(sliceId, delta);
         }
     }
 }
@@ -893,6 +914,8 @@ void RtlSdrBackend::emitInitialState()
     sDelta.mode = m_sliceMode;
     sDelta.filterLow = m_sliceFilterLow;
     sDelta.filterHigh = m_sliceFilterHigh;
+    sDelta.audioGain = m_receiveGain;
+    sDelta.audioMute = m_receiveMuted;
     // No txAntenna or rxAntenna list on hardware without software antenna switches (Constitution Principle II & VI)
     sDelta.modeList = QStringList{QStringLiteral("AM"), QStringLiteral("SAM"),
                                   QStringLiteral("FM"), QStringLiteral("FMN"),

--- a/src/core/backends/rtl/RtlSdrBackend.h
+++ b/src/core/backends/rtl/RtlSdrBackend.h
@@ -108,6 +108,8 @@ private:
     // Slice 0 state — default to 95.2 MHz FM Wide
     double m_sliceFreqHz{95'200'000.0};
     QString m_sliceMode{"WFM"};
+    int m_receiveGain{100};
+    bool m_receiveMuted{false};
     int m_sliceFilterLow{-100000};
     int m_sliceFilterHigh{100000};
 

--- a/src/core/backends/sim/SimBackend.cpp
+++ b/src/core/backends/sim/SimBackend.cpp
@@ -258,6 +258,12 @@ RadioCapabilities SimBackend::capabilities() const
     // advertised hardware tuning range. Off-scene signals simply become silent.
     caps.sliceFrequencyControl = {SliceFrequencyControl::Authority::Engine,
                                   1, 1'000'000'000'000};
+    caps.receiveModeControl = ReceiveModeControl{SliceFrequencyControl::Authority::Engine,
+                                                {QStringLiteral("USB"), QStringLiteral("LSB")}};
+    caps.receiveFilterControl = std::nullopt; // demo passband setters only echo state
+    caps.receiveAudioControl = std::nullopt; // no independently controlled RX mixer yet
+    caps.receivePanCenterControl = std::nullopt; // spectrum remains anchored to the VFO
+    caps.receivePanBandwidthControl = std::nullopt; // fixed synthetic span
     caps.canReboot = false;
     caps.hasRemoteOnControl = false;
     caps.canUpgradeFirmware = false;

--- a/src/core/control/ControlService.cpp
+++ b/src/core/control/ControlService.cpp
@@ -606,8 +606,10 @@ QJsonObject ControlService::capabilities(const ControlSession& session) const
         available.append(QStringLiteral("radioCatalogue.read"));
     }
     if (observe && m_resources->get({QStringLiteral("transmitState"), QStringLiteral("radio-1"), {}})) {
-        available.append(QStringLiteral("meter.read"));
         available.append(QStringLiteral("transmitState.read"));
+    }
+    if (observe && !m_resources->snapshot({{QStringLiteral("meter"), QStringLiteral("radio-1"), {}}}).isEmpty()) {
+        available.append(QStringLiteral("meter.read"));
     }
     if (session.canControl() && m_connectionTarget) {
         if (m_connectionTarget->state() == RadioConnectionTarget::State::Idle) {

--- a/src/core/control/ControlService.cpp
+++ b/src/core/control/ControlService.cpp
@@ -5,6 +5,7 @@
 #include <QThread>
 
 #include <cmath>
+#include <limits>
 
 namespace AetherSDR::control {
 namespace {
@@ -47,7 +48,8 @@ std::optional<ProtocolError> parseSelector(
     const QSet<QString> supportedTypes{
         QStringLiteral("server"), QStringLiteral("radioSession"),
         QStringLiteral("radioCatalogue"),
-        QStringLiteral("slice"), QStringLiteral("panadapter")};
+        QStringLiteral("slice"), QStringLiteral("panadapter"),
+        QStringLiteral("meter"), QStringLiteral("transmitState")};
     if (!supportedTypes.contains(type)) {
         return ProtocolError{QStringLiteral("request.invalid_params"),
                              QStringLiteral("unsupported resource type"),
@@ -79,9 +81,14 @@ std::optional<ProtocolError> parseSelector(
             return ProtocolError{QStringLiteral("request.invalid_params"),
                                  QStringLiteral("radioSession selector requires id only"), {}, false};
         }
+    } else if (type == QStringLiteral("transmitState")) {
+        if (radioSession.isEmpty() || !idValue.isUndefined()) {
+            return ProtocolError{QStringLiteral("request.invalid_params"),
+                                 QStringLiteral("transmitState requires radioSession only"), {}, false};
+        }
     } else if (radioSession.isEmpty() || (!wildcardAllowed && id.isEmpty())) {
         return ProtocolError{QStringLiteral("request.invalid_params"),
-                             QStringLiteral("slice and panadapter selectors require radioSession and id"),
+                             QStringLiteral("child resource selectors require radioSession and id"),
                              {}, false};
     }
 
@@ -147,13 +154,26 @@ bool ControlService::bindFrequencyTarget(SliceFrequencyTarget* target)
     return true;
 }
 
+bool ControlService::bindReceiveTarget(ReceiveControlTarget* target)
+{
+    if (m_resources->thread() != QThread::currentThread() || !target
+        || target->thread() != QThread::currentThread()
+        || m_receiveTargetBound || m_dispatchStarted) {
+        return false;
+    }
+    m_receiveTarget = target;
+    m_receiveTargetBound = true;
+    return true;
+}
+
 ServiceReply ControlService::handle(
     const QByteArray& bytes, ControlSession* session) const
 {
     if (!session || session->thread() != QThread::currentThread()
         || m_resources->thread() != QThread::currentThread()
         || (m_connectionTarget && m_connectionTarget->thread() != QThread::currentThread())
-        || (m_frequencyTarget && m_frequencyTarget->thread() != QThread::currentThread())) {
+        || (m_frequencyTarget && m_frequencyTarget->thread() != QThread::currentThread())
+        || (m_receiveTarget && m_receiveTarget->thread() != QThread::currentThread())) {
         return failure({}, {QStringLiteral("engine.failed"),
                             QStringLiteral("service owning thread required"), {}, false}, true);
     }
@@ -236,6 +256,11 @@ ServiceReply ControlService::handle(
     }
     if (request.method == QStringLiteral("slice.setFrequency")) {
         return handleFrequency(request, *session);
+    }
+    for (const auto& [operation, method] : kReceiveMethods) {
+        if (request.method == QLatin1String(method)) {
+            return handleReceive(request, *session, operation);
+        }
     }
     if (request.method == QStringLiteral("resource.get")) {
         if (const std::optional<ProtocolError> error = session->observationError()) {
@@ -461,6 +486,107 @@ ServiceReply ControlService::handleFrequency(
                 {{QStringLiteral("accepted"), true}}), false};
 }
 
+ServiceReply ControlService::handleReceive(const ProtocolRequest& request,
+    const ControlSession& session, ReceiveOperation operation) const
+{
+    const auto reject = [&request](const char* code, const char* message) {
+        return failure(request.id, {QString::fromLatin1(code), QString::fromLatin1(message), {}, false});
+    };
+    if (!session.canControl()) {
+        return reject("auth.grant_denied", "control grant required");
+    }
+    if (!m_receiveTarget) {
+        return reject("capability.unavailable", "receive control unavailable");
+    }
+    const bool pan = operation == ReceiveOperation::PanCenter || operation == ReceiveOperation::PanBandwidth;
+    const QString idKey = pan ? QStringLiteral("panadapter") : QStringLiteral("slice");
+    QSet<QString> keys{QStringLiteral("radioSession"), idKey, QStringLiteral("expectedRevision")};
+    switch (operation) {
+    case ReceiveOperation::Mode: keys.insert(QStringLiteral("mode")); break;
+    case ReceiveOperation::Filter:
+        keys.insert(QStringLiteral("lowHz")); keys.insert(QStringLiteral("highHz")); break;
+    case ReceiveOperation::AudioGain: keys.insert(QStringLiteral("gain")); break;
+    case ReceiveOperation::AudioMute: keys.insert(QStringLiteral("muted")); break;
+    case ReceiveOperation::PanCenter:
+    case ReceiveOperation::PanBandwidth: keys.insert(QStringLiteral("hz")); break;
+    }
+    if (const auto error = onlyKeys(request.params, keys)) {
+        return failure(request.id, *error);
+    }
+    for (const QString& key : keys) {
+        if (!request.params.contains(key)) {
+            return reject("request.invalid_params", "missing receive-control parameter");
+        }
+    }
+    const auto integer = [](const QJsonValue& value, double minimum, double maximum) {
+        const double number = value.toDouble();
+        return value.isDouble() && std::isfinite(number) && number >= minimum
+            && number <= maximum && std::floor(number) == number;
+    };
+    const QJsonValue sessionId = request.params.value(QStringLiteral("radioSession"));
+    const QJsonValue id = request.params.value(idKey);
+    const QJsonValue revision = request.params.value(QStringLiteral("expectedRevision"));
+    bool canonicalSlice = false;
+    const int sliceId = id.toString().toInt(&canonicalSlice);
+    if (!sessionId.isString() || !id.isString() || id.toString().isEmpty()
+        || id.toString().size() > ProtocolLimits::kMaxRequestIdChars
+        || (!pan && (!canonicalSlice || sliceId < 0 || QString::number(sliceId) != id.toString()))
+        || !integer(revision, 1, 9'007'199'254'740'991.0)) {
+        return reject("request.invalid_params", "canonical resource identity and integer revision required");
+    }
+    const QJsonValue mode = request.params.value(QStringLiteral("mode"));
+    const QJsonValue low = request.params.value(QStringLiteral("lowHz"));
+    const QJsonValue high = request.params.value(QStringLiteral("highHz"));
+    const QJsonValue gain = request.params.value(QStringLiteral("gain"));
+    const QJsonValue muted = request.params.value(QStringLiteral("muted"));
+    const QJsonValue hz = request.params.value(QStringLiteral("hz"));
+    bool valid = true;
+    switch (operation) {
+    case ReceiveOperation::Mode:
+        valid = mode.isString() && !mode.toString().isEmpty() && mode.toString().size() <= 32;
+        for (const QChar c : mode.toString()) {
+            valid = valid && ((c >= QLatin1Char('A') && c <= QLatin1Char('Z'))
+                              || (c >= QLatin1Char('0') && c <= QLatin1Char('9')));
+        }
+        break;
+    case ReceiveOperation::Filter:
+        valid = integer(low, std::numeric_limits<int>::min(), std::numeric_limits<int>::max())
+            && integer(high, std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+        break;
+    case ReceiveOperation::AudioGain:
+        valid = integer(gain, std::numeric_limits<int>::min(), std::numeric_limits<int>::max()); break;
+    case ReceiveOperation::AudioMute: valid = muted.isBool(); break;
+    case ReceiveOperation::PanCenter:
+    case ReceiveOperation::PanBandwidth: valid = integer(hz, 1, 9'007'199'254'740'991.0); break;
+    }
+    if (!valid) {
+        return reject("request.invalid_params", "invalid typed receive-control value");
+    }
+    if (sessionId.toString() != QStringLiteral("radio-1")
+        || !m_resources->get({QStringLiteral("radioSession"), {}, sessionId.toString()})) {
+        return reject("resource.not_found", "radio session unavailable");
+    }
+    const auto snapshot = m_resources->get({pan ? QStringLiteral("panadapter") : QStringLiteral("slice"),
+                                            sessionId.toString(), id.toString()});
+    if (!snapshot) {
+        return reject("resource.not_found", "receive resource unavailable");
+    }
+    if (snapshot->revision != static_cast<quint64>(revision.toDouble())) {
+        return reject("request.conflict", "resource changed; refresh before deciding whether to retry");
+    }
+    std::optional<ProtocolError> error;
+    switch (operation) {
+    case ReceiveOperation::Mode: error = m_receiveTarget->setMode(sliceId, mode.toString()); break;
+    case ReceiveOperation::Filter: error = m_receiveTarget->setFilter(sliceId, low.toInt(), high.toInt()); break;
+    case ReceiveOperation::AudioGain: error = m_receiveTarget->setAudioGain(sliceId, gain.toInt()); break;
+    case ReceiveOperation::AudioMute: error = m_receiveTarget->setAudioMute(sliceId, muted.toBool()); break;
+    case ReceiveOperation::PanCenter: error = m_receiveTarget->setPanCenter(id.toString(), hz.toInteger()); break;
+    case ReceiveOperation::PanBandwidth: error = m_receiveTarget->setPanBandwidth(id.toString(), hz.toInteger()); break;
+    }
+    return error ? failure(request.id, *error) : ServiceReply{
+        ControlProtocolCodec::successResponse(request.id, {{QStringLiteral("accepted"), true}}), false};
+}
+
 QJsonObject ControlService::capabilities(const ControlSession& session) const
 {
     const bool observe = session.canObserve();
@@ -478,6 +604,10 @@ QJsonObject ControlService::capabilities(const ControlSession& session) const
         QStringLiteral("resource.unsubscribe")} : QJsonArray{};
     if (observe && m_resources->get({QStringLiteral("radioCatalogue"), {}, {}})) {
         available.append(QStringLiteral("radioCatalogue.read"));
+    }
+    if (observe && m_resources->get({QStringLiteral("transmitState"), QStringLiteral("radio-1"), {}})) {
+        available.append(QStringLiteral("meter.read"));
+        available.append(QStringLiteral("transmitState.read"));
     }
     if (session.canControl() && m_connectionTarget) {
         if (m_connectionTarget->state() == RadioConnectionTarget::State::Idle) {
@@ -499,6 +629,13 @@ QJsonObject ControlService::capabilities(const ControlSession& session) const
     }
     if (session.canControl() && m_frequencyTarget && m_frequencyTarget->available()) {
         available.append(QStringLiteral("slice.setFrequency"));
+    }
+    if (session.canControl() && m_receiveTarget) {
+        for (const auto& [operation, method] : kReceiveMethods) {
+            if (m_receiveTarget->available(operation)) {
+                available.append(QString::fromLatin1(method));
+            }
+        }
     }
     return {
         {QStringLiteral("sessionId"), session.sessionId()},

--- a/src/core/control/ControlService.h
+++ b/src/core/control/ControlService.h
@@ -5,6 +5,7 @@
 #include "ControlSession.h"
 #include "RadioConnectionTarget.h"
 #include "SliceFrequencyTarget.h"
+#include "ReceiveControlTarget.h"
 
 #include <QJsonObject>
 #include <QString>
@@ -30,6 +31,7 @@ public:
     // This lets the daemon claim its endpoint before constructing any models.
     [[nodiscard]] bool bindConnectionTarget(RadioConnectionTarget* target);
     [[nodiscard]] bool bindFrequencyTarget(SliceFrequencyTarget* target);
+    [[nodiscard]] bool bindReceiveTarget(ReceiveControlTarget* target);
 
     [[nodiscard]] ServiceReply handle(
         const QByteArray& bytes, ControlSession* session) const;
@@ -46,12 +48,16 @@ private:
         const ProtocolRequest& request, const ControlSession& session) const;
     [[nodiscard]] ServiceReply handleFrequency(
         const ProtocolRequest& request, const ControlSession& session) const;
+    [[nodiscard]] ServiceReply handleReceive(const ProtocolRequest& request,
+        const ControlSession& session, ReceiveOperation operation) const;
 
     ControlResourceStore* m_resources{nullptr};
     QPointer<RadioConnectionTarget> m_connectionTarget;
     bool m_targetBound{false};
     QPointer<SliceFrequencyTarget> m_frequencyTarget;
     bool m_frequencyTargetBound{false};
+    QPointer<ReceiveControlTarget> m_receiveTarget;
+    bool m_receiveTargetBound{false};
     mutable bool m_dispatchStarted{false};
 };
 

--- a/src/core/control/ControlSession.cpp
+++ b/src/core/control/ControlSession.cpp
@@ -172,25 +172,36 @@ std::optional<ProtocolError> ControlSession::subscribe(
                              QStringLiteral("maximum subscriptions reached"), {}, false};
     }
 
+    QJsonArray resources;
+    const QList<ResourceSnapshot> snapshots = m_resources->snapshot(selectors);
+    for (const ResourceSnapshot& snapshot : snapshots) {
+        resources.append(snapshot.toJson());
+    }
+    const QString subscriptionId = QStringLiteral("sub-%1").arg(m_nextSubscription);
+    const QJsonObject baseline{{QStringLiteral("subscription"), subscriptionId},
+                              {QStringLiteral("sequence"), static_cast<qint64>(m_drainedSequence)},
+                              {QStringLiteral("resources"), resources}};
+    // Reserve more than the largest escaped request id + response envelope.
+    // Refuse before registration, including during resync: an oversized atomic
+    // baseline cannot be split into partial success or silently drop resources.
+    constexpr qint64 kEnvelopeReserve = 1024;
+    const qint64 limit = ProtocolLimits::kMaxMessageBytes;
+    if (QJsonDocument(baseline).toJson(QJsonDocument::Compact).size() + kEnvelopeReserve > limit) {
+        return ProtocolError{QStringLiteral("transport.limit_exceeded"),
+                             QStringLiteral("subscription baseline is too large; narrow selectors"), {}, false};
+    }
     if (m_resyncRequired) {
         // A fresh atomic baseline supersedes an undrained resync notice. Do not
         // deliver that older invalidation after the successful subscribe reply.
         m_pending.clear();
         m_pendingBytes = 0;
     }
-    const QString subscriptionId = QStringLiteral("sub-%1").arg(m_nextSubscription++);
+    ++m_nextSubscription;
     m_subscriptions.insert(subscriptionId, selectors);
     rebuildSelectorIndex();
     m_resyncRequired = false;
 
-    QJsonArray resources;
-    const QList<ResourceSnapshot> snapshots = m_resources->snapshot(selectors);
-    for (const ResourceSnapshot& snapshot : snapshots) {
-        resources.append(snapshot.toJson());
-    }
-    *result = {{QStringLiteral("subscription"), subscriptionId},
-               {QStringLiteral("sequence"), static_cast<qint64>(m_drainedSequence)},
-               {QStringLiteral("resources"), resources}};
+    *result = baseline;
     return std::nullopt;
 }
 

--- a/src/core/control/LocalControlServer.cpp
+++ b/src/core/control/LocalControlServer.cpp
@@ -87,7 +87,14 @@ bool LocalControlServer::bindFrequencyTarget(SliceFrequencyTarget* target)
         && m_service.bindFrequencyTarget(target);
 }
 
-bool LocalControlServer::listen(const QString& name)
+bool LocalControlServer::bindReceiveTarget(ReceiveControlTarget* target)
+{
+    return thread() == QThread::currentThread() && m_clients.empty()
+        && m_localAuthorization == SessionAuthorization::ObserverController
+        && m_service.bindReceiveTarget(target);
+}
+
+bool LocalControlServer::listen(const QString& name, ListenMode mode)
 {
     if (m_server.isListening() || m_lock || m_limits.maxClients < 1
         || m_limits.handshakeTimeoutMs < 1 || m_limits.maxQueuedOutputBytes < 1) {
@@ -127,11 +134,22 @@ bool LocalControlServer::listen(const QString& name)
     m_resources.upsert(
         {QStringLiteral("server"), {}, {}},
         serverValue(QStringLiteral("listening")));
+    return mode == ListenMode::ReserveEndpoint || startServing();
+}
+
+bool LocalControlServer::startServing()
+{
+    if (thread() != QThread::currentThread() || !m_server.isListening() || m_serving) {
+        return false;
+    }
+    m_serving = true;
+    acceptConnections();
     return true;
 }
 
 void LocalControlServer::close()
 {
+    m_serving = false;
     const bool wasListening = m_server.isListening();
     m_server.close();
     QList<QLocalSocket*> sockets;
@@ -157,6 +175,14 @@ void LocalControlServer::acceptConnections()
     while (m_server.hasPendingConnections()) {
         QLocalSocket* socket = m_server.nextPendingConnection();
         if (!socket) {
+            continue;
+        }
+        if (!m_serving) {
+            // Settings/model construction can pump a nested event loop. Do
+            // not create a session or dispatch into partially initialized
+            // targets. The endpoint remains claimed; clients may retry.
+            socket->abort();
+            socket->deleteLater();
             continue;
         }
         if (m_clients.size() >= static_cast<std::size_t>(m_limits.maxClients)) {
@@ -204,6 +230,11 @@ void LocalControlServer::acceptConnections()
                     socket->deleteLater();
                 });
         client->handshakeTimer.start();
+        // Data can precede our readyRead connection when acceptance was
+        // delayed by startup or another event callback.
+        if (socket->bytesAvailable() > 0) {
+            readClient(socket);
+        }
     }
 }
 

--- a/src/core/control/LocalControlServer.h
+++ b/src/core/control/LocalControlServer.h
@@ -29,16 +29,22 @@ public:
         qint64 maxQueuedOutputBytes{kMaxQueuedOutputBytes};
     };
 
+    enum class ListenMode { Serve, ReserveEndpoint };
+
     explicit LocalControlServer(QObject* parent = nullptr);
     LocalControlServer(QObject* parent, Limits limits,
                        RadioConnectionTarget* connectionTarget = nullptr,
                        bool allowLocalControl = false);
     ~LocalControlServer() override;
 
-    [[nodiscard]] bool listen(const QString& name);
+    // ReserveEndpoint claims the private endpoint but closes early arrivals.
+    // Startup code must finish binding targets before calling startServing().
+    [[nodiscard]] bool listen(const QString& name, ListenMode mode = ListenMode::Serve);
+    [[nodiscard]] bool startServing();
     // Startup-only binding; never changes grants or replaces a lost target.
     [[nodiscard]] bool bindConnectionTarget(RadioConnectionTarget* target);
     [[nodiscard]] bool bindFrequencyTarget(SliceFrequencyTarget* target);
+    [[nodiscard]] bool bindReceiveTarget(ReceiveControlTarget* target);
     void close();
     [[nodiscard]] bool isListening() const { return m_server.isListening(); }
     [[nodiscard]] QString fullServerName() const { return m_server.fullServerName(); }
@@ -64,6 +70,7 @@ private:
     const SessionAuthorization m_localAuthorization;
     std::unordered_map<QLocalSocket*, std::unique_ptr<Client>> m_clients;
     std::unique_ptr<QLockFile> m_lock;
+    bool m_serving{false};
 };
 
 } // namespace AetherSDR::control

--- a/src/core/control/ModelReceiveControlTarget.cpp
+++ b/src/core/control/ModelReceiveControlTarget.cpp
@@ -83,6 +83,9 @@ public:
         if (!m_watchedSlices.contains(slice)) {
             m_watchedSlices.insert(slice);
             connect(slice, &SliceModel::receiveModeReported, this, [this, slice] {
+                // An old-mode report may already be queued ahead of the intent's
+                // effect. It is not a rejection/acknowledgement; releasing here
+                // would admit an old-mode filter behind the pending mode write.
                 const auto pending = m_pendingModes.constFind(slice);
                 if (pending != m_pendingModes.constEnd()
                     && slice->receiveObservation().mode == pending.value()) {

--- a/src/core/control/ModelReceiveControlTarget.cpp
+++ b/src/core/control/ModelReceiveControlTarget.cpp
@@ -1,0 +1,264 @@
+#include "ReceiveControlTarget.h"
+#include "ReceiveControlGuard.h"
+#include "models/PanadapterModel.h"
+
+#include <QHash>
+#include <QSet>
+
+namespace AetherSDR::control {
+namespace {
+using Authority = SliceFrequencyControl::Authority;
+
+bool known(Authority authority)
+{
+    return authority == Authority::Radio || authority == Authority::Engine;
+}
+
+bool validRange(const std::optional<ReceivePanRangeControl>& range)
+{
+    return range && known(range->authority) && range->minimumHz > 0
+        && range->maximumHz >= range->minimumHz
+        && range->maximumHz <= SliceModel::kMaximumReportedFrequencyHz;
+}
+
+const ReceiveFilterMode* filterMode(const RadioCapabilities& caps, const QString& mode)
+{
+    if (!caps.receiveFilterControl || !known(caps.receiveFilterControl->authority)) {
+        return nullptr;
+    }
+    for (const ReceiveFilterMode& range : caps.receiveFilterControl->modes) {
+        if (range.mode == mode && range.minimumLowHz <= range.maximumLowHz
+            && range.minimumHighHz <= range.maximumHighHz && range.minimumWidthHz > 0
+            && range.maximumWidthHz >= range.minimumWidthHz) {
+            return &range;
+        }
+    }
+    return nullptr;
+}
+
+class ModelReceiveControlTarget final : public ReceiveControlTarget {
+public:
+    ModelReceiveControlTarget(RadioModel* radio, RadioConnectionTarget* connection)
+        : m_radio(radio), m_guard(radio, connection)
+    {
+        connect(radio, &RadioModel::backendRebuilt, this, [this] { m_pendingModes.clear(); });
+        connect(radio, &RadioModel::connectionStateChanged, this, [this](bool connected) {
+            if (!connected) {
+                m_pendingModes.clear();
+            }
+        });
+    }
+
+    bool available(ReceiveOperation op) const override
+    {
+        if (thread() != QThread::currentThread() || !m_guard.ready()) {
+            return false;
+        }
+        if (op == ReceiveOperation::PanCenter || op == ReceiveOperation::PanBandwidth) {
+            for (PanadapterModel* pan : m_radio->panadapters()) {
+                if (pan && !checkPan(pan->panId(), op)) {
+                    return true;
+                }
+            }
+        } else {
+            for (SliceModel* slice : m_radio->slices()) {
+                if (slice && !checkSlice(slice->sliceId(), op)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    std::optional<ProtocolError> setMode(int id, const QString& mode) override
+    {
+        if (const auto error = checkSlice(id, ReceiveOperation::Mode)) {
+            return error;
+        }
+        const RadioCapabilities caps = m_radio->backendCapabilities();
+        if (!caps.receiveModeControl->modes.contains(mode)) {
+            return refusal("request.out_of_range", "mode is not supported by this receive path");
+        }
+        SliceModel* slice = m_radio->slice(id);
+        if (!m_watchedSlices.contains(slice)) {
+            m_watchedSlices.insert(slice);
+            connect(slice, &SliceModel::receiveModeReported, this, [this, slice] {
+                const auto pending = m_pendingModes.constFind(slice);
+                if (pending != m_pendingModes.constEnd()
+                    && slice->receiveObservation().mode == pending.value()) {
+                    m_pendingModes.remove(slice);
+                }
+            });
+            connect(slice, &QObject::destroyed, this, [this, slice] {
+                m_pendingModes.remove(slice);
+                m_watchedSlices.remove(slice);
+            });
+        }
+        // A delayed mode write must not let a filter validated against the old
+        // mode follow it. This is a filter-admission interlock, not a TX lease
+        // or a claim that the mode response confirms hardware completion.
+        m_pendingModes.insert(slice, mode);
+        m_radio->backend()->setSliceMode(id, mode);
+        return {};
+    }
+
+    std::optional<ProtocolError> setFilter(int id, int low, int high) override
+    {
+        if (const auto error = checkSlice(id, ReceiveOperation::Filter)) {
+            return error;
+        }
+        SliceModel* slice = m_radio->slice(id);
+        const RadioCapabilities caps = m_radio->backendCapabilities();
+        const ReceiveFilterMode* range = filterMode(caps, *slice->receiveObservation().mode);
+        const qint64 width = qint64(high) - low;
+        if (!range || low < range->minimumLowHz || low > range->maximumLowHz
+            || high < range->minimumHighHz || high > range->maximumHighHz
+            || width < range->minimumWidthHz || width > range->maximumWidthHz) {
+            return refusal("request.out_of_range", "passband is outside this mode's receive limits");
+        }
+        slice->noteReceiveFilterIntent();
+        m_radio->backend()->setSliceFilter(id, low, high);
+        return {};
+    }
+
+    std::optional<ProtocolError> setAudioGain(int id, int gain) override
+    {
+        if (const auto error = checkSlice(id, ReceiveOperation::AudioGain)) {
+            return error;
+        }
+        if (gain < 0 || gain > 100) {
+            return refusal("request.out_of_range", "receive gain must be 0..100");
+        }
+        m_radio->backend()->setSliceAudioGain(id, gain);
+        return {};
+    }
+
+    std::optional<ProtocolError> setAudioMute(int id, bool muted) override
+    {
+        if (const auto error = checkSlice(id, ReceiveOperation::AudioMute)) {
+            return error;
+        }
+        m_radio->backend()->setSliceAudioMute(id, muted);
+        return {};
+    }
+
+    std::optional<ProtocolError> setPanCenter(const QString& id, qint64 hz) override
+    {
+        return setPan(id, hz, ReceiveOperation::PanCenter);
+    }
+    std::optional<ProtocolError> setPanBandwidth(const QString& id, qint64 hz) override
+    {
+        return setPan(id, hz, ReceiveOperation::PanBandwidth);
+    }
+
+private:
+    static ProtocolError refusal(const char* code, const char* message)
+    {
+        return ReceiveControlGuard::refusal(code, message);
+    }
+    std::optional<ProtocolError> checkSlice(int id, ReceiveOperation op) const
+    {
+        if (thread() != QThread::currentThread()) {
+            return refusal("request.conflict", "receive target owning thread required");
+        }
+        if (const auto error = m_guard.checkSlice(id)) {
+            return error;
+        }
+        const SliceModel* slice = m_radio->slice(id);
+        const RadioCapabilities caps = m_radio->backendCapabilities();
+        if (const auto error = m_guard.checkTransmit(caps)) {
+            return error;
+        }
+        if (slice->externalReceiveReplacementActive() || slice->isDiversityChild()) {
+            return refusal("capability.unavailable", "slice receive path is not independently controlled");
+        }
+        const auto& observed = slice->receiveObservation();
+        bool supported = false;
+        switch (op) {
+        case ReceiveOperation::Mode:
+            if (m_pendingModes.contains(slice)) {
+                return refusal("request.conflict", "await mode readback before another mode intent");
+            }
+            supported = caps.receiveModeControl && known(caps.receiveModeControl->authority)
+                && observed.mode && caps.receiveModeControl->modes.contains(*observed.mode);
+            break;
+        case ReceiveOperation::Filter:
+            if (m_pendingModes.contains(slice)) {
+                return refusal("request.conflict", "await mode readback before selecting a filter");
+            }
+            supported = observed.mode && observed.filterLowHz && observed.filterHighHz
+                && *observed.filterLowHz < *observed.filterHighHz
+                && filterMode(caps, *observed.mode);
+            break;
+        case ReceiveOperation::AudioGain:
+        case ReceiveOperation::AudioMute:
+            supported = caps.receiveAudioControl && known(caps.receiveAudioControl->authority)
+                && (op == ReceiveOperation::AudioGain ? observed.gain.has_value() : observed.muted.has_value());
+            break;
+        default: break;
+        }
+        return supported ? std::nullopt : std::optional<ProtocolError>(
+            refusal("capability.unavailable", "receive operation or observation unavailable"));
+    }
+
+    std::optional<ProtocolError> checkPan(const QString& id, ReceiveOperation op) const
+    {
+        if (thread() != QThread::currentThread() || !m_guard.ready()) {
+            return refusal("request.conflict", "radio connection is not ready");
+        }
+        if (!m_radio->receiveControlPanId(id)) {
+            return refusal("resource.not_found", "owned panadapter unavailable");
+        }
+        const RadioCapabilities caps = m_radio->backendCapabilities();
+        if (const auto error = m_guard.checkTransmit(caps)) {
+            return error;
+        }
+        const PanadapterModel* pan = m_radio->panadapter(id);
+        const auto& range = op == ReceiveOperation::PanCenter
+            ? caps.receivePanCenterControl : caps.receivePanBandwidthControl;
+        if (!validRange(range) || !pan->reportedCenterHz() || !pan->reportedBandwidthHz()) {
+            return refusal("capability.unavailable", "pan operation or geometry observation unavailable");
+        }
+        return {};
+    }
+
+    std::optional<ProtocolError> setPan(const QString& id, qint64 hz, ReceiveOperation op)
+    {
+        if (const auto error = checkPan(id, op)) {
+            return error;
+        }
+        const RadioCapabilities caps = m_radio->backendCapabilities();
+        const auto& range = op == ReceiveOperation::PanCenter
+            ? caps.receivePanCenterControl : caps.receivePanBandwidthControl;
+        const PanadapterModel* pan = m_radio->panadapter(id);
+        const qint64 center = op == ReceiveOperation::PanCenter ? hz : *pan->reportedCenterHz();
+        const qint64 bandwidth = op == ReceiveOperation::PanBandwidth ? hz : *pan->reportedBandwidthHz();
+        if (hz < range->minimumHz || hz > range->maximumHz || bandwidth <= 0
+            || center <= 0 || center < (bandwidth + 1) / 2) {
+            return refusal("request.out_of_range", "pan geometry is outside supported receive limits");
+        }
+        const QString backendId = *m_radio->receiveControlPanId(id);
+        if (op == ReceiveOperation::PanCenter) {
+            m_radio->backend()->setPanCenter(backendId, double(hz), IRadioBackend::PanCenterIntent::Range);
+        } else {
+            m_radio->backend()->setPanBandwidth(backendId, double(hz));
+        }
+        return {};
+    }
+
+    QPointer<RadioModel> m_radio;
+    ReceiveControlGuard m_guard;
+    QSet<SliceModel*> m_watchedSlices;
+    QHash<const SliceModel*, QString> m_pendingModes;
+};
+} // namespace
+
+std::unique_ptr<ReceiveControlTarget> makeModelReceiveControlTarget(
+    RadioModel* radio, RadioConnectionTarget* connection)
+{
+    if (!ReceiveControlGuard::canBind(radio, connection)) {
+        return {};
+    }
+    return std::make_unique<ModelReceiveControlTarget>(radio, connection);
+}
+} // namespace AetherSDR::control

--- a/src/core/control/ModelSliceFrequencyTarget.cpp
+++ b/src/core/control/ModelSliceFrequencyTarget.cpp
@@ -1,4 +1,5 @@
 #include "SliceFrequencyTarget.h"
+#include "ReceiveControlGuard.h"
 
 #include "RadioConnectionTarget.h"
 #include "core/backends/IRadioBackend.h"
@@ -38,46 +39,12 @@ bool validCoverage(const RadioCapabilities& caps)
 class ModelSliceFrequencyTarget final : public SliceFrequencyTarget {
 public:
     ModelSliceFrequencyTarget(RadioModel* radio, RadioConnectionTarget* connection)
-        : m_radio(radio), m_connection(connection)
-    {
-        // A command edge or construction default is NOT an idle observation.
-        connect(radio, &RadioModel::radioTransmitConfirmed, this, [this](bool tx) {
-            m_confirmedIdle = !tx;
-        });
-        connect(radio, &RadioModel::radioTransmittingChanged, this, [this](bool tx) {
-            if (tx) {
-                m_confirmedIdle = false;
-            }
-        });
-        // A locally initiated keying interval can precede radio readback.
-        // Do not reuse an idle observation from before that interval ends.
-        const auto invalidateOnActive = [this](bool active) {
-            if (active) {
-                m_confirmedIdle = false;
-            }
-        };
-        TransmitModel* transmit = &radio->transmitModel();
-        connect(transmit, &TransmitModel::transmittingChanged, this, invalidateOnActive);
-        connect(transmit, &TransmitModel::moxChanged, this, invalidateOnActive);
-        connect(transmit, &TransmitModel::tuneChanged, this, invalidateOnActive);
-        connect(radio, &RadioModel::connectionStateChanged, this, [this](bool connected) {
-            if (!connected) {
-                m_confirmedIdle = false;
-            }
-        });
-        connect(radio, &RadioModel::backendRebuilt, this, [this] {
-            m_confirmedIdle = false;
-        });
-        connect(connection, &RadioConnectionTarget::stateChanged, this, [this] {
-            if (!m_connection || m_connection->state() != RadioConnectionTarget::State::Connected) {
-                m_confirmedIdle = false;
-            }
-        });
-    }
+        : m_radio(radio), m_guard(radio, connection)
+    {}
 
     bool available() const override
     {
-        if (!ready()) {
+        if (thread() != QThread::currentThread() || !m_guard.ready()) {
             return false;
         }
         for (SliceModel* slice : m_radio->slices()) {
@@ -115,28 +82,15 @@ public:
     }
 
 private:
-    bool ready() const
-    {
-        return thread() == QThread::currentThread()
-            && m_radio && m_radio->thread() == thread()
-            && m_connection && m_connection->thread() == thread()
-            && m_connection->state() == RadioConnectionTarget::State::Connected
-            && m_radio->isConnected() && m_radio->backend()
-            && m_radio->backend()->thread() == thread();
-    }
-
     std::optional<ProtocolError> checkSlice(int sliceId) const
     {
-        if (!ready()) {
+        if (thread() != QThread::currentThread()) {
             return refusal("request.conflict", "radio connection is not ready");
         }
+        if (const std::optional<ProtocolError> error = m_guard.checkSlice(sliceId)) {
+            return error;
+        }
         SliceModel* slice = m_radio->slice(sliceId);
-        if (!slice || !m_radio->isSlotOurs(sliceId) || m_radio->isSlotForeign(sliceId)) {
-            return refusal("resource.not_found", "owned slice unavailable");
-        }
-        if (slice->isLocked()) {
-            return refusal("request.conflict", "slice is locked");
-        }
         const RadioCapabilities caps = m_radio->backendCapabilities();
         if (!validCoverage(caps) || !slice->frequencyReportedKnown()) {
             return refusal("capability.unavailable", "frequency coverage or observation unavailable");
@@ -144,19 +98,11 @@ private:
         // TX-slice designation alone is not keying: this receive intent may
         // retune it while confirmed idle. Any lease/inhibit policy coupling
         // belongs to the Stage 4 arbiter before TX-capable daemon enablement.
-        if (caps.canTransmit
-            && (!m_confirmedIdle || m_radio->isRadioTransmitting()
-                || m_radio->transmitModel().isTransmitting()
-                || m_radio->transmitModel().isMox()
-                || m_radio->transmitModel().isTuning())) {
-            return refusal("request.conflict", "transmitter is active or idle state is unconfirmed");
-        }
-        return std::nullopt;
+        return m_guard.checkTransmit(caps);
     }
 
     QPointer<RadioModel> m_radio;
-    QPointer<RadioConnectionTarget> m_connection;
-    bool m_confirmedIdle{false};
+    ReceiveControlGuard m_guard;
 };
 
 } // namespace
@@ -164,10 +110,7 @@ private:
 std::unique_ptr<SliceFrequencyTarget> makeModelSliceFrequencyTarget(
     RadioModel* radio, RadioConnectionTarget* connection)
 {
-    if (!radio || !connection || radio->thread() != QThread::currentThread()
-        || connection->thread() != QThread::currentThread()
-        || radio->isConnected() || radio->isConnectAttemptInFlight()
-        || connection->state() != RadioConnectionTarget::State::Idle) {
+    if (!ReceiveControlGuard::canBind(radio, connection)) {
         return {};
     }
     return std::make_unique<ModelSliceFrequencyTarget>(radio, connection);

--- a/src/core/control/RadioResourceAdapter.cpp
+++ b/src/core/control/RadioResourceAdapter.cpp
@@ -32,6 +32,52 @@ QString frequencyAuthority(SliceFrequencyControl::Authority authority)
     return QStringLiteral("unknown");
 }
 
+template<class T>
+QString receiveAuthority(const std::optional<T>& capability)
+{
+    return capability ? frequencyAuthority(capability->authority) : QStringLiteral("unknown");
+}
+
+QJsonValue receiveRange(const std::optional<ReceivePanRangeControl>& range)
+{
+    return range ? QJsonValue(QJsonObject{{QStringLiteral("authority"), receiveAuthority(range)},
+        {QStringLiteral("minimumHz"), range->minimumHz},
+        {QStringLiteral("maximumHz"), range->maximumHz}}) : QJsonValue(QJsonValue::Null);
+}
+
+QJsonValue receiveFilter(const std::optional<ReceiveFilterControl>& filter)
+{
+    if (!filter) {
+        return QJsonValue(QJsonValue::Null);
+    }
+    QJsonArray modes;
+    for (const ReceiveFilterMode& range : filter->modes) {
+        modes.append(QJsonObject{{QStringLiteral("mode"), range.mode},
+            {QStringLiteral("minimumLowHz"), range.minimumLowHz},
+            {QStringLiteral("maximumLowHz"), range.maximumLowHz},
+            {QStringLiteral("minimumHighHz"), range.minimumHighHz},
+            {QStringLiteral("maximumHighHz"), range.maximumHighHz},
+            {QStringLiteral("minimumWidthHz"), range.minimumWidthHz},
+            {QStringLiteral("maximumWidthHz"), range.maximumWidthHz}});
+    }
+    return QJsonObject{{QStringLiteral("authority"), receiveAuthority(filter)},
+                       {QStringLiteral("modes"), modes}};
+}
+
+template<class T>
+QJsonValue observedValue(const std::optional<T>& value)
+{
+    return value ? QJsonValue(*value) : QJsonValue(QJsonValue::Null);
+}
+
+template<class T>
+QJsonObject receiveObservation(const std::optional<T>& value, const QJsonValue& authority)
+{
+    return {{QStringLiteral("known"), value.has_value()},
+            {QStringLiteral("value"), observedValue(value)},
+            {QStringLiteral("authority"), authority}};
+}
+
 QJsonObject capabilityValue(const RadioCapabilities& capabilities)
 {
     QJsonArray sampleRates;
@@ -56,6 +102,17 @@ QJsonObject capabilityValue(const RadioCapabilities& capabilities)
              {QStringLiteral("authority"), frequencyAuthority(capabilities.sliceFrequencyControl.authority)},
              {QStringLiteral("minimumHz"), capabilities.sliceFrequencyControl.minimumHz},
              {QStringLiteral("maximumHz"), capabilities.sliceFrequencyControl.maximumHz}}},
+        {QStringLiteral("receiveModeControl"), capabilities.receiveModeControl
+            ? QJsonValue(QJsonObject{{QStringLiteral("authority"), receiveAuthority(capabilities.receiveModeControl)},
+                {QStringLiteral("modes"), strings(capabilities.receiveModeControl->modes)}})
+            : QJsonValue(QJsonValue::Null)},
+        {QStringLiteral("receiveFilterControl"), receiveFilter(capabilities.receiveFilterControl)},
+        {QStringLiteral("receiveAudioControl"), capabilities.receiveAudioControl
+            ? QJsonValue(QJsonObject{{QStringLiteral("authority"), receiveAuthority(capabilities.receiveAudioControl)},
+                {QStringLiteral("minimumGain"), 0}, {QStringLiteral("maximumGain"), 100}})
+            : QJsonValue(QJsonValue::Null)},
+        {QStringLiteral("receivePanCenterControl"), receiveRange(capabilities.receivePanCenterControl)},
+        {QStringLiteral("receivePanBandwidthControl"), receiveRange(capabilities.receivePanBandwidthControl)},
         {QStringLiteral("canTransmit"), capabilities.canTransmit},
         {QStringLiteral("maximumTransmitWatts"), capabilities.txPowerMaxWatts},
         {QStringLiteral("hasTuner"), capabilities.hasTuner},
@@ -149,6 +206,9 @@ RadioResourceAdapter::RadioResourceAdapter(
                                      panId});
             });
 
+    m_telemetry = std::make_unique<RadioTelemetryAdapter>(m_radio, m_resources, m_radioSessionId);
+    connect(m_telemetry.get(), &RadioTelemetryAdapter::deliveryChanged,
+            this, &RadioResourceAdapter::publishRadioSession);
     publishAll();
 }
 
@@ -173,6 +233,7 @@ void RadioResourceAdapter::attachSlice(SliceModel* slice)
     connect(slice, &SliceModel::letterChanged, this, refresh);
     connect(slice, &SliceModel::frequencyChanged, this, refresh);
     connect(slice, &SliceModel::frequencyReported, this, refresh);
+    connect(slice, &SliceModel::receiveObservationChanged, this, refresh);
     connect(slice, &SliceModel::panIdChanged, this, refresh);
     connect(slice, &SliceModel::modeChanged, this, refresh);
     connect(slice, &SliceModel::filterChanged, this, refresh);
@@ -226,6 +287,7 @@ void RadioResourceAdapter::attachPanadapter(PanadapterModel* panadapter)
     m_panadapters.insert(panadapter);
     const auto refresh = [this, panadapter] { publishPanadapter(panadapter); };
     connect(panadapter, &PanadapterModel::infoChanged, this, refresh);
+    connect(panadapter, &PanadapterModel::geometryObservationChanged, this, refresh);
     connect(panadapter, &PanadapterModel::levelChanged, this, refresh);
     connect(panadapter, &PanadapterModel::bandwidthLimitsChanged, this, refresh);
     connect(panadapter, &PanadapterModel::rxAntennaChanged, this, refresh);
@@ -287,6 +349,11 @@ void RadioResourceAdapter::publishRadioSession()
 {
     const RadioCapabilities capabilities = m_radio->backendCapabilities();
     m_frequencyAuthority = frequencyAuthority(capabilities.sliceFrequencyControl.authority);
+    m_receiveAuthorities = {{QStringLiteral("mode"), receiveAuthority(capabilities.receiveModeControl)},
+        {QStringLiteral("filter"), receiveAuthority(capabilities.receiveFilterControl)},
+        {QStringLiteral("audio"), receiveAuthority(capabilities.receiveAudioControl)},
+        {QStringLiteral("center"), receiveAuthority(capabilities.receivePanCenterControl)},
+        {QStringLiteral("bandwidth"), receiveAuthority(capabilities.receivePanBandwidthControl)}};
     QJsonObject value{
         {QStringLiteral("id"), m_radioSessionId},
         {QStringLiteral("connected"), m_radio->isConnected()},
@@ -298,6 +365,9 @@ void RadioResourceAdapter::publishRadioSession()
              {QStringLiteral("version"), m_radio->version()},
              {QStringLiteral("manufacturer"), capabilities.manufacturer}}},
         {QStringLiteral("capabilities"), capabilityValue(capabilities)}};
+    if (m_telemetry) {
+        value.insert(QStringLiteral("meterDelivery"), m_telemetry->meterDelivery());
+    }
     if (m_connectionTarget) {
         QString state;
         switch (m_connectionTarget->state()) {
@@ -311,6 +381,14 @@ void RadioResourceAdapter::publishRadioSession()
             {QStringLiteral("errorCode"), m_connectionTarget->errorCode()}});
     }
     m_resources->upsert({QStringLiteral("radioSession"), {}, m_radioSessionId}, value);
+    // Refresh cached-authority projections on lifecycle/capability edges, not
+    // on each sample. A newly unsupported operation must not retain old labels.
+    for (SliceModel* slice : std::as_const(m_slices)) {
+        publishSlice(slice);
+    }
+    for (PanadapterModel* pan : std::as_const(m_panadapters)) {
+        publishPanadapter(pan);
+    }
 }
 
 void RadioResourceAdapter::publishSlice(SliceModel* slice)
@@ -322,6 +400,7 @@ void RadioResourceAdapter::publishSlice(SliceModel* slice)
         m_frequencyAuthority = frequencyAuthority(
             m_radio->backendCapabilities().sliceFrequencyControl.authority);
     }
+    const SliceModel::ReceiveObservation& observed = slice->receiveObservation();
     const QJsonObject value{
         {QStringLiteral("id"), QString::number(slice->sliceId())},
         {QStringLiteral("letter"), slice->letter()},
@@ -335,6 +414,17 @@ void RadioResourceAdapter::publishSlice(SliceModel* slice)
                   : QJsonValue(QJsonValue::Null)},
              {QStringLiteral("authority"), m_frequencyAuthority}}},
         {QStringLiteral("mode"), slice->mode()},
+        {QStringLiteral("receiveObservation"), QJsonObject{
+            {QStringLiteral("mode"), receiveObservation(observed.mode, m_receiveAuthorities.value(QStringLiteral("mode")))},
+            {QStringLiteral("filter"), QJsonObject{
+                {QStringLiteral("known"), observed.mode && observed.filterLowHz && observed.filterHighHz
+                     && *observed.filterLowHz < *observed.filterHighHz},
+                {QStringLiteral("lowHz"), observedValue(observed.filterLowHz)},
+                {QStringLiteral("highHz"), observedValue(observed.filterHighHz)},
+                {QStringLiteral("authority"), m_receiveAuthorities.value(QStringLiteral("filter"))}}},
+            {QStringLiteral("audio"), QJsonObject{
+                {QStringLiteral("gain"), receiveObservation(observed.gain, m_receiveAuthorities.value(QStringLiteral("audio")))},
+                {QStringLiteral("muted"), receiveObservation(observed.muted, m_receiveAuthorities.value(QStringLiteral("audio")))}}}}},
         {QStringLiteral("filter"), QJsonObject{
              {QStringLiteral("lowHz"), slice->filterLow()},
              {QStringLiteral("highHz"), slice->filterHigh()}}},
@@ -366,6 +456,14 @@ void RadioResourceAdapter::publishPanadapter(PanadapterModel* panadapter)
     }
     const QJsonObject value{
         {QStringLiteral("id"), panadapter->panId()},
+        {QStringLiteral("owned"), m_radio->receiveControlPanId(panadapter->panId()).has_value()},
+        {QStringLiteral("geometryObservation"), QJsonObject{
+            {QStringLiteral("centerKnown"), panadapter->reportedCenterHz().has_value()},
+            {QStringLiteral("bandwidthKnown"), panadapter->reportedBandwidthHz().has_value()},
+            {QStringLiteral("centerHz"), observedValue(panadapter->reportedCenterHz())},
+            {QStringLiteral("bandwidthHz"), observedValue(panadapter->reportedBandwidthHz())},
+            {QStringLiteral("centerAuthority"), m_receiveAuthorities.value(QStringLiteral("center"))},
+            {QStringLiteral("bandwidthAuthority"), m_receiveAuthorities.value(QStringLiteral("bandwidth"))}}},
         {QStringLiteral("centerHz"), qRound64(panadapter->centerMhz() * 1'000'000.0)},
         {QStringLiteral("centerKnown"), panadapter->centerKnown()},
         {QStringLiteral("bandwidthHz"),

--- a/src/core/control/RadioResourceAdapter.h
+++ b/src/core/control/RadioResourceAdapter.h
@@ -2,11 +2,13 @@
 
 #include "ControlResourceStore.h"
 #include "RadioConnectionTarget.h"
+#include "RadioTelemetryAdapter.h"
 
 #include <QObject>
 #include <QSet>
 #include <QPointer>
 #include <QString>
+#include <memory>
 
 namespace AetherSDR {
 
@@ -52,6 +54,8 @@ private:
     // same edges that republish the radio session (capabilities, rebuild,
     // connection). Empty means "read it on the next publish".
     QString m_frequencyAuthority;
+    QJsonObject m_receiveAuthorities;
+    std::unique_ptr<RadioTelemetryAdapter> m_telemetry;
     QSet<PanadapterModel*> m_panadapters;
 };
 

--- a/src/core/control/RadioTelemetryAdapter.cpp
+++ b/src/core/control/RadioTelemetryAdapter.cpp
@@ -1,0 +1,219 @@
+#include "RadioTelemetryAdapter.h"
+
+#include "models/RadioModel.h"
+
+#include <QDateTime>
+
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
+namespace AetherSDR::control {
+namespace {
+// Reject rather than truncate identifiers/descriptions into misleading aliases.
+bool boundedText(const QString& text, qsizetype limit)
+{
+    if (text.size() > limit || !text.isValidUtf16()) {
+        return false;
+    }
+    for (QChar ch : text) {
+        if (ch.isNull() || ch.category() == QChar::Other_Control) {
+            return false;
+        }
+    }
+    return true;
+}
+} // namespace
+
+RadioTelemetryAdapter::RadioTelemetryAdapter(RadioModel* radio, ControlResourceStore* store,
+    QString sessionId, QObject* parent, std::function<qint64()> clockMs)
+    : QObject(parent), m_radio(radio), m_store(store), m_sessionId(std::move(sessionId)),
+      m_clockMs(std::move(clockMs))
+{
+    m_clock.start();
+    MeterModel* meters = &radio->meterModel();
+    connect(meters, &MeterModel::meterDefinitionChanged, this, [this](int id) { define(id); });
+    connect(meters, &MeterModel::meterUpdated, this, &RadioTelemetryAdapter::sample);
+    connect(meters, &MeterModel::meterRemoved, this, [this](int id) {
+        m_meters.remove(id);
+        m_store->remove({QStringLiteral("meter"), m_sessionId, QString::number(id)});
+    });
+    connect(meters, &MeterModel::metersCleared, this, &RadioTelemetryAdapter::clear);
+    connect(radio, &RadioModel::connectionStateChanged, this, &RadioTelemetryAdapter::resetConnection);
+    connect(radio, &RadioModel::backendRebuilt, this, &RadioTelemetryAdapter::resetConnection);
+    connect(radio, &RadioModel::capabilitiesChanged, this, [this] {
+        m_canTransmit = m_radio->backendCapabilities().canTransmit;
+        m_confirmedTransmit.reset();
+        publishTransmit();
+    });
+    connect(radio, &RadioModel::radioTransmitConfirmed, this, [this](bool active) {
+        if (m_radio->isConnected()) {
+            m_confirmedTransmit = active;
+            publishTransmit();
+        }
+    });
+    const auto activity = [this](bool active) {
+        if (active && m_confirmedTransmit != true) {
+            m_confirmedTransmit.reset();
+        }
+        publishTransmit();
+    };
+    connect(radio, &RadioModel::radioTransmittingChanged, this, activity);
+    connect(&radio->transmitModel(), &TransmitModel::transmittingChanged, this, activity);
+    connect(&radio->transmitModel(), &TransmitModel::moxChanged, this, activity);
+    connect(&radio->transmitModel(), &TransmitModel::tuneChanged, this, activity);
+    connect(&m_timer, &QTimer::timeout, this, &RadioTelemetryAdapter::flush);
+    m_timer.setInterval(kPublishIntervalMs);
+    // A precise timer never publishes more frequently than the advertised cap.
+    m_timer.setTimerType(Qt::PreciseTimer);
+    resetConnection();
+}
+
+RadioTelemetryAdapter::~RadioTelemetryAdapter()
+{
+    // The owning RadioResourceAdapter is already destroying its members.
+    // Unlike a live clear, teardown must neither emit deliveryChanged (which
+    // re-enters that owner) nor restart the publication timer.
+    m_timer.stop();
+    for (auto it = m_meters.cbegin(); it != m_meters.cend(); ++it) {
+        m_store->remove({QStringLiteral("meter"), m_sessionId, QString::number(it.key())});
+    }
+    m_store->remove({QStringLiteral("transmitState"), m_sessionId, {}});
+}
+
+qint64 RadioTelemetryAdapter::now() const
+{
+    return m_clockMs ? m_clockMs() : m_clock.elapsed();
+}
+
+QJsonObject RadioTelemetryAdapter::meterDelivery() const
+{
+    return {{QStringLiteral("maxEntries"), kMaxMeters}, {QStringLiteral("limited"), m_limited},
+            {QStringLiteral("publishIntervalMs"), kPublishIntervalMs},
+            {QStringLiteral("staleAfterMs"), kStaleAfterMs}};
+}
+
+void RadioTelemetryAdapter::clear()
+{
+    m_timer.stop();
+    for (auto it = m_meters.cbegin(); it != m_meters.cend(); ++it) {
+        m_store->remove({QStringLiteral("meter"), m_sessionId, QString::number(it.key())});
+    }
+    m_meters.clear();
+    const bool wasLimited = std::exchange(m_limited, false);
+    if (wasLimited) {
+        emit deliveryChanged();
+    }
+    if (m_radio->isConnected()) {
+        m_timer.start();
+    }
+}
+
+void RadioTelemetryAdapter::resetConnection()
+{
+    clear();
+    m_confirmedTransmit.reset();
+    m_canTransmit = m_radio->backendCapabilities().canTransmit;
+    if (m_radio->isConnected()) {
+        for (int id : m_radio->meterModel().firstDefinedIndices(kMaxMeters)) {
+            define(id);
+        }
+        if (m_radio->meterModel().definitionCount() > kMaxMeters && !m_limited) {
+            m_limited = true;
+            emit deliveryChanged();
+        }
+        m_timer.start();
+    }
+    publishTransmit();
+    flush();
+}
+
+void RadioTelemetryAdapter::define(int index)
+{
+    if (!m_radio->isConnected()) {
+        return;
+    }
+    const MeterDef* def = m_radio->meterModel().meterDef(index);
+    if (!def) {
+        return;
+    }
+    const bool valid = index >= 0 && index <= 65535
+        && boundedText(def->source, 32) && boundedText(def->name, 32)
+        && !def->source.isEmpty() && !def->name.isEmpty()
+        && boundedText(def->unit, 16) && boundedText(def->description, 128)
+        && std::isfinite(def->low) && std::isfinite(def->high) && def->low <= def->high;
+    if (!valid || (!m_meters.contains(index) && m_meters.size() >= kMaxMeters)) {
+        m_meters.remove(index);
+        m_store->remove({QStringLiteral("meter"), m_sessionId, QString::number(index)});
+        if (!m_limited) {
+            m_limited = true;
+            emit deliveryChanged();
+        }
+        return;
+    }
+    const QJsonObject definition{{QStringLiteral("source"), def->source},
+        {QStringLiteral("sourceIndex"), def->sourceIndex}, {QStringLiteral("name"), def->name},
+        {QStringLiteral("unit"), def->unit}, {QStringLiteral("minimum"), def->low},
+        {QStringLiteral("maximum"), def->high}, {QStringLiteral("description"), def->description}};
+    auto existing = m_meters.find(index);
+    if (existing != m_meters.end() && existing->definition == definition) {
+        return;
+    }
+    // Changed metadata (especially units) invalidates the old sample. A model
+    // definition is not a sample, even if MeterModel retains its legacy value.
+    m_meters[index] = Meter{definition, {}, 0, def->name == QStringLiteral("SWR")};
+}
+
+void RadioTelemetryAdapter::sample(int index, float value)
+{
+    auto it = m_meters.find(index);
+    if (!m_radio->isConnected() || it == m_meters.end() || !std::isfinite(value)) {
+        return;
+    }
+    it->sample = value;
+    it->sampledAt = now(); // unchanged samples refresh liveness too
+}
+
+void RadioTelemetryAdapter::flush()
+{
+    if (!m_radio->isConnected()) {
+        return;
+    }
+    const qint64 current = now();
+    for (auto it = m_meters.cbegin(); it != m_meters.cend(); ++it) {
+        const Meter& meter = it.value();
+        const qint64 age = meter.sample ? std::clamp(current - meter.sampledAt,
+            qint64(0), qint64(kStaleAfterMs + 1)) : -1;
+        const bool fresh = meter.sample && age <= kStaleAfterMs;
+        const bool valid = fresh && (!meter.swr || m_radio->meterModel().swrSampleLive(
+            QDateTime::currentMSecsSinceEpoch(), MeterModel::kTxMeterStaleMs));
+        QJsonObject value{{QStringLiteral("id"), QString::number(it.key())},
+            {QStringLiteral("definition"), meter.definition},
+            {QStringLiteral("sample"), QJsonObject{{QStringLiteral("known"), meter.sample.has_value()},
+                {QStringLiteral("fresh"), fresh}, {QStringLiteral("valid"), valid},
+                {QStringLiteral("ageMs"), age},
+                {QStringLiteral("value"), valid ? QJsonValue(*meter.sample) : QJsonValue(QJsonValue::Null)}}}};
+        m_store->upsert({QStringLiteral("meter"), m_sessionId, QString::number(it.key())}, value);
+    }
+}
+
+void RadioTelemetryAdapter::publishTransmit()
+{
+    const bool connected = m_radio->isConnected();
+    QString state = QStringLiteral("unknown");
+    if (connected && !m_canTransmit) {
+        state = QStringLiteral("unsupported");
+    } else if (connected && m_confirmedTransmit
+               && (*m_confirmedTransmit || (!m_radio->isRadioTransmitting()
+                   && !m_radio->transmitModel().isTransmitting()
+                   && !m_radio->transmitModel().isMox() && !m_radio->transmitModel().isTuning()))) {
+        state = *m_confirmedTransmit ? QStringLiteral("transmitting") : QStringLiteral("idle");
+    }
+    const TransmitModel& tx = m_radio->transmitModel();
+    m_store->upsert({QStringLiteral("transmitState"), m_sessionId, {}},
+        {{QStringLiteral("connected"), connected}, {QStringLiteral("canTransmit"), m_canTransmit},
+         {QStringLiteral("state"), state},
+         {QStringLiteral("localRequests"), QJsonObject{{QStringLiteral("mox"), tx.isMox()},
+             {QStringLiteral("tune"), tx.isTuning()}, {QStringLiteral("transmitting"), tx.isTransmitting()}}}});
+}
+} // namespace AetherSDR::control

--- a/src/core/control/RadioTelemetryAdapter.cpp
+++ b/src/core/control/RadioTelemetryAdapter.cpp
@@ -16,8 +16,9 @@ bool boundedText(const QString& text, qsizetype limit)
     if (text.size() > limit || !text.isValidUtf16()) {
         return false;
     }
-    for (QChar ch : text) {
-        if (ch.isNull() || ch.category() == QChar::Other_Control) {
+    for (char32_t ch : text.toUcs4()) {
+        if (ch == 0 || QChar::category(ch) == QChar::Other_Control
+            || QChar::category(ch) == QChar::Other_Format) {
             return false;
         }
     }
@@ -32,11 +33,20 @@ RadioTelemetryAdapter::RadioTelemetryAdapter(RadioModel* radio, ControlResourceS
 {
     m_clock.start();
     MeterModel* meters = &radio->meterModel();
-    connect(meters, &MeterModel::meterDefinitionChanged, this, [this](int id) { define(id); });
+    connect(meters, &MeterModel::meterDefinitionChanged, this, [this](int id) {
+        const qsizetype before = m_meters.size();
+        define(id);
+        if (m_meters.size() < before) {
+            fillVacancies();
+        }
+    });
     connect(meters, &MeterModel::meterUpdated, this, &RadioTelemetryAdapter::sample);
     connect(meters, &MeterModel::meterRemoved, this, [this](int id) {
-        m_meters.remove(id);
+        const bool removed = m_meters.remove(id) > 0;
         m_store->remove({QStringLiteral("meter"), m_sessionId, QString::number(id)});
+        if (removed) {
+            fillVacancies();
+        }
     });
     connect(meters, &MeterModel::metersCleared, this, &RadioTelemetryAdapter::clear);
     connect(radio, &RadioModel::connectionStateChanged, this, &RadioTelemetryAdapter::resetConnection);
@@ -48,7 +58,13 @@ RadioTelemetryAdapter::RadioTelemetryAdapter(RadioModel* radio, ControlResourceS
     });
     connect(radio, &RadioModel::radioTransmitConfirmed, this, [this](bool active) {
         if (m_radio->isConnected()) {
-            m_confirmedTransmit = active;
+            if (!active && (m_radio->isRadioTransmitting()
+                || m_radio->transmitModel().isTransmitting()
+                || m_radio->transmitModel().isMox() || m_radio->transmitModel().isTuning())) {
+                m_confirmedTransmit.reset();
+            } else {
+                m_confirmedTransmit = active;
+            }
             publishTransmit();
         }
     });
@@ -115,9 +131,7 @@ void RadioTelemetryAdapter::resetConnection()
     m_confirmedTransmit.reset();
     m_canTransmit = m_radio->backendCapabilities().canTransmit;
     if (m_radio->isConnected()) {
-        for (int id : m_radio->meterModel().firstDefinedIndices(kMaxMeters)) {
-            define(id);
-        }
+        fillVacancies();
         if (m_radio->meterModel().definitionCount() > kMaxMeters && !m_limited) {
             m_limited = true;
             emit deliveryChanged();
@@ -126,6 +140,29 @@ void RadioTelemetryAdapter::resetConnection()
     }
     publishTransmit();
     flush();
+}
+
+void RadioTelemetryAdapter::fillVacancies()
+{
+    if (!m_radio->isConnected()) {
+        return;
+    }
+    // Page through definitions, not samples. Invalid early entries must not
+    // hide later valid ones; copying the complete model would defeat the cap.
+    std::optional<int> after;
+    while (m_meters.size() < kMaxMeters) {
+        const QList<int> ids = m_radio->meterModel().firstDefinedIndices(kMaxMeters, after);
+        if (ids.isEmpty()) {
+            break;
+        }
+        for (int id : ids) {
+            define(id);
+            if (m_meters.size() == kMaxMeters) {
+                return;
+            }
+        }
+        after = ids.last();
+    }
 }
 
 void RadioTelemetryAdapter::define(int index)

--- a/src/core/control/RadioTelemetryAdapter.h
+++ b/src/core/control/RadioTelemetryAdapter.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "ControlResourceStore.h"
+
+#include <QElapsedTimer>
+#include <QMap>
+#include <QTimer>
+
+#include <functional>
+#include <optional>
+
+namespace AetherSDR {
+class RadioModel;
+namespace control {
+
+// A bounded latest-value projection, not a sample stream. All callbacks and
+// publication run on the model's owning thread; no transport or intent lives here.
+class RadioTelemetryAdapter final : public QObject {
+    Q_OBJECT
+public:
+    static constexpr int kMaxMeters = 64;
+    static constexpr int kPublishIntervalMs = 100;
+    static constexpr int kStaleAfterMs = 2000;
+
+    RadioTelemetryAdapter(RadioModel* radio, ControlResourceStore* store, QString sessionId,
+                          QObject* parent = nullptr, std::function<qint64()> clockMs = {});
+    ~RadioTelemetryAdapter() override;
+    QJsonObject meterDelivery() const;
+    // Same bounded pass used by the timer; the clock can be injected for
+    // deterministic, socket-free freshness and coalescing tests.
+    void flush();
+
+signals:
+    void deliveryChanged();
+
+private:
+    struct Meter {
+        QJsonObject definition;
+        std::optional<float> sample;
+        qint64 sampledAt{0};
+        bool swr{false};
+    };
+    void define(int index);
+    void sample(int index, float value);
+    void clear();
+    void resetConnection();
+    void publishTransmit();
+    qint64 now() const;
+
+    RadioModel* m_radio;
+    ControlResourceStore* m_store;
+    QString m_sessionId;
+    QTimer m_timer;
+    QElapsedTimer m_clock;
+    std::function<qint64()> m_clockMs;
+    QMap<int, Meter> m_meters;
+    std::optional<bool> m_confirmedTransmit;
+    bool m_limited{false};
+    bool m_canTransmit{false};
+};
+} // namespace control
+} // namespace AetherSDR

--- a/src/core/control/RadioTelemetryAdapter.h
+++ b/src/core/control/RadioTelemetryAdapter.h
@@ -41,6 +41,7 @@ private:
         bool swr{false};
     };
     void define(int index);
+    void fillVacancies();
     void sample(int index, float value);
     void clear();
     void resetConnection();

--- a/src/core/control/ReceiveControlGuard.h
+++ b/src/core/control/ReceiveControlGuard.h
@@ -19,7 +19,14 @@ public:
         : m_radio(radio), m_connection(connection)
     {
         connect(radio, &RadioModel::radioTransmitConfirmed, this,
-                [this](bool transmitting) { m_confirmedIdle = !transmitting; });
+                [this](bool transmitting) {
+                    // Never save conflicting idle readback for a later falling edge.
+                    m_confirmedIdle = !transmitting && m_radio->isConnected()
+                        && !m_radio->isRadioTransmitting()
+                        && !m_radio->transmitModel().isTransmitting()
+                        && !m_radio->transmitModel().isMox()
+                        && !m_radio->transmitModel().isTuning();
+                });
         const auto invalidateOnActive = [this](bool active) {
             if (active) {
                 m_confirmedIdle = false;

--- a/src/core/control/ReceiveControlGuard.h
+++ b/src/core/control/ReceiveControlGuard.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "ControlProtocolCodec.h"
+#include "RadioConnectionTarget.h"
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+
+#include <QPointer>
+#include <QThread>
+
+namespace AetherSDR::control {
+
+// Shared conservative receive admission, NOT the Stage-4 TX arbiter. A false
+// command edge is never evidence that a transmitter is idle. This object is
+// bound before connecting and never survives its radio/connection dependencies.
+class ReceiveControlGuard final : public QObject {
+public:
+    ReceiveControlGuard(RadioModel* radio, RadioConnectionTarget* connection)
+        : m_radio(radio), m_connection(connection)
+    {
+        connect(radio, &RadioModel::radioTransmitConfirmed, this,
+                [this](bool transmitting) { m_confirmedIdle = !transmitting; });
+        const auto invalidateOnActive = [this](bool active) {
+            if (active) {
+                m_confirmedIdle = false;
+            }
+        };
+        connect(radio, &RadioModel::radioTransmittingChanged, this, invalidateOnActive);
+        TransmitModel* transmit = &radio->transmitModel();
+        connect(transmit, &TransmitModel::transmittingChanged, this, invalidateOnActive);
+        connect(transmit, &TransmitModel::moxChanged, this, invalidateOnActive);
+        connect(transmit, &TransmitModel::tuneChanged, this, invalidateOnActive);
+        connect(radio, &RadioModel::connectionStateChanged, this, [this](bool connected) {
+            if (!connected) {
+                m_confirmedIdle = false;
+            }
+        });
+        connect(radio, &RadioModel::backendRebuilt, this, [this] { m_confirmedIdle = false; });
+        connect(connection, &RadioConnectionTarget::stateChanged, this, [this] {
+            if (!m_connection || m_connection->state() != RadioConnectionTarget::State::Connected) {
+                m_confirmedIdle = false;
+            }
+        });
+    }
+
+    [[nodiscard]] bool ready() const
+    {
+        return thread() == QThread::currentThread()
+            && m_radio && m_radio->thread() == thread()
+            && m_connection && m_connection->thread() == thread()
+            && m_connection->state() == RadioConnectionTarget::State::Connected
+            && m_radio->isConnected() && m_radio->backend()
+            && m_radio->backend()->thread() == thread();
+    }
+
+    [[nodiscard]] std::optional<ProtocolError> checkSlice(int id) const
+    {
+        if (!ready()) {
+            return refusal("request.conflict", "radio connection is not ready");
+        }
+        SliceModel* slice = m_radio->slice(id);
+        if (!slice || !m_radio->isSlotOurs(id) || m_radio->isSlotForeign(id)) {
+            return refusal("resource.not_found", "owned slice unavailable");
+        }
+        if (slice->isLocked()) {
+            return refusal("request.conflict", "slice is locked");
+        }
+        return {};
+    }
+
+    [[nodiscard]] std::optional<ProtocolError> checkTransmit(const RadioCapabilities& caps) const
+    {
+        if (!ready()) {
+            return refusal("request.conflict", "radio connection is not ready");
+        }
+        if (caps.canTransmit
+            && (!m_confirmedIdle || m_radio->isRadioTransmitting()
+                || m_radio->transmitModel().isTransmitting()
+                || m_radio->transmitModel().isMox()
+                || m_radio->transmitModel().isTuning())) {
+            return refusal("request.conflict", "transmitter is active or idle state is unconfirmed");
+        }
+        return {};
+    }
+
+    [[nodiscard]] static bool canBind(RadioModel* radio, RadioConnectionTarget* connection)
+    {
+        return radio && connection && radio->thread() == QThread::currentThread()
+            && connection->thread() == QThread::currentThread()
+            && !radio->isConnected() && !radio->isConnectAttemptInFlight()
+            && connection->state() == RadioConnectionTarget::State::Idle;
+    }
+
+    [[nodiscard]] static ProtocolError refusal(const char* code, const char* message)
+    {
+        return {QString::fromLatin1(code), QString::fromLatin1(message), {}, false};
+    }
+
+private:
+    QPointer<RadioModel> m_radio;
+    QPointer<RadioConnectionTarget> m_connection;
+    bool m_confirmedIdle{false};
+};
+
+} // namespace AetherSDR::control

--- a/src/core/control/ReceiveControlTarget.h
+++ b/src/core/control/ReceiveControlTarget.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "ControlProtocolCodec.h"
+
+#include <QObject>
+#include <QString>
+#include <memory>
+#include <array>
+#include <utility>
+
+namespace AetherSDR {
+class RadioModel;
+namespace control {
+class RadioConnectionTarget;
+
+enum class ReceiveOperation { Mode, Filter, AudioGain, AudioMute, PanCenter, PanBandwidth };
+inline constexpr std::array<std::pair<ReceiveOperation, const char*>, 6> kReceiveMethods{{
+    {ReceiveOperation::Mode, "slice.setMode"},
+    {ReceiveOperation::Filter, "slice.setFilter"},
+    {ReceiveOperation::AudioGain, "slice.setAudioGain"},
+    {ReceiveOperation::AudioMute, "slice.setAudioMute"},
+    {ReceiveOperation::PanCenter, "panadapter.setCenter"},
+    {ReceiveOperation::PanBandwidth, "panadapter.setBandwidth"},
+}};
+
+// Closed typed intent set; no reflection, raw commands or runtime setter names.
+class ReceiveControlTarget : public QObject {
+public:
+    using QObject::QObject;
+    [[nodiscard]] virtual bool available(ReceiveOperation operation) const = 0;
+    [[nodiscard]] virtual std::optional<ProtocolError> setMode(int slice, const QString& mode) = 0;
+    [[nodiscard]] virtual std::optional<ProtocolError> setFilter(int slice, int lowHz, int highHz) = 0;
+    [[nodiscard]] virtual std::optional<ProtocolError> setAudioGain(int slice, int gain) = 0;
+    [[nodiscard]] virtual std::optional<ProtocolError> setAudioMute(int slice, bool muted) = 0;
+    [[nodiscard]] virtual std::optional<ProtocolError> setPanCenter(const QString& pan, qint64 hz) = 0;
+    [[nodiscard]] virtual std::optional<ProtocolError> setPanBandwidth(const QString& pan, qint64 hz) = 0;
+};
+
+[[nodiscard]] std::unique_ptr<ReceiveControlTarget> makeModelReceiveControlTarget(
+    RadioModel* radio, RadioConnectionTarget* connection);
+
+} // namespace control
+} // namespace AetherSDR

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -214,6 +214,16 @@ void MeterModel::defineMeter(const MeterDef& def)
     if (isTxWaveformMeter(def) && def.name == "COMPPEAK") {
         logCompressionMeterMap(def);
     }
+    emit meterDefinitionChanged(def.index);
+}
+
+QList<int> MeterModel::firstDefinedIndices(int limit) const
+{
+    QList<int> indices;
+    for (auto it = m_defs.cbegin(); it != m_defs.cend() && indices.size() < limit; ++it) {
+        indices.append(it.key());
+    }
+    return indices;
 }
 
 void MeterModel::removeMeter(int index)
@@ -225,6 +235,7 @@ void MeterModel::removeMeter(int index)
     m_defs.remove(index);
     m_values.remove(index);
     m_valueUpdatedMs.remove(index);
+    emit meterRemoved(index);
 
     const auto matchesIndex = [index](QMap<int, int>::iterator entry) {
         return entry.value() == index;
@@ -415,6 +426,7 @@ void MeterModel::clear()
     m_ampFwdPwr = 0.0f;
     m_ampSwr = 1.0f;
     m_ampTemp = 0.0f;
+    emit metersCleared();
 }
 
 void MeterModel::setCompressionMaximumDb(float maximum)

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -217,10 +217,11 @@ void MeterModel::defineMeter(const MeterDef& def)
     emit meterDefinitionChanged(def.index);
 }
 
-QList<int> MeterModel::firstDefinedIndices(int limit) const
+QList<int> MeterModel::firstDefinedIndices(int limit, std::optional<int> after) const
 {
     QList<int> indices;
-    for (auto it = m_defs.cbegin(); it != m_defs.cend() && indices.size() < limit; ++it) {
+    for (auto it = after ? m_defs.upperBound(*after) : m_defs.cbegin();
+         it != m_defs.cend() && indices.size() < limit; ++it) {
         indices.append(it.key());
     }
     return indices;

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -89,7 +89,7 @@ public:
     // meter that is published and rendered nowhere becomes visible.
     QList<int> definedIndices() const { return m_defs.keys(); }
     // Bounded traversal for telemetry consumers; never copies the full map.
-    QList<int> firstDefinedIndices(int limit) const;
+    QList<int> firstDefinedIndices(int limit, std::optional<int> after = {}) const;
     qsizetype definitionCount() const { return m_defs.size(); }
 
     // Current converted value for a meter index. Returns 0 if unknown.

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -88,6 +88,9 @@ public:
     // the producer->consumer direction as well as the reverse, which is how a
     // meter that is published and rendered nowhere becomes visible.
     QList<int> definedIndices() const { return m_defs.keys(); }
+    // Bounded traversal for telemetry consumers; never copies the full map.
+    QList<int> firstDefinedIndices(int limit) const;
+    qsizetype definitionCount() const { return m_defs.size(); }
 
     // Current converted value for a meter index. Returns 0 if unknown.
     float value(int index) const;
@@ -246,6 +249,9 @@ public:
     bool hasSupplyVoltage() const { return m_hasSupplyVoltsValue; }
 
 signals:
+    void meterDefinitionChanged(int index);
+    void meterRemoved(int index);
+    void metersCleared();
     // Emitted when the S-meter value changes (dBm).
     // sliceIndex identifies which slice's LEVEL meter this is.
     void sLevelChanged(int sliceIndex, float dbm);

--- a/src/models/PanadapterModel.cpp
+++ b/src/models/PanadapterModel.cpp
@@ -150,6 +150,8 @@ void PanadapterModel::recordGeometryObservation(double centerMhz, double bandwid
         if (mhz < 0 && std::isfinite(mhz)) {
             return; // normalized absent-field sentinel
         }
+        // Unlike the legacy display setter, non-finite reports invalidate
+        // control observations: retaining old geometry would admit stale intents.
         field = std::isfinite(mhz) && mhz >= 0.000001 && mhz <= 9'007'199'254.0
             ? std::optional<qint64>(qRound64(mhz * 1'000'000.0)) : std::nullopt;
     };

--- a/src/models/PanadapterModel.cpp
+++ b/src/models/PanadapterModel.cpp
@@ -52,8 +52,16 @@ quint32 parseHandleHex(const QString& text)
 
 void PanadapterModel::setClientHandle(const QString& h)
 {
+    const bool ownerChanged = m_ownerHandle != parseHandleHex(h);
+    if (ownerChanged) {
+        m_reportedCenterHz.reset();
+        m_reportedBandwidthHz.reset();
+    }
     m_clientHandle = h;
     m_ownerHandle = parseHandleHex(h);
+    if (ownerChanged) {
+        emit geometryObservationChanged();
+    }
 }
 
 bool PanadapterModel::ownedByClient(quint32 handle) const
@@ -132,6 +140,34 @@ bool PanadapterModel::setCenterBandwidth(double centerMhz, double bandwidthMhz)
         emit infoChanged(m_centerMhz, m_bandwidthMhz);
     }
     return changed;
+}
+
+void PanadapterModel::recordGeometryObservation(double centerMhz, double bandwidthMhz)
+{
+    const auto beforeCenter = m_reportedCenterHz;
+    const auto beforeBandwidth = m_reportedBandwidthHz;
+    const auto record = [](double mhz, std::optional<qint64>& field) {
+        if (mhz < 0 && std::isfinite(mhz)) {
+            return; // normalized absent-field sentinel
+        }
+        field = std::isfinite(mhz) && mhz >= 0.000001 && mhz <= 9'007'199'254.0
+            ? std::optional<qint64>(qRound64(mhz * 1'000'000.0)) : std::nullopt;
+    };
+    record(centerMhz, m_reportedCenterHz);
+    record(bandwidthMhz, m_reportedBandwidthHz);
+    if (beforeCenter != m_reportedCenterHz || beforeBandwidth != m_reportedBandwidthHz) {
+        emit geometryObservationChanged();
+    }
+}
+
+void PanadapterModel::resetCenterKnownForReconnect()
+{
+    m_centerKnown = false;
+    if (m_reportedCenterHz || m_reportedBandwidthHz) {
+        m_reportedCenterHz.reset();
+        m_reportedBandwidthHz.reset();
+        emit geometryObservationChanged();
+    }
 }
 
 // Re-announce the current centre/span even though neither changed.

--- a/src/models/PanadapterModel.h
+++ b/src/models/PanadapterModel.h
@@ -5,6 +5,7 @@
 #include <QVariantMap>
 #include <QString>
 #include <QStringList>
+#include <optional>
 
 namespace AetherSDR {
 
@@ -65,13 +66,17 @@ public:
     // is populated for the first time (even if it equals the placeholder).
     // Returns true when a value actually changed (and infoChanged was emitted).
     bool setCenterBandwidth(double centerMhz, double bandwidthMhz);
+    // Backend publications only; UI geometry setters do not establish proof.
+    void recordGeometryObservation(double centerMhz, double bandwidthMhz);
+    std::optional<qint64> reportedCenterHz() const { return m_reportedCenterHz; }
+    std::optional<qint64> reportedBandwidthHz() const { return m_reportedBandwidthHz; }
     // Force an infoChanged with the current values — for a backend re-asserting
     // a span it refused to change. See the definition.
     void republishCenterBandwidth();
     // A reclaimed model retains its numeric display state while reconnecting,
     // but that previous-session center is not authoritative until the radio
     // reports the new session's pan state.
-    void resetCenterKnownForReconnect() { m_centerKnown = false; }
+    void resetCenterKnownForReconnect();
     // Normalized display-level-range setter driven by the backend (aetherd RFC
     // 2.3, second universal pan field). NaN for either bound means "leave
     // unchanged" (dBm is signed, so no numeric sentinel is safe). Emits
@@ -216,6 +221,7 @@ public:
     void applyStateExtension(const QVariantMap& fields);
 
 signals:
+    void geometryObservationChanged();
     void infoChanged(double centerMhz, double bandwidthMhz);
     void levelChanged(float minDbm, float maxDbm);
     void bandwidthLimitsChanged(double minMhz, double maxMhz);
@@ -258,6 +264,8 @@ private:
     quint32     m_ownerHandle{0};   // parsed m_clientHandle; 0 = unknown (#3977)
     double      m_centerMhz{14.1};
     bool        m_centerKnown{false}; // true after a normalized center update
+    std::optional<qint64> m_reportedCenterHz;
+    std::optional<qint64> m_reportedBandwidthHz;
     double      m_bandwidthMhz{0.2};
     float       m_minDbm{-130.0f};
     float       m_maxDbm{-40.0f};

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1519,6 +1519,7 @@ void RadioModel::wireBackendReceiverState()
                 pan->setWaterfallId(neutralWfIdString(panIdx));
         }
         if (!pan) return;
+        pan->recordGeometryObservation(centerMhz, bandwidthMhz);
         const bool spanChanged = pan->setCenterBandwidth(centerMhz, bandwidthMhz);
         // A backend that snaps a requested span to fixed hardware rates (HL2
         // offers four) reports back the span it actually runs. When that equals
@@ -9338,6 +9339,28 @@ QString RadioModel::backendPanIdFor(const QString& modelPanId) const
     // backend that does not recognise it will refuse, which is the correct
     // outcome for a pan this session never mapped.
     return modelPanId;
+}
+
+std::optional<QString> RadioModel::receiveControlPanId(const QString& modelPanId) const
+{
+    const PanadapterModel* pan = m_panadapters.value(modelPanId, nullptr);
+    if (!pan) {
+        return {};
+    }
+    if (pan->ownerHandle() != 0) {
+        return pan->ownerHandle() == clientHandle()
+            ? std::optional<QString>(backendPanIdFor(modelPanId)) : std::nullopt;
+    }
+    // A wire-less engine owns the pan it materialized from its current backend
+    // mapping. Unknown ownership on a wire transport is never sufficient.
+    if (!m_connection) {
+        const QString id = backendPanIdFor(modelPanId);
+        const auto it = m_backendPanIndex.constFind(id);
+        if (it != m_backendPanIndex.constEnd() && neutralPanIdString(it.value()) == modelPanId) {
+            return id;
+        }
+    }
+    return {};
 }
 
 int RadioModel::neutralPanIndexFor(const QString& backendPanId)

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -728,6 +728,9 @@ public:
     // 2.3 backend-signal handlers, single-sourced (#4065 review).
     PanadapterModel* resolvePan(const QString& panId) const;
     QList<PanadapterModel*> panadapters() const { return m_panadapters.values(); }
+    // Exact live identity + confirmed ownership for an untrusted local intent.
+    // Returns the backend's own id, not an invented or caller-supplied wire id.
+    std::optional<QString> receiveControlPanId(const QString& modelPanId) const;
 
     // Radio-authoritative display inventory vs what we own (#3856 Layer B).
     // Built from the accumulated "display pan"/"display waterfall" status maps;

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -1167,6 +1167,32 @@ void SliceModel::emitLetterRefresh()
 
 void SliceModel::applyChanges(const SliceDelta& d)
 {
+    const ReceiveObservation previousObservation = m_receiveObservation;
+    if (d.mode) {
+        // A mode change invalidates the old mode's passband. Partial filter
+        // reports may restore each edge independently, never from UI state.
+        if (m_receiveObservation.mode != d.mode) {
+            m_receiveObservation.filterLowHz.reset();
+            m_receiveObservation.filterHighHz.reset();
+        }
+        m_receiveObservation.mode = d.mode->isEmpty() || d.mode->size() > 32
+            ? std::nullopt : d.mode;
+    }
+    if (d.filterLow) {
+        m_receiveObservation.filterLowHz = d.filterLow;
+    }
+    if (d.filterHigh) {
+        m_receiveObservation.filterHighHz = d.filterHigh;
+    }
+    if (d.audioGain) {
+        const double gain = *d.audioGain;
+        m_receiveObservation.gain = std::isfinite(gain) && gain >= 0 && gain <= 100
+                && std::floor(gain) == gain
+            ? std::optional<int>(static_cast<int>(gain)) : std::nullopt;
+    }
+    if (d.audioMute) {
+        m_receiveObservation.muted = d.audioMute;
+    }
     // aetherd RFC 2.3: the Flex slice-status wire decode moved to
     // FlexBackend::decodeSliceStatus, which emits sliceChanged(sliceId, changes)
     // with normalized, canonically-named typed values. This applies those
@@ -1723,10 +1749,20 @@ void SliceModel::applyChanges(const SliceDelta& d)
         emit frequencyChanged(m_frequency);
     if (modeChanged_)   emit modeChanged(m_mode);
     if (filterChanged_) emit filterChanged(m_filterLow, m_filterHigh);
+    if (previousObservation != m_receiveObservation) {
+        emit receiveObservationChanged();
+    }
+    if (d.mode) {
+        emit receiveModeReported();
+    }
 }
 
 void SliceModel::invalidateFrequencyObservation()
 {
+    if (m_receiveObservation != ReceiveObservation{}) {
+        m_receiveObservation = {};
+        emit receiveObservationChanged();
+    }
     if (m_frequencyReportedKnown) {
         m_frequencyReportedKnown = false;
         m_reportedFrequency = 0.0;

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -24,6 +24,18 @@ class SliceModel : public QObject {
     Q_PROPERTY(bool txSlice      READ isTxSlice  NOTIFY txSliceChanged)
 
 public:
+    struct ReceiveObservation {
+        std::optional<QString> mode;
+        std::optional<int> filterLowHz;
+        std::optional<int> filterHighHz;
+        std::optional<int> gain;
+        std::optional<bool> muted;
+        bool operator==(const ReceiveObservation&) const = default;
+    };
+    const ReceiveObservation& receiveObservation() const { return m_receiveObservation; }
+    // Records explicit filter intent without an optimistic value or a wire
+    // write. Adaptive filtering must still recognize a daemon operator edit.
+    void noteReceiveFilterIntent() { ++m_userFilterEpoch; }
     // Conservative whole-MHz observation domain below JSON's 2^53-1 Hz
     // integer limit. Keep target admission and MHz observation validation
     // on this same bound; the general protocol integer domain is wider.
@@ -380,6 +392,8 @@ signals:
     // Supplemental observation notification when frequencyChanged does not
     // fire (same-value reports, optimistic-value echoes, or invalidation).
     void frequencyReported();
+    void receiveObservationChanged();
+    void receiveModeReported(); // including same-value reports after an intent
     // Emitted after a local setter has issued a frequency command. Unlike
     // frequencyChanged, radio-status application does not emit this signal.
     void frequencyCommandIssued(double mhz);
@@ -559,6 +573,7 @@ private:
     double  m_frequency{0.0};
     double  m_reportedFrequency{0.0};
     bool    m_frequencyReportedKnown{false};
+    ReceiveObservation m_receiveObservation;
     QString m_mode{"USB"};
     QString m_modeBeforeDigitalVoice;
     QStringList m_modeList;

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -579,7 +579,7 @@ private:
     QStringList m_modeList;
     int     m_filterLow{-1500};
     int     m_filterHigh{1500};
-    quint64 m_userFilterEpoch{0};   // bumped only by setFilterWidth() (RFC #3878)
+    quint64 m_userFilterEpoch{0};   // setFilterWidth() and daemon filter intent (RFC #3878)
     // Adaptive RX filter — client-side config + runtime state (RFC #3878).
     // The filter edges themselves stay radio-authoritative (never persisted);
     // only enabled + the two bounds are persisted by the GUI.

--- a/tests/control_connection_test.cpp
+++ b/tests/control_connection_test.cpp
@@ -261,8 +261,10 @@ void validationAndLifecycle()
               == QStringLiteral("capability.unavailable"), "stopped source cannot connect");
     check(error(invoke(f.service, f.controller, QStringLiteral("slice.setFrequency")))
               == QStringLiteral("capability.unavailable"), "absent frequency target cannot tune");
+    check(error(invoke(f.service, f.controller, QStringLiteral("slice.setMode")))
+              == QStringLiteral("capability.unavailable"), "absent receive target cannot change mode");
     for (const QString& method : {QStringLiteral("transmit.setMox"), QStringLiteral("tx.acquire"),
-                                 QStringLiteral("slice.setMode"), QStringLiteral("invoke")}) {
+                                 QStringLiteral("slice.create"), QStringLiteral("invoke")}) {
         check(error(invoke(f.service, f.controller, method)) == QStringLiteral("request.unknown_method"),
               "TX and out-of-scope control remain absent");
     }

--- a/tests/control_receive_test.cpp
+++ b/tests/control_receive_test.cpp
@@ -291,6 +291,37 @@ void modeAndFilterOrdering()
     f.reject(ReceiveOperation::Mode, f.params(ReceiveOperation::Mode), "capability.unavailable");
 }
 
+void delayedIdleCannotAuthorizeReceive()
+{
+    for (int kind = 0; kind < 4; ++kind) {
+        Fixture f;
+        f.backend->caps.canTransmit = true;
+        const auto activity = [&](bool active) {
+            if (kind == 0) {
+                f.radio.transmitModel().setTransmitting(active);
+            } else {
+                TransmitDelta delta;
+                if (kind == 2) { delta.tune = active; } else { delta.mox = active; }
+                if (kind == 3) {
+                    f.radio.handleStatusForTest("interlock", {{"state", active ? "TRANSMITTING" : "READY"}});
+                }
+                else { f.radio.transmitModel().applyChanges(delta); }
+                if (kind == 1) { f.radio.transmitModel().moxChanged(active); }
+            }
+        };
+        f.radio.radioTransmitConfirmed(false);
+        activity(true);
+        f.radio.radioTransmitConfirmed(false);
+        f.reject(ReceiveOperation::AudioGain, f.params(ReceiveOperation::AudioGain), "request.conflict");
+        activity(false);
+        f.reject(ReceiveOperation::AudioGain, f.params(ReceiveOperation::AudioGain), "request.conflict");
+        f.radio.radioTransmitConfirmed(false);
+        check(f.send(ReceiveOperation::AudioGain, f.params(ReceiveOperation::AudioGain)).contains("result"),
+              "only fresh post-activity idle reopens receive admission");
+        check(f.backend->keys == 0, "injected activity never dispatches keying");
+    }
+}
+
 void safetyAndLifetime()
 {
     for (const auto& [op, method] : kReceiveMethods) {
@@ -391,6 +422,12 @@ void productionCapabilityContracts()
         unsafeFlexFilter |= mode.mode == "CW" || mode.mode == "FM" || mode.mode == "NFM" || mode.mode == "RTTY";
     }
     check(!unsafeFlexFilter, "pitch/preset/shift-dependent Flex filters are not guessed");
+    QStringList flexCommands;
+    flex.setSliceCommandSink([&](const QString& command) { flexCommands.append(command); });
+    flex.setSliceMode(0, "LSB");
+    flex.setSliceFilter(0, -2800, -100);
+    check(flexCommands == QStringList{"slice set 0 mode=LSB", "filt 0 -2800 -100"},
+        "Flex records have implemented typed verbs behind an injected command sink");
     SimBackend sim;
     const auto simCaps = sim.capabilities();
     check(simCaps.receiveModeControl && simCaps.receiveModeControl->modes == QStringList{"USB", "LSB"}
@@ -403,9 +440,21 @@ void productionCapabilityContracts()
         && hl2Caps.receivePanCenterControl && !hl2Caps.receivePanBandwidthControl,
         "HL2 exposes receive controls but not topology-changing bandwidth");
     SliceDelta observed;
-    QObject::connect(&hl2, &IRadioBackend::sliceChanged, &hl2, [&](int, const SliceDelta& delta) { observed = delta; });
+    int gainReports = 0;
+    QObject::connect(&hl2, &IRadioBackend::sliceChanged, &hl2, [&](int, const SliceDelta& delta) {
+        observed = delta;
+        ++gainReports;
+    });
     hl2.setSliceAudioGain(0, 37);
     check(observed.audioGain == 37, "HL2 publishes backend mixer gain as normalized observation");
+    const int beforeDuplicate = gainReports;
+    hl2.setSliceAudioGain(0, 37);
+    check(gainReports == beforeDuplicate, "duplicate HL2 gain does not republish the full slice");
+    hl2.setSliceAudioGain(0, 150);
+    check(observed.audioGain == 100 && gainReports == beforeDuplicate + 1, "changed HL2 gain is clamped and reported");
+    hl2.setSliceAudioGain(0, 101);
+    check(gainReports == beforeDuplicate + 1, "equal clamped HL2 gain is also change gated");
+    hl2.setSliceAudioGain(0, 37);
     hl2.setSliceAudioMute(0, true);
     check(observed.audioMute == true && observed.audioGain == 37, "HL2 mute readback preserves mixer gain");
     hl2.setSliceMode(0, "LSB");
@@ -442,6 +491,7 @@ int main(int argc, char** argv)
     dispatchAndReadback();
     modeAndFilterOrdering();
     safetyAndLifetime();
+    delayedIdleCannotAuthorizeReceive();
     rangesAndBudget();
     productionCapabilityContracts();
     return failures == 0 ? 0 : 1;

--- a/tests/control_receive_test.cpp
+++ b/tests/control_receive_test.cpp
@@ -1,0 +1,448 @@
+#include "TestSettingsProfile.h"
+#include "core/control/ControlService.h"
+#include "core/control/LocalControlServer.h"
+#include "core/control/RadioResourceAdapter.h"
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+#include "models/PanadapterModel.h"
+#include "core/backends/flex/FlexBackend.h"
+#include "core/backends/hl2/Hl2Backend.h"
+#include "core/backends/icom/IcomCivBackend.h"
+#include "core/backends/anan/AnanBackend.h"
+#include "core/backends/sim/SimBackend.h"
+#ifdef AETHER_BACKEND_RTL
+#include "core/backends/rtl/RtlSdrBackend.h"
+#endif
+
+#include <QCoreApplication>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QThread>
+
+#include <cstdio>
+#include <limits>
+
+using namespace AetherSDR;
+using namespace AetherSDR::control;
+
+namespace {
+int failures = 0;
+void check(bool ok, const char* message)
+{
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", message);
+    failures += !ok;
+}
+
+// Injected intent recorder, not a firmware simulator: observations are fed
+// separately. No socket, discovery, DSP worker, synthetic peer or TX path.
+class Backend final : public IRadioBackend {
+public:
+    RadioCapabilities caps;
+    bool connected{false};
+    int intents{0};
+    int keys{0};
+    QString method;
+    QString panId;
+    QJsonObject args;
+    mutable int reads{0};
+    RadioCapabilities capabilities() const override { ++reads; return caps; }
+    bool isConnected() const override { return connected; }
+    void connectRadio(const RadioConnectRequest&) override { connected = true; }
+    void disconnectRadio() override { connected = false; }
+    void setSliceFrequency(int, double hz) override { record("frequency", {{"hz", hz}}); }
+    void setSliceMode(int id, const QString& mode) override { record("mode", {{"slice", id}, {"mode", mode}}); }
+    void setSliceFilter(int id, int low, int high) override { record("filter", {{"slice", id}, {"low", low}, {"high", high}}); }
+    void setSliceAudioGain(int id, int gain) override { record("gain", {{"slice", id}, {"gain", gain}}); }
+    void setSliceAudioMute(int id, bool muted) override { record("mute", {{"slice", id}, {"muted", muted}}); }
+    void setSliceAgc(int, const QString&, int) override {}
+    void setPanCenter(const QString& id, double hz, PanCenterIntent) override { panId = id; record("center", {{"hz", hz}}); }
+    void setPanBandwidth(const QString& id, double hz) override { panId = id; record("bandwidth", {{"hz", hz}}); }
+    void setKeying(bool) override { ++keys; }
+    void invokeExtension(const QString&, const QString&, quint64, const QVariant&) override {}
+    void record(const QString& name, const QJsonObject& values) { ++intents; method = name; args = values; }
+};
+
+class Connection final : public RadioConnectionTarget {
+public:
+    State current{State::Idle};
+    State state() const override { return current; }
+    QString errorCode() const override { return {}; }
+    bool supports(const DiscoveredRadio&) const override { return true; }
+    void connectRadio(const DiscoveredRadio&) override {}
+    void disconnectRadio() override { change(State::Disconnecting); }
+    void change(State next) { current = next; emit stateChanged(); }
+};
+
+QJsonObject call(ControlService& service, ControlSession& session, const QString& method,
+                 const QJsonObject& params = {})
+{
+    QJsonObject request{{"v", 1}, {"id", "request"}, {"method", method}, {"params", params}};
+    if (method != QStringLiteral("hello")) {
+        request.insert("sessionId", session.sessionId());
+    }
+    return service.handle(QJsonDocument(request).toJson(QJsonDocument::Compact), &session).message;
+}
+
+QString error(const QJsonObject& response) { return response.value("error").toObject().value("code").toString(); }
+const QString kBackendPan = QStringLiteral("receiver-main");
+
+struct Fixture {
+    RadioModel radio;
+    Connection connection;
+    ControlResourceStore store;
+    std::unique_ptr<ReceiveControlTarget> target;
+    ControlService service{&store};
+    ControlSession controller{&store, 256 * 1024, SessionAuthorization::ObserverController};
+    RadioResourceAdapter adapter{&radio, &store, QStringLiteral("radio-1"), nullptr, &connection};
+    Backend* backend{nullptr};
+    const QString pan = RadioModel::neutralPanIdStringForTest(0);
+    const ResourceAddress sliceAddress{QStringLiteral("slice"), QStringLiteral("radio-1"), QStringLiteral("0")};
+    const ResourceAddress panAddress{QStringLiteral("panadapter"), QStringLiteral("radio-1"), pan};
+
+    Fixture()
+    {
+        auto owned = std::make_unique<Backend>();
+        backend = owned.get();
+        using Authority = SliceFrequencyControl::Authority;
+        backend->caps.canTransmit = false;
+        backend->caps.receiveModeControl = ReceiveModeControl{Authority::Engine, {"USB", "LSB", "AM"}};
+        backend->caps.receiveFilterControl = ReceiveFilterControl{Authority::Engine, {
+            {"USB", 0, 11990, 10, 12000, 10, 12000},
+            {"LSB", -12000, -10, -11990, 0, 10, 12000},
+            {"AM", -12000, -10, 10, 12000, 20, 24000}}};
+        backend->caps.receiveAudioControl = ReceiveAudioControl{Authority::Engine};
+        backend->caps.receivePanCenterControl = ReceivePanRangeControl{Authority::Engine, 100000, 60000000};
+        backend->caps.receivePanBandwidthControl = ReceivePanRangeControl{Authority::Engine, 48000, 1536000};
+        radio.setBackendForTest(std::move(owned), QStringLiteral("receive-test"));
+        check(radio.automationApplySliceFixture(0, QStringLiteral("A")), "socket-free owned slice installed");
+        target = makeModelReceiveControlTarget(&radio, &connection);
+        check(target && service.bindReceiveTarget(target.get()), "receive target bound before connection and negotiation");
+        backend->connected = true;
+        connection.change(RadioConnectionTarget::State::Connected);
+        radio.connectionStateChanged(true);
+        report("USB", 100, 2800);
+        SliceDelta audio; audio.audioGain = 50; audio.audioMute = false;
+        radio.slice(0)->applyChanges(audio);
+        backend->panCenterBandwidthChanged(kBackendPan, 14.225, .192);
+        adapter.publishAll();
+        hello(controller);
+    }
+
+    void hello(ControlSession& session)
+    {
+        check(call(service, session, "hello", {{"versions", QJsonArray{1}}}).contains("result"), "session negotiated");
+    }
+    void report(const QString& mode, int low, int high)
+    {
+        SliceDelta delta; delta.mode = mode; delta.filterLow = low; delta.filterHigh = high;
+        radio.slice(0)->applyChanges(delta);
+    }
+    QJsonObject params(ReceiveOperation op) const
+    {
+        const bool isPan = op == ReceiveOperation::PanCenter || op == ReceiveOperation::PanBandwidth;
+        const auto snapshot = store.get(isPan ? panAddress : sliceAddress);
+        QJsonObject values{{"radioSession", "radio-1"}, {isPan ? "panadapter" : "slice", isPan ? pan : "0"},
+            {"expectedRevision", static_cast<qint64>(snapshot ? snapshot->revision : 0)}};
+        switch (op) {
+        case ReceiveOperation::Mode: values.insert("mode", "LSB"); break;
+        case ReceiveOperation::Filter: values.insert("lowHz", 200); values.insert("highHz", 2900); break;
+        case ReceiveOperation::AudioGain: values.insert("gain", 35); break;
+        case ReceiveOperation::AudioMute: values.insert("muted", true); break;
+        case ReceiveOperation::PanCenter: values.insert("hz", 14230000); break;
+        case ReceiveOperation::PanBandwidth: values.insert("hz", 96000); break;
+        }
+        return values;
+    }
+    QJsonObject send(ReceiveOperation op, const QJsonObject& values)
+    {
+        for (const auto& [operation, method] : kReceiveMethods) {
+            if (operation == op) { return call(service, controller, QString::fromLatin1(method), values); }
+        }
+        return {};
+    }
+    void reject(ReceiveOperation op, const QJsonObject& values, const char* code)
+    {
+        const int before = backend->intents;
+        const QString actual = error(send(op, values));
+        if (actual != QString::fromLatin1(code)) { std::printf("Expected %s, got %s\n", code, qPrintable(actual)); }
+        check(actual == QString::fromLatin1(code) && backend->intents == before,
+              "refusal has expected code and dispatches no backend intent");
+    }
+};
+
+void schemaAndAuthorization()
+{
+    for (const auto& [op, method] : kReceiveMethods) {
+        Fixture f;
+        for (SessionAuthorization auth : {SessionAuthorization::Observer, SessionAuthorization::AuthenticatedWithoutGrants}) {
+            ControlSession denied(&f.store, 262144, auth);
+            f.hello(denied);
+            check(error(call(f.service, denied, QString::fromLatin1(method), {{"invalid", true}})) == "auth.grant_denied",
+                  "every receive verb checks grants before schema or target");
+            check(!f.service.capabilities(denied).value("capabilities").toArray().contains(QString::fromLatin1(method)),
+                  "observer never advertises receive mutations");
+        }
+        const QJsonObject good = f.params(op);
+        QJsonObject bad = good; bad.insert("force", true);
+        f.reject(op, bad, "request.invalid_params");
+        for (const QString& field : good.keys()) {
+            bad = good; bad.remove(field); f.reject(op, bad, "request.invalid_params");
+        }
+        for (QJsonValue value : {QJsonValue(0), QJsonValue(1.5), QJsonValue(true), QJsonValue("3"), QJsonValue(9007199254740992.0)}) {
+            bad = good; bad.insert("expectedRevision", value); f.reject(op, bad, "request.invalid_params");
+        }
+        bad = good; bad.insert("radioSession", "radio-2"); f.reject(op, bad, "resource.not_found");
+        bad = good; bad.insert(good.contains("slice") ? "slice" : "panadapter", "missing");
+        f.reject(op, bad, good.contains("slice") ? "request.invalid_params" : "resource.not_found");
+        if (good.contains("slice")) {
+            for (const char* id : {"-1", "+0", "00", "2147483648", "0\nraw"}) {
+                bad = good; bad.insert("slice", id); f.reject(op, bad, "request.invalid_params");
+            }
+        }
+        f.controller.revokeAuthorization();
+        f.reject(op, good, "auth.invalid");
+    }
+    Fixture f;
+    for (QJsonValue mode : {QJsonValue("usb"), QJsonValue("USB\ntransmit"), QJsonValue(""), QJsonValue(true), QJsonValue(QString(33, 'A'))}) {
+        auto bad = f.params(ReceiveOperation::Mode); bad.insert("mode", mode);
+        f.reject(ReceiveOperation::Mode, bad, "request.invalid_params");
+    }
+    for (ReceiveOperation op : {ReceiveOperation::Filter, ReceiveOperation::AudioGain, ReceiveOperation::PanCenter, ReceiveOperation::PanBandwidth}) {
+        const char* field = op == ReceiveOperation::Filter ? "lowHz" : op == ReceiveOperation::AudioGain ? "gain" : "hz";
+        for (QJsonValue value : {QJsonValue(true), QJsonValue("12"), QJsonValue(1.5), QJsonValue(QJsonValue::Null)}) {
+            auto bad = f.params(op); bad.insert(field, value); f.reject(op, bad, "request.invalid_params");
+        }
+    }
+    for (QJsonValue value : {QJsonValue(0), QJsonValue(1), QJsonValue("true"), QJsonValue(QJsonValue::Null)}) {
+        auto bad = f.params(ReceiveOperation::AudioMute); bad.insert("muted", value);
+        f.reject(ReceiveOperation::AudioMute, bad, "request.invalid_params");
+    }
+}
+
+void dispatchAndReadback()
+{
+    for (const auto& [op, method] : kReceiveMethods) {
+        Fixture f;
+        const bool pan = op == ReceiveOperation::PanCenter || op == ReceiveOperation::PanBandwidth;
+        const ResourceAddress address = pan ? f.panAddress : f.sliceAddress;
+        const auto before = *f.store.get(address);
+        check(f.service.capabilities(f.controller).value("capabilities").toArray().contains(QString::fromLatin1(method)),
+              "qualified operation advertised from action-time capability and observation");
+        check(f.send(op, f.params(op)).value("result").toObject().value("accepted").toBool() && f.backend->intents == 1,
+              "accepted dispatches exactly one typed intent");
+        check(f.store.get(address)->revision == before.revision && f.store.get(address)->value == before.value,
+              "acceptance neither fabricates readback nor advances revision");
+        if (pan) {
+            check(f.backend->panId == kBackendPan, "opaque model pan id resolves to exact backend id");
+            check(f.backend->method != "frequency", "pan command does not implicitly tune a slice");
+        }
+        check(f.backend->keys == 0, "receive verbs never invoke keying");
+    }
+    Fixture f;
+    ControlSession observer(&f.store, 262144, SessionAuthorization::Observer);
+    f.hello(observer);
+    call(f.service, observer, "resource.subscribe", {{"resources", QJsonArray{
+        QJsonObject{{"type", "slice"}, {"radioSession", "radio-1"}}}}});
+    const auto stale = f.params(ReceiveOperation::AudioGain);
+    const int beforeReads = f.backend->reads;
+    SliceDelta delta; delta.audioGain = 35; delta.audioMute = true;
+    f.radio.slice(0)->applyChanges(delta);
+    check(f.backend->reads == beforeReads, "receive readback does not rebuild capabilities per sample");
+    check(!observer.takePendingFrames().isEmpty(), "independent observer receives authoritative receive update");
+    f.reject(ReceiveOperation::AudioGain, stale, "request.conflict");
+    const auto revision = f.store.get(f.sliceAddress)->revision;
+    f.radio.slice(0)->applyChanges(delta);
+    check(f.store.get(f.sliceAddress)->revision == revision, "same-value receive echoes do not churn revisions");
+    f.radio.slice(0)->setAudioGain(60);
+    check(f.radio.slice(0)->receiveObservation().gain == 35, "desktop optimistic gain is not an observation");
+    delta.audioGain = 60; f.radio.slice(0)->applyChanges(delta);
+    check(f.radio.slice(0)->receiveObservation().gain == 60, "echo equal to optimistic gain still establishes readback");
+    delta.audioGain = std::numeric_limits<double>::infinity(); f.radio.slice(0)->applyChanges(delta);
+    check(!f.target->available(ReceiveOperation::AudioGain), "non-finite gain observation cannot enable control");
+}
+
+void modeAndFilterOrdering()
+{
+    Fixture f;
+    check(f.send(ReceiveOperation::Mode, f.params(ReceiveOperation::Mode)).contains("result"), "mode intent accepted");
+    auto competing = f.params(ReceiveOperation::Mode); competing.insert("mode", "AM");
+    f.reject(ReceiveOperation::Mode, competing, "request.conflict");
+    f.reject(ReceiveOperation::Filter, f.params(ReceiveOperation::Filter), "request.conflict");
+    f.report("USB", 100, 2800);
+    f.reject(ReceiveOperation::Filter, f.params(ReceiveOperation::Filter), "request.conflict");
+    SliceDelta mode; mode.mode = "LSB"; f.radio.slice(0)->applyChanges(mode);
+    check(!f.target->available(ReceiveOperation::Filter), "mode-only readback invalidates old-mode filter edges");
+    SliceDelta low; low.filterLow = -2800; f.radio.slice(0)->applyChanges(low);
+    check(!f.target->available(ReceiveOperation::Filter), "partial filter readback does not invent its other edge");
+    SliceDelta high; high.filterHigh = -100; f.radio.slice(0)->applyChanges(high);
+    auto filter = f.params(ReceiveOperation::Filter); filter.insert("lowHz", -2900); filter.insert("highHz", -200);
+    check(f.send(ReceiveOperation::Filter, filter).contains("result"), "new-mode passband dispatches after full observation");
+    for (const auto& edges : {std::pair{200, 2900}, std::pair{-100, -200}, std::pair{-12001, -1}, std::pair{-5, 0}}) {
+        filter = f.params(ReceiveOperation::Filter); filter.insert("lowHz", edges.first); filter.insert("highHz", edges.second);
+        f.reject(ReceiveOperation::Filter, filter, "request.out_of_range");
+    }
+    auto same = f.params(ReceiveOperation::Mode); same.insert("mode", "LSB");
+    check(f.send(ReceiveOperation::Mode, same).contains("result"), "same-value mode remains a valid intent");
+    mode.mode = "LSB"; f.radio.slice(0)->applyChanges(mode);
+    check(f.target->available(ReceiveOperation::Filter), "same-value mode report releases pending filter interlock");
+    same = f.params(ReceiveOperation::Mode); same.insert("mode", "RADE");
+    f.reject(ReceiveOperation::Mode, same, "request.out_of_range");
+    f.report("RADE", -3000, 3000);
+    f.reject(ReceiveOperation::Mode, f.params(ReceiveOperation::Mode), "capability.unavailable");
+}
+
+void safetyAndLifetime()
+{
+    for (const auto& [op, method] : kReceiveMethods) {
+        Q_UNUSED(method);
+        Fixture f;
+        const auto old = f.params(op);
+        f.backend->caps.canTransmit = true;
+        f.reject(op, old, "request.conflict");
+        f.radio.radioTransmitConfirmed(false);
+        check(f.send(op, f.params(op)).contains("result"), "explicit idle readback permits non-TX control");
+        f.radio.transmitModel().moxChanged(true);
+        f.radio.transmitModel().moxChanged(false);
+        f.reject(op, f.params(op), "request.conflict");
+        f.radio.radioTransmitConfirmed(false);
+        f.connection.change(RadioConnectionTarget::State::Disconnecting);
+        f.connection.change(RadioConnectionTarget::State::Connected);
+        f.reject(op, f.params(op), "request.conflict");
+        f.backend->caps.canTransmit = false;
+        f.backend->connected = false;
+        f.reject(op, f.params(op), "request.conflict");
+        f.backend->connected = true;
+        bool accepted = true;
+        auto worker = std::unique_ptr<QThread>(QThread::create([&] {
+            accepted = !f.target->setAudioGain(0, 30).has_value();
+        }));
+        worker->start(); worker->wait();
+        check(!accepted, "wrong-thread dispatch fails closed");
+        check(!f.service.bindReceiveTarget(f.target.get()), "service cannot replace target after dispatch");
+        f.target.reset();
+        f.reject(op, f.params(op), "capability.unavailable");
+        check(f.backend->keys == 0, "safety and lifetime failures never key");
+    }
+    Fixture f;
+    f.radio.slice(0)->setLocked(true);
+    f.reject(ReceiveOperation::AudioGain, f.params(ReceiveOperation::AudioGain), "request.conflict");
+    f.radio.slice(0)->setLocked(false);
+    const auto old = f.params(ReceiveOperation::AudioGain);
+    f.radio.slice(0)->invalidateFrequencyObservation();
+    check(!f.target->available(ReceiveOperation::Mode) && !f.target->available(ReceiveOperation::Filter)
+        && !f.target->available(ReceiveOperation::AudioGain) && !f.target->available(ReceiveOperation::AudioMute),
+        "reconnect invalidates every receive observation, not just frequency");
+    f.reject(ReceiveOperation::AudioGain, old, "request.conflict");
+    f.radio.panadapter(f.pan)->resetCenterKnownForReconnect();
+    check(!f.target->available(ReceiveOperation::PanCenter), "reconnect invalidates geometry knowledge");
+    f.backend->panCenterBandwidthChanged(kBackendPan, 14.225, -1);
+    check(!f.target->available(ReceiveOperation::PanCenter), "partial pan report cannot fill missing bandwidth");
+    f.backend->panCenterBandwidthChanged(kBackendPan, -1, .192);
+    check(f.target->available(ReceiveOperation::PanCenter), "split pan reports establish complete geometry");
+    f.radio.panadapter(f.pan)->setClientHandle("0x1234");
+    check(!f.target->available(ReceiveOperation::PanCenter), "foreign owner revokes pan eligibility");
+    check(!f.store.get(f.panAddress)->value.value("owned").toBool(), "ownership change republishes after new owner is installed");
+}
+
+void rangesAndBudget()
+{
+    Fixture f;
+    for (int gain : {-1, 101}) {
+        auto params = f.params(ReceiveOperation::AudioGain); params.insert("gain", gain);
+        f.reject(ReceiveOperation::AudioGain, params, "request.out_of_range");
+    }
+    for (int gain : {0, 100}) {
+        auto params = f.params(ReceiveOperation::AudioGain); params.insert("gain", gain);
+        check(f.send(ReceiveOperation::AudioGain, params).contains("result"), "gain bounds inclusive");
+    }
+    for (ReceiveOperation op : {ReceiveOperation::PanCenter, ReceiveOperation::PanBandwidth}) {
+        auto params = f.params(op); params.insert("hz", 1);
+        f.reject(op, params, "request.out_of_range");
+        params.insert("hz", 60000001); f.reject(op, params, "request.out_of_range");
+    }
+    f.backend->caps.receiveAudioControl.reset();
+    f.reject(ReceiveOperation::AudioMute, f.params(ReceiveOperation::AudioMute), "capability.unavailable");
+    f.backend->caps.receivePanCenterControl->authority = SliceFrequencyControl::Authority::Unknown;
+    f.reject(ReceiveOperation::PanCenter, f.params(ReceiveOperation::PanCenter), "capability.unavailable");
+    qint64 now = 0;
+    ControlSession limited(&f.store, 262144, SessionAuthorization::Controller, nullptr, [&] { return now; });
+    f.hello(limited);
+    const int before = f.backend->intents;
+    bool accepted = true;
+    for (int i = 0; i < ControlSession::kRequestBurst; ++i) {
+        accepted &= call(f.service, limited, "panadapter.setBandwidth", f.params(ReceiveOperation::PanBandwidth)).contains("result");
+    }
+    check(accepted && f.backend->intents == before + ControlSession::kRequestBurst, "receive verbs share existing burst budget");
+    check(error(call(f.service, limited, "slice.setMode", f.params(ReceiveOperation::Mode))) == "transport.limit_exceeded",
+          "switching methods cannot escape shared request budget");
+}
+
+void productionCapabilityContracts()
+{
+    // Constructors only: never connect a backend or start DSP/discovery. These
+    // pin declarations and the HL2 pre-connect normalized state, not RF effects.
+    FlexBackend flex;
+    const auto flexCaps = flex.capabilities();
+    check(flexCaps.receiveModeControl && flexCaps.receiveFilterControl
+        && !flexCaps.receiveAudioControl && !flexCaps.receivePanCenterControl && !flexCaps.receivePanBandwidthControl,
+        "Flex leaves legacy coupled geometry/audio unadvertised");
+    bool unsafeFlexFilter = false;
+    for (const ReceiveFilterMode& mode : flexCaps.receiveFilterControl->modes) {
+        unsafeFlexFilter |= mode.mode == "CW" || mode.mode == "FM" || mode.mode == "NFM" || mode.mode == "RTTY";
+    }
+    check(!unsafeFlexFilter, "pitch/preset/shift-dependent Flex filters are not guessed");
+    SimBackend sim;
+    const auto simCaps = sim.capabilities();
+    check(simCaps.receiveModeControl && simCaps.receiveModeControl->modes == QStringList{"USB", "LSB"}
+        && !simCaps.receiveFilterControl && !simCaps.receiveAudioControl
+        && !simCaps.receivePanCenterControl && !simCaps.receivePanBandwidthControl,
+        "Demo exposes only real sideband behavior, never echo-only filter or fixed scene geometry");
+    hl2::Hl2Backend hl2;
+    const auto hl2Caps = hl2.capabilities();
+    check(hl2Caps.receiveModeControl && hl2Caps.receiveFilterControl && hl2Caps.receiveAudioControl
+        && hl2Caps.receivePanCenterControl && !hl2Caps.receivePanBandwidthControl,
+        "HL2 exposes receive controls but not topology-changing bandwidth");
+    SliceDelta observed;
+    QObject::connect(&hl2, &IRadioBackend::sliceChanged, &hl2, [&](int, const SliceDelta& delta) { observed = delta; });
+    hl2.setSliceAudioGain(0, 37);
+    check(observed.audioGain == 37, "HL2 publishes backend mixer gain as normalized observation");
+    hl2.setSliceAudioMute(0, true);
+    check(observed.audioMute == true && observed.audioGain == 37, "HL2 mute readback preserves mixer gain");
+    hl2.setSliceMode(0, "LSB");
+    check(observed.mode == QStringLiteral("LSB") && observed.filterLow == -2900 && observed.filterHigh == -100,
+        "HL2 reports new-mode default passband with mode");
+    hl2.setSliceFilter(0, -2500, -200);
+    check(observed.filterLow == -2500 && observed.filterHigh == -200, "HL2 filter intent reports backend-owned passband");
+    anan::AnanBackend anan;
+    const auto ananCaps = anan.capabilities();
+    check(!ananCaps.receiveModeControl && !ananCaps.receiveFilterControl && !ananCaps.receiveAudioControl
+        && !ananCaps.receivePanCenterControl && ananCaps.receivePanBandwidthControl,
+        "ANAN exposes qualified bandwidth only, not center that implicitly retunes");
+    icom::IcomCivBackend icom;
+    const auto icomCaps = icom.capabilities();
+    check(!icomCaps.receiveModeControl && !icomCaps.receiveFilterControl && !icomCaps.receiveAudioControl
+        && !icomCaps.receivePanCenterControl && !icomCaps.receivePanBandwidthControl,
+        "Icom profile-dependent receive contracts remain unavailable");
+#ifdef AETHER_BACKEND_RTL
+    rtl::RtlSdrBackend rtl;
+    const auto rtlCaps = rtl.capabilities();
+    check(rtlCaps.receiveModeControl && !rtlCaps.receiveFilterControl && rtlCaps.receiveAudioControl
+        && !rtlCaps.receivePanCenterControl && rtlCaps.receivePanBandwidthControl,
+        "RTL exposes real mixer/bandwidth controls, not unused filter edges or retuning center");
+#endif
+}
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile profile(QStringLiteral("control-receive"));
+    if (!profile.isValid()) { return 1; }
+    QCoreApplication app(argc, argv);
+    schemaAndAuthorization();
+    dispatchAndReadback();
+    modeAndFilterOrdering();
+    safetyAndLifetime();
+    rangesAndBudget();
+    productionCapabilityContracts();
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/control_resource_service_test.cpp
+++ b/tests/control_resource_service_test.cpp
@@ -698,18 +698,20 @@ bool testSimBackendEndToEnd()
     const QJsonObject displayCadence =
         panValue.value(QStringLiteral("displayCadence")).toObject();
     if (!check(hasExactlyKeys(radioValue,
-                              {"id", "connected", "family", "identity", "capabilities"})
+                              {"id", "connected", "family", "identity", "capabilities", "meterDelivery"})
                    && hasExactlyKeys(identity,
                                      {"name", "model", "serial", "version", "manufacturer"})
                    && hasExactlyKeys(capabilities,
                                      {"maxSlices", "maxPanadapters", "sampleRatesHz",
                                       "tuningRangeHz", "declaredBands", "canTransmit",
                                       "maximumTransmitWatts", "hasTuner", "hasAmplifier",
-                                      "extensions", "sliceFrequencyControl"})
+                                      "extensions", "sliceFrequencyControl", "receiveModeControl",
+                                      "receiveFilterControl", "receiveAudioControl",
+                                      "receivePanCenterControl", "receivePanBandwidthControl"})
                    && hasExactlyKeys(sliceValue,
                                      {"id", "letter", "panadapterId", "owned",
                                       "frequencyHz", "frequencyObservation", "mode", "filter", "active",
-                                      "txSlice", "locked", "audio", "receive"})
+                                      "txSlice", "locked", "audio", "receive", "receiveObservation"})
                    && hasExactlyKeys(sliceValue.value(QStringLiteral("filter")).toObject(),
                                      {"lowHz", "highHz"})
                    && hasExactlyKeys(sliceValue.value(QStringLiteral("audio")).toObject(),
@@ -721,7 +723,7 @@ bool testSimBackendEndToEnd()
                    && hasExactlyKeys(receive.value(QStringLiteral("squelch")).toObject(),
                                      {"enabled", "level"})
                    && hasExactlyKeys(panValue,
-                                     {"id", "centerHz", "centerKnown",
+                                     {"id", "centerHz", "centerKnown", "owned", "geometryObservation",
                                       "bandwidthHz", "dbmRange", "bandwidthLimitsHz",
                                       "receive", "displayCadence"})
                    && hasExactlyKeys(panValue.value(QStringLiteral("dbmRange")).toObject(),

--- a/tests/control_telemetry_test.cpp
+++ b/tests/control_telemetry_test.cpp
@@ -195,6 +195,90 @@ void transmitIsObservationOnly()
           "read-only transmit resource exposes no TX command");
 }
 
+void admissionBackfillsValidDefinitions()
+{
+    Fixture f;
+    f.backend->connected = false;
+    f.radio.connectionStateChanged(false);
+    for (int id = 0; id < 130; ++id) {
+        MeterDef def = f.definition(id);
+        if (id < 64) { def.description = QString(129, 'x'); }
+        f.radio.meterModel().defineMeter(def);
+    }
+    f.backend->connected = true;
+    f.radio.connectionStateChanged(true);
+    f.adapter->flush();
+    check(f.store.snapshot({{"meter", "radio-1", {}}}).size() == 64
+        && f.store.get({"meter", "radio-1", "127"}),
+        "initial admission fills 64 valid slots past invalid early definitions");
+    f.radio.meterModel().updateValues({128}, {-12800});
+    f.radio.meterModel().removeMeter(64);
+    f.adapter->flush();
+    check(f.store.snapshot({{"meter", "radio-1", {}}}).size() == 64
+        && f.store.get({"meter", "radio-1", "128"}) && !f.sample(128).value("known").toBool(),
+        "removal promotes excluded definition without importing its retained sample");
+    MeterDef invalid = f.definition(65); invalid.name.clear();
+    f.radio.meterModel().defineMeter(invalid);
+    f.adapter->flush();
+    check(!f.store.get({"meter", "radio-1", "65"}) && f.store.get({"meter", "radio-1", "129"})
+        && f.store.snapshot({{"meter", "radio-1", {}}}).size() == 64,
+        "invalidating a selected definition also fills the vacancy");
+    check(f.adapter->meterDelivery().value("limited").toBool(), "backfill does not erase incomplete-view history");
+}
+
+void unicodeAndMeterAdvertisement()
+{
+    Fixture f;
+    ControlService service(&f.store);
+    ControlSession client(&f.store, 262144, SessionAuthorization::Observer);
+    call(service, client, "hello", {{"versions", QJsonArray{1}}});
+    const auto advertised = [&] { return service.capabilities(client).value("capabilities").toArray(); };
+    check(advertised().contains("transmitState.read") && !advertised().contains("meter.read"),
+        "transmit singleton does not advertise absent meter resources");
+    for (const QString& bad : {QString(QChar(0x202e)), QString(QChar(0x2066)),
+                              QString::fromUcs4(U"\U000e0001"), QString(QChar(0x0009))}) {
+        MeterDef def = f.definition(0); def.description = bad;
+        f.radio.meterModel().defineMeter(def); f.adapter->flush();
+        check(!f.store.get({"meter", "radio-1", "0"}), "Unicode control/format metadata is excluded, including supplementary characters");
+    }
+    MeterDef valid = f.definition(0); valid.description = QString::fromUtf8("Signal — 接收");
+    f.radio.meterModel().defineMeter(valid); f.adapter->flush();
+    check(f.store.get({"meter", "radio-1", "0"}).has_value() && advertised().contains("meter.read"),
+        "ordinary Unicode definition is readable before its first sample");
+    f.radio.meterModel().removeMeter(0);
+    check(!advertised().contains("meter.read"), "last meter removal retires its advertisement");
+}
+
+void delayedIdleCannotSurviveActivity()
+{
+    for (int kind = 0; kind < 4; ++kind) {
+        Fixture f;
+        f.backend->txCapable = true;
+        f.radio.capabilitiesChanged(true, f.backend->capabilities());
+        const auto activity = [&](bool active) {
+            if (kind == 0) {
+                f.radio.transmitModel().setTransmitting(active);
+            } else {
+                TransmitDelta delta;
+                if (kind == 2) { delta.tune = active; } else { delta.mox = active; }
+                if (kind == 3) {
+                    f.radio.handleStatusForTest("interlock", {{"state", active ? "TRANSMITTING" : "READY"}});
+                }
+                else { f.radio.transmitModel().applyChanges(delta); }
+                if (kind == 1) { f.radio.transmitModel().moxChanged(active); }
+            }
+        };
+        f.radio.radioTransmitConfirmed(false);
+        activity(true);
+        f.radio.radioTransmitConfirmed(false);
+        check(f.transmitState() == "unknown", "conflicting idle is not telemetry evidence during activity");
+        activity(false);
+        check(f.transmitState() == "unknown", "falling activity edge cannot revive delayed idle telemetry");
+        f.radio.radioTransmitConfirmed(false);
+        check(f.transmitState() == "idle", "fresh post-activity idle restores telemetry");
+    }
+}
+
 void teardownDoesNotRepublish()
 {
     Fixture f;
@@ -244,5 +328,8 @@ int main(int argc, char** argv)
     transmitIsObservationOnly();
     teardownDoesNotRepublish();
     swrRequiresApplicablePower();
+    admissionBackfillsValidDefinitions();
+    unicodeAndMeterAdvertisement();
+    delayedIdleCannotSurviveActivity();
     return failures == 0 ? 0 : 1;
 }

--- a/tests/control_telemetry_test.cpp
+++ b/tests/control_telemetry_test.cpp
@@ -1,0 +1,248 @@
+#include "TestSettingsProfile.h"
+#include "core/control/ControlService.h"
+#include "core/control/RadioTelemetryAdapter.h"
+#include "models/RadioModel.h"
+
+#include <QCoreApplication>
+#include <QDateTime>
+#include <QJsonArray>
+#include <QJsonDocument>
+
+#include <cstdio>
+#include <limits>
+
+using namespace AetherSDR;
+using namespace AetherSDR::control;
+
+namespace {
+int failures = 0;
+void check(bool ok, const char* message)
+{
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", message);
+    failures += !ok;
+}
+
+class Backend final : public IRadioBackend {
+public:
+    bool connected{false};
+    bool txCapable{false};
+    RadioCapabilities capabilities() const override { RadioCapabilities c; c.canTransmit = txCapable; return c; }
+    bool isConnected() const override { return connected; }
+    void connectRadio(const RadioConnectRequest&) override {}
+    void disconnectRadio() override { connected = false; }
+    void setSliceFrequency(int, double) override {}
+    void setSliceMode(int, const QString&) override {}
+    void setSliceFilter(int, int, int) override {}
+    void setSliceAgc(int, const QString&, int) override {}
+    void setPanCenter(const QString&, double, PanCenterIntent) override {}
+    void setKeying(bool) override { check(false, "telemetry must never key"); }
+    void invokeExtension(const QString&, const QString&, quint64, const QVariant&) override {}
+};
+
+QJsonObject call(ControlService& service, ControlSession& session, const QString& method, const QJsonObject& params)
+{
+    QJsonObject request{{"v", 1}, {"id", "test"}, {"method", method}, {"params", params}};
+    if (method != QStringLiteral("hello")) { request.insert("sessionId", session.sessionId()); }
+    return service.handle(QJsonDocument(request).toJson(QJsonDocument::Compact), &session).message;
+}
+
+struct Fixture {
+    RadioModel radio;
+    ControlResourceStore store;
+    Backend* backend{nullptr};
+    qint64 clock{0};
+    std::unique_ptr<RadioTelemetryAdapter> adapter;
+    Fixture()
+    {
+        auto owned = std::make_unique<Backend>(); backend = owned.get();
+        radio.setBackendForTest(std::move(owned), "telemetry-test");
+        adapter = std::make_unique<RadioTelemetryAdapter>(&radio, &store, "radio-1", nullptr, [&] { return clock; });
+        backend->connected = true;
+        radio.connectionStateChanged(true);
+    }
+    MeterDef definition(int id) const { return {id, "SLC", id, "LEVEL", "dBm", -140, 0, "Receive level"}; }
+    void define(int id) { radio.meterModel().defineMeter(definition(id)); }
+    QJsonObject sample(int id) const
+    {
+        const auto value = store.get({"meter", "radio-1", QString::number(id)});
+        return value ? value->value.value("sample").toObject() : QJsonObject{};
+    }
+    QString transmitState() const { return store.get({"transmitState", "radio-1", {}})->value.value("state").toString(); }
+};
+
+void freshnessAndDefinitions()
+{
+    Fixture f;
+    f.define(0);
+    f.adapter->flush();
+    check(!f.sample(0).value("known").toBool() && f.sample(0).value("value").isNull(),
+          "definition without a sample never fabricates zero");
+    f.radio.meterModel().updateValues({0}, {-12800});
+    f.adapter->flush();
+    check(f.sample(0).value("known").toBool() && f.sample(0).value("valid").toBool()
+        && f.sample(0).value("value").toDouble() == -100, "physical meter value retains definition units");
+    f.clock = 2001; f.adapter->flush();
+    check(f.sample(0).value("known").toBool() && !f.sample(0).value("fresh").toBool()
+        && f.sample(0).value("value").isNull(), "stale sample is explicitly unknown for current value");
+    const auto revision = f.store.get({"meter", "radio-1", "0"})->revision;
+    f.clock += 90000; f.adapter->flush();
+    check(f.store.get({"meter", "radio-1", "0"})->revision == revision, "expired meter does not publish forever as age grows");
+    f.radio.meterModel().updateValues({0}, {-12800}); f.adapter->flush();
+    check(f.sample(0).value("fresh").toBool() && f.sample(0).value("ageMs").toInt() == 0,
+          "unchanged values refresh sample liveness");
+    f.define(0); f.adapter->flush();
+    check(f.sample(0).value("known").toBool(), "duplicate identical definitions retain real samples");
+    MeterDef changed = f.definition(0); changed.unit = "Watts";
+    f.radio.meterModel().defineMeter(changed); f.adapter->flush();
+    check(!f.sample(0).value("known").toBool(), "unit redefinition invalidates a legacy retained sample");
+    f.radio.meterModel().updateValues({0}, {10}); f.adapter->flush();
+    check(f.sample(0).value("value").toInt() == 10, "only a new sample can populate changed units");
+    f.radio.meterModel().removeMeter(0);
+    check(!f.store.get({"meter", "radio-1", "0"}), "meter removal removes resource");
+    f.define(0); f.adapter->flush();
+    check(!f.sample(0).value("known").toBool(), "same id recreated does not inherit former sample");
+    changed = f.definition(1); changed.description = QString(129, 'x');
+    f.radio.meterModel().defineMeter(changed); f.adapter->flush();
+    check(!f.store.get({"meter", "radio-1", "1"}) && f.adapter->meterDelivery().value("limited").toBool(),
+          "oversized metadata is excluded with incomplete delivery disclosed");
+    f.radio.meterModel().clear();
+    check(f.store.snapshot({{"meter", "radio-1", {}}}).isEmpty(), "clear removes every published meter");
+    f.define(0); f.radio.meterModel().updateValues({0}, {-100}); f.adapter->flush();
+    f.backend->connected = false; f.radio.connectionStateChanged(false);
+    check(f.store.snapshot({{"meter", "radio-1", {}}}).isEmpty(), "disconnect clears telemetry resources");
+    f.radio.meterModel().meterUpdated(0, -40); f.adapter->flush();
+    check(f.store.snapshot({{"meter", "radio-1", {}}}).isEmpty(), "late disconnected callback cannot resurrect a resource");
+    f.backend->connected = true; f.radio.connectionStateChanged(true); f.adapter->flush();
+    check(!f.sample(0).value("known").toBool(), "new connection never imports the former connection's retained sample");
+}
+
+void coalescingBoundsAndRevisions()
+{
+    Fixture f;
+    const ResourceAddress slice{"slice", "radio-1", "0"};
+    f.store.upsert(slice, {{"mode", "USB"}});
+    const quint64 sliceRevision = f.store.get(slice)->revision;
+    for (int id = 0; id < RadioTelemetryAdapter::kMaxMeters + 10; ++id) { f.define(id); }
+    f.adapter->flush();
+    check(f.store.snapshot({{"meter", "radio-1", {}}}).size() == RadioTelemetryAdapter::kMaxMeters
+        && f.adapter->meterDelivery().value("limited").toBool(), "resource population is hard bounded and overflow disclosed");
+    ControlService service(&f.store);
+    ControlSession client(&f.store, 262144, SessionAuthorization::Observer);
+    check(call(service, client, "hello", {{"versions", QJsonArray{1}}}).contains("result"), "telemetry observer negotiated");
+    const QJsonArray selectors{QJsonObject{{"type", "meter"}, {"radioSession", "radio-1"}},
+        QJsonObject{{"type", "slice"}, {"radioSession", "radio-1"}},
+        QJsonObject{{"type", "transmitState"}, {"radioSession", "radio-1"}}};
+    const auto baseline = call(service, client, "resource.subscribe", {{"resources", selectors}});
+    check(baseline.contains("result") && QJsonDocument(baseline).toJson(QJsonDocument::Compact).size() < ProtocolLimits::kMaxMessageBytes,
+          "complete bounded meter/slice/transmit baseline fits wire cap");
+    for (int i = 0; i < 10000; ++i) { f.radio.meterModel().meterUpdated(0, float(i)); }
+    check(client.takePendingFrames().isEmpty(), "high-rate samples do not publish from sample callback");
+    f.adapter->flush();
+    const auto frames = client.takePendingFrames();
+    check(frames.size() == 1 && f.sample(0).value("value").toDouble() == 9999, "one tick publishes only bounded latest value");
+    check(f.store.get(slice)->revision == sliceRevision, "telemetry never invalidates independent receive-command revision");
+    ControlSession slow(&f.store, 360, SessionAuthorization::Observer);
+    call(service, slow, "hello", {{"versions", QJsonArray{1}}});
+    call(service, slow, "resource.subscribe", {{"resources", selectors}});
+    f.radio.meterModel().meterUpdated(0, -90); f.adapter->flush();
+    const auto overflow = slow.takePendingFrames();
+    check(overflow.size() == 1 && QJsonDocument::fromJson(overflow.first()).object().value("event") == "resource.resyncRequired",
+          "slow telemetry consumer uses existing bounded resync policy");
+    client.revokeAuthorization();
+    f.radio.meterModel().meterUpdated(0, -80); f.adapter->flush();
+    check(client.takePendingFrames().isEmpty(), "revocation discards pending telemetry and suppresses future delivery");
+}
+
+void snapshotRefusalIsAtomic()
+{
+    ControlResourceStore store;
+    ControlService service(&store);
+    ControlSession client(&store, 1024 * 1024, SessionAuthorization::Observer);
+    call(service, client, "hello", {{"versions", QJsonArray{1}}});
+    for (int id = 0; id < 5; ++id) {
+        store.upsert({"meter", "radio-1", QString::number(id)}, {{"large", QString(65536, 'x')}});
+    }
+    const auto reply = call(service, client, "resource.subscribe", {{"resources", QJsonArray{
+        QJsonObject{{"type", "meter"}, {"radioSession", "radio-1"}}}}});
+    check(reply.value("error").toObject().value("code") == "transport.limit_exceeded", "oversized atomic snapshot refused within wire limit");
+    store.upsert({"meter", "radio-1", "0"}, {{"small", true}});
+    check(client.takePendingFrames().isEmpty(), "failed baseline installs no invisible subscription");
+    const auto narrow = call(service, client, "resource.subscribe", {{"resources", QJsonArray{
+        QJsonObject{{"type", "meter"}, {"radioSession", "radio-1"}, {"id", "0"}}}}});
+    check(narrow.contains("result") && narrow.value("result").toObject().value("subscription") == "sub-1",
+          "narrow baseline succeeds after refusal without consuming subscription identity");
+}
+
+void transmitIsObservationOnly()
+{
+    Fixture f;
+    check(f.transmitState() == "unsupported", "RX-only backend reports unsupported, not confirmed TX idle");
+    f.backend->txCapable = true; f.radio.capabilitiesChanged(true, f.backend->capabilities());
+    check(f.transmitState() == "unknown", "constructor defaults cannot fabricate transmitter idle");
+    f.radio.radioTransmitConfirmed(false);
+    check(f.transmitState() == "idle", "only confirmed backend idle makes state idle");
+    f.radio.transmitModel().moxChanged(true); f.radio.transmitModel().moxChanged(false);
+    check(f.transmitState() == "unknown", "command-off edge cannot establish idle");
+    f.radio.radioTransmitConfirmed(true);
+    check(f.transmitState() == "transmitting", "confirmed active transmit state can be observed");
+    f.radio.backendRebuilt();
+    check(f.transmitState() == "unknown", "backend lifetime edge invalidates transmit knowledge");
+    ControlService service(&f.store);
+    ControlSession client(&f.store, 262144, SessionAuthorization::ObserverController);
+    call(service, client, "hello", {{"versions", QJsonArray{1}}});
+    check(!service.capabilities(client).value("grants").toArray().contains("transmit"), "no transmit grant is representable");
+    check(call(service, client, "transmit.set", {{"enabled", true}}).value("error").toObject().value("code") == "request.unknown_method",
+          "read-only transmit resource exposes no TX command");
+}
+
+void teardownDoesNotRepublish()
+{
+    Fixture f;
+    f.define(0);
+    f.adapter->flush();
+    MeterDef invalid = f.definition(1);
+    invalid.description = QString(129, 'x');
+    f.radio.meterModel().defineMeter(invalid);
+    check(f.adapter->meterDelivery().value("limited").toBool(), "teardown starts with limited delivery");
+    int publications = 0;
+    QObject::connect(f.adapter.get(), &RadioTelemetryAdapter::deliveryChanged, &f.store,
+                     [&] { ++publications; });
+    f.adapter.reset();
+    check(publications == 0, "destruction never calls the partially destroyed projection owner");
+    check(f.store.snapshot({{"meter", "radio-1", {}}}).isEmpty()
+        && !f.store.get({"transmitState", "radio-1", {}}), "teardown still retires telemetry resources");
+}
+
+void swrRequiresApplicablePower()
+{
+    Fixture f;
+    f.radio.meterModel().defineMeter({0, "TX", 0, "SWR", "SWR", 1, 100, "Standing wave ratio"});
+    f.radio.meterModel().defineMeter({1, "TX", 0, "FWDPWR", "Watts", 0, 100, "Forward power"});
+    f.radio.meterModel().updateValues({0, 1}, {256, 10});
+    f.adapter->flush();
+    check(f.sample(0).value("valid").toBool() && f.sample(0).value("value").toDouble() == 2,
+          "fresh SWR with qualifying power is a valid physical sample");
+    f.radio.meterModel().updateValues({1}, {0});
+    f.adapter->flush();
+    check(f.sample(0).value("fresh").toBool() && !f.sample(0).value("valid").toBool()
+        && f.sample(0).value("value").isNull(), "fresh SWR without power never looks like a healthy ratio");
+    f.radio.meterModel().updateValues({0, 1}, {256, 10});
+    f.radio.meterModel().setLastSwrUpdateMsForTest(QDateTime::currentMSecsSinceEpoch() - 3000);
+    f.adapter->flush();
+    check(!f.sample(0).value("valid").toBool(), "the model's own SWR freshness gate remains authoritative");
+}
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile profile(QStringLiteral("control-telemetry"));
+    if (!profile.isValid()) { return 1; }
+    QCoreApplication app(argc, argv);
+    freshnessAndDefinitions();
+    coalescingBoundsAndRevisions();
+    snapshotRefusalIsAtomic();
+    transmitIsObservationOnly();
+    teardownDoesNotRepublish();
+    swrRequiresApplicablePower();
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/local_control_server_test.cpp
+++ b/tests/local_control_server_test.cpp
@@ -533,6 +533,60 @@ bool runCrashRecoveryTest()
                  "server must recover the stale lock and endpoint left by a crash");
 }
 
+bool runReserveEndpointTest()
+{
+    // Startup ordering: aetherd reserves its endpoint before settings/model
+    // construction (which can pump nested event loops) and serves only after
+    // every target is bound. An early client must be closed without a session
+    // or a reply, must not stop a later client from negotiating, and serving
+    // must begin exactly once per listen.
+    const QString name = uniqueName(QStringLiteral("aetherd-reserve-"));
+    LocalControlServer server;
+    if (!check(server.listen(name, LocalControlServer::ListenMode::ReserveEndpoint),
+               "reserved endpoint must listen")) {
+        return false;
+    }
+    QLocalSocket early;
+    if (!check(connectSocket(&early, server), "early client must reach the reserved endpoint")) {
+        return false;
+    }
+    QByteArray request = QJsonDocument(helloRequest()).toJson(QJsonDocument::Compact);
+    request.append('\n');
+    early.write(request);
+    early.flush();
+    if (!check(waitUntil([&early] {
+            return early.state() == QLocalSocket::UnconnectedState;
+        }), "early client must be closed while the endpoint is only reserved")
+        || !check(!early.canReadLine() && early.bytesAvailable() == 0,
+                  "a reserved endpoint must not answer hello or create a session")) {
+        return false;
+    }
+    if (!check(server.startServing(), "serving must begin once targets are bound")
+        || !check(!server.startServing(), "serving cannot begin twice")) {
+        return false;
+    }
+    QLocalSocket retry;
+    if (!check(connectSocket(&retry, server), "retrying client must connect once serving")) {
+        return false;
+    }
+    const QJsonObject welcome = exchange(&retry, helloRequest());
+    if (!check(!welcome.value(QStringLiteral("result")).toObject()
+                    .value(QStringLiteral("sessionId")).toString().isEmpty(),
+               "retrying client must negotiate after startServing")) {
+        return false;
+    }
+    server.close();
+    if (!check(!server.startServing(), "a closed server cannot serve")
+        || !check(server.listen(name), "the default listen mode must serve immediately")) {
+        return false;
+    }
+    QLocalSocket immediate;
+    return check(connectSocket(&immediate, server), "client must connect after relisten")
+        && check(!exchange(&immediate, helloRequest()).value(QStringLiteral("result")).toObject()
+                      .value(QStringLiteral("sessionId")).toString().isEmpty(),
+                 "default listen mode must admit sessions without a separate startServing");
+}
+
 bool runEndpointValidationTest()
 {
     LocalControlServer server;
@@ -564,5 +618,6 @@ int main(int argc, char* argv[])
         && runBackpressureTest()
         && runStaleEndpointTest()
         && runCrashRecoveryTest()
+        && runReserveEndpointTest()
         && runEndpointValidationTest() ? 0 : 1;
 }

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -176,6 +176,27 @@ target_include_directories(control_slice_frequency_test PRIVATE src tests)
 target_link_libraries(control_slice_frequency_test PRIVATE aethercore Qt6::Core)
 add_test(NAME control_slice_frequency_test COMMAND control_slice_frequency_test)
 
+# Socket-free typed receive admission; injected backend intents and separate
+# normalized observations, no synthetic firmware peer or network endpoint.
+add_executable(control_receive_test tests/control_receive_test.cpp)
+target_include_directories(control_receive_test PRIVATE src tests)
+target_link_libraries(control_receive_test PRIVATE aethercore Qt6::Core)
+add_test(NAME control_receive_test COMMAND control_receive_test)
+
+# Socket-free bounded telemetry and transmit observation. The test injects
+# samples and a monotonic clock, with no sockets, peers, timers waited on or TX.
+add_executable(control_telemetry_test tests/control_telemetry_test.cpp)
+target_include_directories(control_telemetry_test PRIVATE src tests)
+target_link_libraries(control_telemetry_test PRIVATE aethercore Qt6::Core)
+add_test(NAME control_telemetry_test COMMAND control_telemetry_test)
+
+# not registered: explicit opt-in diagnostic. Launches OUR aetherd and binds
+# its unique QLocalServer endpoint (Unix-domain socket / Windows named pipe).
+# Built-in Demo only; no third-party firmware peer. Exit 77 on listen refusal.
+# Never part of the default build, CTest graph or per-PR CI gate.
+add_executable(aetherd_receive_smoke EXCLUDE_FROM_ALL tools/aetherd_receive_smoke.cpp)
+target_link_libraries(aetherd_receive_smoke PRIVATE Qt6::Core Qt6::Network)
+
 # Real factory wiring, with local=false: simulator metadata only, no sockets,
 # device scans, radio connections or third-party firmware stand-ins.
 add_executable(radio_discovery_source_test tests/radio_discovery_source_test.cpp)
@@ -4808,6 +4829,8 @@ set(AETHER_SETTINGS_CONSUMERS
     icom_control_profile_test
     control_resource_service_test
     control_slice_frequency_test
+    control_receive_test
+    control_telemetry_test
     aetherd_discovery_startup_test
     automation_bridge_start_outcome_test
     slice_label_test

--- a/tools/aetherd_receive_smoke.cpp
+++ b/tools/aetherd_receive_smoke.cpp
@@ -1,0 +1,230 @@
+// Explicit opt-in integration diagnostic for OUR daemon and built-in Demo.
+// Never a stand-in for third-party firmware and never a TX/hardware test.
+#include <QCoreApplication>
+#include <QCryptographicHash>
+#include <QDir>
+#include <QElapsedTimer>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLocalSocket>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+#include <QThread>
+#include <QUuid>
+
+#include <cstdio>
+#include <functional>
+
+namespace {
+class Client {
+public:
+    QLocalSocket socket;
+    QString session;
+    QString failure;
+    qint64 sequence{0};
+    QHash<QString, QJsonObject> latest;
+    int nextId{0};
+
+    bool attach(const QString& endpoint)
+    {
+        socket.connectToServer(endpoint);
+        return socket.waitForConnected(500);
+    }
+    QJsonObject call(const QString& method, const QJsonObject& params = {})
+    {
+        const QString id = QString::number(++nextId);
+        QJsonObject request{{"v", 1}, {"id", id}, {"method", method}, {"params", params}};
+        if (!session.isEmpty()) { request.insert("sessionId", session); }
+        socket.write(QJsonDocument(request).toJson(QJsonDocument::Compact) + '\n');
+        socket.flush();
+        QElapsedTimer clock; clock.start();
+        while (clock.elapsed() < 5000) {
+            if (!socket.canReadLine()) { socket.waitForReadyRead(100); }
+            while (socket.canReadLine()) {
+                const QByteArray line = socket.readLine(256 * 1024 + 1);
+                if (!line.endsWith('\n')) { failure = "oversized/incomplete daemon frame"; return {}; }
+                const QJsonObject message = QJsonDocument::fromJson(line).object();
+                if (message.contains("event")) {
+                    observe(message);
+                } else if (message.value("id") == id) {
+                    if (message.contains("error")) {
+                        failure = QJsonDocument(message.value("error").toObject()).toJson(QJsonDocument::Compact);
+                        return {};
+                    }
+                    return message.value("result").toObject();
+                }
+            }
+            if (socket.state() == QLocalSocket::UnconnectedState) {
+                failure = "daemon disconnected before responding";
+                return {};
+            }
+        }
+        failure = "daemon response timeout";
+        return {};
+    }
+    void observe(const QJsonObject& message)
+    {
+        const qint64 next = message.value("sequence").toInteger();
+        if (next <= sequence) { failure = "non-monotonic event sequence"; }
+        sequence = next;
+        const QJsonObject resource = message.value("resource").toObject();
+        const QString key = resource.value("type").toString() + '/' + resource.value("id").toString();
+        if (latest.size() < 128 || latest.contains(key)) { latest.insert(key, message); }
+    }
+    QJsonObject get(const QString& type, const QString& id = {})
+    {
+        QJsonObject resource{{"type", type}};
+        if (type != "radioCatalogue" && type != "server" && type != "radioSession") {
+            resource.insert("radioSession", "radio-1");
+        }
+        if (!id.isEmpty()) { resource.insert("id", id); }
+        return call("resource.get", {{"resource", resource}});
+    }
+};
+
+bool waitUntil(const std::function<bool()>& predicate, int timeoutMs = 5000)
+{
+    QElapsedTimer clock; clock.start();
+    while (clock.elapsed() < timeoutMs) {
+        if (predicate()) { return true; }
+        QThread::msleep(100);
+    }
+    return false;
+}
+
+bool check(bool ok, const char* description)
+{
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", description);
+    return ok;
+}
+
+bool exercise(Client& controller, Client& observer)
+{
+    observer.session = observer.call("hello", {{"versions", QJsonArray{1}}}).value("sessionId").toString();
+    if (!check(!controller.session.isEmpty() && !observer.session.isEmpty() && controller.session != observer.session,
+               "two local clients negotiated independent sessions")) { return false; }
+    const QJsonObject baseline = observer.call("resource.subscribe", {{"resources", QJsonArray{
+        QJsonObject{{"type", "slice"}, {"radioSession", "radio-1"}},
+        QJsonObject{{"type", "meter"}, {"radioSession", "radio-1"}},
+        QJsonObject{{"type", "transmitState"}, {"radioSession", "radio-1"}}}}});
+    if (!check(baseline.contains("subscription"), "observer installed atomic resource subscription")) { return false; }
+    for (int cycle = 0; cycle < 2; ++cycle) {
+        const QJsonObject catalogue = controller.get("radioCatalogue");
+        const QJsonArray entries = catalogue.value("value").toObject().value("entries").toArray();
+        QJsonObject demo;
+        for (const QJsonValue& value : entries) {
+            const auto entry = value.toObject();
+            if (entry.value("family") == "sim" && entry.value("serial") == "DEMO-0001") { demo = entry; }
+        }
+        if (!check(!demo.isEmpty(), "catalogue offers exact Demo identity without LAN/USB discovery")) { return false; }
+        const auto connected = controller.call("radio.connect", {{"radioSession", "radio-1"},
+            {"radioId", demo.value("id")}, {"catalogueRevision", catalogue.value("revision")}});
+        if (!check(connected.value("accepted").toBool(), "explicit Demo connection intent accepted")) { return false; }
+        if (!check(waitUntil([&] {
+                const auto caps = controller.call("capabilities.get").value("capabilities").toArray();
+                return caps.contains("slice.setFrequency") && caps.contains("slice.setMode");
+            }), "Demo publishes qualified frequency and mode controls")) { return false; }
+        for (const QString& mode : {QStringLiteral("LSB"), QStringLiteral("USB")}) {
+            const auto slice = controller.get("slice", "0");
+            const auto response = controller.call("slice.setMode", {{"radioSession", "radio-1"}, {"slice", "0"},
+                {"expectedRevision", slice.value("revision")}, {"mode", mode}});
+            if (!check(response.value("accepted").toBool(), "typed mode intent accepted")) { return false; }
+            if (!check(waitUntil([&] {
+                const auto value = observer.get("slice", "0").value("value").toObject();
+                return value.value("receiveObservation").toObject().value("mode").toObject().value("value") == mode;
+            }), "second client converges to authoritative mode readback")) { return false; }
+        }
+        const auto slice = controller.get("slice", "0");
+        const int hz = 14230000 + cycle * 1000;
+        if (!check(controller.call("slice.setFrequency", {{"radioSession", "radio-1"}, {"slice", "0"},
+                {"expectedRevision", slice.value("revision")}, {"hz", hz}}).value("accepted").toBool(),
+                "existing frequency intent remains usable")) { return false; }
+        if (!check(waitUntil([&] {
+                const auto value = observer.get("slice", "0").value("value").toObject();
+                return value.value("frequencyObservation").toObject().value("hz").toInt() == hz;
+            }), "second client converges to authoritative frequency readback")) { return false; }
+        // Normal Demo RX produces audio/spectrum, not MeterModel samples.
+        // Sample delivery/freshness is covered by injected-transport tests;
+        // do not add synthetic telemetry just to make this diagnostic pass.
+        const auto delivery = observer.get("radioSession", "radio-1").value("value").toObject()
+            .value("meterDelivery").toObject();
+        if (!check(delivery.value("maxEntries").toInt() == 64
+                && delivery.value("publishIntervalMs").toInt() == 100
+                && delivery.value("staleAfterMs").toInt() == 2000,
+                "second client reads the bounded meter delivery contract")) { return false; }
+        if (!check(observer.get("transmitState").value("value").toObject().value("state") == "unsupported",
+                   "read-only transmit state correctly describes RX-only Demo")) { return false; }
+        if (!check(controller.call("radio.disconnect", {{"radioSession", "radio-1"}}).value("accepted").toBool(),
+                   "explicit shared-session disconnect accepted")) { return false; }
+        if (!check(waitUntil([&] {
+                return controller.get("radioSession", "radio-1").value("value").toObject()
+                    .value("connectionControl").toObject().value("state") == "idle";
+            }), "daemon returns to idle before reconnect")) { return false; }
+        observer.call("capabilities.get");
+        observer.latest.clear();
+    }
+    return check(controller.failure.isEmpty() && observer.failure.isEmpty(), "responses and event sequences remain valid across reconnect");
+}
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    QCoreApplication::setApplicationName(QStringLiteral("aetherd"));
+    if (app.arguments().size() != 2 || !QFileInfo::exists(app.arguments().at(1))) {
+        std::fprintf(stderr, "usage: aetherd_receive_smoke /absolute/path/to/aetherd[.exe]\n");
+        return 2;
+    }
+    QTemporaryDir scratch;
+    if (!scratch.isValid()) { return 1; }
+    const QString logicalEndpoint = "aetherd-receive-" + QUuid::createUuid().toString(QUuid::WithoutBraces);
+    // Client-side locator for LocalControlServer's current-user transport.
+    // The daemon alone creates/checks the private runtime directory and lock.
+    const QString digest = QString::fromLatin1(QCryptographicHash::hash(
+        logicalEndpoint.toUtf8(), QCryptographicHash::Sha256).toHex().left(24));
+#ifdef Q_OS_WIN
+    const QString endpoint = QStringLiteral("aethersdr-%1").arg(digest);
+#else
+    const QString endpoint = QDir(QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation))
+        .filePath(QStringLiteral("aethersdr/control-%1.sock").arg(digest));
+#endif
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    env.remove("AETHER_AUTOMATION_ALLOW_TX");
+    env.insert("AETHER_AUTOMATION", "1");
+    env.insert("AETHER_AUTOMATION_NO_TX", "1");
+    env.insert("AETHER_SETTINGS_DIR", scratch.path());
+    QProcess daemon;
+    daemon.setProcessEnvironment(env);
+    daemon.setProcessChannelMode(QProcess::MergedChannels);
+    daemon.start(QFileInfo(app.arguments().at(1)).absoluteFilePath(),
+        {"--socket", logicalEndpoint, "--discover-sim", "--allow-local-control"});
+    if (!daemon.waitForStarted(3000)) { return 1; }
+    Client controller;
+    // Readiness is a successful hello, not merely a connected pipe. The
+    // daemon reserves its endpoint before constructors that may pump events;
+    // an early connection is deliberately closed without creating a session.
+    const bool attached = waitUntil([&] {
+        controller.socket.abort();
+        controller.failure.clear();
+        if (controller.attach(endpoint)) {
+            controller.session = controller.call("hello", {{"versions", QJsonArray{1}}})
+                .value("sessionId").toString();
+        }
+        return !controller.session.isEmpty() || daemon.state() == QProcess::NotRunning;
+    }, 15000) && !controller.session.isEmpty();
+    Client observer;
+    const bool ok = attached && observer.attach(endpoint) && exercise(controller, observer);
+    controller.socket.abort(); observer.socket.abort();
+    daemon.terminate();
+    if (!daemon.waitForFinished(3000)) { daemon.kill(); daemon.waitForFinished(3000); }
+    const QByteArray log = daemon.readAll();
+    if (!ok) {
+        std::fprintf(stderr, "%s\n%s\n%s\n", qPrintable(controller.failure), qPrintable(observer.failure), log.right(4096).constData());
+        if (log.contains("cannot listen")) { return 77; }
+    }
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Continue the accepted AetherD Stage 3 plan with capability-qualified local receive controls and bounded read-only telemetry. Related to #3849; follows #5550. This is a milestone, not completion of the headless-engine RFC.

- Add closed, typed `slice.setMode`, `slice.setFilter`, `slice.setAudioGain`, `slice.setAudioMute`, `panadapter.setCenter`, and `panadapter.setBandwidth` methods for existing owned resources.
- Preserve the default observe-only daemon. `--allow-local-control` explicitly grants all current-user local clients non-TX control; every intent rechecks authorization, revision, ownership, lifetime/thread, observation and backend capability constraints.
- Publish separate backend-reported receive/geometry observations, bounded/coalesced meter resources with freshness and SWR validity, and read-only transmit state. Accepted intent does not imply completion or create optimistic observation state.
- Share the existing frequency-control safety guard; bound atomic subscription baselines before installing subscriptions.
- Reserve the daemon endpoint before initialization but admit clients only after target/resource setup. Early clients retry `hello`; they cannot race one-shot target binding.

## Scope and maintainer decisions

| Files/group | Included behavior | Scope assessment |
|---|---|---|
| Daemon, service, target and shared receive guard | Six typed local receive methods; preserve frequency and non-TX admission | Accepted Stage 3 continuation; new public protocol surface requires maintainer review |
| Resource and telemetry adapters, slice/pan/meter models | Authoritative observation, bounded meter delivery, read-only TX state and lifecycle cleanup | Required for client convergence and telemetry |
| Backend capability records | Qualify each operation from its actual implementation, not the radio family name | Required admission policy; unsupported/coupled behavior stays unavailable |
| HL2/RTL gain/mute readback | Publish applied mixer/DDC state; reset RTL state on new DDC | Needed observation provenance; HL2 can now display actual initial unity gain (100) instead of a default-looking 50, without changing audio |
| Tests and CMake | Socket-free contract/regression tests and optional first-party daemon diagnostic | Verification; no expansion of the frozen PR test gate |
| Local server startup | Separate endpoint reservation from request admission | Fixes the early-client startup race exposed by the Windows daemon diagnostic; no change to grants or binding guards |
| Protocol/catalogue/capability docs and AGENTS | Define schema, concurrency, limitations and milestone state | Documentation of this surface; no changelog entry |

No transmit methods/grants/leases, remote access, arbitrary commands/endpoints, receiver creation/removal, desktop adapter migration, or binary streams are added. Desktop control routing is unchanged.

Backend qualification is deliberately conservative: Demo exposes USB/LSB mode but not its echo-only filters/no-op audio/fixed geometry; Flex and normally TX-enabled HL2 still need normalized TX-idle readback before daemon controls become live. Icom remains unqualified and outside the daemon catalogue. See `docs/aetherd-local-receive-control.md` for the full matrix and limits.

## Review and verification

Pre-submission issue-fit and lifecycle/failure-mode review completed. It found and fixed teardown re-entry: destroying a limited telemetry adapter could publish into its partially destroyed owner. The regression failed before the fix and passed afterward. Added SWR power/freshness coverage.

The Windows daemon diagnostic also exposed an initialization race: an early local client could be accepted while model/settings construction pumped a nested event loop, causing the subsequent one-shot connection-target binding to fail. Startup now reserves the endpoint without creating sessions, binds all targets/resources, then begins serving. The diagnostic waits for a successful `hello`, not merely a connected pipe; its retries remain bounded.

The preserved old Windows daemon passed a later timing-dependent run too; this is not claimed as a deterministic old/new comparison. To verify the guard, a temporary one-second startup event loop was injected in the isolated Mac test copy: reservation passed, while restoring immediate serving failed because the clients reached partial resources (`resource.not_found`, Demo catalogue missing). All injection/mutation code was removed, the exact signed tree restored, and the normal diagnostic rerun.

Mutation checks: bypassing the slice-lock guard and publishing telemetry immediately from its sample callback each made the focused tests fail; both mutations were restored before final tests.

- macOS ARM64 with RADE enabled: native app/daemon build, focused 8/8 tests, two-cycle daemon diagnostic and native Demo MCP proof passed; build architecture checked.
- Linux ARM64, Qt 6.8.2/GCC 14, RADE enabled: native app/daemon build, focused 8/8 tests, two-cycle daemon diagnostic and native Demo MCP proof passed on the final feature payload.
- Windows Qt 6.8.3/MSVC x64 on the ARM VM, RADE enabled: native app/daemon build and staged release, focused 8/8 tests, two-cycle daemon diagnostic and two-cycle interactive native Demo MCP proof passed. Exact staged executable and Session 1 process identity verified; owned test process/task cleaned up.
- Static checks: engine boundary `--strict`, test registration `--strict`, frozen CI gate, generated touchpoint manifest and whitespace checks passed.
- Current-main integration on `e6fa1c67`: ARM64 app/daemon build, focused 9/9 tests (the eight feature tests plus upstream's new `atu_seam_gate_test`), two-client daemon diagnostic and two-cycle native Demo MCP proof passed. The new ATU guard and Icom extension removal are preserved.
- Security diff review: completed on that final integrated snapshot, including the startup fix; all 31 changed source files plus changed tests/build/docs and supporting call paths were accounted for, with zero reportable findings. This was a sequential parent review, not an independent security worker (scan `94c75749-b69f-49fd-afa9-e79a8b2aaa3f`).

Earlier Linux MCP attempts timed out waiting for initial pan geometry while the VM was unstable; unchanged base passed its comparison, so those failures are not claimed as proven pre-existing. The VM subsequently froze and left eight empty generated object files. After operator-authorized VM recovery and regeneration of those exact artifacts, the unchanged feature source passed, and the final startup-fix payload passed again. The VM's original freeze cause remains undetermined.

### Integration-test disclosure

The operator explicitly authorized the existing production-Demo resource-service integration and the new optional two-client daemon diagnostic on all three platforms. The latter starts **our own server** on a unique local socket/Windows named pipe, uses isolated settings and Demo-only discovery, and exits 77 on listen refusal. It is `EXCLUDE_FROM_ALL`, not registered with CTest, and not in the PR CI gate. No fake third-party firmware peer, physical radio connection or TX is used.

Normal Demo RX produces audio/spectrum, not meter samples: the diagnostic checks the meter-delivery contract and RX-only transmit state; actual sample coalescing/freshness/bounds/SWR are proven by socket-free injected tests. Native desktop MCP separately exercises two Demo connect/control/disconnect cycles with exact process identity, isolated settings and `txAllowed=false`.

### Remaining validation limits

No physical radio/RF/TX certification. Optional RTL sources were reviewed but are not compiled in the current Mac/Linux/Windows configurations. Windows named-pipe cross-user isolation relies on the unchanged Qt current-user access policy and has not been independently adversarially runtime-tested. CI and maintainer review must still run on the submitted head.


## Review follow-up (d1511d54)

Reviewed against #5554 §2.3 and #5262 M2. Flex's mode/filter capability records have implemented typed verbs; an injected command-sink regression confirms both dispatch paths. Independent TX-idle admission remains fail-closed, so these daemon methods remain unavailable on Flex pending normalized readback. The requested maintainer decision on retaining these declarations remains open.

- Reject conflicting idle reports while any current TX activity flag is active; both control admission and telemetry require a fresh post-activity idle observation.
- Fill meter vacancies on initial admission, removal and invalidation by paging past invalid definitions, retaining the 64-resource cap and never importing retained samples. Reject Unicode control and format characters, including supplementary-plane format characters.
- Advertise meter.read independently from transmitState.read, suppress duplicate clamped HL2 gain publications, and clarify observation invalidation, filter epochs and ANAN bandwidth-change stream interruption.
- Retain the exact-match pending-mode interlock: a queued old-mode report is not a rejection acknowledgement and cannot safely release a filter write. The ordering regression and documented reconnect recovery explain this choice; the review discussion remains open.

Validation on the signed follow-up, after merging upstream/main ae15dd7e: eight focused tests passed; the authorized two-client production-Demo daemon diagnostic passed both cycles; reverting the new guards made the regression tests fail, and restoring them passed. ARM64 architecture, generated touchpoints, test registration, frozen CI gate, engine boundary and whitespace checks passed. The follow-up security diff scan completed with zero reportable findings (44729354-8d15-46a8-845f-f680646b131b; sequential parent review).

This follow-up did not repeat desktop MCP or Windows/Linux runtime testing; the earlier milestone evidence above is separate. CI is running on the new head.

