### PR TITLE
fix(gui): Help → What's New fetches latest release, not build tag

### DIFF
--- a/src/gui/WhatsNewDialog.cpp
+++ b/src/gui/WhatsNewDialog.cpp
@@ -35,6 +35,9 @@ namespace {
 constexpr auto kReleaseApiBase =
     "https://api.github.com/repos/aethersdr/AetherSDR/releases/tags/%1";
 
+constexpr auto kReleaseApiLatest =
+    "https://api.github.com/repos/aethersdr/AetherSDR/releases/latest";
+
 QString normalizedTag(const QString& version)
 {
     QString tag = version.trimmed();
@@ -210,9 +213,11 @@ WhatsNewDialog::WhatsNewDialog(const QString& lastSeenVersion,
                                const QString& currentVersion,
                                QWidget* parent,
                                bool showUpgrade,
-                               bool currentVersionOnly)
+                               bool currentVersionOnly,
+                               bool useLatestRelease)
     : PersistentDialog("What's New - AetherSDR", "WhatsNewDialogGeometry", parent)
     , m_currentVersion(currentVersion)
+    , m_useLatestRelease(useLatestRelease)
 {
     theme::setContainer(this, QStringLiteral("dialog/whatsNew"));
     setAttribute(Qt::WA_DeleteOnClose);
@@ -221,8 +226,12 @@ WhatsNewDialog::WhatsNewDialog(const QString& lastSeenVersion,
 
 WhatsNewDialog* WhatsNewDialog::showAll(QWidget* parent)
 {
+    // Help -> What's New: show the newest published release, not the release
+    // tagged for this exact build.  The running version often has no dedicated
+    // GitHub release (dev builds, point releases, release lag), and the
+    // per-tag API lookup would 404.
     auto* dlg = new WhatsNewDialog("", QCoreApplication::applicationVersion(), parent,
-                                   false, true);
+                                   false, true, true);
     dlg->show();
     return dlg;
 }
@@ -254,6 +263,7 @@ void WhatsNewDialog::buildUI(const QString& lastSeenVersion,
     layout->addWidget(header);
 
     m_statusLabel = new QLabel;
+    m_statusLabel->setObjectName("whatsNewStatusLabel");
     m_statusLabel->setAlignment(Qt::AlignCenter);
     m_statusLabel->setWordWrap(true);
     m_statusLabel->setContentsMargins(18, 0, 18, 8);
@@ -339,10 +349,14 @@ void WhatsNewDialog::fetchLiveReleaseNotes()
     if (!m_browser)
         return;
 
-    const QString tagName = releaseTag();
-    setStatusText(QString("Loading detailed release notes from GitHub for %1...").arg(tagName));
+    const QString endpoint = m_useLatestRelease
+        ? QString::fromLatin1(kReleaseApiLatest)
+        : releaseApiUrl(releaseTag());
+    setStatusText(m_useLatestRelease
+        ? QStringLiteral("Loading the latest AetherSDR release notes from GitHub...")
+        : QString("Loading detailed release notes from GitHub for %1...").arg(releaseTag()));
 
-    QNetworkRequest request{QUrl(releaseApiUrl(tagName))};
+    QNetworkRequest request{QUrl(endpoint)};
     request.setHeader(QNetworkRequest::UserAgentHeader, "AetherSDR");
     request.setRawHeader("Accept", "application/vnd.github+json");
     request.setTransferTimeout(15000);
@@ -387,7 +401,9 @@ void WhatsNewDialog::showLoadingState()
     if (!m_browser)
         return;
 
-    setStatusText(QString("Loading release notes for %1...").arg(releaseTag()));
+    setStatusText(m_useLatestRelease
+        ? QStringLiteral("Loading the latest AetherSDR release notes...")
+        : QString("Loading release notes for %1...").arg(releaseTag()));
     m_browser->setHtml(
         "<div style='color:#8aa8c0; font-family:sans-serif; font-size:13px; "
         "padding:40px; text-align:center;'>Loading release notes from GitHub...</div>");
@@ -398,7 +414,9 @@ void WhatsNewDialog::showReleaseLoadError(const QString& message)
     if (!m_browser)
         return;
 
-    setStatusText(QString("Could not load release notes for %1").arg(releaseTag()));
+    setStatusText(m_useLatestRelease
+        ? QStringLiteral("Could not load the latest AetherSDR release notes")
+        : QString("Could not load release notes for %1").arg(releaseTag()));
     m_browser->setHtml(QString(
         "<div style='color:#c8d8e8; font-family:sans-serif; font-size:13px; "
         "padding:32px; line-height:1.45;'>"

--- a/src/gui/WhatsNewDialog.h
+++ b/src/gui/WhatsNewDialog.h
@@ -24,13 +24,18 @@ public:
     // If lastSeen is empty (first install), uses a welcome heading.
     // currentVersionOnly is used by Help -> What's New so it is not treated
     // as a first-run welcome.
+    // useLatestRelease fetches the repo's newest published release instead of
+    // the release tagged for currentVersion — used by Help -> What's New, where
+    // the running build's exact version may not have a published GitHub release
+    // yet (dev builds, point releases, release lag) and the tag lookup 404s.
     explicit WhatsNewDialog(const QString& lastSeenVersion,
                             const QString& currentVersion,
                             QWidget* parent = nullptr,
                             bool showUpgrade = false,
-                            bool currentVersionOnly = false);
+                            bool currentVersionOnly = false,
+                            bool useLatestRelease = false);
 
-    // Show all entries for the current version (for Help menu).
+    // Show the newest published release notes (for Help menu).
     static WhatsNewDialog* showAll(QWidget* parent);
 
 private:
@@ -51,6 +56,7 @@ private:
     QString m_currentVersion;
     QString m_lastFindText;
     bool m_isWelcome{false};
+    bool m_useLatestRelease{false};
 
     QPointer<QTextBrowser> m_browser;
     QPointer<QLabel> m_statusLabel;

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -4104,6 +4104,31 @@ target_link_libraries(help_dialog_test PRIVATE
 )
 set_target_properties(help_dialog_test PROPERTIES AUTOMOC ON)
 
+# WhatsNewDialog release-notes targeting (Help -> What's New 404 regression).
+# Needs QApplication + Widgets + Network; the dialog fires a network request in
+# its constructor but the test never spins the event loop, so nothing leaves
+# the machine. Offscreen.
+add_executable(whats_new_dialog_test
+    tests/whats_new_dialog_test.cpp
+    src/gui/WhatsNewDialog.cpp
+    src/gui/PersistentDialog.cpp
+    src/gui/FramelessResizer.cpp
+    src/gui/FramelessWindowTitleBar.cpp
+    src/core/ThemeManager.cpp
+    src/core/ThemeSeedGenerated.cpp
+    ${AETHER_SETTINGS_SOURCES}
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+)
+target_include_directories(whats_new_dialog_test PRIVATE src tests)
+target_link_libraries(whats_new_dialog_test PRIVATE
+    Qt6::Core Qt6::Widgets Qt6::Network
+)
+set_target_properties(whats_new_dialog_test PROPERTIES AUTOMOC ON)
+add_test(NAME whats_new_dialog_test COMMAND whats_new_dialog_test)
+set_tests_properties(whats_new_dialog_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
 # FreeDV Reporter status-message row (#4231). Guarded like the dialog
 # itself — FreeDvReporterDialog only exists when WebSockets are available.
 # Dialog-side only: the test never reaches qso.freedv.org.
@@ -4895,6 +4920,7 @@ set(AETHER_SETTINGS_CONSUMERS
     memory_import_test
     transmit_model_apd_test
     help_dialog_test
+    whats_new_dialog_test
     flex_control_dialog_size_test
     pan_layout_dialog_size_test
     transmit_model_test

--- a/tests/whats_new_dialog_test.cpp
+++ b/tests/whats_new_dialog_test.cpp
@@ -1,0 +1,101 @@
+// Standalone test harness for WhatsNewDialog release-notes targeting.
+//
+// Regression: Help -> What's New showed "GitHub returned HTTP 404" because it
+// asked GitHub for the release tagged for this exact build
+// (releases/tags/v<currentVersion>), which frequently does not exist (dev
+// builds, point releases, release lag).  The Help entry point now asks for the
+// repo's newest published release instead; the first-run upgrade path still
+// targets the specific version.
+//
+// Build: CMake target `whats_new_dialog_test`. Exit 0 = pass.
+//
+// The dialog kicks off a live QNetworkAccessManager request in its
+// constructor, but this test never spins the event loop, so the reply's
+// finished handler never runs and no network is required.  The status label
+// is written synchronously from the constructor and is the observable proxy
+// for which GitHub endpoint was chosen.
+
+#include "TestSettingsProfile.h"
+#include "core/AppSettings.h"
+#include "gui/WhatsNewDialog.h"
+
+#include <QApplication>
+#include <QLabel>
+#include <QString>
+
+#include <cstdio>
+#include <memory>
+#include <string>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = {})
+{
+    std::printf("%s %-58s %s\n", ok ? "[ OK ]" : "[FAIL]", name, detail.c_str());
+    if (!ok)
+        ++g_failed;
+}
+
+QString statusText(const WhatsNewDialog& dialog)
+{
+    auto* label = dialog.findChild<QLabel*>("whatsNewStatusLabel");
+    return label ? label->text() : QString();
+}
+
+// Help -> What's New: must target the newest published release, never a
+// build-specific tag that would 404.
+void testHelpMenuTargetsLatestRelease()
+{
+    std::unique_ptr<WhatsNewDialog> dialog(WhatsNewDialog::showAll(nullptr));
+    const QString status = statusText(*dialog);
+
+    report("help menu: status label is present", !status.isEmpty(), status.toStdString());
+    report("help menu: notes are described as 'latest'",
+           status.contains("latest", Qt::CaseInsensitive), status.toStdString());
+    report("help menu: status does not pin a build-specific tag",
+           !status.contains(QCoreApplication::applicationVersion()),
+           status.toStdString());
+}
+
+// First-run upgrade path: still targets the specific version the user moved to.
+void testUpgradePathTargetsSpecificVersion()
+{
+    std::unique_ptr<WhatsNewDialog> dialog(
+        new WhatsNewDialog(QStringLiteral("26.9.0"), QStringLiteral("26.9.5"),
+                           nullptr, /*showUpgrade=*/false,
+                           /*currentVersionOnly=*/false));
+    const QString status = statusText(*dialog);
+
+    report("upgrade path: status names the target version",
+           status.contains(QStringLiteral("26.9.5")), status.toStdString());
+    report("upgrade path: status is not the 'latest' phrasing",
+           !status.contains("latest", Qt::CaseInsensitive), status.toStdString());
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile settingsProfile(QStringLiteral("aether-whats-new-dialog-test"));
+    if (!settingsProfile.isValid())
+        return 1;
+
+    QApplication app(argc, argv);
+    QCoreApplication::setApplicationVersion(QStringLiteral("26.9.5"));
+    AppSettings::instance().load();
+
+    std::printf("WhatsNewDialog release-notes targeting test harness\n\n");
+
+    testHelpMenuTargetsLatestRelease();
+    testUpgradePathTargetsSpecificVersion();
+
+    std::printf("\n%s\n",
+                g_failed == 0
+                    ? "All tests passed."
+                    : (std::to_string(g_failed) + " test(s) failed.").c_str());
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

`Help → What's New` asked GitHub for the release tagged for the exact running build — `GET /repos/aethersdr/AetherSDR/releases/tags/v<appVersion>`. That tag frequently has no published GitHub release (dev builds, point releases, release lag): for a `26.9.5` build, for example, the newest published release on the canonical repo was `v26.9.1`, so the API returned 404 and the dialog showed "GitHub returned HTTP 404 (Not Found)".

`WhatsNewDialog::showAll()` (the `Help` menu entry point) now targets `/releases/latest` instead, so it always resolves to a real published release. The first-run upgrade path is unchanged — it still requests the specific version the operator moved to, via a new `useLatestRelease` constructor flag that defaults to `false`, so every existing caller keeps its current behavior.

This is split out of #5462 per the maintainer review there (item #2 of the suggested break-up — "clean standalone fix, unrelated to HL2, with a real regression test").

## Constitution principle honored

Principle XI (truthful UI — the dialog should show real, fetchable data rather than a 404 for a tag that predictably doesn't exist).

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR`)
- [ ] Behavior verified on a real radio if applicable — n/a, GUI/network-fetch only
- [x] Existing tests pass (CI) — new `tests/whats_new_dialog_test.cpp` added and passing locally (5/5 cases); registered in `tests/tests.cmake`
- [x] Reproduction steps documented — see Summary above (404 on the per-build tag lookup)

Manually verified `GET /repos/aethersdr/AetherSDR/releases/latest` returns 200 with real release-notes markdown.

## Checklist

- [x] Commits are signed
- [x] No new flat-key `AppSettings` calls
- [x] Code is clean-room
- [x] All meter UI uses `MeterSmoother` — n/a, no meter UI touched
- [x] Documentation updated if user-visible behavior changed — none needed; behavior fix is self-describing in the dialog itself
- [ ] Security-sensitive changes reference a GHSA if applicable — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)