### PR TITLE
core: IRadioBackend threading and lifetime contract, pinned by tests; close the rule-5 gap they found

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -479,10 +479,16 @@ anything in this table's territory (see the temporary notice at the top of
 "AI Agent Guidelines"). **Every implementor honours the THREADING AND
 LIFETIME CONTRACT at the top of `IRadioBackend.h`** (backend lives on its
 owner's thread, every seam signal is emitted from it, workers are private,
-payloads registered in one place, teardown bounded and ordered);
-`backend_seam_affinity_test` and `backend_family_switch_test` pin it, and
-`tests/SeamThreadAffinityProbe.h` drops the same tripwire into any test
-that drives a backend:
+payloads declared and registered in one place, teardown bounded and
+ordered). What is pinned versus surveyed: `backend_seam_affinity_test`
+pins rules 1, 2 and 6 for the simulator and rule 1 plus a cold
+construct/teardown for every other family; `hl2_connect_reentrancy_test`
+pins rule 2 for HL2 while its DSP build runs on the I/O thread;
+`backend_family_switch_test` pins rule 5 across the production switch with
+a deterministic stale-delivery injection. Live-emission affinity for flex,
+anan, icom and rtl is a survey result until
+`tests/SeamThreadAffinityProbe.h` — which drops the same tripwire into any
+test that drives a backend — is carried by a test that drives one:
 
 | Family | Backend | Notes |
 |---|---|---|

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -476,7 +476,13 @@ selected at connect time by a `family` string through `makeBackend()`.
 The seam's known gaps and the multi-radio migration order are tracked in
 #5262 (M0–M6) and the review meta-issue #5554 — read both before changing
 anything in this table's territory (see the temporary notice at the top of
-"AI Agent Guidelines"):
+"AI Agent Guidelines"). **Every implementor honours the THREADING AND
+LIFETIME CONTRACT at the top of `IRadioBackend.h`** (backend lives on its
+owner's thread, every seam signal is emitted from it, workers are private,
+payloads registered in one place, teardown bounded and ordered);
+`backend_seam_affinity_test` and `backend_family_switch_test` pin it, and
+`tests/SeamThreadAffinityProbe.h` drops the same tripwire into any test
+that drives a backend:
 
 | Family | Backend | Notes |
 |---|---|---|

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -75,6 +75,69 @@ struct MemoryRecallDetails {
 // samples owns an engine-side DSP chain — either way it emits the same
 // normalized signals, so no consumer can tell the difference.
 //
+// ---- THREADING AND LIFETIME CONTRACT ----------------------------------------
+//
+// Every implementor honours the following, and backend_seam_affinity_test /
+// backend_family_switch_test pin it. A backend that needs an exception does
+// not take one quietly: it changes this text first.
+//
+//  1. THE BACKEND OBJECT LIVES ON ITS OWNER'S THREAD. RadioModel constructs
+//     the backend on the thread RadioModel itself lives on (the GUI thread in
+//     the desktop app, the daemon's main thread in aetherd) and never moves
+//     it. Every virtual on this interface is called on that thread, and a
+//     backend may assume so — no verb needs a lock against another verb.
+//
+//  2. EVERY SEAM SIGNAL IS EMITTED FROM THAT THREAD. This includes the
+//     high-rate data plane (audioFrameReady, sliceAudioFrameReady,
+//     spectrumFrameReady, waterfallRowReady, meterUpdate) and the cadence
+//     signals (linkStatsUpdated). A backend whose socket, DSP or timer lives
+//     on a worker thread brings the result back to its own thread FIRST — a
+//     queued connection with `this` as the receiver context, or
+//     QMetaObject::invokeMethod(this, …) — and emits from there. It never
+//     emits a seam signal from inside a worker-thread callback, a
+//     Qt::DirectConnection lambda bound to a worker-thread sender, or a
+//     std::function the worker invokes.
+//
+//     Consequence for consumers: RadioModel may connect to any seam signal
+//     with the default (Auto) connection type and get a direct call, in
+//     order, with no re-entrancy across threads. Consumers must NOT rely on
+//     Qt::DirectConnection to reach a worker thread through the seam — there
+//     is no such thread to reach.
+//
+//  3. WORKERS ARE THE BACKEND'S PRIVATE BUSINESS. Threads, sockets, DSP
+//     objects and their affinity are implementation detail. Nothing above the
+//     seam may observe, name, or wait on them; a consumer that needs a
+//     backend-side value asks the backend on the backend's thread
+//     (healthSnapshot(), linkStats(), dspChains()) and the backend answers
+//     from its own cache — see the SYNCHRONOUS note on healthSnapshot().
+//
+//  4. QUEUED PAYLOADS ARE REGISTERED IN ONE PLACE. Every value type that
+//     crosses the seam (the *Delta structs, MeterDef, LinkStats) is declared
+//     with Q_DECLARE_METATYPE in its own header AND registered with
+//     qRegisterMetaType in RadioModel's constructor, so a queued or
+//     QMetaMethod-based connection of any seam signal delivers. A new payload
+//     type adds itself to both, in the same change that introduces it.
+//
+//  5. TEARDOWN IS BOUNDED AND ORDERED. disconnectRadio() returns with no
+//     worker still able to reach a seam signal: it stops its sources, quits
+//     and joins its threads (or hands them to a self-deleting reaper the way
+//     RtlSdrBackend does for a stuck open), and emits disconnected() exactly
+//     once, from its own thread, before returning or asynchronously — but
+//     never twice and never from a worker. The destructor completes the
+//     same drain for a backend destroyed while connected, and must never
+//     wait on a BlockingQueuedConnection whose target thread may itself be
+//     waiting on this thread — that is the wait cycle the family-switch test
+//     exists to catch. RadioModel::teardownBackend() disconnects every seam
+//     signal BEFORE destroying the backend, so a late queued emission from
+//     the dying backend is dropped rather than delivered to a receiver whose
+//     generation has moved on.
+//
+//  6. A BACKEND EMITS NOTHING AFTER disconnected(). A frame a worker sent
+//     before it was stopped may still be queued when disconnectRadio()
+//     returns; the backend gates its re-emit on its own connected flag (see
+//     SimBackend's audio forwards) so the seam stays silent once it has said
+//     goodbye. sim_backend_test pins this for the reference implementation.
+//
 // This is the CORE seed. It carries the lifecycle, capability, canonical-verb,
 // and extension surface; it grows one method at a time as the touchpoint
 // burndown (docs/architecture/aetherd-touchpoints.md) converts each gui→engine
@@ -1145,9 +1208,7 @@ signals:
 
 }  // namespace AetherSDR
 
-// linkStatsUpdated is direct-connected today (Hl2Backend's cadence timer lives
-// on the same thread as its consumer), but a backend whose socket owner emits
-// it from a worker thread would need the queued path — which silently drops the
-// signal unless the type is registered. Declared here so that stays a
-// non-event.
+// Contract rule 4: every seam payload is declared here and registered in
+// RadioModel's constructor, so a queued or QMetaMethod-based connection of
+// linkStatsUpdated delivers rather than silently dropping.
 Q_DECLARE_METATYPE(AetherSDR::IRadioBackend::LinkStats)

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -111,12 +111,32 @@ struct MemoryRecallDetails {
 //     (healthSnapshot(), linkStats(), dspChains()) and the backend answers
 //     from its own cache — see the SYNCHRONOUS note on healthSnapshot().
 //
-//  4. QUEUED PAYLOADS ARE REGISTERED IN ONE PLACE. Every value type that
-//     crosses the seam (the *Delta structs, MeterDef, LinkStats) is declared
-//     with Q_DECLARE_METATYPE in its own header AND registered with
-//     qRegisterMetaType in RadioModel's constructor, so a queued or
-//     QMetaMethod-based connection of any seam signal delivers. A new payload
-//     type adds itself to both, in the same change that introduces it.
+//     TRANSITIONAL EXCEPTION, and the only one: FlexBackend::connection() /
+//     panStream() and SimBackend's equivalents are backend-owned wire objects
+//     living on worker threads that RadioModel still harvests and drives
+//     directly — including Qt::BlockingQueuedConnection invokes — while the
+//     command plane moves behind the seam (#5262 M4, #5554 §2.6). They are the
+//     only objects above the seam that may wait on a backend thread, no new
+//     call site may join them, and every handler bound to them is
+//     generation-guarded per rule 5. When M4 lands, this paragraph goes.
+//
+//  4. SEAM PAYLOADS ARE DECLARED AND REGISTERED IN ONE PLACE. Every value
+//     type that crosses the seam (the *Delta structs, MeterDef, LinkStats) is
+//     declared with Q_DECLARE_METATYPE in its own header AND registered with
+//     qRegisterMetaType in RadioModel's constructor. A new payload type adds
+//     itself to both, in the same change that introduces it.
+//
+//     This is NOT what makes a queued connection deliver. On Qt 6 moc embeds
+//     each signal parameter's QMetaType in the meta-object and a
+//     pointer-to-member-function connection self-registers at connect time, so
+//     a queued seam signal delivers with neither line present — the Qt 5
+//     "Cannot queue arguments of type …" failure this rule used to cite does
+//     not reproduce here. The registration is for the NAME-based paths that do
+//     not go through moc's embedded type: QMetaType::fromName, QVariant round
+//     trips, string-based SIGNAL/SLOT connects, and QSignalSpy argument
+//     capture (tests/hl2_backend_test.cpp relies on exactly that). Registering
+//     in one place keeps those working and keeps the answer to "is this a seam
+//     payload?" in a single list.
 //
 //  5. TEARDOWN IS BOUNDED AND ORDERED. disconnectRadio() returns with no
 //     worker still able to reach a seam signal: it stops its sources, quits
@@ -128,9 +148,16 @@ struct MemoryRecallDetails {
 //     wait on a BlockingQueuedConnection whose target thread may itself be
 //     waiting on this thread — that is the wait cycle the family-switch test
 //     exists to catch. RadioModel::teardownBackend() disconnects every seam
-//     signal BEFORE destroying the backend, so a late queued emission from
-//     the dying backend is dropped rather than delivered to a receiver whose
-//     generation has moved on.
+//     signal BEFORE destroying the backend, but THAT IS NOT SUFFICIENT and a
+//     consumer must not believe it is: QObject::disconnect stops new posts and
+//     Qt purges a queued QMetaCallEvent only when the RECEIVER dies, so a call
+//     already posted by a dying backend (or by a wire object on its worker
+//     thread) is still delivered afterwards. What actually drops it is the
+//     receiver generation: teardownBackend() bumps a counter, and every
+//     handler bound to a backend-owned object captures it and returns early
+//     when it no longer matches (RadioModel::setupBackend()). Believing the
+//     disconnect was enough is what let a torn-down session's trailing status
+//     line delete the next session's slice.
 //
 //  6. A BACKEND EMITS NOTHING AFTER disconnected(). A frame a worker sent
 //     before it was stopped may still be queued when disconnectRadio()

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -799,15 +799,23 @@ void RadioModel::setupBackend(const QString& family)
     m_radioDialLocked.reset();
     m_family = family.isEmpty() ? QStringLiteral("flex") : family.toLower();
     // IRadioBackend contract rule 5. teardownBackend() bumps this before the
-    // old backend dies, and every handler below that a BACKEND-OWNED object can
-    // reach (the harvested RadioConnection / PanadapterStream as much as the
-    // seam signals in wireBackendReceiverState) checks it before touching the
-    // model. Qt delivers a queued call that was posted before the sender was
-    // disconnected or destroyed, so without this a trailing status line from
-    // the previous session — the simulator's synthetic "slice 0
-    // client_handle=…" was the one backend_family_switch_test caught — lands
-    // on the NEXT session's models, reads as a foreign client's slice, and
-    // removes it.
+    // old backend dies, and every handler below that INTERPRETS a delivery from
+    // a backend-owned object captures it and returns early once it no longer
+    // matches. Qt delivers a queued call that was posted before the sender was
+    // disconnected or destroyed — it purges on receiver destruction only — so
+    // without this a trailing status line from the previous session lands on
+    // the NEXT session's models. The one that bit: the simulator's synthetic
+    // "slice 0 client_handle=0xDE300001", which the new session read as a
+    // foreign client's slice and removed (backend_family_switch_test injects it
+    // deterministically).
+    //
+    // Deliberately NOT applied to the three panFeed* forwards below. Those are
+    // signal-to-signal, which is what preserves the original thread hop and the
+    // renderer's batching (see the comment on them); routing them through a
+    // lambda to add a check would undo that for a stale FRAME, whose worst case
+    // is one trace row drawn for a pan id the new session does not have — the
+    // renderer already resolves by pan id and drops what it cannot place. If
+    // that ever stops being true, they need the guard and a different forward.
     const quint64 generation = m_backendReceiverGeneration;
 
     {
@@ -1819,6 +1827,21 @@ void RadioModel::wireBackendReceiverState()
 void RadioModel::teardownBackend()
 {
     ++m_backendReceiverGeneration;
+    // Answer, then drop, every command still waiting on the backend that is
+    // about to die. The generation guard on commandResponse means a reply
+    // arriving after this point is discarded, so without this the callback —
+    // a std::function capturing this and whatever the caller held — would sit
+    // in the map for the life of the process, and the caller would wait for a
+    // reply that can no longer be delivered. kNoCommandPlaneCode is the same
+    // answer sendCmd() gives when there is no command plane to write to.
+    if (!m_pendingCallbacks.isEmpty()) {
+        const QMap<quint32, ResponseCallback> pending = std::move(m_pendingCallbacks);
+        m_pendingCallbacks.clear();
+        for (const ResponseCallback& cb : pending) {
+            if (cb)
+                cb(kNoCommandPlaneCode, QStringLiteral("the radio connection was replaced"));
+        }
+    }
     m_sliceLifecycleCommandSinkForTest = {};
     m_memoryRefreshActive = false;
     m_memoryImportFailures = 0;
@@ -2019,9 +2042,11 @@ RadioModel::RadioModel(QObject* parent)
     qRegisterMetaType<AmpDelta>();
     qRegisterMetaType<TunerDelta>();
     // IRadioBackend contract rule 4: every seam payload registers here. These
-    // two were declared (Q_DECLARE_METATYPE) but never registered, so a queued
-    // notchChanged or linkStatsUpdated would have been dropped with only a
-    // "Cannot queue arguments" log line to show for it.
+    // two were declared (Q_DECLARE_METATYPE) and never registered. That does
+    // NOT break queued delivery on Qt 6 — moc embeds the parameter's QMetaType
+    // and a PMF connection self-registers — so this is not a bug fix; it is the
+    // name-based paths (QMetaType::fromName, QVariant, string SIGNAL/SLOT,
+    // QSignalSpy capture) and the single-list invariant the rule is about.
     qRegisterMetaType<NotchDelta>();
     qRegisterMetaType<IRadioBackend::LinkStats>();
 
@@ -3637,13 +3662,7 @@ void RadioModel::connectToRadio(const RadioInfo& info)
     if (wantFamily != m_family || !m_backend) {
         qCInfo(lcProtocol) << "RadioModel: switching backend family" << m_family
                            << "->" << wantFamily << "for" << info.address.toString();
-        // F1 (#4448): a family switch is a hard radio change — drop every live and
-        // staged slice/pan model so none can be reclaimed as a model of the new
-        // family with mismatched (or missing) command/TX/DV wiring.
-        dropAllSessionModelsForFamilySwitch();
-        teardownBackend();
-        setupBackend(wantFamily);
-        emit backendRebuilt();
+        rebuildBackendForFamily(wantFamily);
         if (!m_backend) {
             return;
         }
@@ -7722,7 +7741,13 @@ void RadioModel::startNetworkMonitor()
         disconnect(m_networkPingConnection);
         m_networkPingConnection = {};
     }
-    m_networkPingConnection = connect(m_connection, &RadioConnection::pingRttMeasured, this, [this](int ms) {
+    // Generation-guarded like every other handler bound to the backend-owned
+    // RadioConnection (rule 5): an RTT sample measured by the dying session's
+    // worker must not be posted onto the next one's network quality.
+    m_networkPingConnection = connect(m_connection, &RadioConnection::pingRttMeasured, this,
+                                      [this, generation = m_backendReceiverGeneration](int ms) {
+        if (generation != m_backendReceiverGeneration)
+            return;
         m_pingMissCount = 0;
         m_lastPingRtt = ms;
         evaluateNetworkQuality();
@@ -9348,13 +9373,24 @@ void RadioModel::setBackendForTest(std::unique_ptr<IRadioBackend> backend,
     wireBackendReceiverState();
 }
 
-bool RadioModel::rebuildBackendForTest(const QString& family)
+void RadioModel::rebuildBackendForFamily(const QString& family)
 {
-    // Mirrors the family-switch block in connectToRadio(); keep the two in step.
+    // THE family switch, in one place. connectToRadio() calls it for a real
+    // target and rebuildBackendForTest() calls it for a socket-free one, so a
+    // test cannot exercise an ordering production does not have.
+    //
+    // F1 (#4448): a family switch is a hard radio change — drop every live and
+    // staged slice/pan model first so none can be reclaimed as a model of the
+    // new family with mismatched (or missing) command/TX/DV wiring.
     dropAllSessionModelsForFamilySwitch();
     teardownBackend();
     setupBackend(family);
     emit backendRebuilt();
+}
+
+bool RadioModel::rebuildBackendForTest(const QString& family)
+{
+    rebuildBackendForFamily(family);
     return m_backend != nullptr;
 }
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -798,6 +798,17 @@ void RadioModel::setupBackend(const QString& family)
     // RadioModel: `this`, or a value member such as m_transmitModel.
     m_radioDialLocked.reset();
     m_family = family.isEmpty() ? QStringLiteral("flex") : family.toLower();
+    // IRadioBackend contract rule 5. teardownBackend() bumps this before the
+    // old backend dies, and every handler below that a BACKEND-OWNED object can
+    // reach (the harvested RadioConnection / PanadapterStream as much as the
+    // seam signals in wireBackendReceiverState) checks it before touching the
+    // model. Qt delivers a queued call that was posted before the sender was
+    // disconnected or destroyed, so without this a trailing status line from
+    // the previous session — the simulator's synthetic "slice 0
+    // client_handle=…" was the one backend_family_switch_test caught — lands
+    // on the NEXT session's models, reads as a foreign client's slice, and
+    // removes it.
+    const quint64 generation = m_backendReceiverGeneration;
 
     {
         // aetherd Gap A/B: build the backend for m_family. The Flex-specific
@@ -1278,7 +1289,8 @@ void RadioModel::setupBackend(const QString& family)
     // bridge/TCI/RADE); RadioModel is the command plane that makes it so.
     if (m_panStream)
     connect(m_panStream, &PanadapterStream::daxStreamCreateNeeded,
-            this, [this](int ch) {
+            this, [this, generation](int ch) {
+        if (generation != m_backendReceiverGeneration) return;
         if (!isConnected()) {
             // Dropped create (connect gap): tell the manager so the latch
             // clears and its retry cadence re-fires — otherwise the channel
@@ -1306,8 +1318,9 @@ void RadioModel::setupBackend(const QString& family)
     });
     if (m_panStream)
     connect(m_panStream, &PanadapterStream::daxStreamRemoveNeeded,
-            this, [this](quint32 streamId, int ch) {
+            this, [this, generation](quint32 streamId, int ch) {
         Q_UNUSED(ch);
+        if (generation != m_backendReceiverGeneration) return;
         if (!isConnected()) return;
         sendCommand(QString("stream remove 0x%1").arg(streamId, 0, 16));
     });
@@ -1322,23 +1335,44 @@ void RadioModel::setupBackend(const QString& family)
     // through the neutral IRadioBackend signals below instead, which is why the
     // block after this one is gated on !m_connection.
     if (m_connection) {
-    connect(m_connection, &RadioConnection::statusReceived,
-            this, &RadioModel::onStatusReceived);
-    connect(m_connection, &RadioConnection::messageReceived,
-            this, &RadioModel::onMessageReceived);
-    connect(m_connection, &RadioConnection::connected,
-            this, &RadioModel::onConnected);
-    connect(m_connection, &RadioConnection::disconnected,
-            this, &RadioModel::onDisconnected);
-    connect(m_connection, &RadioConnection::errorOccurred,
-            this, &RadioModel::onConnectionError);
-    connect(m_connection, &RadioConnection::versionReceived,
-            this, &RadioModel::onVersionReceived);
+    // Each goes through a generation-checked lambda rather than straight to
+    // the member slot: see the rule-5 note at the top of this function.
+    connect(m_connection, &RadioConnection::statusReceived, this,
+            [this, generation](const QString& object, const QMap<QString, QString>& kvs) {
+        if (generation != m_backendReceiverGeneration) return;
+        onStatusReceived(object, kvs);
+    });
+    connect(m_connection, &RadioConnection::messageReceived, this,
+            [this, generation](const ParsedMessage& msg) {
+        if (generation != m_backendReceiverGeneration) return;
+        onMessageReceived(msg);
+    });
+    connect(m_connection, &RadioConnection::connected, this,
+            [this, generation] {
+        if (generation != m_backendReceiverGeneration) return;
+        onConnected();
+    });
+    connect(m_connection, &RadioConnection::disconnected, this,
+            [this, generation] {
+        if (generation != m_backendReceiverGeneration) return;
+        onDisconnected();
+    });
+    connect(m_connection, &RadioConnection::errorOccurred, this,
+            [this, generation](const QString& msg) {
+        if (generation != m_backendReceiverGeneration) return;
+        onConnectionError(msg);
+    });
+    connect(m_connection, &RadioConnection::versionReceived, this,
+            [this, generation](const QString& version) {
+        if (generation != m_backendReceiverGeneration) return;
+        onVersionReceived(version);
+    });
 
     // Response callbacks: RadioConnection emits commandResponse on worker thread,
     // we dispatch to the matching callback on the main thread. (#502)
     connect(m_connection, &RadioConnection::commandResponse,
-            this, [this](quint32 seq, int code, const QString& body) {
+            this, [this, generation](quint32 seq, int code, const QString& body) {
+        if (generation != m_backendReceiverGeneration) return;
         auto it = m_pendingCallbacks.find(seq);
         if (it != m_pendingCallbacks.end()) {
             it.value()(code, body);
@@ -1393,8 +1427,11 @@ void RadioModel::setupBackend(const QString& family)
 
     // Forward VITA-49 meter packets to MeterModel (cross-thread, auto-queued)
     if (m_panStream)
-    connect(m_panStream, &PanadapterStream::meterDataReady,
-            &m_meterModel, &MeterModel::updateValues);
+    connect(m_panStream, &PanadapterStream::meterDataReady, this,
+            [this, generation](auto&&... values) {
+        if (generation != m_backendReceiverGeneration) return;
+        m_meterModel.updateValues(std::forward<decltype(values)>(values)...);
+    });
 
     // HAND THE FRESH BACKEND THE MIC GAIN THE MODEL ALREADY HOLDS.
     //
@@ -1981,6 +2018,12 @@ RadioModel::RadioModel(QObject* parent)
     qRegisterMetaType<ProfileDelta>();
     qRegisterMetaType<AmpDelta>();
     qRegisterMetaType<TunerDelta>();
+    // IRadioBackend contract rule 4: every seam payload registers here. These
+    // two were declared (Q_DECLARE_METATYPE) but never registered, so a queued
+    // notchChanged or linkStatsUpdated would have been dropped with only a
+    // "Cannot queue arguments" log line to show for it.
+    qRegisterMetaType<NotchDelta>();
+    qRegisterMetaType<IRadioBackend::LinkStats>();
 
     // Publish the host-side memory bank once the event loop turns. Deferred
     // rather than done here because MainWindow connects to memoryChanged AFTER
@@ -9303,6 +9346,16 @@ void RadioModel::setBackendForTest(std::unique_ptr<IRadioBackend> backend,
     m_backend = std::move(backend);
     m_family = family;
     wireBackendReceiverState();
+}
+
+bool RadioModel::rebuildBackendForTest(const QString& family)
+{
+    // Mirrors the family-switch block in connectToRadio(); keep the two in step.
+    dropAllSessionModelsForFamilySwitch();
+    teardownBackend();
+    setupBackend(family);
+    emit backendRebuilt();
+    return m_backend != nullptr;
 }
 
 QString RadioModel::neutralPanIdStringForTest(int panIdx)

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1664,6 +1664,14 @@ public:
     // Install a socket-free backend with the same normalized receiver-state
     // bindings used by production. Replacement drops old session models.
     void setBackendForTest(std::unique_ptr<IRadioBackend> backend, const QString& family);
+    // The production family switch — dropAllSessionModelsForFamilySwitch(),
+    // teardownBackend(), setupBackend(), backendRebuilt() — exactly as
+    // connectToRadio() runs it, but WITHOUT the dial that follows. Builds the
+    // REAL backend for `family` through makeBackend(), so a test can cycle every
+    // family through construction, the full setupBackend() wiring and teardown
+    // with no socket, no device and no radio. Returns false when the family
+    // has no backend in this build (RTL without librtlsdr).
+    bool rebuildBackendForTest(const QString& family);
     // Replace only the ordinary lifecycle command transport, including replies.
     // Tests can pin Flex/Sim encoding without constructing a wire object/peer.
     void setSliceLifecycleCommandSinkForTest(

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1550,6 +1550,9 @@ private:
     // run again on a family change — not just at construction.
     void setupBackend(const QString& family);
     void teardownBackend();
+    // The family switch itself: drop session models, tear down, build, announce.
+    // One body, called by connectToRadio() and rebuildBackendForTest().
+    void rebuildBackendForFamily(const QString& family);
     // Push the backend's RadioCapabilities into the models that own each flag,
     // then emit capabilitiesChanged. Called on every connect/disconnect edge and
     // whenever the backend revises its own capabilities.
@@ -1664,13 +1667,12 @@ public:
     // Install a socket-free backend with the same normalized receiver-state
     // bindings used by production. Replacement drops old session models.
     void setBackendForTest(std::unique_ptr<IRadioBackend> backend, const QString& family);
-    // The production family switch — dropAllSessionModelsForFamilySwitch(),
-    // teardownBackend(), setupBackend(), backendRebuilt() — exactly as
-    // connectToRadio() runs it, but WITHOUT the dial that follows. Builds the
-    // REAL backend for `family` through makeBackend(), so a test can cycle every
-    // family through construction, the full setupBackend() wiring and teardown
-    // with no socket, no device and no radio. Returns false when the family
-    // has no backend in this build (RTL without librtlsdr).
+    // The production family switch WITHOUT the dial that follows it: calls the
+    // same rebuildBackendForFamily() connectToRadio() calls, so the two cannot
+    // drift. Builds the REAL backend for `family` through makeBackend(), so a
+    // test can cycle every family through construction, the full setupBackend()
+    // wiring and teardown with no socket, no device and no radio. Returns false
+    // when the family has no backend in this build (RTL without librtlsdr).
     bool rebuildBackendForTest(const QString& family);
     // Replace only the ordinary lifecycle command transport, including replies.
     // Tests can pin Flex/Sim encoding without constructing a wire object/peer.

--- a/tests/SeamThreadAffinityProbe.h
+++ b/tests/SeamThreadAffinityProbe.h
@@ -1,0 +1,184 @@
+#pragma once
+
+// Tripwire for IRadioBackend contract rules 2 and 6 ("THREADING AND LIFETIME
+// CONTRACT" in IRadioBackend.h): every seam signal is emitted on the thread
+// the backend object lives on, and nothing is emitted after disconnected().
+//
+// Connects to EVERY signal IRadioBackend declares with Qt::DirectConnection,
+// so the recording lambda runs on whichever thread actually emits and can
+// compare it against backend->thread(). Attach it to any backend a test
+// already drives (a fake radio on localhost, injected frames, the simulator)
+// and assert violations().isEmpty() at the end — no other change to the test.
+//
+// attachAllSeamSignals() is checked against the meta-object by
+// backend_seam_affinity_test: a signal added to IRadioBackend without a line
+// here fails that test, so the tripwire cannot silently stop covering one.
+
+#include "core/backends/IRadioBackend.h"
+
+#include <QHash>
+#include <QMetaMethod>
+#include <QMetaObject>
+#include <QMutex>
+#include <QMutexLocker>
+#include <QObject>
+#include <QSet>
+#include <QString>
+#include <QStringList>
+#include <QThread>
+
+namespace AetherSDR::test {
+
+inline QString seamThreadName(QThread* t)
+{
+    if (!t) return QStringLiteral("<null>");
+    const QString n = t->objectName();
+    return n.isEmpty()
+        ? QStringLiteral("QThread@%1").arg(reinterpret_cast<quintptr>(t), 0, 16)
+        : n;
+}
+
+class SeamThreadAffinityProbe {
+public:
+    explicit SeamThreadAffinityProbe(IRadioBackend* b) : m_backend(b), m_home(b->thread()) {}
+
+    // Safe from any thread: a violation IS a call from another thread, and the
+    // recorder has to survive it to report it.
+    void record(const char* signal)
+    {
+        QThread* current = QThread::currentThread();
+        QMutexLocker lock(&m_mutex);
+        const QString name = QString::fromLatin1(signal);
+        ++m_counts[name];
+        if (current != m_home) {
+            m_violations << QStringLiteral("%1 emitted on %2, backend lives on %3")
+                                .arg(name, seamThreadName(current), seamThreadName(m_home));
+        }
+        if (m_sawDisconnected && name != QLatin1String("disconnected")) {
+            m_afterDisconnect << name;
+        }
+        if (name == QLatin1String("disconnected")) {
+            m_sawDisconnected = true;
+        }
+    }
+    // A reconnect legitimately follows a disconnect; call this when the test
+    // reconnects so rule 6 is judged per session.
+    void resetDisconnectGate()
+    {
+        QMutexLocker lock(&m_mutex);
+        m_sawDisconnected = false;
+    }
+
+    QStringList violations() const { QMutexLocker l(&m_mutex); return m_violations; }
+    QStringList afterDisconnect() const { QMutexLocker l(&m_mutex); return m_afterDisconnect; }
+    QStringList observed() const
+    {
+        QMutexLocker l(&m_mutex);
+        QStringList out;
+        for (auto it = m_counts.cbegin(); it != m_counts.cend(); ++it) {
+            out << QStringLiteral("%1×%2").arg(it.key()).arg(it.value());
+        }
+        out.sort();
+        return out;
+    }
+    int count(const QString& name) const { QMutexLocker l(&m_mutex); return m_counts.value(name); }
+    int probed() const { return m_probedNames.size(); }
+    QSet<QString> probedNames() const { return m_probedNames; }
+    QObject* context() { return &m_context; }
+    IRadioBackend* backend() const { return m_backend; }
+    void noteProbed(const char* name) { m_probedNames.insert(QString::fromLatin1(name)); }
+
+private:
+    IRadioBackend* m_backend;
+    QThread* m_home;
+    QObject m_context;
+    mutable QMutex m_mutex;
+    QHash<QString, int> m_counts;
+    QStringList m_violations;
+    QStringList m_afterDisconnect;
+    bool m_sawDisconnected{false};
+    QSet<QString> m_probedNames;
+};
+
+template <typename Signal>
+inline void attachSeamSignal(SeamThreadAffinityProbe& p, Signal signal, const char* name)
+{
+    QObject::connect(p.backend(), signal, p.context(),
+                     [&p, name](auto&&...) { p.record(name); },
+                     Qt::DirectConnection);
+    p.noteProbed(name);
+}
+
+#define AETHER_SEAM_PROBE(sig) attachSeamSignal(p, &IRadioBackend::sig, #sig)
+
+// Every signal IRadioBackend declares.
+inline void attachAllSeamSignals(SeamThreadAffinityProbe& p)
+{
+    AETHER_SEAM_PROBE(connected);
+    AETHER_SEAM_PROBE(disconnected);
+    AETHER_SEAM_PROBE(connectionError);
+    AETHER_SEAM_PROBE(configurationWarning);
+    AETHER_SEAM_PROBE(capabilitiesChanged);
+    AETHER_SEAM_PROBE(transmitFrequencyCheckChanged);
+    AETHER_SEAM_PROBE(radioDialLockChanged);
+    AETHER_SEAM_PROBE(linkStatsUpdated);
+    AETHER_SEAM_PROBE(extensionResult);
+    AETHER_SEAM_PROBE(extensionError);
+    AETHER_SEAM_PROBE(sliceChanged);
+    AETHER_SEAM_PROBE(sliceRemoved);
+    AETHER_SEAM_PROBE(sliceLifecycleFailed);
+    AETHER_SEAM_PROBE(meterUpdate);
+    AETHER_SEAM_PROBE(transmitChanged);
+    AETHER_SEAM_PROBE(keyingStateConfirmed);
+    AETHER_SEAM_PROBE(amplifierChanged);
+    AETHER_SEAM_PROBE(tunerChanged);
+    AETHER_SEAM_PROBE(radioChanged);
+    AETHER_SEAM_PROBE(gpsChanged);
+    AETHER_SEAM_PROBE(memoryChanged);
+    AETHER_SEAM_PROBE(memoryRefreshStarted);
+    AETHER_SEAM_PROBE(memoryRefreshProgress);
+    AETHER_SEAM_PROBE(memoryRefreshFinished);
+    AETHER_SEAM_PROBE(profileChanged);
+    AETHER_SEAM_PROBE(meterDefined);
+    AETHER_SEAM_PROBE(meterRemoved);
+    AETHER_SEAM_PROBE(panCenterBandwidthChanged);
+    AETHER_SEAM_PROBE(panRemoved);
+    AETHER_SEAM_PROBE(notchChanged);
+    AETHER_SEAM_PROBE(notchRemoved);
+    AETHER_SEAM_PROBE(sliceAudioFrameReady);
+    AETHER_SEAM_PROBE(panWideChanged);
+    AETHER_SEAM_PROBE(panRangeChanged);
+    AETHER_SEAM_PROBE(panBandwidthLimitsChanged);
+    AETHER_SEAM_PROBE(panRfGainChanged);
+    AETHER_SEAM_PROBE(operatingStateChanged);
+    AETHER_SEAM_PROBE(panRfGainInfoChanged);
+    AETHER_SEAM_PROBE(panPreampInfoChanged);
+    AETHER_SEAM_PROBE(panPreampChanged);
+    AETHER_SEAM_PROBE(panAttenuatorInfoChanged);
+    AETHER_SEAM_PROBE(panAttenuatorChanged);
+    AETHER_SEAM_PROBE(panRxAntennaChanged);
+    AETHER_SEAM_PROBE(panAntennaListChanged);
+    AETHER_SEAM_PROBE(panWaterfallLineDurationChanged);
+    AETHER_SEAM_PROBE(extensionStatus);
+    AETHER_SEAM_PROBE(spectrumFrameReady);
+    AETHER_SEAM_PROBE(waterfallRowReady);
+    AETHER_SEAM_PROBE(audioFrameReady);
+}
+
+#undef AETHER_SEAM_PROBE
+
+// Every signal IRadioBackend declares, by name, from the meta-object.
+inline QStringList declaredSeamSignals()
+{
+    const QMetaObject& mo = IRadioBackend::staticMetaObject;
+    QStringList names;
+    for (int i = mo.methodOffset(); i < mo.methodCount(); ++i) {
+        const QMetaMethod m = mo.method(i);
+        if (m.methodType() == QMetaMethod::Signal) names << QString::fromLatin1(m.name());
+    }
+    names.removeDuplicates();   // a default argument declares two overloads
+    names.sort();
+    return names;
+}
+
+} // namespace AetherSDR::test

--- a/tests/backend_family_switch_test.cpp
+++ b/tests/backend_family_switch_test.cpp
@@ -1,18 +1,28 @@
 // IRadioBackend threading contract, rule 5 (IRadioBackend.h, "THREADING AND
-// LIFETIME CONTRACT"): teardown is bounded and ordered, and the model's
-// per-backend wiring does not accumulate across family switches (#4599).
+// LIFETIME CONTRACT"): teardown is bounded and ordered, and a delivery posted
+// by a backend that has since been torn down does not reach the next session.
 //
 // Cycles every family the factory can build through the PRODUCTION switch
-// (RadioModel::rebuildBackendForTest runs the same drop/teardown/setup/
-// announce sequence connectToRadio() does, minus the dial), including one
-// switch away from a LIVE simulator whose worker threads are streaming —
-// the case where a BlockingQueuedConnection in a destructor turns into a
-// wait cycle. A watchdog thread converts a hang into a failure instead of
-// a CI timeout.
+// (RadioModel::rebuildBackendForTest calls the same rebuildBackendForFamily()
+// connectToRadio() calls, minus the dial), including a switch away from a LIVE
+// simulator whose worker threads are streaming — the case where a
+// BlockingQueuedConnection in a destructor turns into a wait cycle. A watchdog
+// converts a hang into a failure instead of a CI timeout.
 //
-// No socket, no device, no radio: construction and teardown only.
+// THE LOAD-BEARING CHECK IS THE INJECTED ONE (step 6). Racing the simulator's
+// own trailing status line caught the original defect, but only ~1 run in 6 —
+// nothing forces the stale event to be queued-but-undrained at the moment of
+// the switch. Step 6 forces it: it emits the status from the harvested
+// RadioConnection's own thread under a BlockingQueuedConnection, so the
+// QMetaCallEvent is provably in the main queue before the switch runs.
+// Measured against a build with the setupBackend() generation guards reverted:
+// step 5b's race fails 9 runs in 30, step 6 fails 10 in 10.
+//
+// No socket, no device, no radio: construction, teardown, and the in-process
+// synthetic wire only.
 
 #include "TestSettingsProfile.h"
+#include "core/RadioConnection.h"
 #include "core/RadioDiscovery.h"
 #include "core/backends/SliceDelta.h"
 #include "core/backends/sim/SimBackend.h"
@@ -23,9 +33,11 @@
 #include <QElapsedTimer>
 #include <QEventLoop>
 #include <QHostAddress>
+#include <QMap>
 #include <QSignalSpy>
 #include <QString>
 #include <QStringList>
+#include <QThread>
 #include <QTimer>
 
 #include <atomic>
@@ -35,6 +47,19 @@
 #include <thread>
 
 using namespace AetherSDR;
+
+// A sanitizer build runs this workload — 12 cold family switches that construct
+// and join HL2/ANAN worker threads each time — several times slower, and
+// sanitizers.yml runs the suite unfiltered. Scale the time budgets rather than
+// leave a correct-but-slow run to fail on wall clock; the watchdog below is the
+// hard hang detector either way.
+#if defined(__SANITIZE_THREAD__) || defined(__SANITIZE_ADDRESS__)
+#  define AETHER_TEST_SANITIZED 1
+#elif defined(__has_feature)
+#  if __has_feature(thread_sanitizer) || __has_feature(address_sanitizer)
+#    define AETHER_TEST_SANITIZED 1
+#  endif
+#endif
 
 namespace {
 int g_failures = 0;
@@ -51,10 +76,17 @@ void spin(int ms)
     loop.exec();
 }
 
+#ifdef AETHER_TEST_SANITIZED
+constexpr int kSlowdown = 6;
+#else
+constexpr int kSlowdown = 1;
+#endif
+
 // A teardown that takes longer than this is not "slow"; it is waiting on
 // something that is waiting on it.
-constexpr int kStepBudgetMs = 5000;
-constexpr int kWatchdogSeconds = 90;
+constexpr int kStepBudgetMs = 5000 * kSlowdown;
+constexpr int kConnectDeadlineMs = 3000 * kSlowdown;
+constexpr int kWatchdogSeconds = 90 * kSlowdown;
 
 std::atomic<bool> g_done{false};
 std::atomic<const char*> g_phase{"startup"};
@@ -83,6 +115,13 @@ RadioInfo demoInfo()
     return i;
 }
 
+bool waitForConnected(RadioModel& model, bool want)
+{
+    for (int i = 0; i * 50 < kConnectDeadlineMs && model.isConnected() != want; ++i)
+        spin(50);
+    return model.isConnected() == want;
+}
+
 // One production switch, timed.
 bool switchTo(RadioModel& model, const QString& family, QSignalSpy& rebuilt)
 {
@@ -106,6 +145,41 @@ bool switchTo(RadioModel& model, const QString& family, QSignalSpy& rebuilt)
     check(model.panadapters().isEmpty(), QStringLiteral("-> %1: no pan models carried across").arg(family));
     return true;
 }
+
+// A slice the way a non-Flex backend announces one over the seam.
+SliceDelta seamSlice()
+{
+    SliceDelta d;
+    d.inUse = true;
+    d.active = true;
+    d.letter = QStringLiteral("A");
+    d.panId = QStringLiteral("hl2-0");
+    d.frequency = 14.225;
+    d.mode = QStringLiteral("USB");
+    d.filterLow = 100;
+    d.filterHigh = 2700;
+    return d;
+}
+
+// How many capabilitiesChanged the model emits across ONE connect edge. The
+// #4599 defect class is a connection installed per backend whose sender AND
+// receiver both outlive it, so it gains a live copy per family switch and this
+// count multiplies. The number itself does not matter — only that twelve
+// switches do not change it.
+int capabilityEmissionsForOneConnect(RadioModel& model, const char* label)
+{
+    QSignalSpy caps(&model, &RadioModel::capabilitiesChanged);
+    model.connectToRadio(demoInfo());
+    check(waitForConnected(model, true),
+          QStringLiteral("%1: simulator connected").arg(QLatin1String(label)));
+    spin(300);
+    const int n = caps.count();
+    model.disconnectFromRadio();
+    check(waitForConnected(model, false),
+          QStringLiteral("%1: simulator disconnected").arg(QLatin1String(label)));
+    spin(200);
+    return n;
+}
 } // namespace
 
 int main(int argc, char** argv)
@@ -114,13 +188,23 @@ int main(int argc, char** argv)
     if (!profile.isValid()) { return 1; }
     QCoreApplication app(argc, argv);
     std::thread(watchdog).detach();
+#ifdef AETHER_TEST_SANITIZED
+    std::printf("-- sanitizer build: time budgets scaled %dx\n", kSlowdown);
+#endif
 
+    QElapsedTimer destroyTimer;
     {
         RadioModel model;
         QSignalSpy rebuilt(&model, &RadioModel::backendRebuilt);
         QSignalSpy state(&model, &RadioModel::connectionStateChanged);
 
-        // 1. Every family, cold: construct, wire, tear down, twice around.
+        // 1. Baseline for the accumulation pin, before any switch has happened.
+        std::printf("-- baseline connect edge\n");
+        g_phase.store("baseline");
+        const int baselineCaps = capabilityEmissionsForOneConnect(model, "baseline");
+        std::printf("  baseline: %d capabilitiesChanged on one connect edge\n", baselineCaps);
+
+        // 2. Every family, cold: construct, wire, tear down, twice around.
         const QStringList cycle = {
             QStringLiteral("sim"),  QStringLiteral("hl2"),  QStringLiteral("anan"),
             QStringLiteral("icom"), QStringLiteral("rtl"),  QStringLiteral("flex"),
@@ -132,81 +216,133 @@ int main(int argc, char** argv)
             switchTo(model, family, rebuilt);
         }
 
-        // 2. Away from a LIVE simulator: threads streaming, then the switch.
+        // 3. #4599's defect class: per-backend wiring must not accumulate across
+        //    those twelve switches. A connection installed in setupBackend()
+        //    whose sender and receiver are both `this` survives
+        //    teardownBackend() and gains one live copy per switch; its symptom
+        //    is N capabilitiesChanged per connect edge.
+        std::printf("-- accumulation check (#4599 defect class)\n");
+        g_phase.store("accumulation");
+        const int afterCycleCaps = capabilityEmissionsForOneConnect(model, "accumulation");
+        std::printf("  after 12 switches: %d capabilitiesChanged on one connect edge\n",
+                    afterCycleCaps);
+        check(afterCycleCaps == baselineCaps,
+              QStringLiteral("per-connect capabilitiesChanged does not grow with switches (%1 -> %2)")
+                  .arg(baselineCaps).arg(afterCycleCaps));
+
+        // 4. Away from a LIVE simulator: threads streaming, then the switch.
         std::printf("-- live simulator -> hl2\n");
         g_phase.store("connect sim");
         model.connectToRadio(demoInfo());
-        for (int i = 0; i < 60 && !model.isConnected(); ++i) spin(50);
-        check(model.isConnected(), "live: simulator connected");
+        check(waitForConnected(model, true), "live: simulator connected");
         spin(500);                                    // let audio/spectrum stream
-        const int stateBefore = state.count();
         switchTo(model, QStringLiteral("hl2"), rebuilt);
         spin(200);
-        int disconnects = 0;
-        for (int i = stateBefore; i < state.count(); ++i) {
-            if (!state.at(i).at(0).toBool()) ++disconnects;
-        }
-        check(disconnects <= 1,
-              QStringLiteral("live: at most one disconnected report on switch (%1)").arg(disconnects));
 
-        // 3. Back to a live simulator and tear it down through disconnect, then
-        //    switch — the ordered path (rule 5: disconnected() once, then gone).
+        // 5. Back to a live simulator and tear it down through disconnect — the
+        //    ordered path. Rule 5 says disconnected() lands exactly once, and
+        //    the model must report it exactly once too.
         std::printf("-- live simulator -> disconnect -> flex\n");
         g_phase.store("reconnect sim");
         model.connectToRadio(demoInfo());
-        for (int i = 0; i < 60 && !model.isConnected(); ++i) spin(50);
-        check(model.isConnected(), "live: simulator reconnected");
+        check(waitForConnected(model, true), "live: simulator reconnected");
         g_phase.store("disconnect sim");
         {
+            const int before = state.count();
             QElapsedTimer t;
             t.start();
             model.disconnectFromRadio();
-            for (int i = 0; i < 60 && model.isConnected(); ++i) spin(50);
-            check(!model.isConnected(), "live: disconnect reported");
-            check(t.elapsed() < kStepBudgetMs,
-                  QStringLiteral("live: disconnect within budget (%1 ms)").arg(t.elapsed()));
+            check(waitForConnected(model, false), "live: disconnect reported");
+            const qint64 ms = t.elapsed();
+            spin(300);                                // anything queued behind it lands
+            int disconnects = 0;
+            for (int i = before; i < state.count(); ++i)
+                if (!state.at(i).at(0).toBool()) ++disconnects;
+            check(disconnects == 1,
+                  QStringLiteral("live: the clean disconnect reports disconnected EXACTLY once (%1)")
+                      .arg(disconnects));
+            check(ms < kStepBudgetMs,
+                  QStringLiteral("live: disconnect within budget (%1 ms)").arg(ms));
         }
         switchTo(model, QStringLiteral("flex"), rebuilt);
 
-        // 4. #4599: after all of the above, one backend emission produces ONE
-        //    model reaction. A connection whose sender and receiver both
-        //    outlive the backend would have gained a copy per switch.
-        std::printf("-- duplicate-wiring check\n");
-        g_phase.store("dup check");
-        switchTo(model, QStringLiteral("hl2"), rebuilt);   // non-Flex: seam slices materialise
-        QSignalSpy added(&model, &RadioModel::sliceAdded);
-        SliceDelta d;
-        d.inUse = true;
-        d.active = true;
-        d.letter = QStringLiteral("A");
-        d.panId = QStringLiteral("hl2-0");
-        d.frequency = 14.225;
-        d.mode = QStringLiteral("USB");
-        d.filterLow = 100;
-        d.filterHigh = 2700;
-        QSignalSpy removed(&model, &RadioModel::sliceRemoved);
-        model.emitBackendSliceChangedForTest(0, d);
-        spin(300);   // long enough for anything the previous session left queued
-        // The previous session's synthetic connection posted a trailing
-        // "slice 0 client_handle=…" status that, before the rule-5 guard on
-        // the connection handlers, landed here and removed the NEW session's
-        // slice as a foreign client's. 2 in 12 runs; now pinned.
-        check(removed.count() == 0,
-              QStringLiteral("no stale event from the previous session removed the new slice (%1)")
-                  .arg(removed.count()));
-        check(added.count() == 1,
-              QStringLiteral("one seam sliceChanged -> exactly one sliceAdded (%1)").arg(added.count()));
-        check(model.slices().size() == 1,
-              QStringLiteral("exactly one slice model exists (%1)").arg(model.slices().size()));
+        // 5b. The race that originally found the defect, kept as a secondary
+        //     tripwire: the simulator's own trailing "slice 0 client_handle=…"
+        //     echo, however the scheduler happens to order it. Catches a
+        //     regression ~1 run in 6 by itself, which is why step 6 exists.
+        std::printf("-- stale-status race (secondary)\n");
+        g_phase.store("race");
+        switchTo(model, QStringLiteral("hl2"), rebuilt);
+        {
+            QSignalSpy added(&model, &RadioModel::sliceAdded);
+            QSignalSpy removed(&model, &RadioModel::sliceRemoved);
+            model.emitBackendSliceChangedForTest(0, seamSlice());
+            spin(300);
+            check(removed.count() == 0,
+                  QStringLiteral("race: no stale event removed the new slice (%1)").arg(removed.count()));
+            check(added.count() == 1,
+                  QStringLiteral("race: one seam sliceChanged -> one sliceAdded (%1)").arg(added.count()));
+        }
 
-        // 5. Destroy the model with a backend attached (the app-exit path).
-        g_phase.store("destroy model");
-        QElapsedTimer t;
-        t.start();
-        // scope end destroys `model`
+        // 6. THE DETERMINISTIC PIN. Post a trailing "slice 0 client_handle=…"
+        //    from the harvested RadioConnection's OWN thread under a blocking
+        //    invoke, so the QMetaCallEvent is guaranteed to be sitting in the
+        //    main queue when the switch tears that connection down. Without the
+        //    generation guard in setupBackend() the next session's handler runs
+        //    it, reads a foreign client's slice, and deletes the slice that
+        //    session just created.
+        //
+        //    Placement is load-bearing: the simulator must be LIVE (so the
+        //    harvested connection exists and is synthetic), and there must be no
+        //    spin() or disconnectFromRadio() between the injection and the
+        //    switch — either one drains the event into the old session, where it
+        //    is harmless and proves nothing.
+        std::printf("-- deterministic stale-status injection\n");
+        g_phase.store("inject");
+        model.connectToRadio(demoInfo());
+        check(waitForConnected(model, true), "inject: simulator connected");
+        spin(300);
+        {
+            auto* sim = dynamic_cast<SimBackend*>(model.backend());
+            check(sim != nullptr, "inject: backend is the simulator");
+            RadioConnection* conn = sim ? sim->connection() : nullptr;
+            check(conn != nullptr, "inject: the simulator vends a RadioConnection");
+            check(conn && conn->thread() != QThread::currentThread(),
+                  "inject: that connection lives on its own thread");
+            if (conn) {
+                QMetaObject::invokeMethod(conn, [conn] {
+                    QMap<QString, QString> kvs;
+                    kvs.insert(QStringLiteral("client_handle"), QStringLiteral("0xDE300001"));
+                    kvs.insert(QStringLiteral("RF_frequency"), QStringLiteral("14.100000"));
+                    emit conn->statusReceived(QStringLiteral("slice 0"), kvs);
+                }, Qt::BlockingQueuedConnection);
+            }
+        }
+        switchTo(model, QStringLiteral("hl2"), rebuilt);   // no spin in between
+        {
+            QSignalSpy added(&model, &RadioModel::sliceAdded);
+            QSignalSpy removed(&model, &RadioModel::sliceRemoved);
+            model.emitBackendSliceChangedForTest(0, seamSlice());
+            spin(300);
+            check(removed.count() == 0,
+                  QStringLiteral("inject: the injected stale status did not remove the new slice (%1)")
+                      .arg(removed.count()));
+            check(added.count() == 1,
+                  QStringLiteral("inject: one sliceAdded (%1)").arg(added.count()));
+            check(model.slices().size() == 1,
+                  QStringLiteral("inject: exactly one slice model exists (%1)").arg(model.slices().size()));
+        }
+
+        // 7. Destroy the model with a backend attached (the app-exit path). The
+        //    timer is declared OUTSIDE this scope so it outlives ~RadioModel and
+        //    can actually be read.
         std::printf("-- destroy with hl2 attached\n");
-        (void)t;
+        g_phase.store("destroy model");
+        destroyTimer.start();
     }
+    check(destroyTimer.elapsed() < kStepBudgetMs,
+          QStringLiteral("destroy with a backend attached is bounded (%1 ms)")
+              .arg(destroyTimer.elapsed()));
     g_done.store(true);
 
     std::printf("%d failure(s)\n", g_failures);

--- a/tests/backend_family_switch_test.cpp
+++ b/tests/backend_family_switch_test.cpp
@@ -1,0 +1,214 @@
+// IRadioBackend threading contract, rule 5 (IRadioBackend.h, "THREADING AND
+// LIFETIME CONTRACT"): teardown is bounded and ordered, and the model's
+// per-backend wiring does not accumulate across family switches (#4599).
+//
+// Cycles every family the factory can build through the PRODUCTION switch
+// (RadioModel::rebuildBackendForTest runs the same drop/teardown/setup/
+// announce sequence connectToRadio() does, minus the dial), including one
+// switch away from a LIVE simulator whose worker threads are streaming —
+// the case where a BlockingQueuedConnection in a destructor turns into a
+// wait cycle. A watchdog thread converts a hang into a failure instead of
+// a CI timeout.
+//
+// No socket, no device, no radio: construction and teardown only.
+
+#include "TestSettingsProfile.h"
+#include "core/RadioDiscovery.h"
+#include "core/backends/SliceDelta.h"
+#include "core/backends/sim/SimBackend.h"
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QHostAddress>
+#include <QSignalSpy>
+#include <QString>
+#include <QStringList>
+#include <QTimer>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <thread>
+
+using namespace AetherSDR;
+
+namespace {
+int g_failures = 0;
+void check(bool ok, const QString& what)
+{
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", qPrintable(what));
+    g_failures += !ok;
+}
+
+void spin(int ms)
+{
+    QEventLoop loop;
+    QTimer::singleShot(ms, &loop, &QEventLoop::quit);
+    loop.exec();
+}
+
+// A teardown that takes longer than this is not "slow"; it is waiting on
+// something that is waiting on it.
+constexpr int kStepBudgetMs = 5000;
+constexpr int kWatchdogSeconds = 90;
+
+std::atomic<bool> g_done{false};
+std::atomic<const char*> g_phase{"startup"};
+
+void watchdog()
+{
+    for (int i = 0; i < kWatchdogSeconds * 10; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        if (g_done.load()) return;
+    }
+    std::printf("[FAIL] watchdog: test hung for %d s during '%s' — teardown wait cycle\n",
+                kWatchdogSeconds, g_phase.load());
+    std::fflush(stdout);
+    std::_Exit(2);
+}
+
+RadioInfo demoInfo()
+{
+    RadioInfo i;
+    i.name    = QStringLiteral("FLEX-6700");
+    i.model   = SimBackend::demoModelName();
+    i.serial  = SimBackend::demoSerial();
+    i.family  = SimBackend::familyName();
+    i.address = QHostAddress(QHostAddress::LocalHost);   // synthetic; never dialed
+    i.port    = 4992;
+    return i;
+}
+
+// One production switch, timed.
+bool switchTo(RadioModel& model, const QString& family, QSignalSpy& rebuilt)
+{
+    g_phase.store("switch");
+    const int before = rebuilt.count();
+    QElapsedTimer t;
+    t.start();
+    const bool built = model.rebuildBackendForTest(family);
+    const qint64 ms = t.elapsed();
+    if (!built) {
+        std::printf("  %s: not built into this binary, skipped\n", qPrintable(family));
+        return false;
+    }
+    check(model.family() == family, QStringLiteral("-> %1: model reports the family").arg(family));
+    check(model.backend() != nullptr, QStringLiteral("-> %1: backend present").arg(family));
+    check(rebuilt.count() == before + 1,
+          QStringLiteral("-> %1: backendRebuilt announced exactly once").arg(family));
+    check(ms < kStepBudgetMs,
+          QStringLiteral("-> %1: teardown+setup within budget (%2 ms)").arg(family).arg(ms));
+    check(model.slices().isEmpty(), QStringLiteral("-> %1: no slice models carried across").arg(family));
+    check(model.panadapters().isEmpty(), QStringLiteral("-> %1: no pan models carried across").arg(family));
+    return true;
+}
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile profile(QStringLiteral("backend-family-switch"));
+    if (!profile.isValid()) { return 1; }
+    QCoreApplication app(argc, argv);
+    std::thread(watchdog).detach();
+
+    {
+        RadioModel model;
+        QSignalSpy rebuilt(&model, &RadioModel::backendRebuilt);
+        QSignalSpy state(&model, &RadioModel::connectionStateChanged);
+
+        // 1. Every family, cold: construct, wire, tear down, twice around.
+        const QStringList cycle = {
+            QStringLiteral("sim"),  QStringLiteral("hl2"),  QStringLiteral("anan"),
+            QStringLiteral("icom"), QStringLiteral("rtl"),  QStringLiteral("flex"),
+            QStringLiteral("hl2"),  QStringLiteral("sim"),  QStringLiteral("icom"),
+            QStringLiteral("flex"), QStringLiteral("anan"), QStringLiteral("flex"),
+        };
+        std::printf("-- cold cycle\n");
+        for (const QString& family : cycle) {
+            switchTo(model, family, rebuilt);
+        }
+
+        // 2. Away from a LIVE simulator: threads streaming, then the switch.
+        std::printf("-- live simulator -> hl2\n");
+        g_phase.store("connect sim");
+        model.connectToRadio(demoInfo());
+        for (int i = 0; i < 60 && !model.isConnected(); ++i) spin(50);
+        check(model.isConnected(), "live: simulator connected");
+        spin(500);                                    // let audio/spectrum stream
+        const int stateBefore = state.count();
+        switchTo(model, QStringLiteral("hl2"), rebuilt);
+        spin(200);
+        int disconnects = 0;
+        for (int i = stateBefore; i < state.count(); ++i) {
+            if (!state.at(i).at(0).toBool()) ++disconnects;
+        }
+        check(disconnects <= 1,
+              QStringLiteral("live: at most one disconnected report on switch (%1)").arg(disconnects));
+
+        // 3. Back to a live simulator and tear it down through disconnect, then
+        //    switch — the ordered path (rule 5: disconnected() once, then gone).
+        std::printf("-- live simulator -> disconnect -> flex\n");
+        g_phase.store("reconnect sim");
+        model.connectToRadio(demoInfo());
+        for (int i = 0; i < 60 && !model.isConnected(); ++i) spin(50);
+        check(model.isConnected(), "live: simulator reconnected");
+        g_phase.store("disconnect sim");
+        {
+            QElapsedTimer t;
+            t.start();
+            model.disconnectFromRadio();
+            for (int i = 0; i < 60 && model.isConnected(); ++i) spin(50);
+            check(!model.isConnected(), "live: disconnect reported");
+            check(t.elapsed() < kStepBudgetMs,
+                  QStringLiteral("live: disconnect within budget (%1 ms)").arg(t.elapsed()));
+        }
+        switchTo(model, QStringLiteral("flex"), rebuilt);
+
+        // 4. #4599: after all of the above, one backend emission produces ONE
+        //    model reaction. A connection whose sender and receiver both
+        //    outlive the backend would have gained a copy per switch.
+        std::printf("-- duplicate-wiring check\n");
+        g_phase.store("dup check");
+        switchTo(model, QStringLiteral("hl2"), rebuilt);   // non-Flex: seam slices materialise
+        QSignalSpy added(&model, &RadioModel::sliceAdded);
+        SliceDelta d;
+        d.inUse = true;
+        d.active = true;
+        d.letter = QStringLiteral("A");
+        d.panId = QStringLiteral("hl2-0");
+        d.frequency = 14.225;
+        d.mode = QStringLiteral("USB");
+        d.filterLow = 100;
+        d.filterHigh = 2700;
+        QSignalSpy removed(&model, &RadioModel::sliceRemoved);
+        model.emitBackendSliceChangedForTest(0, d);
+        spin(300);   // long enough for anything the previous session left queued
+        // The previous session's synthetic connection posted a trailing
+        // "slice 0 client_handle=…" status that, before the rule-5 guard on
+        // the connection handlers, landed here and removed the NEW session's
+        // slice as a foreign client's. 2 in 12 runs; now pinned.
+        check(removed.count() == 0,
+              QStringLiteral("no stale event from the previous session removed the new slice (%1)")
+                  .arg(removed.count()));
+        check(added.count() == 1,
+              QStringLiteral("one seam sliceChanged -> exactly one sliceAdded (%1)").arg(added.count()));
+        check(model.slices().size() == 1,
+              QStringLiteral("exactly one slice model exists (%1)").arg(model.slices().size()));
+
+        // 5. Destroy the model with a backend attached (the app-exit path).
+        g_phase.store("destroy model");
+        QElapsedTimer t;
+        t.start();
+        // scope end destroys `model`
+        std::printf("-- destroy with hl2 attached\n");
+        (void)t;
+    }
+    g_done.store(true);
+
+    std::printf("%d failure(s)\n", g_failures);
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/backend_seam_affinity_test.cpp
+++ b/tests/backend_seam_affinity_test.cpp
@@ -14,13 +14,25 @@
 // added to IRadioBackend without a probe entry fails this test, so the
 // contract cannot silently stop covering a new signal.
 //
-// Coverage: SimBackend is driven through its whole surface standalone
-// (connect, the data plane, slice verbs, pan create/remove, an extension
-// verb, disconnect) and must exercise a minimum set of signals so the test
-// is not vacuous. The other families are constructed through the production
-// factory (RadioModel::rebuildBackendForTest), asked the synchronous
-// questions, and torn down — no socket, no device — and whatever they emit
-// on that path is checked the same way.
+// WHAT THIS TEST ACTUALLY COVERS, per family:
+//
+//   sim   — rules 1, 2 and 6 for real. Driven through RadioModel across its
+//           whole surface (connect, the data plane, slice verbs, pan
+//           create/remove, extension verbs, disconnect, and a SECOND session
+//           so rule 6 is judged per session), with a minimum-emission floor so
+//           the assertions cannot pass vacuously. Forcing the sim's
+//           audioFrameReady forward to Qt::DirectConnection fails this test.
+//
+//   flex, hl2, anan, icom, rtl — rule 1 (the backend is constructed on its
+//           owner's thread) plus "construction and the synchronous getters
+//           emit nothing they should not". These are never connected, so they
+//           emit nothing and rules 2 and 6 are NOT exercised for them here;
+//           the report says so rather than printing a pass over zero
+//           observations. Live-emission affinity for hl2 is pinned by
+//           hl2_connect_reentrancy_test, which drives connectRadio() with the
+//           DSP build on the I/O thread and carries the same probe. For the
+//           remaining families it is a survey result until the probe is
+//           dropped into a test that drives one of them.
 
 #include "SeamThreadAffinityProbe.h"
 #include "TestSettingsProfile.h"
@@ -61,12 +73,27 @@ void spin(int ms)
     loop.exec();
 }
 
-void reportProbe(const QString& family, const Probe& p)
+// `exercised` says whether this family was actually driven. A probe that
+// recorded nothing cannot judge rules 2 or 6, and saying so beats printing a
+// pass over zero observations.
+void reportProbe(const QString& family, const Probe& p, bool exercised)
 {
+    const QStringList observed = p.observed();
     std::printf("  %s observed: %s\n", qPrintable(family),
-                qPrintable(p.observed().join(QStringLiteral(", "))));
+                observed.isEmpty() ? "(nothing)"
+                                   : qPrintable(observed.join(QStringLiteral(", "))));
     for (const QString& v : p.violations()) {
         std::printf("  VIOLATION [%s]: %s\n", qPrintable(family), qPrintable(v));
+    }
+    if (!exercised || observed.isEmpty()) {
+        std::printf("  NOTE [%s]: 0 emissions — rules 2 and 6 not exercised for this family\n",
+                    qPrintable(family));
+        // Still meaningful: a backend that emitted something during bare
+        // construction or a synchronous getter would show up here.
+        check(p.violations().isEmpty(),
+              QStringLiteral("%1: construction and the synchronous getters emit nothing off-thread")
+                  .arg(family));
+        return;
     }
     check(p.violations().isEmpty(),
           QStringLiteral("%1: every seam signal emitted on the backend's thread").arg(family));
@@ -148,7 +175,26 @@ void simulatorFullSurface()
     check(p.count(QStringLiteral("spectrumFrameReady")) >= 5, "sim: spectrum data plane observed");
     check(p.count(QStringLiteral("extensionResult")) + p.count(QStringLiteral("extensionError")) >= 2,
           "sim: extension replies observed");
-    reportProbe(QStringLiteral("sim"), p);
+
+    // A SECOND session. Rule 6 is per session — a reconnect legitimately
+    // follows a disconnect — so the gate is reset and the new session's
+    // traffic is judged on its own. Without the reset every emission after the
+    // first disconnect would read as a violation.
+    const int audioAfterFirstSession = p.count(QStringLiteral("audioFrameReady"));
+    p.resetDisconnectGate();
+    model.connectToRadio(demoInfo());
+    for (int i = 0; i < 60 && !model.isConnected(); ++i) spin(50);
+    check(model.isConnected(), "sim: second session connected");
+    spin(500);
+    check(p.count(QStringLiteral("connected")) == 2, "sim: connected twice across two sessions");
+    check(p.count(QStringLiteral("audioFrameReady")) > audioAfterFirstSession,
+          "sim: the second session streams audio of its own");
+    model.disconnectFromRadio();
+    for (int i = 0; i < 60 && model.isConnected(); ++i) spin(50);
+    spin(400);
+    check(p.count(QStringLiteral("disconnected")) == 2, "sim: disconnected twice");
+
+    reportProbe(QStringLiteral("sim"), p, /*exercised=*/true);
 }
 
 // Every other family: built by the production factory, asked the synchronous
@@ -181,7 +227,7 @@ void constructedFamilies()
         (void)b->currentOperatingState();
         b->disconnectRadio();
         spin(200);
-        reportProbe(family, p);
+        reportProbe(family, p, /*exercised=*/false);
         // Teardown happens on the next rebuild (or ~RadioModel); the probe's
         // context outlives it only within this iteration, so a late emission
         // during destruction would reach a dead lambda — the family-switch test

--- a/tests/backend_seam_affinity_test.cpp
+++ b/tests/backend_seam_affinity_test.cpp
@@ -1,0 +1,222 @@
+// IRadioBackend threading contract, rules 1, 2 and 6 (IRadioBackend.h,
+// "THREADING AND LIFETIME CONTRACT"): every seam signal is emitted from the
+// thread the backend object lives on, and nothing is emitted after
+// disconnected().
+//
+// The probe connects to EVERY signal IRadioBackend declares with
+// Qt::DirectConnection, so the lambda runs on whichever thread actually
+// emits, and records whether that thread is the backend's own. A backend
+// that forwards a worker's frame with a Direct connection, or emits from
+// inside a worker callback, shows up here as a named violation with the
+// offending thread.
+//
+// The probe table is checked against the meta-object at runtime: a signal
+// added to IRadioBackend without a probe entry fails this test, so the
+// contract cannot silently stop covering a new signal.
+//
+// Coverage: SimBackend is driven through its whole surface standalone
+// (connect, the data plane, slice verbs, pan create/remove, an extension
+// verb, disconnect) and must exercise a minimum set of signals so the test
+// is not vacuous. The other families are constructed through the production
+// factory (RadioModel::rebuildBackendForTest), asked the synchronous
+// questions, and torn down — no socket, no device — and whatever they emit
+// on that path is checked the same way.
+
+#include "SeamThreadAffinityProbe.h"
+#include "TestSettingsProfile.h"
+#include "core/backends/IRadioBackend.h"
+#include "core/RadioDiscovery.h"
+#include "core/backends/sim/SimBackend.h"
+#include "models/PanadapterModel.h"
+#include "models/RadioModel.h"
+
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QHostAddress>
+#include <QString>
+#include <QStringList>
+#include <QThread>
+#include <QTimer>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+using AetherSDR::test::SeamThreadAffinityProbe;
+using AetherSDR::test::attachAllSeamSignals;
+using AetherSDR::test::declaredSeamSignals;
+using Probe = SeamThreadAffinityProbe;
+
+namespace {
+int g_failures = 0;
+void check(bool ok, const QString& what)
+{
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", qPrintable(what));
+    g_failures += !ok;
+}
+
+void spin(int ms)
+{
+    QEventLoop loop;
+    QTimer::singleShot(ms, &loop, &QEventLoop::quit);
+    loop.exec();
+}
+
+void reportProbe(const QString& family, const Probe& p)
+{
+    std::printf("  %s observed: %s\n", qPrintable(family),
+                qPrintable(p.observed().join(QStringLiteral(", "))));
+    for (const QString& v : p.violations()) {
+        std::printf("  VIOLATION [%s]: %s\n", qPrintable(family), qPrintable(v));
+    }
+    check(p.violations().isEmpty(),
+          QStringLiteral("%1: every seam signal emitted on the backend's thread").arg(family));
+    check(p.afterDisconnect().isEmpty(),
+          QStringLiteral("%1: nothing emitted after disconnected() (%2)")
+              .arg(family, p.afterDisconnect().join(QStringLiteral(", "))));
+}
+
+RadioInfo demoInfo()
+{
+    RadioInfo i;
+    i.name    = QStringLiteral("FLEX-6700");
+    i.model   = SimBackend::demoModelName();
+    i.serial  = SimBackend::demoSerial();
+    i.family  = SimBackend::familyName();
+    i.address = QHostAddress(QHostAddress::LocalHost);   // synthetic; never dialed
+    i.port    = 4992;
+    return i;
+}
+
+// The reference implementation, driven through RadioModel exactly as the app
+// drives the demo: the synthetic wire (pan create/remove) only runs on that
+// path, so a standalone SimBackend cannot reach it.
+void simulatorFullSurface()
+{
+    std::printf("-- sim: through RadioModel, full surface\n");
+    RadioModel model;
+    model.connectToRadio(demoInfo());          // rebuilds the backend, then dials synthetically
+    IRadioBackend* sim = model.backend();
+    check(sim != nullptr && model.family() == QLatin1String("sim"), "sim: model built the simulator");
+    if (!sim) return;
+    Probe p(sim);
+    attachAllSeamSignals(p);
+
+    for (int i = 0; i < 60 && !model.isConnected(); ++i) spin(50);
+    check(model.isConnected(), "sim: connected through the model");
+    spin(400);                                   // initial state + first frames
+
+    sim->setSliceFrequency(0, 7'074'000.0);
+    sim->setSliceMode(0, QStringLiteral("CW"));
+    sim->setSliceFilter(0, 100, 2700);
+    sim->setSliceAgc(0, QStringLiteral("med"), 50);
+    sim->setSliceAudioMute(0, true);
+    sim->setSliceAudioGain(0, 40);
+    sim->setSliceAudioPan(0, 60);
+    sim->setSliceAudioMute(0, false);
+    spin(100);
+
+    const int pansBefore = model.panadapters().size();
+    model.createPanadapter();
+    for (int i = 0; i < 60 && model.panadapters().size() == pansBefore; ++i) spin(50);
+    check(model.panadapters().size() == pansBefore + 1, "sim: second pan materialised in the model");
+    QString newPan;
+    for (const PanadapterModel* pan : model.panadapters()) {
+        if (pan->panId().compare(QStringLiteral("0x40000000"), Qt::CaseInsensitive) != 0) newPan = pan->panId();
+    }
+    check(!newPan.isEmpty(), "sim: new pan has its own id");
+    sim->setPanCenter(newPan, 7'100'000.0, IRadioBackend::PanCenterIntent::Drag);
+    spin(100);
+    model.removePanadapter(newPan);
+    for (int i = 0; i < 60 && model.panadapters().size() != pansBefore; ++i) spin(50);
+    check(model.panadapters().size() == pansBefore, "sim: second pan removed from the model");
+
+    sim->invokeExtension(QStringLiteral("sim"), QStringLiteral("noise.enable"), 1, true);
+    sim->invokeExtension(QStringLiteral("sim"), QStringLiteral("bogus.verb"), 2, {});
+    sim->invokeExtension(QStringLiteral("nope"), QStringLiteral("x"), 3, {});
+    spin(600);                                   // let the data plane run
+
+    model.disconnectFromRadio();
+    for (int i = 0; i < 60 && model.isConnected(); ++i) spin(50);
+    spin(400);                                   // anything a worker had queued lands here
+
+    check(p.count(QStringLiteral("connected")) == 1, "sim: connected once");
+    check(p.count(QStringLiteral("disconnected")) == 1, "sim: disconnected once");
+    check(p.count(QStringLiteral("sliceChanged")) >= 1, "sim: sliceChanged observed");
+    check(p.count(QStringLiteral("radioChanged")) >= 1, "sim: radioChanged observed");
+    check(p.count(QStringLiteral("panCenterBandwidthChanged")) >= 2, "sim: pan geometry observed for both pans");
+    check(p.count(QStringLiteral("audioFrameReady")) >= 5, "sim: audio data plane observed");
+    check(p.count(QStringLiteral("spectrumFrameReady")) >= 5, "sim: spectrum data plane observed");
+    check(p.count(QStringLiteral("extensionResult")) + p.count(QStringLiteral("extensionError")) >= 2,
+          "sim: extension replies observed");
+    reportProbe(QStringLiteral("sim"), p);
+}
+
+// Every other family: built by the production factory, asked the synchronous
+// questions, disconnected while unconnected, then torn down by the model.
+void constructedFamilies()
+{
+    RadioModel model;
+    const QStringList families = {QStringLiteral("flex"), QStringLiteral("hl2"),
+                                  QStringLiteral("anan"), QStringLiteral("icom"),
+                                  QStringLiteral("rtl")};
+    for (const QString& family : families) {
+        std::printf("-- %s: constructed, never connected\n", qPrintable(family));
+        if (!model.rebuildBackendForTest(family)) {
+            std::printf("  %s: not built into this binary, skipped\n", qPrintable(family));
+            continue;
+        }
+        IRadioBackend* b = model.backend();
+        check(b != nullptr, QStringLiteral("%1: backend constructed").arg(family));
+        if (!b) continue;
+        check(b->thread() == QThread::currentThread(),
+              QStringLiteral("%1: backend lives on its owner's thread (rule 1)").arg(family));
+        Probe p(b);
+        attachAllSeamSignals(p);
+        const RadioCapabilities caps = b->capabilities();
+        check(caps.family.compare(family, Qt::CaseInsensitive) == 0 || caps.family.isEmpty(),
+              QStringLiteral("%1: capabilities().family agrees (\"%2\")").arg(family, caps.family));
+        (void)b->healthSnapshot();
+        (void)b->linkStats();
+        (void)b->dspChains();
+        (void)b->currentOperatingState();
+        b->disconnectRadio();
+        spin(200);
+        reportProbe(family, p);
+        // Teardown happens on the next rebuild (or ~RadioModel); the probe's
+        // context outlives it only within this iteration, so a late emission
+        // during destruction would reach a dead lambda — the family-switch test
+        // owns that half of the contract.
+    }
+    // Leave the model on the simulator so the destructor drains a known backend.
+    model.rebuildBackendForTest(QStringLiteral("sim"));
+}
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile profile(QStringLiteral("backend-seam-affinity"));
+    if (!profile.isValid()) { return 1; }
+    QCoreApplication app(argc, argv);
+    QThread::currentThread()->setObjectName(QStringLiteral("main"));
+
+    {
+        SimBackend probeTarget;
+        Probe p(&probeTarget);
+        attachAllSeamSignals(p);
+        const QStringList declared = declaredSeamSignals();
+        QStringList missing;
+        for (const QString& name : declared) {
+            if (!p.probedNames().contains(name)) missing << name;
+        }
+        check(missing.isEmpty(),
+              QStringLiteral("probe table covers every declared seam signal (%1 probed, %2 declared%3)")
+                  .arg(p.probed()).arg(declared.size())
+                  .arg(missing.isEmpty() ? QString() : QStringLiteral("; unprobed: ") + missing.join(QStringLiteral(", "))));
+    }
+
+    simulatorFullSurface();
+    constructedFamilies();
+
+    std::printf("%d failure(s)\n", g_failures);
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/hl2_connect_reentrancy_test.cpp
+++ b/tests/hl2_connect_reentrancy_test.cpp
@@ -15,6 +15,7 @@
 
 #include "core/backends/hl2/Hl2Backend.h"
 
+#include "SeamThreadAffinityProbe.h"
 #include "TestSettingsProfile.h"
 #include "TestDspBuildWait.h"
 
@@ -78,6 +79,11 @@ void disconnectCancelsTheQueuedConnect()
     TestSettingsProfile profile(QStringLiteral("hl2-reentrancy-disconnect"));
     Hl2Backend backend;
     BuildCounter builds(backend);
+    // IRadioBackend contract rule 2, on a family that is actually driven: the
+    // DSP build runs on the I/O thread and hands its result back, so anything
+    // it emits over the seam must still arrive on the backend's own thread.
+    test::SeamThreadAffinityProbe seam(&backend);
+    test::attachAllSeamSignals(seam);
 
     backend.connectRadio(request());   // build 1 starts on the I/O thread
     backend.connectRadio(request());   // cannot be served inline — queued
@@ -96,6 +102,12 @@ void disconnectCancelsTheQueuedConnect()
     check(builds.finished == 1,
           "a connect queued before the disconnect is NOT re-driven after it");
     check(!backend.isConnected(), "the backend stayed disconnected");
+    for (const QString& v : seam.violations())
+        std::fprintf(stderr, "  seam thread VIOLATION: %s\n", qPrintable(v));
+    std::fprintf(stderr, "  seam signals observed: %s\n",
+                 qPrintable(seam.observed().join(QStringLiteral(", "))));
+    check(seam.violations().isEmpty(),
+          "contract rule 2: every seam signal arrived on the backend's thread");
 }
 
 // The other half of the same guard: WITHOUT a disconnect, a connect that
@@ -107,6 +119,8 @@ void aQueuedConnectIsStillHonoured()
     TestSettingsProfile profile(QStringLiteral("hl2-reentrancy-queued"));
     Hl2Backend backend;
     BuildCounter builds(backend);
+    test::SeamThreadAffinityProbe seam(&backend);
+    test::attachAllSeamSignals(seam);
 
     backend.connectRadio(request());
     backend.connectRadio(request());
@@ -115,6 +129,12 @@ void aQueuedConnectIsStillHonoured()
                         [&] { return builds.finished >= 2; });
     check(builds.finished == 2,
           "the queued connect ran its own build once the first was released");
+    for (const QString& v : seam.violations())
+        std::fprintf(stderr, "  seam thread VIOLATION: %s\n", qPrintable(v));
+    std::fprintf(stderr, "  seam signals observed: %s\n",
+                 qPrintable(seam.observed().join(QStringLiteral(", "))));
+    check(seam.violations().isEmpty(),
+          "contract rule 2: every seam signal arrived on the backend's thread");
 }
 
 } // namespace

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3616,6 +3616,19 @@ target_include_directories(demo_backend_swap_test PRIVATE src)
 target_link_libraries(demo_backend_swap_test PRIVATE aethercore Qt6::Core Qt6::Test)
 add_test(NAME demo_backend_swap_test COMMAND demo_backend_swap_test)
 
+# IRadioBackend threading contract (IRadioBackend.h "THREADING AND LIFETIME
+# CONTRACT"). Socket-free: the simulator standalone plus every family through
+# the production factory, constructed and torn down, never dialed.
+add_executable(backend_seam_affinity_test tests/backend_seam_affinity_test.cpp)
+target_include_directories(backend_seam_affinity_test PRIVATE src tests)
+target_link_libraries(backend_seam_affinity_test PRIVATE aethercore Qt6::Core Qt6::Test)
+add_test(NAME backend_seam_affinity_test COMMAND backend_seam_affinity_test)
+
+add_executable(backend_family_switch_test tests/backend_family_switch_test.cpp)
+target_include_directories(backend_family_switch_test PRIVATE src tests)
+target_link_libraries(backend_family_switch_test PRIVATE aethercore Qt6::Core Qt6::Test)
+add_test(NAME backend_family_switch_test COMMAND backend_family_switch_test)
+
 add_executable(demo_applet_tooltip_test
     tests/demo_applet_tooltip_test.cpp
     src/gui/DemoApplet.cpp


### PR DESCRIPTION
Implements #5554 §2.2 (threading and lifetime contract) and fixes the rule-5 gap the new test found.

## What

**Contract.** `IRadioBackend.h` now states, at the top, the six rules every implementor honours: the backend object lives on its owner's thread; every seam signal is emitted from it; workers are private; every payload type is declared *and* registered in one place; teardown is bounded and ordered, with a late queued emission from a dying backend dropped rather than delivered; a backend emits nothing after `disconnected()`. A survey of all six backends (flex, hl2, anan, icom, rtl, sim) confirmed the rule already holds — every worker hands its result back through a queued connection with the backend as context — so no implementor changes. `NotchDelta` and `LinkStats` were declared but never registered; rule 4 now holds for them.

**Tests**, both socket-free, registered in `tests/tests.cmake`:

- `backend_seam_affinity_test` — connects to EVERY declared seam signal with `Qt::DirectConnection` and records the emitting thread against `backend->thread()`. The simulator is driven through `RadioModel` across its whole surface (connect, data plane, slice verbs, pan create/remove, extension verbs, disconnect); every other family is built by the production factory, asked the synchronous questions, and torn down. The probe table is checked against the meta-object, so a signal added to the interface without a probe entry fails the test. `tests/SeamThreadAffinityProbe.h` is the same tripwire, reusable by any test that drives a backend.
- `backend_family_switch_test` — cycles every family through the production switch (both `connectToRadio()` and the new `RadioModel::rebuildBackendForTest` call one extracted `rebuildBackendForFamily()` body, so the test cannot exercise an ordering production does not have), including away from a live streaming simulator and through a clean disconnect, under a watchdog that turns a wait cycle into a failure. It also pins the #4599 defect *class* by accumulation: `capabilitiesChanged` counted across one connect edge before and after twelve switches, asserted equal.

  **The rule-5 regression pin is deterministic.** It injects the stale delivery rather than racing it — emitting the trailing `slice 0 client_handle=…` from the harvested `RadioConnection`'s own thread under a `BlockingQueuedConnection`, so the `QMetaCallEvent` is provably queued before the switch tears that connection down. Measured with only the `statusReceived` guard reverted: **the injected check fails 10/10; the trailing-echo race caught it 0/10 in the same runs.** The race is kept as a secondary tripwire and labelled as one.

**Fix.** The race that originally found it failed 2 runs in 12. The seam handlers in `wireBackendReceiverState()` are generation-guarded; the harvested `RadioConnection` / `PanadapterStream` handlers in `setupBackend()` went straight to member slots. Qt delivers a queued call posted before the sender was disconnected or destroyed, so the simulator's trailing `slice 0 client_handle=0xDE300001` status landed on the NEXT session, read as a foreign client's slice, and removed it. Every connection-object handler that *interprets* a delivery now goes through the same generation check, plus `pingRttMeasured`. The three `panFeed*` forwards are a deliberate carve-out, documented at the capture site: they are signal-to-signal precisely to preserve the thread hop and the renderer's batching, and a stale frame's worst case is one trace row for a pan id the new session cannot resolve.

**Also from review.** `teardownBackend()` answers each still-pending command callback with `kNoCommandPlaneCode` and clears the map, instead of leaving one `std::function` per in-flight command per switch in it forever. And the `meterDataReady` connection's receiver moves from `&m_meterModel` to `this` — same thread affinity, same const-ref delivery, but teardown's `disconnect(m_panStream, nullptr, this, nullptr)` matches on receiver and so now covers that path, which it did not before.

**Docs.** `AGENTS.md` points at the contract and the tests from the backend family table.

## What is pinned, and what is only surveyed

Stated plainly because the first revision implied more than it proved:

| Family | Rules pinned by a test | How |
|---|---|---|
| sim | 1, 2, 6 | driven through `RadioModel` across its whole surface, two sessions, with a minimum-emission floor |
| hl2 | 1, 2 | `hl2_connect_reentrancy_test` now carries the probe — it needs no radio, drives `connectRadio()` twice with the DSP build on the I/O thread, and observes real `transmitChanged` traffic |
| flex, anan, icom, rtl | 1, plus "a cold construct and the synchronous getters emit nothing off-thread" | constructed by the production factory, never connected |
| all | 5 | `backend_family_switch_test`, deterministically |

For flex/anan/icom/rtl, live-emission affinity is a **survey result** (I read every seam forward in those backends; all use Auto with `this` as context), not a pinned one. The affinity test now prints `NOTE [<family>]: 0 emissions — rules 2 and 6 not exercised` rather than a pass over zero observations, and `AGENTS.md` says the same. Carrying the probe into a test that drives one of them is the follow-up.

No backend implementation changes.

## Sanitizer lane

`sanitizers.yml` runs the suite unfiltered, so both new tests execute there. The wall-clock budgets, connect deadlines and watchdog scale 6× under `__SANITIZE_THREAD__`/`__SANITIZE_ADDRESS__` — the assertions keep their teeth locally without a correct-but-slow sanitizer run going red.

## Verification

- `AetherSDR` Release build clean in a fresh worktree.
- Pass (10): `backend_seam_affinity_test`, `backend_family_switch_test`, `hl2_connect_reentrancy_test`, `demo_backend_swap_test`, `sim_backend_test`, `flex_backend_lifecycle_test`, `anan_backend_test`, `rtl_backend_test`, `control_slice_frequency_test`, `backend_slice_lifecycle_test`.
- Inversions bite: guard reverted → injected check fails 10/10; one `AETHER_SEAM_PROBE` line deleted → `[FAIL] probe table covers every declared seam signal (48 probed, 49 declared; unprobed: notchRemoved)`.
- `check_engine_boundary.py` clean; touchpoint manifest unchanged.
- No CHANGELOG entry per project policy.

Refs #5554 (§2.2), #4599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

