### PR TITLE
fix(icom): disable client auto-squelch and drop autoEnabled persistence

### DIFF
--- a/src/core/backends/RadioCapabilities.h
+++ b/src/core/backends/RadioCapabilities.h
@@ -532,6 +532,13 @@ struct RadioCapabilities {
     // The radio accepts manual SQL in CW/data modes and owns its persistence.
     // False preserves the existing mode-specific client squelch policy.
     bool hasModeIndependentSquelch = false;
+    // Client-side auto-squelch (spectrum noise-floor estimator driving SQL).
+    // This is not a radio register: no supported family exposes an Auto bit.
+    // False: SQL cycles Off ↔ Manual only, Auto is never restored, and any
+    // persisted autoEnabled key is ignored and stripped. Icom is false —
+    // Off is threshold zero, and replaying Auto as client intent is how the
+    // estimator turned itself back on across bands and sessions.
+    bool hasClientAutoSquelch = false;
     bool hasAmCarrierLevel = false;
     bool hasVoxDelay = false;
 

--- a/src/core/backends/anan/AnanBackend.cpp
+++ b/src/core/backends/anan/AnanBackend.cpp
@@ -333,6 +333,7 @@ RadioCapabilities AnanBackend::capabilities() const
     RadioCapabilities c;
     c.family = QStringLiteral("anan");
     c.hasAgcThreshold = true; // Host receiver DSP implements threshold/off gain.
+    c.hasClientAutoSquelch = true; // host spectrum estimator; no radio Auto bit
     c.manufacturer = QStringLiteral("Apache Labs");
     c.model = QStringLiteral("ANAN-G2");
     c.canCreateSlices = false;

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -205,6 +205,7 @@ RadioCapabilities FlexBackend::capabilities() const
     // TransmitModel::setDexp/setDexpLevel.
     caps.hasDownwardExpander = true;
     caps.hasAgcThreshold = true;
+    caps.hasClientAutoSquelch = true; // host spectrum estimator; no radio Auto bit
     caps.hasAmCarrierLevel = true;
     caps.hasVoxDelay = true;
 

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -1531,6 +1531,7 @@ RadioCapabilities Hl2Backend::capabilities() const
     c.hasSelectableMicInputs = false;
     c.hasDownwardExpander = false;
     c.hasAgcThreshold = true; // Host receiver DSP implements threshold/off gain.
+    c.hasClientAutoSquelch = true; // host spectrum estimator; no radio Auto bit
 
     // EMPTY: the HL2's receive filters are the host DSP's, and continuous.
     c.rxFilterWidthsHz = {};

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -500,6 +500,9 @@ RadioCapabilities IcomCivBackend::capabilities() const
     c.hasAgcThreshold = false; // 16 12 selects AGC mode, not Flex AGC-T.
     c.agcModes = {QStringLiteral("slow"), QStringLiteral("med"), QStringLiteral("fast")};
     c.hasModeIndependentSquelch = profile.hasModeIndependentSquelch;
+    // No CI-V Auto-SQL bit. Do not persist or restore a client Auto latch:
+    // Off is threshold zero, and replaying Auto is how SQL re-armed itself.
+    c.hasClientAutoSquelch = false;
     c.hasCwTune = profile.hasCwTune;
     c.hasAmCarrierLevel = false; // RF power is separate; no AM carrier setter.
     c.hasVoxDelay = false; // setVox implements enable/gain only.

--- a/src/core/backends/rtl/RtlSdrBackend.cpp
+++ b/src/core/backends/rtl/RtlSdrBackend.cpp
@@ -107,6 +107,7 @@ RadioCapabilities RtlSdrBackend::capabilities() const
     c.hasVoxDelay = false;
     c.hasAgcThreshold = false;
     c.hasModeIndependentSquelch = false;
+    c.hasClientAutoSquelch = true; // host spectrum estimator; no radio Auto bit
     c.agcModes = {QStringLiteral("off"), QStringLiteral("slow"),
                   QStringLiteral("med"), QStringLiteral("fast")};
     // Unused TX presentation retains the shared legacy shape; canTransmit

--- a/src/core/backends/sim/SimBackend.cpp
+++ b/src/core/backends/sim/SimBackend.cpp
@@ -317,6 +317,7 @@ RadioCapabilities SimBackend::capabilities() const
     caps.hasSelectableMicInputs = false;
     caps.hasDownwardExpander = false;
     caps.hasAgcThreshold = true;
+    caps.hasClientAutoSquelch = true; // host spectrum estimator; no radio Auto bit
 
     // The demo has no transmitter and no radio to ship audio to.
     caps.takesTxAudioOverSeam = false;

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -1383,12 +1383,49 @@ void RxApplet::applySqlModeVisuals()
     }
 }
 
+bool RxApplet::clientAutoSquelchAvailable() const
+{
+    if (usingExternalReceiveSquelch()) {
+        return true;
+    }
+    if (!m_radioModel) {
+        return true;
+    }
+    // Icom identity is the settings scope (same as SquelchIntent). Tests and
+    // pre-connect UI keep a Flex default backend, so the backend flag alone
+    // would still advertise Auto. The Icom backend also declares the flag
+    // false for connected sessions.
+    if (m_radioModel->settingsScope().family() == QLatin1String("icom")) {
+        return false;
+    }
+    return m_radioModel->backendCapabilities().hasClientAutoSquelch;
+}
+
+void RxApplet::dropClientAutoSquelchIfUnsupported()
+{
+    if (clientAutoSquelchAvailable()) {
+        return;
+    }
+    if (m_sqlMode == SqlMode::Auto) {
+        const bool sqOn = m_slice && m_slice->receiveSquelchOn();
+        setSqlMode(sqOn ? SqlMode::Manual : SqlMode::Off,
+                   /*propagateToRadio=*/false);
+    }
+    if (m_flexSqlMode == SqlMode::Auto) {
+        m_flexSqlMode = m_sqlMode;
+    }
+}
+
 void RxApplet::cycleSqlMode()
 {
-    const SqlMode next =
-        (m_sqlMode == SqlMode::Off)    ? SqlMode::Manual :
-        (m_sqlMode == SqlMode::Manual) ? SqlMode::Auto   :
-                                          SqlMode::Off;
+    SqlMode next;
+    if (!clientAutoSquelchAvailable()) {
+        next = (m_sqlMode == SqlMode::Off) ? SqlMode::Manual : SqlMode::Off;
+    } else {
+        next = (m_sqlMode == SqlMode::Off)    ? SqlMode::Manual :
+               (m_sqlMode == SqlMode::Manual) ? SqlMode::Auto   :
+                                                 SqlMode::Off;
+    }
     setSqlMode(next, /*propagateToRadio=*/true);
 }
 
@@ -1498,7 +1535,6 @@ void RxApplet::loadClientSquelchIntent()
     m_pendingSquelchWrites.flush();
     m_clientSquelchScope = {};
     m_clientManualSqlLevel.reset();
-    m_restoreAutoSql = false;
     m_clientSqlAwaitingReport = false;
     if (!m_slice || !m_radioModel || usingExternalReceiveSquelch()) {
         return;
@@ -1512,7 +1548,7 @@ void RxApplet::loadClientSquelchIntent()
     m_clientSquelchScope = scope;
     m_clientSqlAwaitingReport = true;
     int version = 0;
-    const QJsonObject doc = scope.featureExact(QStringLiteral("SquelchIntent"), &version);
+    QJsonObject doc = scope.featureExact(QStringLiteral("SquelchIntent"), &version);
     if (version != 1) {
         return;
     }
@@ -1520,12 +1556,18 @@ void RxApplet::loadClientSquelchIntent()
     const int level = manual.toInt(-1);
     if (manual.isDouble() && manual.toDouble() == level && level >= 0 && level <= 100) {
         m_clientManualSqlLevel = level;
-        if (!m_slice->squelchStateKnown() || !m_slice->squelchOn()
-            || doc.value(QStringLiteral("autoEnabled")).toBool(false)) {
+        if (!m_slice->squelchStateKnown() || !m_slice->squelchOn()) {
             m_slice->setManualSquelchLevel(level);
         }
     }
-    m_restoreAutoSql = doc.value(QStringLiteral("autoEnabled")).toBool(false);
+    // Drop the retired Auto latch. Icom has no radio Auto bit; writing
+    // autoEnabled made the client re-arm SQL after Off / band / reconnect.
+    if (doc.contains(QStringLiteral("autoEnabled"))) {
+        doc.remove(QStringLiteral("autoEnabled"));
+        if (!scope.setFeature(QStringLiteral("SquelchIntent"), 1, doc)) {
+            qWarning() << "SquelchIntent: failed to strip retired autoEnabled";
+        }
+    }
 }
 
 void RxApplet::saveClientSquelchIntent()
@@ -1536,8 +1578,7 @@ void RxApplet::saveClientSquelchIntent()
     }
     const RadioSettingsScope scope = m_clientSquelchScope;
     const int manualLevel = sqlManualLevel();
-    const bool autoEnabled = m_sqlMode == SqlMode::Auto;
-    m_pendingSquelchWrites.schedule(QStringLiteral("squelch"), [scope, manualLevel, autoEnabled] {
+    m_pendingSquelchWrites.schedule(QStringLiteral("squelch"), [scope, manualLevel] {
         int version = 0;
         AppSettings::FeatureReadStatus status;
         QJsonObject doc = scope.featureExact(
@@ -1548,7 +1589,7 @@ void RxApplet::saveClientSquelchIntent()
             return;
         }
         doc.insert(QStringLiteral("manualLevel"), manualLevel);
-        doc.insert(QStringLiteral("autoEnabled"), autoEnabled);
+        doc.remove(QStringLiteral("autoEnabled"));
         if (!scope.setFeature(QStringLiteral("SquelchIntent"), 1, doc)) {
             qWarning() << "SquelchIntent: settings write did not persist";
         }
@@ -1557,6 +1598,10 @@ void RxApplet::saveClientSquelchIntent()
 
 void RxApplet::setSqlMode(SqlMode m, bool propagateToRadio)
 {
+    if (m == SqlMode::Auto && !clientAutoSquelchAvailable()) {
+        m = (m_slice && m_slice->receiveSquelchOn()) ? SqlMode::Manual
+                                                     : SqlMode::Off;
+    }
     if (propagateToRadio) {
         m_clientSqlAwaitingReport = false;
     }
@@ -1977,6 +2022,7 @@ void RxApplet::setRadioModel(RadioModel* radioModel)
         });
         connect(m_radioModel, &RadioModel::capabilitiesChanged, this,
                 [this](bool, const RadioCapabilities&) {
+            dropClientAutoSquelchIfUnsupported();
             configureRepeaterReverseControl();
             configureFmToneControls();
             syncAgcSliderFromSlice();
@@ -2017,6 +2063,7 @@ void RxApplet::setRadioModel(RadioModel* radioModel)
         }
         refreshAllMutedDim();
     }
+    dropClientAutoSquelchIfUnsupported();
     updateAntennaButtons();
     configureRepeaterReverseControl();
     configureFmToneControls();
@@ -2583,16 +2630,8 @@ void RxApplet::connectSlice(SliceModel* s)
                 return;
             }
             m_clientSqlAwaitingReport = false;
-            if (m_clientManualSqlLevel && (!on || m_restoreAutoSql)) {
+            if (m_clientManualSqlLevel && !on) {
                 m_slice->setManualSquelchLevel(*m_clientManualSqlLevel);
-            }
-            // Wait for real readback before enabling the algorithm. A radio
-            // now reporting Off wins over old client Auto intent. An enabled
-            // manual radio threshold is otherwise adopted by the usual path.
-            if (on && m_restoreAutoSql) {
-                setSqlMode(SqlMode::Auto, /*propagateToRadio=*/false);
-            } else if (!on && m_restoreAutoSql) {
-                saveClientSquelchIntent();
             }
         }
         if (!externalReceive && !on && m_clientSquelchScope.hasRadioIdentity()
@@ -2660,14 +2699,12 @@ void RxApplet::connectSlice(SliceModel* s)
                 mode = SqlMode::Auto;
             }
         } else if (m_clientSqlAwaitingReport) {
-            // A previous radio/slice's Auto mode is not this radio's intent.
+            // A previous radio/slice's SQL mode is not this radio's intent.
             // Wait for its first SQL report instead of starting on defaults.
-            if (s->squelchStateKnown()) {
-                mode = s->squelchOn() && m_restoreAutoSql ? SqlMode::Auto : mode;
-            } else {
+            if (!s->squelchStateKnown()) {
                 mode = SqlMode::Off;
             }
-        } else if (m_flexSqlMode == SqlMode::Auto) {
+        } else if (clientAutoSquelchAvailable() && m_flexSqlMode == SqlMode::Auto) {
             mode = SqlMode::Auto;
         } else {
             m_flexSqlMode = mode;

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -47,9 +47,8 @@ class RxApplet : public QWidget {
     Q_OBJECT
 
 public:
-    // 3-way squelch state.  Off → Manual → Auto cycle on SQL button click.
-    // Mirrored by VfoWidget's SQL button via the sqlModeChanged signal so
-    // both UI surfaces present the same state and value.
+    // Squelch state. Off → Manual → Auto when RadioCapabilities::hasClientAutoSquelch
+    // is set; otherwise Off ↔ Manual only (Icom). Mirrored by VfoWidget.
     enum class SqlMode : uint8_t { Off, Manual, Auto };
 
     explicit RxApplet(QWidget* parent = nullptr);
@@ -67,8 +66,7 @@ public:
     int     sqlManualLevel() const;
     int     sqlManualMaximum() const;
     int     autoSqlMarginDb() const;
-    // Externally cycle the mode (Off → Manual → Auto → Off) — same path the
-    // RxApplet's own SQL button takes.  Emits sqlModeChanged.
+    // Externally cycle SQL mode — same path the RxApplet SQL button takes.
     void    cycleSqlModeExternal();
     // Programmatic slider drag from another UI surface.  Branches by mode
     // exactly like the in-applet slider does: Manual writes the current
@@ -325,10 +323,11 @@ private:
     // Only client intent is retained, never a live threshold to replay at attach.
     RadioSettingsScope m_clientSquelchScope;
     std::optional<int> m_clientManualSqlLevel;
-    bool m_restoreAutoSql{false};
     bool m_clientSqlAwaitingReport{false};
     void loadClientSquelchIntent();
     void saveClientSquelchIntent();
+    bool clientAutoSquelchAvailable() const;
+    void dropClientAutoSquelchIfUnsupported();
     AetherSDR::DeferredSettingsWrites m_pendingSquelchWrites;
     QMetaObject::Connection m_squelchDisconnectConnection;
     void applySqlModeVisuals();

--- a/tests/icom_control_profile_test.cpp
+++ b/tests/icom_control_profile_test.cpp
@@ -170,6 +170,7 @@ int main(int argc, char** argv)
         check(caps.hasAgcThreshold && caps.hasAmCarrierLevel && caps.hasVoxDelay,
               "Flex retains AGC threshold, AM carrier, and VOX delay");
         check(!caps.hasModeIndependentSquelch, "Flex retains its mode-specific SQL policy");
+        check(caps.hasClientAutoSquelch, "Flex keeps the host auto-squelch estimator");
         check(caps.cwSpeedMinWpm == 5 && caps.cwSpeedMaxWpm == 100
                   && caps.cwPitchMinHz == 100 && caps.cwPitchMaxHz == 6000
                   && caps.cwPitchStepHz == 10,
@@ -201,6 +202,8 @@ int main(int argc, char** argv)
             check(pitch == 601 && caps.cwPitchStepHz == 10,
                   "IC-705 retains its existing pitch conversion and step");
             check(!caps.hasModeIndependentSquelch, "IC-705 SQL policy remains unchanged");
+            check(!caps.hasClientAutoSquelch,
+                  "Icom does not advertise client auto-squelch");
             check(caps.hasFmRepeaterOffset, "IC-705 retains native repeater offsets");
             check(caps.hasCwTune, "IC-705 CW Tune policy remains unchanged");
         }
@@ -227,6 +230,8 @@ int main(int argc, char** argv)
                   "unsupported Icom AGC Off never writes Fast to the radio");
             check(caps.hasModeIndependentSquelch,
                   "IC-7300MK2 allows its native squelch in data and CW modes");
+            check(!caps.hasClientAutoSquelch,
+                  "IC-7300MK2 does not advertise client auto-squelch");
             check(!caps.hasFmRepeaterOffset, "MK2 does not advertise absent duplex commands");
             check(!caps.hasCwTune, "MK2 does not advertise an unimplemented CW tune carrier");
             {

--- a/tests/rx_applet_squelch_reconciliation_test.cpp
+++ b/tests/rx_applet_squelch_reconciliation_test.cpp
@@ -135,12 +135,13 @@ private slots:
         rx.setSlice(&slice);
         QCOMPARE(rx.sqlMode(), RxApplet::SqlMode::Manual);
         QCOMPARE(rx.sqlManualLevel(), 26);
-        rx.cycleSqlModeExternal();
-        status(slice, true, slice.squelchLevel()); // confirm the explicit Auto threshold
+        rx.cycleSqlModeExternal(); // Icom: Manual -> Off, never Auto
+        QCOMPARE(rx.sqlMode(), RxApplet::SqlMode::Off);
         rx.setSlice(nullptr);
         commands.clear();
         rx.setSlice(&slice);
-        QCOMPARE(rx.sqlMode(), RxApplet::SqlMode::Auto);
+        QCOMPARE(rx.sqlMode(), RxApplet::SqlMode::Off);
+        QVERIFY(rx.sqlMode() != RxApplet::SqlMode::Auto);
         QVERIFY(commands.isEmpty());
         rx.setSlice(nullptr);
         slice.invalidateSquelchState(); // reclaimed model from a disconnected session
@@ -151,32 +152,20 @@ private slots:
         QCOMPARE(rx.sqlMode(), RxApplet::SqlMode::Off);
     }
 
-    void icomClientIntentSurvivesRecreation_data()
-    {
-        QTest::addColumn<bool>("automatic");
-        QTest::newRow("manual-memory-while-off") << false;
-        QTest::newRow("explicit-auto") << true;
-    }
-
     void icomClientIntentSurvivesRecreation()
     {
-        QFETCH(bool, automatic);
         RadioModel radio;
         RadioModelWakeTestAccess::identity(radio, QStringLiteral("icom"),
-            automatic ? QStringLiteral("icom:auto-test") : QStringLiteral("icom:off-test"));
+            QStringLiteral("icom:off-test"));
         {
             SliceModel first(0);
             RxApplet rx;
             rx.setRadioModel(&radio);
             rx.setSlice(&first);
             status(first, true, 26, QStringLiteral("USB"));
-            rx.cycleSqlModeExternal(); // Manual -> Auto
-            first.setSquelch(true, 8); // algorithm changes threshold, not manual choice
-            status(first, true, 8);
-            if (!automatic) {
-                rx.cycleSqlModeExternal(); // Auto -> Off
-                status(first, false, 0);
-            }
+            rx.cycleSqlModeExternal(); // Icom: Manual -> Off
+            status(first, false, 0);
+            QCOMPARE(rx.sqlMode(), RxApplet::SqlMode::Off);
             QCOMPARE(first.manualSquelchLevel(), 26);
             rx.setSlice(nullptr);
         }
@@ -189,18 +178,36 @@ private slots:
         QCOMPARE(restarted.sqlMode(), RxApplet::SqlMode::Off);
         for (const auto& args : algorithm) { QVERIFY(!args[0].toBool()); }
         QVERIFY(commands.isEmpty()); // no attach/default threshold replay
-        status(second, automatic, automatic ? 8 : 0, QStringLiteral("USB"));
-        QCOMPARE(restarted.sqlMode(), automatic ? RxApplet::SqlMode::Auto : RxApplet::SqlMode::Off);
+        status(second, false, 0, QStringLiteral("USB"));
+        QCOMPARE(restarted.sqlMode(), RxApplet::SqlMode::Off);
         QCOMPARE(second.manualSquelchLevel(), 26);
         QVERIFY(commands.isEmpty()); // adopting state is passive
-        if (automatic) {
-            restarted.cycleSqlModeExternal(); // Auto -> Off
-            status(second, false, 0);
-        }
         restarted.cycleSqlModeExternal(); // Off -> Manual is explicit intent
         QCOMPARE(second.squelchLevel(), 26);
         QCOMPARE(restarted.sqlManualLevel(), 26);
         QCOMPARE(control<QSlider>(restarted, QStringLiteral("Squelch threshold"))->value(), 26);
+    }
+
+    void icomPersistedAutoEnabledIsStrippedAndIgnored()
+    {
+        RadioModel radio;
+        RadioModelWakeTestAccess::identity(radio, QStringLiteral("icom"),
+            QStringLiteral("icom:strip-auto"));
+        QVERIFY(radio.settingsScope().setFeature(QStringLiteral("SquelchIntent"), 1,
+            {{QStringLiteral("manualLevel"), 26}, {QStringLiteral("autoEnabled"), true}}));
+        SliceModel slice(0);
+        RxApplet rx;
+        rx.setRadioModel(&radio);
+        rx.setSlice(&slice);
+        status(slice, true, 26, QStringLiteral("USB"));
+        QCOMPARE(rx.sqlMode(), RxApplet::SqlMode::Manual);
+        QVERIFY(rx.sqlMode() != RxApplet::SqlMode::Auto);
+        rx.cycleSqlModeExternal();
+        QCOMPARE(rx.sqlMode(), RxApplet::SqlMode::Off);
+        QVERIFY(!radio.settingsScope().featureExact(QStringLiteral("SquelchIntent"))
+                     .contains(QStringLiteral("autoEnabled")));
+        QCOMPARE(radio.settingsScope().featureExact(QStringLiteral("SquelchIntent"))
+                     .value(QStringLiteral("manualLevel")).toInt(), 26);
     }
 
     void icomRadioTruthAndScopeWin()
@@ -217,7 +224,7 @@ private slots:
         status(slice, true, 43, QStringLiteral("USB"));
         QCOMPARE(rx.sqlManualLevel(), 43); // fresh radio value overrides saved cache
         QVERIFY(commands.isEmpty());
-        rx.cycleSqlModeExternal(); // saves Auto and current manual 43
+        rx.cycleSqlModeExternal(); // Icom: Manual -> Off; still keeps manual 43
         rx.setSlice(nullptr);
         RadioModelWakeTestAccess::identity(radio, QStringLiteral("icom"), QStringLiteral("icom:other"));
         SliceModel other(0);
@@ -234,7 +241,7 @@ private slots:
         QCOMPARE(rx.sqlManualLevel(), 43);
         rx.setSlice(nullptr); // disconnect flushes the bounded pending write
         QVERIFY(!radio.settingsScope().featureExact(QStringLiteral("SquelchIntent"))
-                     .value(QStringLiteral("autoEnabled")).toBool());
+                     .contains(QStringLiteral("autoEnabled")));
     }
 
     void icomFutureIntentIsPreserved()


### PR DESCRIPTION
## Summary

Client auto-squelch does not exist on Icom (or any radio — there is no Auto SQL register). On Icom, Off is threshold zero, so `SquelchIntent.autoEnabled` was invented to stand in for a bit the radio cannot store. That latch re-armed SQL after the operator turned it off, across bands, radios, and reconnects.

This PR disables Auto on Icom via capability mapping and removes the persisted Auto flag.

- Add `RadioCapabilities::hasClientAutoSquelch` (fail-closed default `false`).
- Icom declares **false**; Flex / HL2 / ANAN / RTL / Sim declare **true**.
- SQL cycle on Icom is Off ↔ Manual only; `setSqlMode(Auto)` is coerced away.
- Capabilities / radio-model changes drop a leftover Auto latch.
- `SquelchIntent` no longer writes `autoEnabled`; existing keys are stripped on load. Manual-level persistence for Icom Off=0 is unchanged.
- Flex auto-squelch behavior is unchanged.

## Test plan

- [x] `QT_QPA_PLATFORM=offscreen ctest --test-dir build -j22 -R 'rx_applet_squelch_reconciliation_test|icom_control_profile_test'`
- [ ] Connect an Icom: SQL button never shows AUTO; one click is Off/Manual only.
- [ ] Confirm a previously saved `SquelchIntent.autoEnabled: true` is stripped on attach and does not restore Auto.
- [ ] Flex still cycles Off → SQL → Auto.