### PR TITLE
Fix spectrum and VFO menu shutdown crashes — Principle XI.

### DIFF
--- a/src/gui/ScopedChildWidget.h
+++ b/src/gui/ScopedChildWidget.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <QPointer>
+#include <QWidget>
+
+namespace AetherSDR {
+
+// A transient widget may be destroyed by its parent inside exec()'s nested
+// event loop. Keep normal scoped cleanup without putting a Qt-owned child on
+// the stack or deleting it twice after parent teardown.
+template <typename Widget>
+class ScopedChildWidget final {
+public:
+    explicit ScopedChildWidget(QWidget* parent)
+        : m_widget(new Widget(parent))
+    {
+    }
+
+    ~ScopedChildWidget()
+    {
+        // QPointer is cleared if the parent already destroyed the widget.
+        delete m_widget.data();
+    }
+
+    ScopedChildWidget(const ScopedChildWidget&) = delete;
+    ScopedChildWidget& operator=(const ScopedChildWidget&) = delete;
+
+    Widget* get() const { return m_widget.data(); }
+    explicit operator bool() const { return !m_widget.isNull(); }
+
+private:
+    QPointer<Widget> m_widget;
+};
+
+} // namespace AetherSDR

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1,4 +1,5 @@
 #include "SpectrumWidget.h"
+#include "ScopedChildWidget.h"
 
 #include "SliceToneCues.h"
 #include "gui/FftHeatMap.h"
@@ -9471,7 +9472,13 @@ static double snapToStep(double mhz, int stepHz)
 void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
 {
     PerfInputScope perfScope("mousePress");
-    const auto dragStatePublisher = makeScopeExit([this] { publishPerfDragState(); });
+    // A menu's nested event loop can destroy this panadapter during shutdown.
+    const QPointer<SpectrumWidget> self(this);
+    const auto dragStatePublisher = makeScopeExit([self] {
+        if (self) {
+            self->publishPerfDragState();
+        }
+    });
     (void)dragStatePublisher;
 
     // A prior off-screen-pill press is relevant only to Qt's immediately
@@ -9924,7 +9931,8 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
                 // Follow display mode so menu labels match the pill above (#2606).
                 const QString letter =
                     SliceLabel::unicodeForm(so.sliceId, so.perClientLetter);
-                QMenu menu(this);
+                ScopedChildWidget<QMenu> menuOwner(this);
+                QMenu& menu = *menuOwner.get();
                 menu.addAction(QString("Close Slice %1").arg(letter), this,
                     [this, id = so.sliceId]{ emit sliceCloseRequested(id); });
                 menu.addAction(QString("Move Slice %1 Here").arg(letter), this,
@@ -9938,8 +9946,8 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
                 menu.addSeparator();
                 addCenterLockAction(&menu, so, true);
                 addSliceLinkControls(menu);
-                menu.exec(ev->globalPosition().toPoint());
                 ev->accept();
+                menu.exec(ev->globalPosition().toPoint());
                 return;
             }
         }
@@ -9965,7 +9973,8 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
             }
         }
 
-        QMenu menu(this);
+        ScopedChildWidget<QMenu> menuOwner(this);
+        QMenu& menu = *menuOwner.get();
 
         // Spot-on-label context menu
         if (hitSpotIdx >= 0) {
@@ -10145,8 +10154,8 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
             });
         }
 
-        menu.exec(ev->globalPosition().toPoint());
         ev->accept();
+        menu.exec(ev->globalPosition().toPoint());
         return;
     }
 
@@ -11218,7 +11227,9 @@ void SpectrumWidget::showAddSpotDialog(double freqMhz)
         freqMhz = std::round(freqMhz / stepMhz) * stepMhz;
     }
     auto& as = AppSettings::instance();
-    QDialog dlg(this);
+    const QPointer<SpectrumWidget> self(this);
+    ScopedChildWidget<QDialog> dialogOwner(this);
+    QDialog& dlg = *dialogOwner.get();
     dlg.setWindowTitle("Add Spot");
     AetherSDR::ThemeManager::instance().applyStyleSheet(&dlg, "QDialog { background: {{color.background.0}}; color: {{color.text.primary}}; }"
                       "QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.2}}; padding: 4px; }"
@@ -11275,7 +11286,10 @@ void SpectrumWidget::showAddSpotDialog(double freqMhz)
     freqSpin->setFocus();
     freqSpin->selectAll();
 
-    if (dlg.exec() != QDialog::Accepted) return;
+    const int result = dlg.exec();
+    if (!self || !dialogOwner || result != QDialog::Accepted) {
+        return;
+    }
 
     const double finalFreqMhz = freqSpin->value();
     const QString callsign = callEdit->text().trimmed().toUpper();

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -844,25 +844,28 @@ void VfoWidget::buildUI()
     m_txAntBtn->setStyleSheet(kFlatBtn + "QPushButton { color: #ff4444; }");
     connect(m_txAntBtn, &QPushButton::clicked, this, [this] {
         if (!m_slice) return;
-        const QPointer<VfoWidget> self(this);
-        const QPointer<SliceModel> slice(m_slice);
-        ScopedChildWidget<QMenu> menuOwner(this);
-        QMenu& menu = *menuOwner.get();
+        // Same non-blocking shape as the RX antenna menu above: no nested
+        // event loop, so widget teardown or a slice change while the popup is
+        // open cannot strand a suspended frame (#5566).
+        QPointer<SliceModel> slice = m_slice;
+        QMenu* menu = new QMenu(m_txAntBtn);
+        connect(menu, &QMenu::aboutToHide, menu, &QObject::deleteLater);
         const QStringList options = txAntennaOptions();
         for (const QString& ant : options) {
-            auto* act = menu.addAction(antennaMenuLabel(ant, options));
+            auto* act = menu->addAction(antennaMenuLabel(ant, options));
             act->setData(ant);
             act->setCheckable(true);
             act->setChecked(ant == m_slice->txAntenna());
             act->setToolTip(ant);
             act->setStatusTip(ant);
         }
-        QAction* selected = menu.exec(
-            m_txAntBtn->mapToGlobal(QPoint(0, m_txAntBtn->height())));
-        if (!self || !menuOwner || !slice || self->m_slice != slice.data() || !selected) {
-            return;
-        }
-        slice->setTxAntenna(selected->data().toString());
+        connect(menu, &QMenu::triggered, this, [slice](QAction* sel) {
+            if (!sel || !slice) {
+                return;
+            }
+            slice->setTxAntenna(sel->data().toString());
+        });
+        menu->popup(m_txAntBtn->mapToGlobal(QPoint(0, m_txAntBtn->height())));
     });
     hdr->addWidget(m_txAntBtn);
 

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -6720,8 +6720,12 @@ bool VfoWidget::eventFilter(QObject* obj, QEvent* event)
             QMenu& menu = *menuOwner.get();
             AetherSDR::ThemeManager::instance().applyStyleSheet(&menu, "QMenu { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid #304060; }"
                 "QMenu::item:selected { background: {{color.accent}}; color: {{color.background.0}}; }");
-            menu.addAction("Add Spot", this, [this] {
-                emit addSpotRequested(m_slice->frequency());
+            const QPointer<SliceModel> slice(m_slice);
+            menu.addAction("Add Spot", this, [this, slice] {
+                if (!slice || m_slice != slice.data()) {
+                    return;
+                }
+                emit addSpotRequested(slice->frequency());
             });
             menu.exec(me->globalPosition().toPoint());
             return true;

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -844,7 +844,10 @@ void VfoWidget::buildUI()
     m_txAntBtn->setStyleSheet(kFlatBtn + "QPushButton { color: #ff4444; }");
     connect(m_txAntBtn, &QPushButton::clicked, this, [this] {
         if (!m_slice) return;
-        QMenu menu(this);
+        const QPointer<VfoWidget> self(this);
+        const QPointer<SliceModel> slice(m_slice);
+        ScopedChildWidget<QMenu> menuOwner(this);
+        QMenu& menu = *menuOwner.get();
         const QStringList options = txAntennaOptions();
         for (const QString& ant : options) {
             auto* act = menu.addAction(antennaMenuLabel(ant, options));
@@ -854,8 +857,12 @@ void VfoWidget::buildUI()
             act->setToolTip(ant);
             act->setStatusTip(ant);
         }
-        if (auto* sel = menu.exec(m_txAntBtn->mapToGlobal(QPoint(0, m_txAntBtn->height()))))
-            m_slice->setTxAntenna(sel->data().toString());
+        QAction* selected = menu.exec(
+            m_txAntBtn->mapToGlobal(QPoint(0, m_txAntBtn->height())));
+        if (!self || !menuOwner || !slice || self->m_slice != slice.data() || !selected) {
+            return;
+        }
+        slice->setTxAntenna(selected->data().toString());
     });
     hdr->addWidget(m_txAntBtn);
 
@@ -5647,10 +5654,17 @@ void VfoWidget::rebuildFilterButtons()
         }
         btn->setContextMenuPolicy(Qt::CustomContextMenu);
         connect(btn, &QPushButton::customContextMenuRequested, this, [this, i, btn](const QPoint& pos) {
-            QMenu menu;
-            menu.addAction("Set Custom Edges...", [this, i] {
+            ScopedChildWidget<QMenu> menuOwner(this);
+            QMenu& menu = *menuOwner.get();
+            // Rebuilding presets deletes btn; old actions must not address the
+            // replacement mode's preset arrays after a nested event loop.
+            menu.addAction("Set Custom Edges...", btn,
+                           [this, i, button = QPointer<QPushButton>(btn)] {
                 if (!m_slice) return;
-                QDialog dlg(this);
+                const QPointer<VfoWidget> self(this);
+                const QPointer<SliceModel> slice(m_slice);
+                ScopedChildWidget<QDialog> dialogOwner(this);
+                QDialog& dlg = *dialogOwner.get();
                 dlg.setWindowTitle("Set Custom Filter Edges");
                 auto* form = new QFormLayout(&dlg);
                 auto* loSpin = new QSpinBox(&dlg);
@@ -5674,7 +5688,11 @@ void VfoWidget::rebuildFilterButtons()
                 QObject::connect(btns, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
                 QObject::connect(btns, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
                 form->addRow(btns);
-                if (dlg.exec() != QDialog::Accepted) return;
+                const int result = dlg.exec();
+                if (!self || !dialogOwner || !button || !slice
+                    || self->m_slice != slice.data() || result != QDialog::Accepted) {
+                    return;
+                }
                 int lo = loSpin->value();
                 int hi = hiSpin->value();
                 if (hi <= lo) return;
@@ -5685,7 +5703,7 @@ void VfoWidget::rebuildFilterButtons()
                 rebuildFilterButtons();
                 m_slice->setFilterWidth(lo, hi);
             });
-            menu.addAction("Reset to Default", [this, i] {
+            menu.addAction("Reset to Default", btn, [this, i] {
                 if (!m_slice) return;
                 const auto& factory = filterPresetsFor(m_slice->mode()).filterWidths;
                 if (i >= factory.size()) return;

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1,4 +1,5 @@
 #include "VfoWidget.h"
+#include "ScopedChildWidget.h"
 #include "AgcModeAvailability.h"
 #include "FmTonePresentation.h"
 #include "gui/CtcssToneLabel.h"
@@ -6697,7 +6698,8 @@ bool VfoWidget::eventFilter(QObject* obj, QEvent* event)
     if ((obj == m_freqLabel || obj == m_collapsedFreqLabel) && event->type() == QEvent::MouseButtonPress) {
         auto* me = static_cast<QMouseEvent*>(event);
         if (me->button() == Qt::RightButton && m_slice) {
-            QMenu menu(this);
+            ScopedChildWidget<QMenu> menuOwner(this);
+            QMenu& menu = *menuOwner.get();
             AetherSDR::ThemeManager::instance().applyStyleSheet(&menu, "QMenu { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid #304060; }"
                 "QMenu::item:selected { background: {{color.accent}}; color: {{color.background.0}}; }");
             menu.addAction("Add Spot", this, [this] {

--- a/tests/scoped_child_widget_test.cpp
+++ b/tests/scoped_child_widget_test.cpp
@@ -4,8 +4,15 @@
 #include <QApplication>
 #include <QDialog>
 #include <QMenu>
+#include <QKeyEvent>
 #include <QPointer>
 #include <QTimer>
+#include <QWidget>
+#include <QPoint>
+#include <QObject>
+#include <QEvent>
+#include <QString>
+#include <QVariant>
 
 #include <cstdio>
 #include <memory>
@@ -97,6 +104,27 @@ void nestedDialogLifetime()
           returnedFromDialog && menuObserver.isNull() && dialogObserver.isNull());
 }
 
+void selectedActionLifetime()
+{
+    QWidget parent;
+    QPointer<QAction> actionObserver;
+    {
+        AetherSDR::ScopedChildWidget<QMenu> child(&parent);
+        QAction* action = child.get()->addAction("Select antenna");
+        action->setData(QStringLiteral("ANT1"));
+        actionObserver = action;
+        QTimer::singleShot(0, child.get(), [&] {
+            child.get()->setActiveAction(action);
+            QKeyEvent key(QEvent::KeyPress, Qt::Key_Return, Qt::NoModifier);
+            QApplication::sendEvent(child.get(), &key);
+        });
+        QAction* selected = child.get()->exec(QPoint(20, 20));
+        check("selected action remains readable after exec",
+              selected == action && selected->data().toString() == QStringLiteral("ANT1"));
+    }
+    check("selected action is released with menu", actionObserver.isNull());
+}
+
 void actionLifetime()
 {
     QWidget parent;
@@ -123,6 +151,7 @@ int main(int argc, char** argv)
     dialogLifetime(false, true);
     dialogLifetime(true, false);
     nestedDialogLifetime();
+    selectedActionLifetime();
     actionLifetime();
     return failures ? 1 : 0;
 }

--- a/tests/scoped_child_widget_test.cpp
+++ b/tests/scoped_child_widget_test.cpp
@@ -1,0 +1,128 @@
+#include "gui/ScopedChildWidget.h"
+
+#include <QAction>
+#include <QApplication>
+#include <QDialog>
+#include <QMenu>
+#include <QPointer>
+#include <QTimer>
+
+#include <cstdio>
+#include <memory>
+
+namespace {
+int failures = 0;
+void check(const char* name, bool passed)
+{
+    std::printf("[%s] %s\n", passed ? "OK" : "FAIL", name);
+    if (!passed) {
+        ++failures;
+    }
+}
+
+void menuLifetime(bool destroyParent)
+{
+    auto parent = std::make_unique<QWidget>();
+    QPointer<QMenu> observer;
+    int destroyed = 0;
+    {
+        AetherSDR::ScopedChildWidget<QMenu> child(parent.get());
+        observer = child.get();
+        observer->addAction("Example");
+        QObject::connect(observer, &QObject::destroyed, qApp,
+                         [&destroyed] { ++destroyed; });
+        QTimer::singleShot(0, observer, [&] {
+            if (destroyParent) {
+                parent.reset();
+            } else {
+                observer->close();
+            }
+        });
+        child.get()->exec(QPoint(20, 20));
+        check("menu guard reflects parent lifetime", bool(child) != destroyParent);
+    }
+    check("menu destroyed exactly once", observer.isNull() && destroyed == 1);
+}
+
+void dialogLifetime(bool destroyParent, bool accept)
+{
+    auto parent = std::make_unique<QWidget>();
+    QPointer<QDialog> observer;
+    int destroyed = 0;
+    {
+        AetherSDR::ScopedChildWidget<QDialog> child(parent.get());
+        observer = child.get();
+        QObject::connect(observer, &QObject::destroyed, qApp,
+                         [&destroyed] { ++destroyed; });
+        QTimer::singleShot(0, observer, [&] {
+            if (destroyParent) {
+                parent.reset();
+            } else if (accept) {
+                observer->accept();
+            } else {
+                observer->reject();
+            }
+        });
+        const int result = child.get()->exec();
+        check("dialog guard reflects parent lifetime", bool(child) != destroyParent);
+        check("dialog result preserved", result ==
+              ((!destroyParent && accept) ? QDialog::Accepted : QDialog::Rejected));
+    }
+    check("dialog destroyed exactly once", observer.isNull() && destroyed == 1);
+}
+
+void nestedDialogLifetime()
+{
+    auto parent = std::make_unique<QWidget>();
+    QPointer<QMenu> menuObserver;
+    QPointer<QDialog> dialogObserver;
+    bool returnedFromDialog = false;
+    {
+        AetherSDR::ScopedChildWidget<QMenu> menu(parent.get());
+        menuObserver = menu.get();
+        QAction* action = menu.get()->addAction("Open dialog");
+        QObject::connect(action, &QAction::triggered, parent.get(), [&] {
+            AetherSDR::ScopedChildWidget<QDialog> dialog(parent.get());
+            dialogObserver = dialog.get();
+            QTimer::singleShot(0, dialog.get(), [&] { parent.reset(); });
+            dialog.get()->exec();
+            returnedFromDialog = true;
+            check("nested dialog observes owner destruction", !dialog);
+        });
+        QTimer::singleShot(0, action, &QAction::trigger);
+        menu.get()->exec(QPoint(20, 20));
+        check("outer menu observes owner destruction", !menu);
+    }
+    check("both nested loops return after owner destruction",
+          returnedFromDialog && menuObserver.isNull() && dialogObserver.isNull());
+}
+
+void actionLifetime()
+{
+    QWidget parent;
+    AetherSDR::ScopedChildWidget<QMenu> child(&parent);
+    auto receiver = std::make_unique<QObject>();
+    int calls = 0;
+    QAction* action = child.get()->addAction("Example");
+    QObject::connect(action, &QAction::triggered, receiver.get(), [&] { ++calls; });
+    action->trigger();
+    check("live action receiver runs", calls == 1);
+    receiver.reset();
+    action->trigger();
+    check("deleted action receiver is disconnected", calls == 1);
+}
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QApplication app(argc, argv);
+    app.setQuitOnLastWindowClosed(false);
+    menuLifetime(false);
+    menuLifetime(true);
+    dialogLifetime(false, false);
+    dialogLifetime(false, true);
+    dialogLifetime(true, false);
+    nestedDialogLifetime();
+    actionLifetime();
+    return failures ? 1 : 0;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -2079,8 +2079,7 @@ target_include_directories(scoped_child_widget_test PRIVATE src)
 target_link_libraries(scoped_child_widget_test PRIVATE Qt6::Widgets)
 add_test(NAME scoped_child_widget_test COMMAND scoped_child_widget_test)
 set_tests_properties(scoped_child_widget_test PROPERTIES
-    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
-    TIMEOUT 15)
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
 add_executable(spectrum_preview_logic_test
     tests/spectrum_preview_logic_test.cpp

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -2072,6 +2072,16 @@ add_executable(fft_line_width_test tests/fft_line_width_test.cpp)
 target_include_directories(fft_line_width_test PRIVATE src)
 add_test(NAME fft_line_width_test COMMAND fft_line_width_test)
 
+# Transient menu/dialog ownership under nested event-loop teardown (#5566).
+# Socket-free; also runs in the unfiltered full-suite and sanitizer lanes.
+add_executable(scoped_child_widget_test tests/scoped_child_widget_test.cpp)
+target_include_directories(scoped_child_widget_test PRIVATE src)
+target_link_libraries(scoped_child_widget_test PRIVATE Qt6::Widgets)
+add_test(NAME scoped_child_widget_test COMMAND scoped_child_widget_test)
+set_tests_properties(scoped_child_widget_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+    TIMEOUT 15)
+
 add_executable(spectrum_preview_logic_test
     tests/spectrum_preview_logic_test.cpp
 )


### PR DESCRIPTION
Fixes #5566.

Closing the app while a spectrum context menu is open currently aborts: shutdown deletes the panadapter, and Qt attempts to free a menu allocated on the suspended mouse-handler stack. The Add Spot dialog has the same ownership problem, and the mouse handler also runs a cleanup callback against the destroyed spectrum widget after the nested event loop returns.

This change keeps the existing parent relationships, menus and modal behavior while allocating these transient widgets on the heap. A small scoped owner uses QPointer to release each widget once, whether its parent or normal scope exit destroys it. Both spectrum context menus, the Add Spot dialog, the VFO frequency-label and TX-antenna menus, and the custom-filter menu/dialog use it. Custom-filter actions are tied to their source preset button so a mode/preset rebuild disconnects stale actions; dialog acceptance also checks that the button, slice and VFO survived. The mouse-handler cleanup and post-dialog reads check that their objects survived.

## Validation

Native ARM64 RelWithDebInfo app built using the dedicated macOS toolchain, RADE enabled; ARM64 host/system/binary verified and no RNNoise x86 sources in the build graph. The branch was updated to upstream/main `ae15dd7e841105bf8c18707f9431258eba36cf7c` before final validation.

Agent automation bridge, production Demo `DEMO-0001`, fresh isolated settings and a unique authentication token per run, `AETHER_AUTOMATION_NO_TX=1`; no physical radio:

| Path | Actual process exit |
|---|---|
| Clean main `e6fa1c67`: right-click spectrum → Display → close MainWindow | SIGABRT, shell 134 (PID 50937) |
| Repaired on latest main `ae15dd7e`: identical sequence | 0 (PID 58290) |
| Repaired: off-screen slice context menu → close MainWindow | 0 |
| Repaired: spectrum menu → Add Spot dialog → close MainWindow | 0 |
| Repaired: frequency-label menu → Add Spot dialog → close MainWindow | 0 |

On latest main, selecting Show Tune Guides, reopening to confirm the toggle, restoring it, and closing exited 0 (PID 58362). Cancelling Add Spot, reopening the menu, and closing also exited 0 (PID 58434).

The close reply is not used as the shutdown oracle: each driver waits for and records the launched process's exit status. The original clean-base crash is also documented in [the #5557 review](https://github.com/aethersdr/AetherSDR/pull/5557#pullrequestreview-5174729358); this repair is separate from that FFT-width change and from AetherD #5563.

The socket-free `scoped_child_widget_test` exercises normal menu cleanup, dialog acceptance/rejection, parent deletion during menu/dialog `exec()`, nested menu-to-dialog teardown, and action callback disconnection. It passes under AddressSanitizer. A scratch mutation replacing the guarded pointer with a raw pointer fails with heap-use-after-free on scope cleanup; the unchanged production guard passes. The spectrum overlay wheel, band-highlight, and incoming upstream WSJT-X dial-tracker tests pass (4/4 selected CTests on latest main). Test registration, frozen CI gate, engine-boundary and touchpoint checks pass.

An independent code review found no remaining actionable findings. The regression test covers the production ownership helper; native bridge runs cover its application call sites. Other unrelated modal menus throughout the app are outside this repair. No socket-owning CTest or frozen per-PR test-gate addition; the new test runs in the unfiltered full-suite and sanitizer lanes.

Publication: local 1Password signing failed; GitHub created signed commit `1b829739e345e941e5483d58930bb32ecec08f97` and follow-up `4e737f1ebc33216d2114e842b319b0eac5f3a10e` (both `verified: true`, reason `valid`). Its Git tree was compared against the tested index and matches exactly.

## VFO validation

The TX-antenna menu reproduced SIGABRT / exit 134 on the original PR binary (PID 71445, matching the supplied September 11 crash report). After the fix, leaving it open during shutdown exits 0 (PID 73500). No antenna selection or TX keying was performed.

Custom-filter dialog open during shutdown exits 0 (PID 73611); normal acceptance also exits 0 (PID 73683). With a draft low edge edited to 500 Hz, switching to CW while the dialog remains open and then accepting preserves the current slice snapshot (`filterLow: 100`, `filterHigh: 2900`, `mode: CW`) and exits 0 (PID 75873). The deleted preset button prevents applying stale dialog data.

The expanded socket-free ownership test passes CTest and AddressSanitizer, including reading the selected QAction after menu exec and its cleanup afterward. Direct Qt includes were added. The follow-up received an independent code review with no remaining actionable findings. Local ARM64 app rebuild, registration, frozen-gate, touchpoint and whitespace checks pass. GitHub CI reruns on the new head.

## Follow-up review

The VFO Add Spot action now captures its original slice with QPointer and checks that the VFO still owns that slice before reading its frequency. This prevents a stale action from dereferencing a deleted or cleared slice or acting on a replacement slice. Signed commit `9d0a5af83c0e0c784c9c85d4406edcc2c8a4e418` is verified by GitHub; its tree matches the tested local index.

ARM64 rebuild and the focused ownership CTest pass. Native Demo Add Spot shutdown (PID 88594) and disconnect while its frequency menu is open (PID 88677) both exit 0. Demo disconnect destroys the VFO, so this is integration evidence rather than an isolated test of a retained VFO with a null slice. The guard itself was checked against the setSlice lifecycle.

The broader audit of remaining parented stack menus/dialogs is tracked in #5568; those source-level candidates are not all confirmed crashes.

Generated with OpenAI Codex.
