### PR TITLE
Fix WSJT-X UDP spot decodes placed on another instance's band (#3595).

### DIFF
--- a/src/core/WsjtxClient.cpp
+++ b/src/core/WsjtxClient.cpp
@@ -9,6 +9,8 @@
 #include <QFileInfo>
 #include <QRegularExpression>
 
+#include <optional>
+
 namespace AetherSDR {
 
 WsjtxClient::WsjtxClient(QObject* parent)
@@ -112,11 +114,12 @@ void WsjtxClient::parseMessage(const QByteArray& data)
     switch (msgType) {
     case 1:  parseStatus(ds);  break;  // Status — dial freq, mode
     case 2:  parseDecode(ds);  break;  // Decode — the spots
+    case 6:  parseClose(ds);   break;  // Close — instance exiting
     default: break;
     }
 }
 
-// ── Status message (type 1) — track dial frequency ──────────────────────────
+// ── Status message (type 1) — track dial frequency per instance ─────────────
 
 void WsjtxClient::parseStatus(QDataStream& ds)
 {
@@ -129,10 +132,19 @@ void WsjtxClient::parseStatus(QDataStream& ds)
     QString mode;
     if (!readQString(ds, mode)) return;
 
-    m_dialFreqHz = static_cast<double>(dialFreq);
-    m_mode = mode;
+    const double dialFreqHz = static_cast<double>(dialFreq);
+    m_dialTracker.noteStatus(id, dialFreqHz);
 
-    emit statusReceived(id, m_dialFreqHz, mode);
+    emit statusReceived(id, dialFreqHz, mode);
+}
+
+// ── Close message (type 6) — instance is exiting ────────────────────────────
+
+void WsjtxClient::parseClose(QDataStream& ds)
+{
+    QString id;
+    if (!readQString(ds, id)) return;
+    m_dialTracker.forget(id);
 }
 
 // ── Decode message (type 2) — extract spots ─────────────────────────────────
@@ -171,8 +183,19 @@ void WsjtxClient::parseDecode(QDataStream& ds)
     QString call = extractCallsign(message);
     if (call.isEmpty()) return;
 
-    // Calculate actual frequency: dial + audio offset
-    double freqHz = m_dialFreqHz + deltaFreqHz;
+    // Calculate actual frequency: THIS instance's dial + audio offset. The
+    // dial must come from the same instance id as the decode — with two
+    // WSJT-X instances on one port, using whichever Status arrived last put
+    // one band's decodes on the other band's panadapter (#3595). An instance
+    // that has not reported a dial yet cannot be placed; drop the decode
+    // rather than paint it on a guessed band.
+    const std::optional<double> dialFreqHz = m_dialTracker.dialFreqHzFor(id);
+    if (!dialFreqHz) {
+        qCDebug(lcDxCluster) << "WsjtxClient: dropping decode from" << id
+                             << "- no Status (dial frequency) seen from that instance yet";
+        return;
+    }
+    double freqHz = *dialFreqHz + deltaFreqHz;
     double freqMhz = freqHz / 1.0e6;
 
     // Build the spot

--- a/src/core/WsjtxClient.h
+++ b/src/core/WsjtxClient.h
@@ -7,6 +7,7 @@
 #include <QString>
 #include <atomic>
 #include "DxClusterClient.h"  // for DxSpot
+#include "WsjtxDialTracker.h"
 
 namespace AetherSDR {
 
@@ -50,6 +51,7 @@ private:
     void parseMessage(const QByteArray& data);
     void parseStatus(QDataStream& ds);
     void parseDecode(QDataStream& ds);
+    void parseClose(QDataStream& ds);
     QString extractCallsign(const QString& message) const;
 
     QUdpSocket* m_socket{nullptr};
@@ -59,9 +61,10 @@ private:
     quint16     m_port{2237};
     std::atomic<bool> m_listening{false};
 
-    // Track dial frequency from Status messages (type 1)
-    double m_dialFreqHz{0.0};
-    QString m_mode;
+    // Dial frequency from Status messages (type 1), kept PER INSTANCE ID so
+    // two WSJT-X instances sharing this port each place their decodes on
+    // their own band (#3595) — see WsjtxDialTracker.
+    WsjtxDialTracker m_dialTracker;
 };
 
 } // namespace AetherSDR

--- a/src/core/WsjtxDialTracker.h
+++ b/src/core/WsjtxDialTracker.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <QHash>
+#include <QString>
+
+#include <optional>
+
+namespace AetherSDR {
+
+// Per-instance dial-frequency memory for the WSJT-X UDP feed (#3595).
+//
+// A WSJT-X Decode datagram carries only the audio offset of the decoded
+// signal (0–5000 Hz); the dial frequency it must be added to arrives
+// separately, in that instance's Status datagram. Every WSJT-X message
+// begins with the instance `id` ("WSJT-X", "WSJT-X - 2", …), and two
+// instances sharing one UDP port interleave their traffic freely, so a
+// single "last dial frequency seen" is wrong whenever more than one
+// instance is running: a decode from the 40 m instance added to the 20 m
+// instance's dial paints a 40 m station on the 20 m panadapter.
+//
+// This keeps one dial frequency per instance id. A decode whose instance
+// has not yet reported a dial frequency cannot be placed on any band and
+// is refused (nullopt) rather than guessed — WSJT-X emits a Status with
+// every decode cycle, so in practice the only unplaceable decode is the
+// first one after AetherSDR starts listening mid-cycle. Header-only and
+// Qt-Core-only so it is testable without WsjtxClient's socket and logging
+// dependencies.
+class WsjtxDialTracker {
+public:
+    // Record the dial frequency `id` reported in its Status message.
+    // Non-positive frequencies are ignored: WSJT-X reports 0 Hz while it has
+    // no rig connection, and a 0 Hz dial would place every decode at the
+    // audio offset itself.
+    void noteStatus(const QString& id, double dialFreqHz)
+    {
+        if (dialFreqHz <= 0.0) {
+            return;
+        }
+        m_dialFreqHzById.insert(id, dialFreqHz);
+    }
+
+    // The dial frequency to add to a Decode from `id`, or nullopt when that
+    // instance has not reported one yet.
+    std::optional<double> dialFreqHzFor(const QString& id) const
+    {
+        const auto it = m_dialFreqHzById.constFind(id);
+        if (it == m_dialFreqHzById.constEnd()) {
+            return std::nullopt;
+        }
+        return it.value();
+    }
+
+    // WSJT-X sends a Close (type 6) datagram on exit; forgetting the id then
+    // keeps a relaunched instance from inheriting a stale band until its
+    // first Status arrives.
+    void forget(const QString& id) { m_dialFreqHzById.remove(id); }
+
+    void clear() { m_dialFreqHzById.clear(); }
+
+    int instanceCount() const { return static_cast<int>(m_dialFreqHzById.size()); }
+
+private:
+    QHash<QString, double> m_dialFreqHzById;
+};
+
+}  // namespace AetherSDR

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -2256,6 +2256,17 @@ target_include_directories(spot_auto_scroll_test PRIVATE src)
 target_link_libraries(spot_auto_scroll_test PRIVATE Qt6::Core)
 add_test(NAME spot_auto_scroll_test COMMAND spot_auto_scroll_test)
 
+# SpotHub WSJT-X feed: per-instance dial frequency for Decode placement
+# (#3595). Header-only and Qt-Core-only so it runs without WsjtxClient's
+# QUdpSocket / LogManager dependency graph. Socket-free by design — the UDP
+# framing is unchanged by the fix.
+add_executable(wsjtx_dial_tracker_test
+    tests/wsjtx_dial_tracker_test.cpp
+)
+target_include_directories(wsjtx_dial_tracker_test PRIVATE src)
+target_link_libraries(wsjtx_dial_tracker_test PRIVATE Qt6::Core)
+add_test(NAME wsjtx_dial_tracker_test COMMAND wsjtx_dial_tracker_test)
+
 add_executable(n1mm_spot_client_test
     tests/n1mm_spot_client_test.cpp
     src/core/N1MMSpotParser.cpp

--- a/tests/wsjtx_dial_tracker_test.cpp
+++ b/tests/wsjtx_dial_tracker_test.cpp
@@ -1,0 +1,140 @@
+// WsjtxDialTracker unit tests (#3595).
+//
+// SpotHub's WSJT-X UDP feed used to keep ONE dial frequency — whichever
+// Status datagram arrived last — and add every Decode's audio offset to it.
+// WSJT-X Decode messages carry only the offset (0–5000 Hz), so with two
+// instances sharing the port (20 m FT8 on slice A, 40 m FT8 on slice B) a
+// 40 m decode that landed between two 20 m Status messages was placed at
+// 14.07x MHz and painted on the 20 m panadapter. The fix keys the dial on
+// the instance id every WSJT-X datagram begins with.
+//
+// The tracker is header-only and Qt-Core-only so these checks run without
+// WsjtxClient's QUdpSocket / LogManager dependency graph. The datagram
+// framing itself (magic, schema, Qt-serialised strings) is unchanged by the
+// fix and is not what this test pins.
+
+#include "core/WsjtxDialTracker.h"
+
+#include <QCoreApplication>
+#include <QString>
+
+#include <cmath>
+#include <cstdio>
+#include <optional>
+
+namespace AetherSDR {
+
+static int g_failures = 0;
+static void check(bool ok, const char* what)
+{
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", what); ++g_failures; }
+}
+
+static bool approxEq(std::optional<double> v, double expected)
+{
+    return v.has_value() && std::abs(*v - expected) < 0.5;
+}
+
+const QString kInstanceA = QStringLiteral("WSJT-X");
+const QString kInstanceB = QStringLiteral("WSJT-X - 2");
+constexpr double k20mFt8Hz = 14074000.0;
+constexpr double k40mFt8Hz = 7074000.0;
+
+// The exact interleaving from the report: A reports 20 m, B reports 40 m,
+// then A reports again. A decode from B must still resolve to 40 m.
+static void testDecodeUsesItsOwnInstancesDial()
+{
+    WsjtxDialTracker t;
+    t.noteStatus(kInstanceA, k20mFt8Hz);
+    t.noteStatus(kInstanceB, k40mFt8Hz);
+    t.noteStatus(kInstanceA, k20mFt8Hz);   // the "last Status wins" trap
+
+    check(approxEq(t.dialFreqHzFor(kInstanceB), k40mFt8Hz),
+          "B's decode resolves against B's 40 m dial even after A's later Status");
+    check(approxEq(t.dialFreqHzFor(kInstanceA), k20mFt8Hz),
+          "A's decode resolves against A's 20 m dial");
+    check(t.instanceCount() == 2, "two instances are tracked independently");
+}
+
+// Without a Status from that instance there is no band to place the decode
+// on; the tracker must refuse rather than hand back another instance's dial.
+static void testUnknownInstanceIsRefused()
+{
+    WsjtxDialTracker t;
+    check(!t.dialFreqHzFor(kInstanceA).has_value(),
+          "an empty tracker places nothing");
+
+    t.noteStatus(kInstanceA, k20mFt8Hz);
+    check(!t.dialFreqHzFor(kInstanceB).has_value(),
+          "an instance that has never reported a dial is refused, not given A's — "
+          "this is the exact leak: B's decode on A's band");
+}
+
+// A band change on one instance must not move the other.
+static void testBandChangeIsPerInstance()
+{
+    WsjtxDialTracker t;
+    t.noteStatus(kInstanceA, k20mFt8Hz);
+    t.noteStatus(kInstanceB, k40mFt8Hz);
+
+    t.noteStatus(kInstanceA, 21074000.0);   // A QSYs to 15 m
+    check(approxEq(t.dialFreqHzFor(kInstanceA), 21074000.0),
+          "A follows its own QSY to 15 m");
+    check(approxEq(t.dialFreqHzFor(kInstanceB), k40mFt8Hz),
+          "B stays on 40 m when A changes band");
+}
+
+// WSJT-X reports dial 0 while it has no rig connection. Adding a 1.5 kHz
+// audio offset to 0 Hz would 'place' the decode at 1.5 kHz; that Status must
+// be ignored, and it must not wipe a good dial already known for the id.
+static void testZeroDialIsIgnored()
+{
+    WsjtxDialTracker t;
+    t.noteStatus(kInstanceA, 0.0);
+    check(!t.dialFreqHzFor(kInstanceA).has_value(),
+          "a 0 Hz dial (no rig) does not register an instance");
+
+    t.noteStatus(kInstanceA, k20mFt8Hz);
+    t.noteStatus(kInstanceA, 0.0);          // rig link drops momentarily
+    check(approxEq(t.dialFreqHzFor(kInstanceA), k20mFt8Hz),
+          "a transient 0 Hz Status does not overwrite the last good dial");
+}
+
+// A Close datagram means that instance is gone; a relaunch must start from
+// its own first Status rather than inherit the old band.
+static void testCloseForgetsTheInstance()
+{
+    WsjtxDialTracker t;
+    t.noteStatus(kInstanceA, k20mFt8Hz);
+    t.noteStatus(kInstanceB, k40mFt8Hz);
+
+    t.forget(kInstanceB);
+    check(!t.dialFreqHzFor(kInstanceB).has_value(),
+          "a closed instance is forgotten");
+    check(approxEq(t.dialFreqHzFor(kInstanceA), k20mFt8Hz),
+          "forgetting B leaves A intact");
+    check(t.instanceCount() == 1, "instance count drops on Close");
+
+    t.forget(QStringLiteral("never-seen"));
+    check(t.instanceCount() == 1, "forgetting an unknown id is a no-op");
+
+    t.clear();
+    check(t.instanceCount() == 0, "clear() empties the tracker");
+}
+
+}  // namespace AetherSDR
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    AetherSDR::testDecodeUsesItsOwnInstancesDial();
+    AetherSDR::testUnknownInstanceIsRefused();
+    AetherSDR::testBandChangeIsPerInstance();
+    AetherSDR::testZeroDialIsIgnored();
+    AetherSDR::testCloseForgetsTheInstance();
+
+    if (AetherSDR::g_failures == 0)
+        std::fprintf(stderr, "wsjtx_dial_tracker_test: all checks passed\n");
+    return AetherSDR::g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION

## Summary

Fixes #3595.

SpotHub's WSJT-X UDP listener (WsjtxClient) kept a single dial frequency — from whichever Status datagram arrived last — and added every Decode's audio offset to it. WSJT-X Decode messages carry only the audio offset (0–5000 Hz), so with two WSJT-X instances sharing the UDP port (20 m FT8 on slice A, 40 m FT8 on slice B) a 40 m decode that landed between two 20 m Status messages was placed at 14.07x MHz and drawn on the 20 m panadapter. That is the "band leak" in the report.

The listener now keys the dial frequency on the instance id that begins every WSJT-X datagram, via a new header-only WsjtxDialTracker (src/core/). Behaviour changes, all in the UDP feed:

A Decode is placed using its own instance's last reported dial frequency.
A Decode from an instance that has not yet reported a dial is dropped (debug-logged) rather than placed on a guessed band. WSJT-X sends a Status with every decode cycle, so in practice this only affects the first decode after AetherSDR starts listening mid-cycle.
A Status reporting 0 Hz (WSJT-X with no rig link) is ignored instead of registering a dial that would place decodes at the audio offset itself.
The Close datagram (type 6) forgets that instance, so a relaunched instance cannot inherit a stale band.

UDP framing, callsign extraction, filtering, colouring and single-instance behaviour are unchanged. No TCI, SpotModel or GUI code is touched.

Note on the issue title: the report reads as TCI-related because WSJT-X's CAT and audio both run over TCI in this setup. The TCI traffic monitor shows WSJT-X sends no spot: commands, and the leaked spots' tooltips read Source: WSJT-X — the decodes travel by UDP. An earlier TCI-side attempt that scoped spot: commands to the sending client's audio_start receiver was built and did not fix the leak, because the leaking spots never pass through the TCI server; it is not part of this PR.

## Constitution principle honored

Principle VII — Untrusted Input Is Validated At The Boundary. A Decode whose instance has no known dial frequency is refused at the UDP boundary rather than rendered on a guessed band. Principle XI — the fix is demonstrated by a mutation-checked test (below).

## Test plan

Local build passes (cmake --build build) — Windows, MSVC 2022, Qt 6.8.3
 Behavior verified on a real radio — FLEX 6400 with two WSJT-X instances (20 m and 40 m FT8, CAT and audio via TCI) through multiple decode cycles: 40 m decodes now stay on the 40 m panadapter; spot tooltips still read Source: WSJT-X
 Existing tests pass (CI)
 Reproduction steps documented: run two WSJT-X instances on different bands, both reporting to AetherSDR's WSJT-X UDP port (default 2237); with SpotHub's WSJT-X feed enabled, decodes from one instance appear on the other instance's band.

New test: wsjtx_dial_tracker_test (tests/wsjtx_dial_tracker_test.cpp, registered in tests/tests.cmake). Socket-free, Qt Core only — the tracker is header-only so the test runs without WsjtxClient's QUdpSocket/LogManager graph. It pins the exact interleaving from the report (A→20 m, B→40 m, A→20 m again; B's decode must still resolve to 40 m), refusal of an unknown instance, per-instance band changes, the 0 Hz guard, and Close.

Mutation-checked: replacing the per-id lookup with "first dial in the map" (the original behaviour) fails the test on the B-resolves-to-40 m and unknown-instance checks; restoring the lookup passes.

## Checklist

 Commits are signed (docs/COMMIT-SIGNING.md)
 No new flat-key AppSettings calls — no settings touched
 Code is clean-room — WSJT-X UDP message layout per its published NetworkMessage.hpp
 All meter UI uses MeterSmoother — n/a, no UI changes
 Documentation updated if user-visible behavior changed — n/a; behaviour is now what the SpotHub WSJT-X feed already claimed to do. No CHANGELOG.md entry, per AGENTS.md
 Security-sensitive changes reference a GHSA — n/a