### PR TITLE
chore(skills): add /graph-review — the pr-review skill as a multi-agent graph

### DIFF
--- a/.claude/skills/graph-review/SKILL.md
+++ b/.claude/skills/graph-review/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: graph-review
+description: Graph-orchestrated adversarial PR review for AetherSDR — the /pr-review stance and rules, run as a multi-agent workflow. Four parallel audits (issue-fit, scope→preference, governance, quality) fan out alongside a single build; every finding is independently refuted by two verifier lenses before it can be reported; one bridge session drives every runtime claim against the demo backend; one synthesis node writes the review and report. Posts one GitHub review with inline comments and returns a markdown report. Use when asked to graph-review a PR (e.g. "/graph-review 4609"). Falls back to /pr-review where the Workflow tool is unavailable.
+---
+
+# Graph review (issue-fit + governance + quality, as a graph)
+
+Review the PR given in `$ARGUMENTS` (a PR number, or a full PR URL; if
+absent, use the PR for the current branch via `gh pr view`). The
+deliverables are the same as `/pr-review`: **one posted GitHub review**
+(inline comments, suggestions, the right review event) and **a markdown
+report to the operator**. Post nothing else to GitHub — no labels, no extra
+comments, no merges.
+
+The difference is shape. `/pr-review` is one agent walking ten steps in one
+context. This skill runs the same steps as a graph:
+
+```
+              ┌──────────── you (coordinator, inline) ────────────┐
+              │ 0 preflight   1 gather + worktrees   2 dispatch    │
+              └───────────────────────┬───────────────────────────┘
+                                      ▼  Workflow(workflow.js, args)
+   ┌───────────┬────────────┬─────────────┬───────────┐   ┌───────┐
+   │ issue-fit │ scope      │ governance  │ quality   │   │ build │  Audit (parallel)
+   │           │  └►pref.   │             │           │   │       │
+   └─────┬─────┴─────┬──────┴──────┬──────┴─────┬─────┘   └───┬───┘
+         ▼           ▼             ▼            ▼             │
+      verify×2    verify×2      verify×2     verify×2         │       Verify (per finding,
+     (reproduce, calibrate) — as each audit lands, no barrier │        two lenses)
+         └───────────┴──────┬──────┴────────────┘             │
+                            ▼  barrier: all runtime claims + build
+                        ┌───────┐
+                        │ drive │  one bridge session, demo backend only    Drive
+                        └───┬───┘
+                            ▼
+                      ┌────────────┐
+                      │ synthesize │  review payload + operator report      Synthesize
+                      └─────┬──────┘
+              ┌─────────────▼───────────────────────────────────┐
+              │ you: 3 post the review   4 report + clean up     │
+              └─────────────────────────────────────────────────┘
+```
+
+Why this shape earns its cost: each audit gets a small, single-purpose
+context instead of position 400 of 640 lines; the scope table and the
+"attacks survived" list are schema-required, so they cannot be skipped; and
+no finding reaches the author until an agent with no stake in it has tried
+to refute it. Expect roughly 8 agents plus 2 per raised finding; the
+verifiers are what make a clean verdict trustworthy, so do not trim them.
+
+Every node reads [`nodes/stance.md`](nodes/stance.md) and then its own file
+under [`nodes/`](nodes/). Those files are the rules; this file is the
+control flow. Edit the rules there, the graph in
+[`workflow.js`](workflow.js), and keep this file about what you do inline.
+
+**If the `Workflow` tool is not available in this session** (Codex, Copilot,
+a remote session without it), do not emulate the graph by hand — invoke
+`/pr-review` on the same argument and say so in the report. This skill's
+instructions are the explicit opt-in the Workflow tool requires; you do not
+need the operator to say "workflow" as well.
+
+Do all repo reads through `gh` / `git show`, or in the scratch worktrees you
+create below. **Never mutate the checkout you were invoked in.** Someone else
+may be working in it, and a `git checkout` there retargets them silently.
+Where `gh` is unavailable, use the GitHub MCP tools (`pull_request_read`,
+`issue_read`, `pull_request_review_write` + `add_comment_to_pending_review`)
+in its place throughout.
+
+## 0. Test-boundary preflight — inline, before anything runs
+
+This is the gate for the whole graph; the build node treats its output as
+binding and will not build or run anything you flag.
+
+Read `AGENTS.md`'s "Test-layer boundary". Fetch the PR's own sources first —
+`gh pr diff <PR>`, or `git fetch origin pull/<PR>/head` then
+`git show FETCH_HEAD:<path>`; never the working tree, which is the base
+branch and passes this preflight vacuously. Inspect the PR's added or
+modified test sources — not only `tests.cmake` — for socket ownership or a
+synthetic peer: `QTcpServer`, `QTcpSocket`, `QUdpSocket`, `QLocalServer`,
+`QWebSocketServer`, `bind()`, `listen()`, `connectToHost()`, peer
+processes, and `Fake*` radio, amplifier, or tuner classes. Also check
+whether an existing registered target has quietly gained network behavior.
+Distinguish a socket object used as an inert value from a test that opens,
+binds, listens, or connects.
+
+If a new or modified socket-based test is found:
+
+- Notify the operator now, with the test, socket type, target, and whether
+  CI runs it. Do not wait for the graph to finish.
+- Record it as `preflight.socketTestFound: true`, list the CTest targets in
+  `preflight.socketTargets`, and put the notification text in
+  `preflight.notice` — the synthesis node includes it in the review body.
+- Continue: the rest of the review still runs and still gets posted.
+  `AGENTS.md` requires the operator be notified *before continuing*, not
+  that the review be abandoned. Getting explicit, PR-specific direction
+  before anyone *executes* that target is the build node's constraint, and
+  it honors it.
+- A PR that **removes** a socket test or fake peer is the remediation
+  #5254 asks for. Notify, then review it normally.
+
+## 1. Gather — inline, then create the worktrees
+
+Scout first; the graph needs a work-list, not a blank PR number.
+
+```sh
+gh pr view <PR> --json title,body,author,baseRefName,headRefName,state,mergeable,statusCheckRollup,closingIssuesReferences,reviews,comments,headRefOid
+gh pr view <PR> --json files   -q '.files[] | "\(.additions)+ \(.deletions)-  \(.path)"'
+gh pr view <PR> --json commits -q '.commits[] | "\(.oid[0:8]) \(.authoredDate[0:10]) \(.messageHeadline)"'
+gh pr diff <PR>
+```
+
+From that, assemble:
+
+- `linkedIssues`: `closingIssuesReferences` plus any `#NNNN` the title/body
+  says it fixes/closes/resolves.
+- `ciSummary`: one line — which checks passed/failed, and whether the
+  trigger was `pull_request` (tests the merge result, so green includes
+  current main) or `push` (does not).
+- `botComments`: the text of any review-bot comment already on the PR, or
+  null. Nodes treat it as leads, never as findings.
+- `testsToInvert`: for every test the diff adds or modifies, an entry
+  `{test: <ctest name>, mutation: "revert the fix hunks in <files>"}`. The
+  build node runs these; audits may request more, and the report will say
+  which of those did not get run.
+- `buildBase`: true when the PR claims a fix whose "before" the drive node
+  could reproduce against the demo backend (a user-visible symptom with a
+  repro in the issue). False for refactors, docs, headless changes.
+
+Then the worktrees — on disk, never on the tmpfs scratchpad, per the local
+operator rules if present:
+
+```sh
+SID=<first 8 chars of your session id>
+ROOT=~/agent-worktrees/$SID; mkdir -p $ROOT/tmp
+git -C <shared checkout> fetch origin pull/<PR>/head:refs/remotes/origin/pr-<PR>-head
+git -C <shared checkout> worktree add $ROOT/wt-pr<PR>-head origin/pr-<PR>-head --detach
+# only if buildBase:
+BASE=$(git -C <shared checkout> merge-base origin/main origin/pr-<PR>-head)
+git -C <shared checkout> worktree add $ROOT/wt-pr<PR>-base $BASE --detach
+```
+
+Chain `worktree add && …` — a failed add must not drop later commands into
+the shared checkout.
+
+## 2. Dispatch the graph
+
+Call the `Workflow` tool with `scriptPath` pointing at this skill's
+[`workflow.js`](workflow.js) and `args` as a real JSON object (not a
+string):
+
+```json
+{
+  "pr": 4609, "title": "…", "author": "…", "body": "…",
+  "headSha": "…", "baseSha": "…",
+  "linkedIssues": [4600],
+  "files": ["12+ 3-  src/…", "…"],
+  "commits": ["abcd1234 2026-09-01 fix(gui): …", "…"],
+  "headWorktree": "/home/…/wt-pr4609-head",
+  "baseWorktree": "/home/…/wt-pr4609-base",   // or null
+  "tmpDir": "/home/…/agent-worktrees/<sid>/tmp",
+  "scratchDir": "<your scratchpad>",
+  "buildBase": true,
+  "testsToInvert": [{"test": "…", "mutation": "…"}],
+  "preflight": {"socketTestFound": false, "socketTargets": [], "notice": ""},
+  "ciSummary": "…", "botComments": null,
+  "skillDir": "/abs/path/to/checkout/.claude/skills/graph-review"
+}
+```
+
+`skillDir` must be **absolute** (the nodes `Read` their rule files by absolute
+path); point it at this skill directory in the checkout you were invoked
+from. The workflow runs in the background; you get a task notification
+when it completes. Do not do parallel review work of your own while you
+wait — that defeats the point, and your context is needed clean for step 3.
+
+While waiting, if the preflight flagged a socket test and the operator has
+answered with direction, hold it for the report; the graph will not have
+run that target either way.
+
+When the notification arrives, read the return value. If it is empty or the
+run failed, read `<transcriptDir>/journal.jsonl` before diagnosing — it
+records each agent's actual return. Resume with `resumeFromRunId` after
+fixing whatever broke rather than re-running from scratch.
+
+## 3. Post the review
+
+The synthesis node returned `synth.review` as `{event, body, comments}`.
+Post exactly ONE review from it:
+
+- Write it to `review.json` in your scratchpad and pass it with `--input` —
+  bodies contain newlines, backticks, and code fences that do not survive
+  shell quoting:
+  `gh api repos/{owner}/{repo}/pulls/<PR>/reviews --input review.json`
+- If `socketNotice` is non-empty and not already in the body, prepend it.
+- If the call fails (an anchor line not in the diff is the usual cause),
+  drop or re-anchor the offending comment and retry once; if it still
+  fails, fall back to `gh pr review --comment|--request-changes -F body.md`
+  with the inline findings folded into the body, and say so in the report.
+- Branch protection has `dismiss_stale_reviews` enabled: any push dismisses
+  an existing approval. Approval stays the operator's call; this skill never
+  posts `APPROVE`.
+
+## 4. Report and clean up
+
+Return `synth.report` to the operator as markdown, verbatim, followed by a
+short **Graph stats** line from the workflow's `stats`: findings raised /
+confirmed / refuted, runtime claims driven, whether the build succeeded and
+the app was driven, and any inversions the audits requested that were not
+run. A high refuted count is a feature — it is the plausible-but-wrong
+findings that did not reach the author.
+
+Then clean up, in this order:
+
+1. `pgrep -a AetherSDR` — if the drive node left an instance with your
+   `AETHER_AUTOMATION_IDENTITY=pr-<PR>-review`, close it. Never touch one
+   that is not yours.
+2. `git -C <shared checkout> worktree remove --force $ROOT/wt-pr<PR>-head`
+   (and `-base`), then `git worktree prune`. The build trees go with them.
+
+Say in the report which instance was driven and that it was the demo, and
+that the worktrees were removed.

--- a/.claude/skills/graph-review/SKILL.md
+++ b/.claude/skills/graph-review/SKILL.md
@@ -45,13 +45,27 @@ Why this shape earns its cost: each audit gets a small, single-purpose
 context instead of position 400 of 640 lines; the scope table and the
 "attacks survived" list are schema-required, so they cannot be skipped; and
 no finding reaches the author until an agent with no stake in it has tried
-to refute it. Expect roughly 8 agents plus 2 per raised finding; the
-verifiers are what make a clean verdict trustworthy, so do not trim them.
+to refute it — including findings the drive node discovers, and including
+the degraded case where a verifier never returns (the finding is dropped,
+not promoted). The `reproduce` lens alone decides whether a finding exists;
+the `calibrate` lens can only adjust its severity.
 
 Every node reads [`nodes/stance.md`](nodes/stance.md) and then its own file
 under [`nodes/`](nodes/). Those files are the rules; this file is the
-control flow. Edit the rules there, the graph in
-[`workflow.js`](workflow.js), and keep this file about what you do inline.
+control flow; the graph is [`workflow.js`](workflow.js).
+
+**Rule source of truth: [`/pr-review`](../pr-review/SKILL.md).** The
+`nodes/*.md` files are a per-node mirror of its sections, split so each
+agent gets only its own rules. When a rule changes in `pr-review`, re-sync
+the matching node file; do not let a rule be corrected here and not there.
+The verifier lens contract in `nodes/verify.md` and the build/drive node
+splits are graph-specific and have no `pr-review` counterpart.
+
+**Agent budget.** Expect roughly 8 agents plus 2 per raised finding (the
+two verifier lenses). A finding-heavy PR — ten findings is ~28 agents —
+exceeds the default workflow-size guideline of about 15; that is expected
+for this skill and not a reason to trim the verifiers, but say so to the
+operator if the count runs high.
 
 **If the `Workflow` tool is not available in this session** (Codex, Copilot,
 a remote session without it), do not emulate the graph by hand — invoke

--- a/.claude/skills/graph-review/nodes/build.md
+++ b/.claude/skills/graph-review/nodes/build.md
@@ -1,0 +1,52 @@
+# Node: build — build the PR head once, run its tests, invert what was asked
+
+Read `stance.md` first. You are the only node allowed to build. Everything
+else reads. Inputs: the PR-head worktree path, optionally a merge-base
+worktree path, the coordinator's preflight result, and the union of
+`testsToInvert` requests from the audit nodes (they may arrive empty — the
+audits run concurrently with you, so the coordinator passes only what it
+gathered up front; the drive node gets the rest).
+
+Rules that override everything below:
+
+- **Preflight is binding.** The coordinator already inspected the PR's test
+  sources for socket ownership (`QTcpServer`, `QUdpSocket`, `QLocalServer`,
+  `bind()`, `listen()`, `connectToHost()`, `Fake*` peers). Any target named
+  in `preflight.socketTargets` is **not to be built or run** by you. Do not
+  reason your way around this; record `skipped: preflight` for it.
+- **Never touch the shared checkout.** Configure and build only inside the
+  worktree paths you were given, in `build/` under each. Export
+  `TMPDIR=<the tmp path you were given>` before configuring; GCC writes to
+  it and the default is a tmpfs shared with other agents.
+- Cap parallelism at `-j$(($(nproc)/2))` if `pgrep -f ninja` shows another
+  build running; otherwise use all cores.
+- `ccache` is on; do not disable it.
+
+Do, in order:
+
+1. Configure and build the PR head:
+   `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo` then
+   `ninja -C build AetherSDR <PR's own test targets>`. Build only what the
+   review needs — the app binary (for the drive node) plus the tests the PR
+   adds or modifies. A full build is not required and is discouraged.
+2. Run the PR's own tests with `ctest --test-dir build -R <name>` per
+   target. Record pass/fail and the tail of any failing output.
+3. **Invert each requested test**: apply the named mutation (revert the fix
+   hunk, or delete the guard) in the PR-head worktree with `git stash`
+   **forbidden** — use `git diff > /tmp/…patch` + `git apply -R` on the hunk,
+   or edit and then `git checkout -- <file>` inside *your* worktree only —
+   rebuild the target, rerun the test, restore the file, and record whether
+   the test noticed. A test that still passes with the fix reverted is a
+   `blocker` finding.
+4. If a merge-base worktree was given, configure and build **only the app
+   binary** there (the drive node reproduces "before" against it).
+5. **"CI is green" is not "the suite passes."** Every `ctest` call in
+   `ci.yml` is `-R`-filtered, so only a few of the ~240 tests gate a merge.
+   Do not run the whole suite; if you did run something broad and it failed,
+   run the same test on the merge-base build before attributing it to the
+   PR. If the base fails the same way, it is environment or test-layer
+   boundary, not a PR finding — say so.
+
+Return `buildDir` for the head (and `baseBuildDir` if built), `ok`, the
+per-target results, the inversion results, and the tail of any build error.
+Never delete the worktrees; the coordinator owns cleanup.

--- a/.claude/skills/graph-review/nodes/drive.md
+++ b/.claude/skills/graph-review/nodes/drive.md
@@ -1,0 +1,108 @@
+# Node: drive — verify runtime claims against the running app
+
+Read `stance.md` first. Inputs: the head build dir (and base build dir if
+one exists), the PR number, a scratch dir, and a list of **runtime claims**
+gathered from the PR body and the audit nodes, each with a suggested way to
+test it. **Any claim about runtime behavior gets tested against the running
+app, not argued from the diff.** UI state, a control's effect, a dialog's
+lifecycle, what the panadapter renders, connect/disconnect and slice-recreate
+paths, whether a setting survives a restart — the automation bridge reaches
+all of it. `docs/automation-bridge.md` is the reference; it is written for
+agents and is copy-pasteable.
+
+## Demo mode, never the live radio
+
+**Every bridge session runs against the built-in demo simulator
+(`SimBackend`, RFC #4288) — never the operator's FLEX-8600.** The demo
+generates its own RX audio and matching panadapter, exercises the same
+`RadioModel` / slice / pan / settings paths as real hardware, and by
+construction **cannot key** (Principle VI).
+
+The trap is that this is opt-*out*: `AutoConnectToLastRadio` defaults on, and
+on the operator's machine the saved settings point at the real radio, so an
+instance launched with the default config **will connect itself to the live
+FLEX** before you issue a verb. Two things prevent it, and you do both:
+
+1. **Isolate the settings store** — `AETHER_SETTINGS_DIR` pointed at a fresh
+   scratch dir. A clean store also leaves `ShowDemoRadio` at its default
+   (on), so the demo entry is in the list.
+2. **Connect explicitly to the demo, and to nothing else.** Its discovery
+   serial is `DEMO-0001` (`SimBackend::demoSerial()`), family `sim`, shown
+   as "Simulator (not on the air)".
+
+```sh
+export SCRATCH=<your scratch dir>
+AETHER_AUTOMATION=1 QT_QPA_PLATFORM=offscreen \
+AETHER_SETTINGS_DIR="$SCRATCH/settings" \
+AETHER_AUTOMATION_IDENTITY=pr-<PR>-review \
+AETHER_AUTOMATION_SOCKET=aethersdr-pr<PR> \
+AETHER_AUTOMATION_NO_TX=1 \
+setsid nohup <buildDir>/AetherSDR >"$SCRATCH/app.log" 2>&1 &
+```
+
+Then, before anything else:
+
+```text
+connect list                      → verify DEMO-0001 is offered
+connect local serial DEMO-0001
+connect wait 30000                → asserts connected, returns the radio block
+get radio                         → confirm model "AetherSDR Demo", family sim
+```
+
+If `get radio` ever shows a FLEX serial, you are on the operator's hardware:
+`disconnect` immediately, fix the isolation, and report it in `incidents`.
+
+The `sim` verb injects faults while connected (`swr`, `dropslice`,
+`stallscope`, `disconnect`, `malformed`, `clear`) — that is how you exercise
+error handling rather than only reading it. Its limits, so you don't mistake
+one for a finding: it advertises a **single slice**, it cannot transmit, and
+it does not implement every Flex-specific protocol surface. When a claim
+genuinely cannot be reached in demo mode, return `outcome: unreachable` with
+the reason. That is **not** a licence to reach for the real radio.
+
+## Driving it
+
+Use the `aethersdr-automation` MCP tools (load via ToolSearch):
+`bridge_status` → `dump_tree filter=<widget>` → `invoke` / `gesture` /
+`shortcut` / `tune` / `slice` / `menu` → `assert_state` / `wait_for` on the
+model property that should have changed → `grab_widget` when the claim is
+visual. `bridge_command` is the escape hatch for verbs without a typed tool.
+If MCP is unavailable, `python3 tools/automation_probe.py` or raw
+line-delimited JSON over the socket does the same job — the bridge being
+awkward to reach is not a reason to skip it.
+
+The loop that produces evidence, per claim:
+
+1. **Reproduce on the merge base first** when the PR claims a fix and a base
+   build exists. A "before" you cannot make fail is itself a finding — either
+   the repro is wrong or the fix is fixing nothing.
+2. **Re-run identically on the PR head.** Prefer `assert_state`/`wait_for`
+   over eyeballing a screenshot. Grab pixels when the claim is about pixels.
+3. **Then attack past the happy path**, which the author almost certainly
+   did not drive: the second slice, the second pan, disconnect
+   mid-operation, the dialog closed and reopened, the value at its range
+   limits, the same action twice. Persistence claims are only proven across
+   a process boundary — relaunch and re-read.
+4. **Quote what the app returned** — the `get_state`/`assert_state` JSON,
+   the `get_log` lines, the PNG path — verbatim in `evidence`.
+
+Anything you break that no claim predicted goes in `newFindings` with the
+same finding shape as the audit nodes, `needsRuntime: false`, and the
+evidence attached.
+
+Non-negotiable operating rules:
+
+- **`pgrep -a AetherSDR` first.** Instances that are not yours — especially
+  any launched from the shared checkout — are the operator's session. Never
+  drive, close, or kill one.
+- **Always pass an explicit socket.** The discovery file is
+  last-writer-wins and will point you at another agent's instance.
+- **Never key TX.** Launch with `AETHER_AUTOMATION_NO_TX=1`; a review never
+  needs the transmit verbs.
+- **Close your instance when done** and record which instance you drove and
+  that it was the demo (`instance` in the output).
+
+When you genuinely cannot drive — the build failed, the change is headless —
+return `drove: false` with the reason and leave every claim `unreachable`.
+An unverified claim reported as unverified is honest; one reported as
+observed is not.

--- a/.claude/skills/graph-review/nodes/governance.md
+++ b/.claude/skills/graph-review/nodes/governance.md
@@ -1,0 +1,54 @@
+# Node: governance — project canon, in priority order
+
+Read `stance.md` first. Read the diff against each of these and cite the
+specific rule when flagging:
+
+- **CONSTITUTION.md** — the principles are binding. Most commonly implicated:
+  I (FlexLib is protocol/model authority — `reference/FlexLib_*` is the
+  answer, and for HL2 the gateware RTL is the analogue), II/III
+  (radio-authoritative state: the client never re-asserts what the radio
+  owns; persistence must be **capability-shaped**, never family-checked),
+  V (feature-owned config: one versioned JSON document, one owner, one
+  migration point), VI (TX safety: nothing restores or automates into a
+  keyed transmitter).
+- **AGENTS.md** — Settings Persistence (SQLite store; flat keys are
+  app-global only; per-radio state goes in `radio_settings` feature
+  documents via `RadioModel::settingsScope()`; check the write result),
+  Settings Migration (one-shot claim-and-freeze; no perpetual legacy
+  fallbacks), credentials (never in the store — `SettingsCredentialPolicy.h`
+  is THE table; QtKeychain only), capability declarations
+  (`RadioCapabilities` + caps-map doc + gating test, per that file's
+  ADDING-A-FIELD contract).
+- **CMake contract** — any target compiling `AppSettings.cpp` uses
+  `${AETHER_SETTINGS_SOURCES}` and joins `AETHER_SETTINGS_CONSUMERS`; tests
+  isolate via `TestSettingsProfile.h` (`AETHER_SETTINGS_DIR`).
+- **docs/style/dialog-patterns.md** — new dialogs ride `PersistentDialog`
+  (#2605); geometry base64; frameless propagation.
+- **docs/a11y.md** — accessible names on interactive widgets, throttled
+  `updateAccessibility`, no interactive QLabels.
+- **CONTRIBUTING.md** — tests for behavior changes, touchpoint manifest regen
+  when applicable, cross-platform unless solving a platform-specific problem.
+- **GOVERNANCE.md** — should this change have had an RFC/issue first? Is it
+  within the scope a maintainer already ruled on?
+- **Socket-test obligations** (`AGENTS.md` "Test-layer boundary"): if the
+  coordinator's preflight flagged a socket-owning test of AetherSDR's own
+  server surfaces (rigctld, CAT, TCI server, bridge transport), check the
+  three obligations and report any missing: disclosed in the PR body; its
+  `tests.cmake` block names the socket it binds; it fails fast or skips with
+  exit 77 (`SKIP_RETURN_CODE 77`) when it cannot bind. A synthetic peer
+  standing in for third-party firmware is a blocker under that section —
+  quote it.
+
+### Cite the sentence, or downgrade it to a nit
+
+Before returning anything as a governance `blocker`, **find the sentence in
+canon that states the rule** and put it in `ruleCited`. If you cannot, it is
+a convention at most, and conventions are nits.
+
+Do not infer a rule from `git log`. `git log -- <path>` returns *only*
+commits that touched that path, so "N of the last N commits did X" computed
+that way is circular and always returns 100%. This exact error once turned a
+nonexistent CHANGELOG rule into a merge blocker on someone else's PR.
+
+Every rule you checked and found satisfied goes in `attacksSurvived`, named
+by document and rule, so the synthesis node can say what was checked.

--- a/.claude/skills/graph-review/nodes/issue-fit.md
+++ b/.claude/skills/graph-review/nodes/issue-fit.md
@@ -1,0 +1,48 @@
+# Node: issue-fit — does the PR actually solve the linked issue?
+
+Read `stance.md` first. Inputs you were given: the PR number, head/base SHAs,
+the PR body, and the linked-issue numbers the coordinator found.
+
+- Linked issues = `closingIssuesReferences` plus any `#NNNN` referenced in
+  the PR title/body as "fixes/closes/resolves". Read each with
+  `gh issue view <N> --json title,body,comments` and **skim the comments** —
+  accepted repro steps, maintainer rulings, and scope changes live in the
+  thread, which often redefines the ask.
+- Build a short requirements list from the issue (symptom, repro, acceptance
+  expectations, explicit non-goals), then map each requirement to the diff:
+  which hunk addresses it? Return that mapping in `requirementMap`. Flag
+  requirements the diff does not touch as findings; note diff changes that no
+  requirement explains in `unexplained` (the scope node will rule on them —
+  do not duplicate its verdicts, just hand it the list).
+- Coverage: does admissible coverage fail without the fix and pass with it?
+  Prefer the smallest socket-free behavioral seam. Missing coverage is a
+  blocker only when the reported behavior has a deterministic,
+  policy-compliant test seam or project canon explicitly makes that coverage
+  merge-gating (quote it). If the only apparent approach is a synthetic
+  firmware peer, do **not** request it — describe the honest coverage
+  boundary and route positive convergence to bridge/`radiocert` evidence.
+  Report an untestable gap as a nit; it is worth naming but not a reason to
+  withhold a merge.
+- Acceptable coverage by kind (from `AGENTS.md` "Test-layer boundary"):
+  wire encoding, parsing, model tables, scheduling, DSP, capabilities, and
+  safety policy → socket-free CTest; refusals, malformed/disconnected input,
+  dropped messages, non-events, TX guards → socket-free transport or
+  state-machine injection; race/lifetime behavior → sanitizer lane; positive
+  session/RX/control/meter convergence → automation bridge plus `radiocert`
+  against real firmware; a simulator closed loop → explicit opt-in only.
+- Never count additions to a retired target, a bracket-commented test, or an
+  unregistered target that lacks the `# not registered: <reason>` marker, as
+  coverage. An `option()`-gated or `EXCLUDE_FROM_ALL` target carrying that
+  marker does count if the PR says how to run it.
+- If a test was added or changed, say whether it would pass with the fix
+  reverted (reason from the assertions; the build node will try to invert it
+  if you list it in `testsToInvert`).
+- If there is NO linked issue: say so in `summary`, review the PR against its
+  own stated intent, and note whether project process wanted an issue/RFC
+  first (GOVERNANCE.md — architectural changes need an RFC; "bug fixes with a
+  clear root cause" explicitly do not).
+- Every runtime claim in the body ("no behavior change", "other radios
+  unaffected", "the panel still remembers its geometry") goes into
+  `runtimeClaims` with a concrete way to test it against the demo backend.
+
+Return `verdict`: `yes` / `partially` / `no`, with the mapping as evidence.

--- a/.claude/skills/graph-review/nodes/issue-fit.md
+++ b/.claude/skills/graph-review/nodes/issue-fit.md
@@ -11,9 +11,11 @@ the PR body, and the linked-issue numbers the coordinator found.
 - Build a short requirements list from the issue (symptom, repro, acceptance
   expectations, explicit non-goals), then map each requirement to the diff:
   which hunk addresses it? Return that mapping in `requirementMap`. Flag
-  requirements the diff does not touch as findings; note diff changes that no
-  requirement explains in `unexplained` (the scope node will rule on them —
-  do not duplicate its verdicts, just hand it the list).
+  requirements the diff does not touch as findings; list diff changes that no
+  requirement explains in `unexplained` for the synthesis node, which
+  reconciles that list against the scope node's table (the scope node runs
+  in parallel with you and does not see your output — do not rule on scope
+  yourself, and do not assume it will see this list).
 - Coverage: does admissible coverage fail without the fix and pass with it?
   Prefer the smallest socket-free behavioral seam. Missing coverage is a
   blocker only when the reported behavior has a deterministic,

--- a/.claude/skills/graph-review/nodes/preference.md
+++ b/.claude/skills/graph-review/nodes/preference.md
@@ -1,0 +1,41 @@
+# Node: preference — fix, or smuggled personal preference?
+
+Read `stance.md` first. You receive the scope node's `uiRows` (rows of the
+scope table that touch existing UI, defaults, or user-facing behavior) plus
+the PR body and linked issues. If `uiRows` is empty, still skim the diff for
+changed defaults and restyles — the scope node classifies files, not values.
+
+Some contributors code their personal preferences into the app without going
+through the RFC process. **Any modification to an EXISTING UI element or
+behavior** (new features notwithstanding) gets classified: is this a *fix*
+(restores documented/intended behavior, corrects a defect, matches SmartSDR/
+FlexLib reference behavior, closes an accessibility gap) or a *preference*
+(changes a default, reorders/rewords/restyles working UI, alters workflow
+because the author likes it better)?
+
+How to tell them apart — a fix can point at an authority; a preference can't:
+
+- The linked issue describes it as broken, with a repro — not "I find it
+  annoying".
+- FlexLib / SmartSDR reference behavior, the HL2 gateware, a spec, or
+  project docs say what SHOULD happen, and the PR moves toward that.
+- The old behavior contradicts the Constitution, a11y doc, or an explicit
+  maintainer ruling.
+
+Red flags: changed default values (an existing settings key's default, a
+slider range, a timer interval) with no issue citing the old default as a
+defect; visual restyles (colors, spacing, order, labels) bundled into an
+unrelated fix; keyboard/mouse behavior changes described as "improvements";
+removed confirmations or notices. Bundling is itself the tell — a genuine fix
+rarely needs to adjust neighboring working UI.
+
+Verdicts: a preference change inside a fix PR is a `blocker` — not because
+the preference is necessarily wrong, but because it needs its own issue/RFC
+and a maintainer ruling per GOVERNANCE.md (cite it). Suggest the split: keep
+the fix hunks, move the preference to a proposal. If the whole PR is a
+preference change presented as a fix, say so plainly as
+`maintainer-decision`. Never let polished code quality launder an unratified
+behavior change.
+
+Return `classifications`: one entry per UI/behavior change with `fix` or
+`preference` and the authority (or its absence) that decided it.

--- a/.claude/skills/graph-review/nodes/quality.md
+++ b/.claude/skills/graph-review/nodes/quality.md
@@ -24,9 +24,16 @@ the test and the mutation in `testsToInvert` for the build node. A
 regression test that still passes with the fix reverted is a `blocker` in
 its own right — it pins nothing and will read as coverage forever after.
 
-If a `code-review` skill or bot comment exists on the PR, treat its output
-as leads: verify each yourself and keep only what you confirmed, attributed
-("automated pass found …" in `evidence`). Drop anything you can refute.
+**Automated pass.** If a `code-review` skill is available and
+model-invocable, run it at medium effort on this PR first and set
+`automatedPassRan: true`. Treat its output — and any review-bot comment the
+context block carries — as leads: verify each yourself and keep only what you
+confirmed, attributed ("automated pass found …" in `evidence`). Drop anything
+you can refute. If the skill is not invocable (some builds mark it
+`disable-model-invocation`, and the call fails), set `automatedPassRan:
+false` with the reason in `automatedPassNote` and do the equivalent pass
+yourself. Never imply the automated pass ran when it did not; the synthesis
+node states which it was.
 
 Prefer the claim the PR most depends on and would most like you to take on
 faith — that is the one to push hardest.

--- a/.claude/skills/graph-review/nodes/quality.md
+++ b/.claude/skills/graph-review/nodes/quality.md
@@ -1,0 +1,32 @@
+# Node: quality — code-quality audit
+
+Read `stance.md` first. Read for: correctness of the actual state
+machine/lifecycle being touched (connect/disconnect, slice recreate, radio
+swap are the recurring minefields), thread-safety (audio callback vs main
+thread; AppSettings is thread-safe but `save()` does I/O — never on the
+render callback), Qt object lifetime (`QPointer`/`WA_DeleteOnClose`,
+parenting), error handling per house style (no exceptions; check returns;
+`qWarning` with category), silent failure modes (unchecked writes, swallowed
+errors), and whether comments explain *why* (constraints), not *what*.
+
+Read hostilely: for each non-trivial hunk, construct the input, ordering, or
+lifecycle event that makes it misbehave before you accept that it doesn't.
+Walk the failure paths as carefully as the happy path — what the code does
+when the write fails, the pointer is stale, the radio drops mid-call, or the
+user does it twice. Each hunk you attacked and could not break goes in
+`attacksSurvived` with the attack named.
+
+You do not build or run anything. Where a suspicion needs the running app to
+settle, return it as a finding with `needsRuntime: true` and a concrete
+repro the drive node can execute against the demo backend; where it needs a
+test inverted (break the code on purpose and confirm the test notices), name
+the test and the mutation in `testsToInvert` for the build node. A
+regression test that still passes with the fix reverted is a `blocker` in
+its own right — it pins nothing and will read as coverage forever after.
+
+If a `code-review` skill or bot comment exists on the PR, treat its output
+as leads: verify each yourself and keep only what you confirmed, attributed
+("automated pass found …" in `evidence`). Drop anything you can refute.
+
+Prefer the claim the PR most depends on and would most like you to take on
+faith — that is the one to push hardest.

--- a/.claude/skills/graph-review/nodes/scope.md
+++ b/.claude/skills/graph-review/nodes/scope.md
@@ -1,0 +1,75 @@
+# Node: scope — does the PR do only what it says?
+
+Read `stance.md` first. This runs on every review. A PR is a claim ("this
+does X") and the diff is the evidence; anything in the diff that X does not
+explain is a finding. This is the check that most often turns up something
+real, and it is cheap.
+
+Start from the file and commit lists, not the prose:
+
+```sh
+gh pr view <PR> --json files   -q '.files[] | "\(.additions)+ \(.deletions)-  \(.path)"'
+gh pr view <PR> --json commits -q '.commits[] | "\(.oid[0:8]) \(.authoredDate[0:10]) \(.messageHeadline)"'
+```
+
+Use **`authoredDate`, not `committedDate`** — a rebase rewrites the commit
+date to the day the branch was pushed, so `committedDate` flattens the whole
+branch to one date and hides exactly the outlier you are looking for.
+
+Then build the **scope table** — one row per file or coherent group: what it
+changes, whether the title/body claims it, and a verdict. Return it as
+`scopeTable`; it is the artifact and it is required even when every row is
+clean. Also return `uiRows`: the subset of rows that touch existing UI
+elements, defaults, or user-facing behavior — the preference node consumes
+that list.
+
+What to look for:
+
+- **Commit dates that predate the PR's own first commit**, or a commit whose
+  message has nothing to do with the linked issue. A local build workaround
+  cherry-picked onto the branch shows up exactly this way.
+- **Files no requirement explains.** Build config, CI, unrelated plugins,
+  vendored trees, formatting-only churn in files the fix does not need.
+- **New public surface**: a new protocol verb, wire message, config key, CLI
+  flag, exported API, settings key, or capability field. Third parties bind
+  to these and they outlive the fix. Even when the linked issue motivates it,
+  a *protocol addition arriving as a side effect of a bug fix* is a
+  maintainer call — `maintainer-decision`, not a blocker and not a pass.
+- **Deleted behavior, not just added code.** Read the `-` lines as carefully
+  as the `+` lines. A removed guard, early return, confirmation, or comment
+  citing a fixed issue means a previously-fixed bug may be back:
+  `gh pr diff <PR> | grep '^-' | grep -iE 'guard|#[0-9]{3,}|return|if \(' `
+  When a removal deletes a comment that *names a symptom*, quote that comment
+  back in `evidence` and ask what now prevents it. If the replacement code
+  still concedes the same precondition, the removal is a regression.
+- **Sibling implementations left behind.** If the fix touches one of several
+  parallel copies (one of N plugins, backends, call sites), grep for the
+  others and say which remain broken. A completeness nit, not usually a
+  blocker — but the PR should not read as "fixed" when two of three surfaces
+  still carry the defect.
+- **Dead additions.** An added file or target that nothing references is
+  still scope. Verify reachability (grep for whatever registers it) before
+  believing it works.
+- **The body's own checklist.** "Changes are limited to the scope of this
+  issue" / "No unrelated files or formatting changes" — check them against
+  the diff. A false self-certification is worth reporting, plainly and
+  without moralizing. Return the result in `checklistHolds`.
+- **`CHANGELOG.md`** is a release-prep file; an ordinary PR must not add an
+  entry. Flag one as a change to remove (a nit with a concrete fix). Never
+  ask for one.
+
+Verdicts — apply consistently:
+
+| Finding | Severity |
+|---|---|
+| Unrelated to the issue and to the stated fix | `blocker` — ask to unbundle: drop the commit, open its own PR |
+| Explained by the issue *thread* but absent from the PR body | `nit` — ask for the body to be updated so it is reviewable later |
+| New public/protocol surface | `maintainer-decision` |
+| A removed guard whose symptom can recur | `blocker` (a regression), with the deleted comment quoted |
+| User-visible default changed, correct but undisclosed | `nit` — plus a request to state it in the body |
+
+Scope is about *whether the change belongs in this PR*, not whether it is
+legitimate at all (the preference node rules on that). A change can be
+perfectly correct and still be out of scope, and that is the common case —
+say so without implying bad faith. Bundling is usually convenience, not
+concealment.

--- a/.claude/skills/graph-review/nodes/stance.md
+++ b/.claude/skills/graph-review/nodes/stance.md
@@ -1,0 +1,99 @@
+# Shared stance — every graph-review node reads this first
+
+You are one node in a multi-agent review graph for an AetherSDR pull
+request. You have one job (your node file says which). Other nodes cover the
+rest; do not drift into their territory, and do not soften your own findings
+because "someone else will catch it". Your final output is data for the
+synthesis node, not prose for a human — return exactly the structured shape
+you were asked for.
+
+## Adversarially red-team the PR
+
+**Your job is to break the PR, not to bless it.** Assume the author is
+competent and that the PR body is written to sound airtight; verify every
+claim anyway.
+
+- **The burden of proof is on the PR, not on you.** The author asserts; you
+  falsify. "I see no problem" is not a conclusion — "I tried X, Y and Z and
+  the code survived all three" is. Every clean verdict must name the attacks
+  it survived (return them in `attacksSurvived`).
+- **Every sentence in the body is a claim to test.** "No behavior change",
+  "pure refactor", "trivial", "cannot fail", "matches SmartSDR", "no impact
+  on other radios", "existing tests cover this", "safe on all platforms" —
+  each one is a hypothesis with a specific way to be wrong. Find the way, run
+  it if you can, and report the result either way. A claim you could not test
+  from the diff is itself reportable: return it in `runtimeClaims` with what
+  would settle it, so the drive node can go and settle it.
+- **Reading the diff is not reviewing it.** Ask what input makes this code
+  wrong: first/last/empty/zero/negative/overflow, null or dangling pointers,
+  disconnect mid-operation, reentrancy, the callback firing during teardown,
+  two threads, the error path nobody exercises, the second radio, the second
+  slice, the second monitor. Then look for whether the diff handles it.
+- **Read what is NOT in the diff.** The strongest findings are usually
+  absences: the sibling call site left unfixed, the error return nobody
+  checks, the migration path for existing users' saved state, the test that
+  would have caught this. A diff can only show you what changed; you have to
+  go get what didn't.
+- **Attack the tests, not just the code.** A test that passes against the
+  *unfixed* code proves nothing. Tests that assert the implementation back to
+  itself, or that would pass with the function body deleted, are findings.
+- **Polish is not evidence.** Clean formatting, a confident PR body, a
+  thorough-looking test file, and a green CI badge are all cheap to produce
+  and none of them are correctness. Where the presentation is most polished,
+  spend *more* scrutiny, not less.
+- **Distrust green.** CI proves the filtered subset passed on some merge
+  base, nothing more. A bot's comment is a lead, not a finding. A previous
+  approving review is not a reason to look less hard.
+- **Disagree with the framing when the framing is wrong.** The PR chooses the
+  problem statement, the fix's shape, and where the seam goes. Any of those
+  can be the actual defect — a correct implementation of the wrong change is
+  still a finding.
+
+The one thing adversarial does **not** mean: manufacturing findings. The
+stance is a burden of proof, not a quota. A PR that survives it earns an
+empty `findings` array and a full `attacksSurvived` list, stated plainly.
+Severity stays calibrated, tone stays collegial and evidence-first, and every
+finding cites what you actually observed — file:line, command output, failing
+scenario. Break the code, not the author.
+
+## Severity vocabulary (use exactly these)
+
+- `blocker` — must change before merge. Includes: does not solve the issue,
+  regression, removed guard whose symptom can recur, unrelated bundled
+  change, preference change inside a fix PR, a regression test that passes
+  with the fix reverted, a governance rule you can quote from canon.
+- `maintainer-decision` — new public/protocol surface, a preference change
+  presented as a fix, an RFC-shaped change arriving as a bug fix. Name the
+  maintainer.
+- `nit` — non-blocking. Style, naming, stale docs, undisclosed-but-correct
+  default change, a convention you cannot quote from canon, an untestable
+  coverage gap.
+
+## How to read the PR (read-only, always)
+
+- The diff: `gh pr diff <PR>` (or `git diff <base>...<head>` inside the
+  PR-head worktree you were given).
+- Whole files at the PR head: `git show <headSha>:<path>`, or read them in
+  the PR-head worktree.
+- The merge base for comparison: `git show <baseSha>:<path>`.
+- Linked issues: `gh issue view <N> --json title,body,comments`.
+- **Never mutate anything.** No `git checkout`, `switch`, `stash`, `reset`,
+  no builds, no app launches — the build and drive nodes own those. The
+  worktree paths you were given are read-only reference for you.
+- Where `gh` is unavailable, use the GitHub MCP tools (`pull_request_read`,
+  `issue_read`) in its place.
+
+## Finding shape
+
+Every finding you return needs: a one-line `title`; `severity` from the
+vocabulary above; `category` (a short slug such as `issue-fit`, `scope`,
+`governance`, `preference`, `correctness`, `lifetime`, `thread-safety`,
+`tests`, `a11y`, `docs`); `file` and `line` at the PR head (`line` may be 0
+for a whole-file or absent-code finding; set `inDiff` true only if that line
+is in the diff hunks, because only those can carry an inline comment);
+`evidence` (what you observed — quote the hunk, the removed comment, the
+command output); `ruleCited` (the sentence from canon, or empty); `fix`
+(what a fix looks like — a drop-in ` ```suggestion ` block when the fix is a
+small concrete edit, otherwise a sentence); and `needsRuntime` (true when
+the finding is a hypothesis about runtime behavior that the drive node
+should reproduce before it is reported).

--- a/.claude/skills/graph-review/nodes/synthesize.md
+++ b/.claude/skills/graph-review/nodes/synthesize.md
@@ -1,0 +1,73 @@
+# Node: synthesize — write the one GitHub review and the operator report
+
+Read `stance.md` first. You receive every confirmed finding (with verifier
+notes), the refuted findings (for the "what I tried to break" section — do
+not resurrect them), the scope table, the issue-fit verdict and requirement
+map, the build and inversion results, the drive results with their evidence,
+and the union of `attacksSurvived`. You post nothing; you return a payload
+the coordinator posts verbatim, so get the shape exactly right.
+
+## `review` — the GitHub review payload
+
+`{event, body, comments: [{path, line, side: "RIGHT", body}, …]}`; use
+`start_line` + `line` for multi-line anchors. Rules:
+
+- **Inline comments anchor to diff lines only** (`inDiff: true`). A finding
+  about untouched code goes in the review body with a `file:line`
+  reference. An out-of-scope added file anchors at line 1 of that file.
+- Where the fix is a concrete small edit, embed a fenced ` ```suggestion `
+  block so the author can one-click apply. Suggestions must be drop-in
+  correct — matching indentation, compiling in context — never pseudocode.
+- **`event`:** any `blocker` → `REQUEST_CHANGES`. No blockers → `COMMENT`
+  (nits inline, verdict in the body). Approval stays the operator's call.
+- The **body**, in this order: the issue-fit verdict (one short paragraph);
+  the **scope table** (always — write "everything in the diff is explained by
+  the issue" when clean); the numbered blockers, each cross-referencing its
+  inline comment; `maintainer-decision` items addressed to the maintainer by
+  name; then nits marked explicitly non-blocking. State what was verified
+  empirically versus read, and — briefly — what you tried to break that held
+  up, so the author can see the review was adversarial and can correct you
+  if the wrong thing was attacked. Where a finding came from the drive node,
+  paste its evidence with it: the state JSON, the log line, the PNG path.
+- Tone: collegial, evidence-first, no moralizing. Break the code, not the
+  author.
+
+## `report` — markdown for the operator
+
+```markdown
+## PR #NNNN — <title> (@author)
+
+**Issue:** #MMMM — one-paragraph summary of the problem as reported.
+**Proposed fix:** one-paragraph summary of the approach the diff takes.
+**Does it solve the issue?** Yes / Partially / No — with the requirement→hunk
+mapping and anything unaddressed.
+
+### Scope
+The scope table, then one line on whether the body's own checklist holds up.
+Never omit the section: "checked and clean" and "did not check" must not
+look the same.
+
+### Blockers
+Numbered. What's wrong, the evidence, the rule (if governance), the fix.
+"None." if none.
+
+### Nits
+Bulleted, explicitly non-blocking.
+
+### What I tried to break
+The attacks that did NOT produce a finding: the body claims tested and held,
+the edge cases walked, the tests inverted, what was built and run, and the
+bridge session (which build, against the demo, which tools, what state was
+asserted). Include the findings the verify nodes refuted, in one line each,
+so the operator can see the graph's rejection rate. Name anything that could
+not be tested and why.
+
+### Recommendation
+**Approve** / **Approve with nits** / **Request changes** /
+**Needs maintainer decision** — plus 2–3 sentences: reasoning, what was
+verified empirically, the concrete next step.
+```
+
+Also return `socketNotice`: if the coordinator's preflight flagged a socket
+test, one paragraph recording the test, socket type, target, whether CI runs
+it, and that the operator was notified — it goes in the review body too.

--- a/.claude/skills/graph-review/nodes/verify.md
+++ b/.claude/skills/graph-review/nodes/verify.md
@@ -1,0 +1,29 @@
+# Node: verify — refute one finding
+
+Read `stance.md` first. You receive **one** finding produced by another node,
+plus the PR context. That node had a stake in the finding being real; you do
+not. Your job is to make it go away, and to report honestly when you cannot.
+
+Your lens is given in the prompt — one of:
+
+- **`reproduce`**: is the defect real? Read the code at the PR head and the
+  merge base, walk the exact input/ordering/lifecycle the finding names, and
+  look for the guard, the earlier return, the sibling handler, or the caller
+  contract that makes it impossible. Check that the evidence quoted actually
+  says what the finding says it says. A finding about an absence ("the
+  sibling call site was not fixed") is refuted by finding that site fixed.
+- **`calibrate`**: is the severity right and the rule real? For a
+  governance `blocker`, open the cited document and confirm the quoted
+  sentence exists and means what the finding claims. If it does not, the
+  finding is a nit at most. For a scope `blocker`, check whether the issue
+  *thread* explains the change (then it is a nit, not a blocker). For a
+  preference `blocker`, look for the authority the author could point to.
+  Confirm the `fix` is drop-in correct if it is a suggestion block.
+
+Default to `refuted: true` when the evidence is thin — "I could not
+disprove it" is not confirmation. But a finding you actually tried to break
+and could not is confirmed; say what you tried in `reason`.
+
+Return `refuted`, `reason`, `severityAdjusted` (a severity from the shared
+vocabulary if it should change, else null), and any `evidence` you gathered
+that the synthesis node should quote. Read-only: no builds, no app launches.

--- a/.claude/skills/graph-review/nodes/verify.md
+++ b/.claude/skills/graph-review/nodes/verify.md
@@ -4,7 +4,12 @@ Read `stance.md` first. You receive **one** finding produced by another node,
 plus the PR context. That node had a stake in the finding being real; you do
 not. Your job is to make it go away, and to report honestly when you cannot.
 
-Your lens is given in the prompt — one of:
+Your lens is given in the prompt. The two lenses are asymmetric on purpose:
+**only `reproduce` can drop a finding.** `calibrate` decides severity and rule
+citation and may raise or lower it, but a finding it cannot confirm the
+severity of is downgraded, not deleted. The graph enforces this — a
+`refuted: true` from `calibrate` is ignored, so put your conclusion in
+`severityAdjusted` instead.
 
 - **`reproduce`**: is the defect real? Read the code at the PR head and the
   merge base, walk the exact input/ordering/lifecycle the finding names, and
@@ -18,11 +23,14 @@ Your lens is given in the prompt — one of:
   finding is a nit at most. For a scope `blocker`, check whether the issue
   *thread* explains the change (then it is a nit, not a blocker). For a
   preference `blocker`, look for the authority the author could point to.
-  Confirm the `fix` is drop-in correct if it is a suggestion block.
+  Confirm the `fix` is drop-in correct if it is a suggestion block. Express
+  every conclusion as `severityAdjusted` (`nit` when the rule cannot be
+  quoted or the thread explains the change; `blocker` when the finding
+  under-called it); leave `refuted` false.
 
-Default to `refuted: true` when the evidence is thin — "I could not
-disprove it" is not confirmation. But a finding you actually tried to break
-and could not is confirmed; say what you tried in `reason`.
+For `reproduce`: default to `refuted: true` when the evidence is thin — "I
+could not disprove it" is not confirmation. But a finding you actually tried
+to break and could not is confirmed; say what you tried in `reason`.
 
 Return `refuted`, `reason`, `severityAdjusted` (a severity from the shared
 vocabulary if it should change, else null), and any `evidence` you gathered

--- a/.claude/skills/graph-review/workflow.js
+++ b/.claude/skills/graph-review/workflow.js
@@ -1,0 +1,298 @@
+export const meta = {
+  name: 'graph-review',
+  description: 'Adversarial AetherSDR PR review as a graph: parallel audits, single build, bridge drive, per-finding refutation, one synthesis',
+  whenToUse: 'Invoked by the /graph-review skill after its inline preflight and gather steps. Not for direct use.',
+  phases: [
+    { title: 'Audit', detail: 'issue-fit, scope→preference, governance, quality — in parallel with the build' },
+    { title: 'Verify', detail: 'two refuters per finding (reproduce, calibrate) as each audit lands' },
+    { title: 'Drive', detail: 'one bridge session against the demo backend for every runtime claim' },
+    { title: 'Synthesize', detail: 'one review payload + operator report' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// args (from the coordinator, see SKILL.md step 2):
+//   pr, title, author, body, headSha, baseSha, linkedIssues[], files[], commits[],
+//   headWorktree, baseWorktree|null, tmpDir, scratchDir, buildBase (bool),
+//   preflight: { socketTestFound, socketTargets[], notice },
+//   ciSummary, botComments (string|null), skillDir
+// ---------------------------------------------------------------------------
+
+const A = args
+if (!A || !A.pr) throw new Error('graph-review: args.pr is required')
+const NODES = `${A.skillDir}/nodes`
+
+const SEV = { enum: ['blocker', 'maintainer-decision', 'nit'] }
+const FINDING = {
+  type: 'object',
+  properties: {
+    title: { type: 'string' },
+    severity: SEV,
+    category: { type: 'string' },
+    file: { type: 'string' },
+    line: { type: 'integer' },
+    inDiff: { type: 'boolean' },
+    evidence: { type: 'string' },
+    ruleCited: { type: 'string' },
+    fix: { type: 'string' },
+    needsRuntime: { type: 'boolean' },
+  },
+  required: ['title', 'severity', 'category', 'file', 'line', 'inDiff', 'evidence', 'fix', 'needsRuntime'],
+}
+const CLAIM = {
+  type: 'object',
+  properties: { claim: { type: 'string' }, source: { type: 'string' }, howToTest: { type: 'string' } },
+  required: ['claim', 'source', 'howToTest'],
+}
+const SCOPE_ROW = {
+  type: 'object',
+  properties: { group: { type: 'string' }, changes: { type: 'string' }, claimed: { type: 'string' }, verdict: { type: 'string' } },
+  required: ['group', 'changes', 'claimed', 'verdict'],
+}
+const AUDIT = {
+  type: 'object',
+  properties: {
+    summary: { type: 'string' },
+    verdict: { type: 'string' },
+    findings: { type: 'array', items: FINDING },
+    runtimeClaims: { type: 'array', items: CLAIM },
+    attacksSurvived: { type: 'array', items: { type: 'string' } },
+    testsToInvert: { type: 'array', items: { type: 'object', properties: { test: { type: 'string' }, mutation: { type: 'string' } }, required: ['test', 'mutation'] } },
+    scopeTable: { type: 'array', items: SCOPE_ROW },
+    uiRows: { type: 'array', items: SCOPE_ROW },
+    checklistHolds: { type: 'string' },
+    requirementMap: { type: 'array', items: { type: 'object', properties: { requirement: { type: 'string' }, hunk: { type: 'string' }, addressed: { type: 'boolean' } }, required: ['requirement', 'hunk', 'addressed'] } },
+    unexplained: { type: 'array', items: { type: 'string' } },
+    classifications: { type: 'array', items: { type: 'object', properties: { change: { type: 'string' }, kind: { enum: ['fix', 'preference'] }, authority: { type: 'string' } }, required: ['change', 'kind', 'authority'] } },
+  },
+  required: ['summary', 'findings', 'runtimeClaims', 'attacksSurvived'],
+}
+const VERDICT = {
+  type: 'object',
+  properties: {
+    refuted: { type: 'boolean' },
+    reason: { type: 'string' },
+    severityAdjusted: { anyOf: [SEV, { type: 'null' }] },
+    evidence: { type: 'string' },
+  },
+  required: ['refuted', 'reason', 'severityAdjusted'],
+}
+const BUILD = {
+  type: 'object',
+  properties: {
+    ok: { type: 'boolean' },
+    buildDir: { type: 'string' },
+    baseBuildDir: { type: 'string' },
+    targets: { type: 'array', items: { type: 'object', properties: { target: { type: 'string' }, result: { type: 'string' }, output: { type: 'string' } }, required: ['target', 'result'] } },
+    inversions: { type: 'array', items: { type: 'object', properties: { test: { type: 'string' }, mutation: { type: 'string' }, noticed: { type: 'boolean' }, output: { type: 'string' } }, required: ['test', 'mutation', 'noticed'] } },
+    errorTail: { type: 'string' },
+    notes: { type: 'string' },
+  },
+  required: ['ok', 'buildDir', 'targets', 'inversions'],
+}
+const DRIVE = {
+  type: 'object',
+  properties: {
+    drove: { type: 'boolean' },
+    instance: { type: 'string' },
+    reason: { type: 'string' },
+    results: { type: 'array', items: { type: 'object', properties: { claim: { type: 'string' }, outcome: { enum: ['confirmed', 'refuted', 'unreachable'] }, evidence: { type: 'string' } }, required: ['claim', 'outcome', 'evidence'] } },
+    newFindings: { type: 'array', items: FINDING },
+    incidents: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['drove', 'results', 'newFindings', 'incidents'],
+}
+const SYNTH = {
+  type: 'object',
+  properties: {
+    review: {
+      type: 'object',
+      properties: {
+        event: { enum: ['REQUEST_CHANGES', 'COMMENT'] },
+        body: { type: 'string' },
+        comments: { type: 'array', items: { type: 'object', properties: { path: { type: 'string' }, line: { type: 'integer' }, start_line: { type: 'integer' }, side: { type: 'string' }, body: { type: 'string' } }, required: ['path', 'line', 'side', 'body'] } },
+      },
+      required: ['event', 'body', 'comments'],
+    },
+    report: { type: 'string' },
+    recommendation: { enum: ['Approve', 'Approve with nits', 'Request changes', 'Needs maintainer decision'] },
+    socketNotice: { type: 'string' },
+  },
+  required: ['review', 'report', 'recommendation'],
+}
+
+// Shared context block every node prompt starts with.
+const CONTEXT = `
+AetherSDR PR #${A.pr} — "${A.title}" by @${A.author}
+head ${A.headSha}  base ${A.baseSha}
+Linked issues: ${A.linkedIssues.length ? A.linkedIssues.map(n => '#' + n).join(', ') : 'none'}
+PR-head worktree (READ-ONLY for you): ${A.headWorktree}
+${A.baseWorktree ? 'Merge-base worktree (READ-ONLY for you): ' + A.baseWorktree : ''}
+Preflight: ${A.preflight.socketTestFound ? 'SOCKET TEST FOUND — targets ' + A.preflight.socketTargets.join(', ') + ' must not be built or run' : 'no socket-owning test in the PR'}
+CI: ${A.ciSummary}
+Files:
+${A.files.join('\n')}
+Commits (author date):
+${A.commits.join('\n')}
+
+PR body:
+---
+${A.body}
+---
+Read ${NODES}/stance.md before doing anything else, then your node file.
+`
+
+const audit = (node, extra = '') => agent(
+  `${CONTEXT}\nYou are the **${node}** node. Read ${NODES}/${node}.md and do exactly that job.${extra}\nReturn the AUDIT structure. Every finding needs the full finding shape from stance.md.`,
+  { label: `audit:${node}`, phase: 'Audit', schema: AUDIT })
+
+// ---------------------------------------------------------------------------
+// Phase 1+2: audits fan out; each finding is refuted as soon as its audit lands.
+// The build runs concurrently with the audits (it needs none of their output
+// except testsToInvert, which the coordinator collected up front from the diff).
+// ---------------------------------------------------------------------------
+phase('Audit')
+log(`PR #${A.pr}: fanning out 4 audits + build`)
+
+const DIMENSIONS = ['issue-fit', 'scope', 'governance', 'quality']
+
+let findingSeq = 0
+const tag = (f, origin) => ({ ...f, id: `F${++findingSeq}`, origin })
+
+const verifyOne = async (f) => {
+  const lenses = ['reproduce', 'calibrate']
+  const votes = await parallel(lenses.map(lens => () => agent(
+    `${CONTEXT}\nYou are a **verify** node with the **${lens}** lens. Read ${NODES}/verify.md.\n` +
+    `The finding to refute (produced by the ${f.origin} node):\n${JSON.stringify(f, null, 2)}\n` +
+    `Default to refuted=true if the evidence is thin. Return the VERDICT structure.`,
+    { label: `verify:${lens}:${f.id}`, phase: 'Verify', schema: VERDICT })))
+  const vs = votes.filter(Boolean)
+  const refuted = vs.some(v => v.refuted)
+  const adj = vs.map(v => v.severityAdjusted).find(Boolean)
+  return { ...f, refuted, severity: refuted ? f.severity : (adj || f.severity), verifierNotes: vs.map((v, i) => `${lenses[i]}: ${v.reason}${v.evidence ? ' — ' + v.evidence : ''}`) }
+}
+
+const auditChain = pipeline(
+  DIMENSIONS,
+  // stage 1: the audit itself; scope additionally feeds the preference node
+  async (dim) => {
+    const r = await audit(dim)
+    if (!r) return null
+    if (dim === 'scope') {
+      const pref = await audit('preference',
+        `\nThe scope node's uiRows (rows touching existing UI/defaults/behavior):\n${JSON.stringify(r.uiRows || [], null, 2)}\nIts scope table for context:\n${JSON.stringify(r.scopeTable || [], null, 2)}`)
+      if (pref) {
+        r.findings = [...r.findings, ...pref.findings.map(f => ({ ...f, origin: 'preference' }))]
+        r.runtimeClaims = [...r.runtimeClaims, ...pref.runtimeClaims]
+        r.attacksSurvived = [...r.attacksSurvived, ...pref.attacksSurvived]
+        r.classifications = pref.classifications || []
+      }
+    }
+    return r
+  },
+  // stage 2: verify each finding of this dimension, no barrier on the other dimensions
+  async (r, dim) => {
+    if (!r) return null
+    const tagged = r.findings.map(f => tag(f, f.origin || dim))
+    const verified = await parallel(tagged.map(f => () => verifyOne(f)))
+    return { dim, audit: r, findings: verified.filter(Boolean) }
+  },
+)
+
+const buildTask = agent(
+  `${CONTEXT}\nYou are the **build** node. Read ${NODES}/build.md.\n` +
+  `TMPDIR to export: ${A.tmpDir}\n` +
+  `Build the merge base too: ${A.buildBase ? 'YES (' + A.baseWorktree + ')' : 'no'}\n` +
+  `Tests to invert (from the coordinator's read of the diff): ${JSON.stringify(A.testsToInvert || [])}\n` +
+  `Return the BUILD structure.`,
+  { label: 'build', phase: 'Audit', schema: BUILD })
+
+const [auditResults, build] = await Promise.all([auditChain, buildTask.catch(() => null)])
+const audits = auditResults.filter(Boolean)
+
+const allFindings = audits.flatMap(a => a.findings)
+const confirmed = allFindings.filter(f => !f.refuted)
+const refuted = allFindings.filter(f => f.refuted)
+log(`audits done: ${allFindings.length} findings, ${confirmed.length} survived refutation, ${refuted.length} refuted; build ${build && build.ok ? 'ok' : 'FAILED'}`)
+
+// Inversions the audits asked for that the coordinator did not already pass.
+const wantedInversions = audits.flatMap(a => a.audit.testsToInvert || [])
+const doneInversions = new Set((build && build.inversions || []).map(i => i.test + '|' + i.mutation))
+const missedInversions = wantedInversions.filter(i => !doneInversions.has(i.test + '|' + i.mutation))
+if (missedInversions.length) log(`NOTE: ${missedInversions.length} inversion request(s) from audits were not run (build ran concurrently); listed in the report`)
+
+// ---------------------------------------------------------------------------
+// Phase 3: one drive session. Needs ALL runtime claims + the build → genuine barrier.
+// ---------------------------------------------------------------------------
+phase('Drive')
+const runtimeClaims = [
+  ...audits.flatMap(a => a.audit.runtimeClaims || []),
+  ...confirmed.filter(f => f.needsRuntime).map(f => ({ claim: `[${f.id}] ${f.title}`, source: f.origin, howToTest: f.evidence })),
+]
+const dedupClaims = []
+const seenClaims = new Set()
+for (const c of runtimeClaims) { const k = c.claim.trim().toLowerCase(); if (!seenClaims.has(k)) { seenClaims.add(k); dedupClaims.push(c) } }
+
+let drive = null
+if (build && build.ok && dedupClaims.length) {
+  drive = await agent(
+    `${CONTEXT}\nYou are the **drive** node. Read ${NODES}/drive.md.\n` +
+    `Head build dir: ${build.buildDir}\n${build.baseBuildDir ? 'Merge-base build dir: ' + build.baseBuildDir + '\n' : ''}` +
+    `Scratch dir: ${A.scratchDir}\n` +
+    `Runtime claims to settle (${dedupClaims.length}):\n${JSON.stringify(dedupClaims, null, 2)}\n` +
+    `Return the DRIVE structure.`,
+    { label: 'drive', phase: 'Drive', schema: DRIVE })
+} else {
+  log(build && build.ok ? 'no runtime claims to drive' : 'build failed — drive skipped, all runtime claims stay unreachable')
+}
+
+// Findings that needed runtime evidence and did not get it are downgraded to "reasoned-from-code".
+const driveOutcome = new Map((drive && drive.results || []).map(r => [r.claim.trim().toLowerCase(), r]))
+for (const f of confirmed) {
+  if (!f.needsRuntime) continue
+  const r = driveOutcome.get(`[${f.id}] ${f.title}`.trim().toLowerCase())
+  if (!r || r.outcome === 'unreachable') { f.runtime = 'unverified'; continue }
+  f.runtime = r.outcome; f.driveEvidence = r.evidence
+  if (r.outcome === 'refuted') { f.refuted = true; f.verifierNotes.push(`drive: refuted — ${r.evidence}`) }
+}
+const finalConfirmed = confirmed.filter(f => !f.refuted)
+const driveRefuted = confirmed.filter(f => f.refuted)
+const newFromDrive = (drive && drive.newFindings || []).map(f => tag(f, 'drive'))
+
+// ---------------------------------------------------------------------------
+// Phase 4: synthesis.
+// ---------------------------------------------------------------------------
+phase('Synthesize')
+const scopeAudit = audits.find(a => a.dim === 'scope')
+const issueAudit = audits.find(a => a.dim === 'issue-fit')
+const synth = await agent(
+  `${CONTEXT}\nYou are the **synthesize** node. Read ${NODES}/synthesize.md.\n` +
+  `Preflight notice (include verbatim if non-empty): ${A.preflight.notice || ''}\n\n` +
+  `Issue-fit verdict: ${issueAudit ? issueAudit.audit.verdict : 'n/a'}\n${issueAudit ? issueAudit.audit.summary : ''}\n` +
+  `Requirement map:\n${JSON.stringify(issueAudit && issueAudit.audit.requirementMap || [], null, 2)}\n\n` +
+  `Scope table:\n${JSON.stringify(scopeAudit && scopeAudit.audit.scopeTable || [], null, 2)}\n` +
+  `Body checklist holds: ${scopeAudit && scopeAudit.audit.checklistHolds || 'not assessed'}\n` +
+  `Preference classifications:\n${JSON.stringify(scopeAudit && scopeAudit.audit.classifications || [], null, 2)}\n\n` +
+  `CONFIRMED findings (${finalConfirmed.length + newFromDrive.length}):\n${JSON.stringify([...finalConfirmed, ...newFromDrive], null, 2)}\n\n` +
+  `REFUTED findings — do NOT report as findings; summarize one line each under "What I tried to break" (${refuted.length + driveRefuted.length}):\n${JSON.stringify([...refuted, ...driveRefuted].map(f => ({ id: f.id, title: f.title, origin: f.origin, verifierNotes: f.verifierNotes })), null, 2)}\n\n` +
+  `Attacks survived (union):\n${JSON.stringify(audits.flatMap(a => a.audit.attacksSurvived || []), null, 2)}\n\n` +
+  `Build:\n${JSON.stringify(build, null, 2)}\n` +
+  `Inversions requested but not run: ${JSON.stringify(missedInversions)}\n\n` +
+  `Drive:\n${JSON.stringify(drive, null, 2)}\n\n` +
+  `Return the SYNTH structure. The review payload is posted verbatim by the coordinator.`,
+  { label: 'synthesize', phase: 'Synthesize', schema: SYNTH })
+
+return {
+  synth,
+  stats: {
+    findingsRaised: allFindings.length + newFromDrive.length,
+    confirmed: finalConfirmed.length + newFromDrive.length,
+    refuted: refuted.length + driveRefuted.length,
+    runtimeClaims: dedupClaims.length,
+    drove: !!(drive && drive.drove),
+    buildOk: !!(build && build.ok),
+    missedInversions,
+  },
+  headWorktree: A.headWorktree,
+  baseWorktree: A.baseWorktree,
+}

--- a/.claude/skills/graph-review/workflow.js
+++ b/.claude/skills/graph-review/workflow.js
@@ -20,6 +20,10 @@ export const meta = {
 
 const A = args
 if (!A || !A.pr) throw new Error('graph-review: args.pr is required')
+for (const k of ['title', 'author', 'body', 'headSha', 'baseSha', 'linkedIssues', 'files', 'commits', 'headWorktree', 'tmpDir', 'scratchDir', 'preflight', 'ciSummary', 'skillDir']) {
+  if (A[k] === undefined || A[k] === null) throw new Error(`graph-review: args.${k} is required (see SKILL.md step 2)`)
+}
+if (!Array.isArray(A.preflight.socketTargets)) throw new Error('graph-review: args.preflight.socketTargets must be an array')
 const NODES = `${A.skillDir}/nodes`
 
 const SEV = { enum: ['blocker', 'maintainer-decision', 'nit'] }
@@ -37,7 +41,7 @@ const FINDING = {
     fix: { type: 'string' },
     needsRuntime: { type: 'boolean' },
   },
-  required: ['title', 'severity', 'category', 'file', 'line', 'inDiff', 'evidence', 'fix', 'needsRuntime'],
+  required: ['title', 'severity', 'category', 'file', 'line', 'inDiff', 'evidence', 'ruleCited', 'fix', 'needsRuntime'],
 }
 const CLAIM = {
   type: 'object',
@@ -63,6 +67,8 @@ const AUDIT = {
     checklistHolds: { type: 'string' },
     requirementMap: { type: 'array', items: { type: 'object', properties: { requirement: { type: 'string' }, hunk: { type: 'string' }, addressed: { type: 'boolean' } }, required: ['requirement', 'hunk', 'addressed'] } },
     unexplained: { type: 'array', items: { type: 'string' } },
+    automatedPassRan: { type: 'boolean' },
+    automatedPassNote: { type: 'string' },
     classifications: { type: 'array', items: { type: 'object', properties: { change: { type: 'string' }, kind: { enum: ['fix', 'preference'] }, authority: { type: 'string' } }, required: ['change', 'kind', 'authority'] } },
   },
   required: ['summary', 'findings', 'runtimeClaims', 'attacksSurvived'],
@@ -130,6 +136,8 @@ PR-head worktree (READ-ONLY for you): ${A.headWorktree}
 ${A.baseWorktree ? 'Merge-base worktree (READ-ONLY for you): ' + A.baseWorktree : ''}
 Preflight: ${A.preflight.socketTestFound ? 'SOCKET TEST FOUND — targets ' + A.preflight.socketTargets.join(', ') + ' must not be built or run' : 'no socket-owning test in the PR'}
 CI: ${A.ciSummary}
+Prior review-bot comments (LEADS ONLY — verify each yourself, keep only what you confirm, attribute it as "automated pass found …", drop what you can refute):
+${A.botComments || 'none'}
 Files:
 ${A.files.join('\n')}
 Commits (author date):
@@ -159,17 +167,25 @@ const DIMENSIONS = ['issue-fit', 'scope', 'governance', 'quality']
 let findingSeq = 0
 const tag = (f, origin) => ({ ...f, id: `F${++findingSeq}`, origin })
 
+// Two lenses, asymmetric by design (nodes/verify.md):
+//   reproduce — decides whether the defect EXISTS; its refutation drops the finding.
+//   calibrate — decides severity and rule-citation; it may only raise/lower severity.
+// Fail closed: a finding whose reproduce lens never returned is NOT verified and is dropped.
 const verifyOne = async (f) => {
   const lenses = ['reproduce', 'calibrate']
   const votes = await parallel(lenses.map(lens => () => agent(
     `${CONTEXT}\nYou are a **verify** node with the **${lens}** lens. Read ${NODES}/verify.md.\n` +
     `The finding to refute (produced by the ${f.origin} node):\n${JSON.stringify(f, null, 2)}\n` +
-    `Default to refuted=true if the evidence is thin. Return the VERDICT structure.`,
-    { label: `verify:${lens}:${f.id}`, phase: 'Verify', schema: VERDICT })))
+    `Return the VERDICT structure.`,
+    { label: `verify:${lens}:${f.id}`, phase: 'Verify', schema: VERDICT }).then(v => (v ? { ...v, lens } : null))))
   const vs = votes.filter(Boolean)
-  const refuted = vs.some(v => v.refuted)
-  const adj = vs.map(v => v.severityAdjusted).find(Boolean)
-  return { ...f, refuted, severity: refuted ? f.severity : (adj || f.severity), verifierNotes: vs.map((v, i) => `${lenses[i]}: ${v.reason}${v.evidence ? ' — ' + v.evidence : ''}`) }
+  const repro = vs.find(v => v.lens === 'reproduce')
+  const calib = vs.find(v => v.lens === 'calibrate')
+  const refuted = repro ? repro.refuted : true
+  const severity = refuted ? f.severity : ((calib && calib.severityAdjusted) || f.severity)
+  const notes = vs.map(v => `${v.lens}: ${v.reason}${v.evidence ? ' — ' + v.evidence : ''}`)
+  if (!repro) notes.push('reproduce lens failed to return — finding NOT verified; dropped rather than reported unverified')
+  return { ...f, refuted, severity, verifiers: vs.length, verifierNotes: notes }
 }
 
 const auditChain = pipeline(
@@ -257,7 +273,12 @@ for (const f of confirmed) {
 }
 const finalConfirmed = confirmed.filter(f => !f.refuted)
 const driveRefuted = confirmed.filter(f => f.refuted)
-const newFromDrive = (drive && drive.newFindings || []).map(f => tag(f, 'drive'))
+// Drive-node discoveries get the same two-lens refutation as everything else.
+const driveVerified = (await parallel(((drive && drive.newFindings) || [])
+  .map(f => tag(f, 'drive'))
+  .map(f => () => verifyOne(f)))).filter(Boolean)
+const newFromDrive = driveVerified.filter(f => !f.refuted)
+const driveNewRefuted = driveVerified.filter(f => f.refuted)
 
 // ---------------------------------------------------------------------------
 // Phase 4: synthesis.
@@ -265,16 +286,19 @@ const newFromDrive = (drive && drive.newFindings || []).map(f => tag(f, 'drive')
 phase('Synthesize')
 const scopeAudit = audits.find(a => a.dim === 'scope')
 const issueAudit = audits.find(a => a.dim === 'issue-fit')
+const qualityAudit = audits.find(a => a.dim === 'quality')
 const synth = await agent(
   `${CONTEXT}\nYou are the **synthesize** node. Read ${NODES}/synthesize.md.\n` +
   `Preflight notice (include verbatim if non-empty): ${A.preflight.notice || ''}\n\n` +
   `Issue-fit verdict: ${issueAudit ? issueAudit.audit.verdict : 'n/a'}\n${issueAudit ? issueAudit.audit.summary : ''}\n` +
-  `Requirement map:\n${JSON.stringify(issueAudit && issueAudit.audit.requirementMap || [], null, 2)}\n\n` +
+  `Requirement map:\n${JSON.stringify(issueAudit && issueAudit.audit.requirementMap || [], null, 2)}\n` +
+  `Diff content issue-fit could not explain (reconcile against the scope table):\n${JSON.stringify(issueAudit && issueAudit.audit.unexplained || [], null, 2)}\n\n` +
+  `Automated code-review pass: ${qualityAudit && qualityAudit.audit.automatedPassRan ? 'RAN' : 'DID NOT RUN — say so; never imply it ran'}${qualityAudit && qualityAudit.audit.automatedPassNote ? ' — ' + qualityAudit.audit.automatedPassNote : ''}\n\n` +
   `Scope table:\n${JSON.stringify(scopeAudit && scopeAudit.audit.scopeTable || [], null, 2)}\n` +
   `Body checklist holds: ${scopeAudit && scopeAudit.audit.checklistHolds || 'not assessed'}\n` +
   `Preference classifications:\n${JSON.stringify(scopeAudit && scopeAudit.audit.classifications || [], null, 2)}\n\n` +
   `CONFIRMED findings (${finalConfirmed.length + newFromDrive.length}):\n${JSON.stringify([...finalConfirmed, ...newFromDrive], null, 2)}\n\n` +
-  `REFUTED findings — do NOT report as findings; summarize one line each under "What I tried to break" (${refuted.length + driveRefuted.length}):\n${JSON.stringify([...refuted, ...driveRefuted].map(f => ({ id: f.id, title: f.title, origin: f.origin, verifierNotes: f.verifierNotes })), null, 2)}\n\n` +
+  `REFUTED findings — do NOT report as findings; summarize one line each under "What I tried to break" (${refuted.length + driveRefuted.length + driveNewRefuted.length}):\n${JSON.stringify([...refuted, ...driveRefuted, ...driveNewRefuted].map(f => ({ id: f.id, title: f.title, origin: f.origin, verifierNotes: f.verifierNotes })), null, 2)}\n\n` +
   `Attacks survived (union):\n${JSON.stringify(audits.flatMap(a => a.audit.attacksSurvived || []), null, 2)}\n\n` +
   `Build:\n${JSON.stringify(build, null, 2)}\n` +
   `Inversions requested but not run: ${JSON.stringify(missedInversions)}\n\n` +
@@ -285,9 +309,10 @@ const synth = await agent(
 return {
   synth,
   stats: {
-    findingsRaised: allFindings.length + newFromDrive.length,
+    findingsRaised: allFindings.length + driveVerified.length,
     confirmed: finalConfirmed.length + newFromDrive.length,
-    refuted: refuted.length + driveRefuted.length,
+    refuted: refuted.length + driveRefuted.length + driveNewRefuted.length,
+    automatedPassRan: !!(qualityAudit && qualityAudit.audit.automatedPassRan),
     runtimeClaims: dedupClaims.length,
     drove: !!(drive && drive.drove),
     buildOk: !!(build && build.ok),


### PR DESCRIPTION
## Summary

Adds `/graph-review`, a copy of `/pr-review` restructured as a Workflow-tool graph. Same adversarial stance, same rules, same deliverables (one posted GitHub review with inline comments + a markdown operator report), different shape:

- **Four read audits fan out in parallel** — issue-fit, scope, governance, quality — each with a small single-purpose context instead of one agent walking 640 lines. The scope node's UI rows feed the preference node as an explicit edge.
- **A single build node** runs concurrently with the audits and owns every build, test run, and test inversion. Nothing else builds.
- **Every finding is refuted before it can be reported**: two independent verifier lenses (`reproduce`, `calibrate`) per finding, with no stake in the finding being real. Refuted findings are only surfaced under "What I tried to break".
- **One bridge session** drives every runtime claim (from the PR body and the audits) against the demo backend, and can refute a finding a second time with app evidence.
- **One synthesis node** writes the review payload and the report; the coordinator posts it verbatim.
- **Schema-enforced artifacts**: the scope table, the attacks-survived list, and the verified-vs-read split are required output fields, so they cannot be skipped.

The coordinator (`SKILL.md`) keeps the socket-test preflight, gather, worktree creation, posting, and cleanup inline. Rules live one-per-node under `nodes/`; the graph is `workflow.js`. Where the Workflow tool is unavailable the skill defers to `/pr-review`.

## Scope

New files only under `.claude/skills/graph-review/`. `/pr-review` is untouched.

## Testing

- `workflow.js` body parses as JavaScript; phase labels match the `meta` block.
- Not yet run against a live PR — the first run should target a small PR to shake out the args contract between `SKILL.md` and the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
