### PR TITLE
build(bridge-docs): audit pan / audioCapture sub-actions, not just slice

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -2310,9 +2310,11 @@ Panadapter lifecycle — create or tear down a pan regardless of how it was open
 | `create` (alias `add`) | — | create a new panadapter (panafall). The only UI path is an unaddressable label. |
 | `center` | `<mhz>` | recenter the active pan — the band-change lever (a plain `tune` only moves the slice and clamps to the pan's RF range, #292). **MHz, not Hz**: the [four refusals listed under `tune`](#tune) apply here too, with `pan center` in the message. It matters more on this verb — `setPanCenter()` clamps only the low edge, so an unguarded out-of-range centre is stored and advertised over TCI (`dds:`) even though the radio rejects it. |
 | `close` (alias `remove`) | `<panId>` (`0x…`) / `<index>` (panIndex) / `active` / `all` | close pan(s). Sends `display pan remove` **and** `display panafall remove`, so a panafall-created pan closes without the slice-removal workaround. A single target won't close the last pan; `all` will. |
+| `rfgain` | `[<panId>] <dB>` | set the front-end RF/LNA gain. On a radio-wide preamp (the HL2's single AD9866 behind every DDC) the change reaches every pan; the optional `panId` addresses one where the backend supports it. |
+| `float` / `dock` | `<panId>` / `<index>` / `active` | undock / redock the pan via `PanadapterStack`'s real reparent path (#2495/#4319/#4617/#4864); re-poll `layout get` for `floatingCount` / `dockedCount`. |
 
-All are async (the radio echoes the change) — re-poll `get pans`. Every `pan`
-action is RX/config only; none keys the transmitter.
+All lifecycle actions are async (the radio echoes the change) — re-poll
+`get pans`. Every `pan` action is RX/config only; none keys the transmitter.
 
 Floating and docking use the production pan title-bar control rather than a
 radio lifecycle command. Target its stable object name through the pan scope;
@@ -3106,6 +3108,15 @@ while the engine runs):
 Bounded, automation-only PCM capture for receive-sync diagnostics. It is active
 only inside an `AETHER_AUTOMATION=1` process, is read-only, and does not change
 audio routing or playback buffers.
+
+| `action` | args | effect |
+|---|---|---|
+| `start` | `[<durationMs>] [<points>]` | begin capturing at the named tap points (`raw`,`post`,`output`,`final`, or `all`); default 5000 ms |
+| `stop` | — | stop early and return a compact snapshot |
+| `status` | — | compact snapshot (metadata only) without stopping |
+| `read` | `[<path>]` | write the full snapshot (base64 PCM) to a file, or return the compact snapshot when no path is given |
+| `probeNr2Stereo` | — | the no-option SpectralNR/`NR2` stereo-balance probe |
+| `probeDspStereo` | `<mode> [key=value …]` | deterministic synthetic RX proof for a DSP module (see the RN2 sub-section) |
 
 ```json
 → {"cmd":"audioCapture","action":"start","value":"5000 raw,post,output,final"}

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1257,6 +1257,22 @@ QString sliceActionList()
         "centerlock|link|txant|rxant|rxsource|fixture|clearfixture");
 }
 
+// Same single-source contract as sliceActionList(): doPan()'s fallthrough
+// error reads this, so a new pan action cannot land there and drift from the
+// others (#5102's failure mode, one verb over).
+QString panActionList()
+{
+    return QStringLiteral(
+        "create|add|remove|close|center|rfgain|float|dock");
+}
+
+// Likewise for audioCapture; doAudioCapture()'s fallthrough error reads this.
+QString audioCaptureActionList()
+{
+    return QStringLiteral(
+        "start|stop|status|read|probeNr2Stereo|probeDspStereo");
+}
+
 QJsonObject err(const QString& msg)
 {
     return QJsonObject{{QStringLiteral("ok"), false},
@@ -10611,7 +10627,7 @@ QJsonObject AutomationServer::doPan(const QString& action, const QString& arg)
     }
 
     return err(QStringLiteral("unknown pan action: ") + action
-               + QStringLiteral(" (create|add|remove|close|center|rfgain)"));
+               + QStringLiteral(" (") + panActionList() + QStringLiteral(")"));
 }
 
 // ── Panadapter layout (bridge test hook) ────────────────────────────────────
@@ -12136,7 +12152,8 @@ QJsonObject AutomationServer::doAudioCapture(const QString& action,
         return m_audioEngine->automationDspStereoProbe(arg);
     }
 
-    return err(QStringLiteral("audioCapture action must be start, stop, status, read, probeNr2Stereo, or probeDspStereo"));
+    return err(QStringLiteral("unknown audioCapture action: ") + normalizedAction
+               + QStringLiteral(" (") + audioCaptureActionList() + QStringLiteral(")"));
 }
 
 QJsonObject AutomationServer::doWhoami() const

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -2859,6 +2859,11 @@ if(PYTHON3_EXECUTABLE)
     add_test(NAME bridge_docs_check
              COMMAND ${PYTHON3_EXECUTABLE}
                      ${CMAKE_CURRENT_SOURCE_DIR}/tools/gen_bridge_docs.py --check)
+    # Guards the generalised sub-action audit itself: pan/audioCapture actions,
+    # not just slice, must round-trip against their *ActionList() single source.
+    add_test(NAME bridge_docs_subaction_audit
+             COMMAND ${PYTHON3_EXECUTABLE}
+                     ${CMAKE_CURRENT_SOURCE_DIR}/tools/test_gen_bridge_docs.py)
 endif()
 
 # Retired local-listener fixture. Positive behavior is covered through the live

--- a/tools/gen_bridge_docs.py
+++ b/tools/gen_bridge_docs.py
@@ -116,75 +116,94 @@ def generated_block(verbs):
             f"{END}")
 
 
-# The slice ACTION set is its own drift surface. #5102 was filed against a
-# working feature because two hand-maintained copies of this list disagreed;
-# the in-code copies were then collapsed into sliceActionList(). The docs held
-# a third and a fourth copy, and the `slice` action table is the one a reader
-# actually consults — so pin it to the code the same way the verb table is.
-_SLICE_LIST_RE = re.compile(
-    r'QString\s+sliceActionList\(\)\s*\{\s*return\s+QStringLiteral\('
+# A verb's ACTION set is its own drift surface. #5102 was filed against a
+# working feature because two hand-maintained copies of `slice`'s list
+# disagreed; the in-code copies were collapsed into sliceActionList(), and the
+# docs table a reader actually consults is pinned to it here. The same shape
+# now covers any verb with a `QString <verb>ActionList()` single source and a
+# `### \`<verb>\`` section whose table's first column names the actions.
+_ACTION_LIST_RE = re.compile(
+    r'QString\s+(?P<stem>\w+?)ActionList\(\)\s*\{\s*return\s+QStringLiteral\('
     r'(?P<body>(?:\s*"(?:[^"\\]|\\.)*")+)\s*\)\s*;',
     re.DOTALL)
 
+# verb -> (C++ ActionList() stem, doc heading). Add a row here, a
+# `<stem>ActionList()` function in AutomationServer.cpp, and a first-column
+# `` `action` `` table under the heading, and the drift check covers it.
+SUBACTION_VERBS = {
+    "slice": ("slice", "### `slice`"),
+    "pan": ("pan", "### `pan`"),
+    "audioCapture": ("audioCapture", "### `audioCapture`"),
+}
 
-def extract_slice_actions(cpp_path):
-    """The action names sliceActionList() advertises, in code order."""
+# Deliberately documented, deliberately NOT in the advertised list — accepted
+# aliases the *ActionList() strings omit on purpose (e.g. `slice source` is an
+# alias of `slice rxsource`). Naming them here is the difference between a lint
+# that encodes a known exception and one someone turns off.
+DOCUMENTED_ALIASES = {
+    "slice": {"source"},
+    "pan": set(),
+    "audioCapture": set(),
+}
+
+
+def extract_actions(cpp_path, stem):
+    """The action names `<stem>ActionList()` advertises, in code order."""
     with open(cpp_path, encoding="utf-8") as f:
         src = f.read()
-    m = _SLICE_LIST_RE.search(src)
-    if not m:
-        raise SystemExit(
-            "error: could not parse sliceActionList() from "
-            f"{cpp_path} — the docs-vs-code slice-action lint cannot run, and "
-            "silently skipping it is how the list drifted in the first place.")
-    joined = _join_literals(m.group("body"))
-    return [a for a in joined.split("|") if a]
+    for m in _ACTION_LIST_RE.finditer(src):
+        if m.group("stem") == stem:
+            joined = _join_literals(m.group("body"))
+            return [a for a in joined.split("|") if a]
+    raise SystemExit(
+        f"error: could not parse {stem}ActionList() from {cpp_path} — the "
+        "docs-vs-code action lint cannot run, and silently skipping it is how "
+        "the list drifted in the first place.")
 
 
-# Deliberately documented, deliberately NOT in sliceActionList(): `source` is
-# an accepted alias of `rxsource` (AutomationServer.cpp, the `rxsource`/`source`
-# branch) that the advertised list omits on purpose. Naming it here is the
-# difference between a lint that encodes one known exception and a lint someone
-# turns off.
-DOCUMENTED_SLICE_ALIASES = {"source"}
+def documented_actions(md_text, heading):
+    r"""Action names in the first column of `heading`'s *action* table(s).
 
-
-def documented_slice_actions(md_text):
-    """Action names in the first column of the `slice` section's table body.
-
-    Header rows are skipped structurally — a markdown table's header is the row
-    before its `|---|` separator — rather than by filtering the word "action",
-    which would also hide a real action called `action`.
+    A verb's section can carry more than one table (``### `audioCapture` `` also
+    has a "Capture points" table). Only rows of a table whose header's first
+    cell names "action" are counted, so a neighbouring ``| point | ... |``
+    table does not feed phantom actions into the drift check. Header rows are
+    skipped structurally — the row before the ``|---|`` separator.
     """
     lines = md_text.splitlines()
     start = None
     for i, ln in enumerate(lines):
-        if ln.strip() == "### `slice`":
+        if ln.strip() == heading:
             start = i
             break
     if start is None:
         raise SystemExit(
-            "error: no '### `slice`' section in the docs — the slice-action "
-            "lint cannot run.")
+            f"error: no '{heading}' section in the docs — its action lint "
+            "cannot run.")
     found = set()
-    pending_header = None
-    body = False
+    prev_line = ""
+    in_action_table = False
     for ln in lines[start + 1:]:
         # Stop at the next section of the same level; #### subsections belong
-        # to `slice` and may legitimately carry rows.
-        if ln.startswith("### ") and ln.strip() != "### `slice`":
+        # to this verb and may legitimately carry rows.
+        if ln.startswith("### ") and ln.strip() != heading:
             break
         if not ln.startswith("|"):
-            pending_header, body = None, False
+            in_action_table = False
+            prev_line = ln
             continue
         if re.fullmatch(r'\|[\s|:-]+', ln.strip()):
-            pending_header, body = None, True   # separator: header was above
+            # Separator: prev_line was this table's header. Count its rows only
+            # when the first header cell is about actions.
+            header_first = prev_line.split("|")[1] if "|" in prev_line else ""
+            header_first = header_first.replace("`", "").strip().lower()
+            in_action_table = "action" in header_first
             continue
-        if not body:
-            pending_header = ln                 # candidate header, not counted
-            continue
-        first_cell = ln.split("|")[1]
-        found.update(re.findall(r'`([a-z]+)`', first_cell))
+        if in_action_table:
+            first_cell = ln.split("|")[1]
+            # Allow digits after the first letter so `probeNr2Stereo` counts.
+            found.update(re.findall(r'`([a-zA-Z][a-zA-Z0-9]*)`', first_cell))
+        prev_line = ln
     return found
 
 
@@ -247,13 +266,19 @@ def main():
     # honest regardless of what the generator would produce.
     dups = find_duplicate_headings(md)
 
-    slice_actions = extract_slice_actions(CPP)
-    documented = documented_slice_actions(md)
-    undocumented = [a for a in slice_actions if a not in documented]
-    # ...and the other direction: an action the docs still describe after the
-    # code stopped advertising it. A reader cannot tell a removed action from a
-    # working one, and the drift that produced #5102 ran this way round too.
-    stale_docs = sorted(documented - set(slice_actions) - DOCUMENTED_SLICE_ALIASES)
+    # {verb: (advertised_actions, undocumented, stale_docs)}, in registry order.
+    action_audit = {}
+    total_actions = 0
+    for verb, (stem, heading) in SUBACTION_VERBS.items():
+        advertised = extract_actions(CPP, stem)
+        documented = documented_actions(md, heading)
+        undoc = [a for a in advertised if a not in documented]
+        # ...and the other direction: an action the docs still describe after
+        # the code stopped advertising it. A reader cannot tell a removed action
+        # from a working one; the drift that produced #5102 ran this way too.
+        stale = sorted(documented - set(advertised) - DOCUMENTED_ALIASES[verb])
+        action_audit[verb] = (advertised, undoc, stale)
+        total_actions += len(advertised)
 
     if args.check:
         problems = []
@@ -264,37 +289,39 @@ def main():
         if dups:
             problems.append("duplicate detail-section heading(s): "
                             + ", ".join(sorted(set(dups))))
-        if undocumented:
-            problems.append(
-                "slice action(s) advertised by sliceActionList() but absent "
-                "from the `slice` action table in the docs: "
-                + ", ".join(undocumented)
-                + " — document them (this table cannot be generated; the "
-                  "per-action prose is hand-written on purpose)")
-        if stale_docs:
-            problems.append(
-                "slice action(s) documented in the `slice` action table but "
-                "NOT advertised by sliceActionList(): " + ", ".join(stale_docs)
-                + " — remove the row, or add the action back to the code "
-                  "(known aliases live in DOCUMENTED_SLICE_ALIASES)")
+        for verb, (_adv, undoc, stale) in action_audit.items():
+            if undoc:
+                problems.append(
+                    f"`{verb}` action(s) advertised by {verb}ActionList() but "
+                    f"absent from the `### {verb}` action table in the docs: "
+                    + ", ".join(undoc)
+                    + " — document them (this table cannot be generated; the "
+                      "per-action prose is hand-written on purpose)")
+            if stale:
+                problems.append(
+                    f"`{verb}` action(s) documented but NOT advertised by "
+                    f"{verb}ActionList(): " + ", ".join(stale)
+                    + " — remove the row, or add the action back to the code "
+                      f"(known aliases live in DOCUMENTED_ALIASES['{verb}'])")
         if problems:
             for p in problems:
                 print("FAIL:", p, file=sys.stderr)
             return 1
         print(f"ok: docs verb table matches the registry ({len(verbs)} verbs), "
-              f"no duplicate headings, all {len(slice_actions)} slice actions "
-              "documented")
+              f"no duplicate headings, all {total_actions} sub-actions across "
+              f"{len(SUBACTION_VERBS)} verbs documented")
         return 0
 
     if dups:
         print("warning: duplicate detail-section heading(s): "
               + ", ".join(sorted(set(dups))), file=sys.stderr)
-    if undocumented:
-        print("warning: slice action(s) missing from the docs table: "
-              + ", ".join(undocumented), file=sys.stderr)
-    if stale_docs:
-        print("warning: slice action(s) documented but not advertised: "
-              + ", ".join(stale_docs), file=sys.stderr)
+    for verb, (_adv, undoc, stale) in action_audit.items():
+        if undoc:
+            print(f"warning: `{verb}` action(s) missing from the docs table: "
+                  + ", ".join(undoc), file=sys.stderr)
+        if stale:
+            print(f"warning: `{verb}` action(s) documented but not advertised: "
+                  + ", ".join(stale), file=sys.stderr)
     if want != md:
         with open(DOCS, "w", encoding="utf-8") as f:
             f.write(want)

--- a/tools/test_gen_bridge_docs.py
+++ b/tools/test_gen_bridge_docs.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Regression guard for gen_bridge_docs.py's generalised sub-action check.
+
+The verb-table drift check has its own CI test (`bridge_docs_check`). This one
+pins the part that used to be `slice`-only: `pan` and `audioCapture` sub-actions
+are now audited against `panActionList()` / `audioCaptureActionList()` too, and
+a doc that stops documenting one of them must fail `--check`.
+
+Pure Python, no app/Qt. Mutates docs/automation-bridge.md in place and restores
+it under try/finally.
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(HERE)
+DOCS = os.path.join(REPO, "docs", "automation-bridge.md")
+SCRIPT = os.path.join(HERE, "gen_bridge_docs.py")
+
+
+def check(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def run_check():
+    return subprocess.run(
+        [sys.executable, SCRIPT, "--check"],
+        cwd=REPO, capture_output=True, text=True)
+
+
+def test_clean_tree_passes():
+    r = run_check()
+    check(r.returncode == 0, f"--check failed on a clean tree:\n{r.stdout}\n{r.stderr}")
+    check("sub-actions across 3 verbs" in r.stdout,
+          f"--check no longer reports the multi-verb audit:\n{r.stdout}")
+
+
+def test_removing_a_pan_action_row_fails_check():
+    original = open(DOCS, encoding="utf-8").read()
+    # Drop the `rfgain` row from the `### `pan`` action table.
+    broken = re.sub(r'^\| `rfgain` \|.*\n', "", original, count=1, flags=re.M)
+    check(broken != original, "expected a `| `rfgain` |` row to remove")
+    try:
+        open(DOCS, "w", encoding="utf-8").write(broken)
+        r = run_check()
+        check(r.returncode == 1, f"--check should fail with a pan row missing:\n{r.stdout}")
+        check("`pan`" in r.stderr and "rfgain" in r.stderr,
+              f"--check should name the missing `pan` action:\n{r.stderr}")
+    finally:
+        open(DOCS, "w", encoding="utf-8").write(original)
+
+
+def test_removing_an_audiocapture_action_row_fails_check():
+    original = open(DOCS, encoding="utf-8").read()
+    broken = re.sub(r'^\| `probeNr2Stereo` \|.*\n', "", original, count=1, flags=re.M)
+    check(broken != original, "expected a `| `probeNr2Stereo` |` row to remove")
+    try:
+        open(DOCS, "w", encoding="utf-8").write(broken)
+        r = run_check()
+        check(r.returncode == 1,
+              f"--check should fail with an audioCapture row missing:\n{r.stdout}")
+        check("`audioCapture`" in r.stderr and "probeNr2Stereo" in r.stderr,
+              f"--check should name the missing `audioCapture` action:\n{r.stderr}")
+    finally:
+        open(DOCS, "w", encoding="utf-8").write(original)
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_") or not callable(fn):
+            continue
+        try:
+            fn()
+            print(f"ok: {name}")
+        except AssertionError as exc:
+            failures += 1
+            print(f"FAIL: {name}: {exc}", file=sys.stderr)
+    print("ALL PASS" if failures == 0 else f"{failures} FAILED")
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
## Summary

`gen_bridge_docs.py`'s doc-drift check only audited `slice`'s sub-actions against `sliceActionList()`. This generalises it from that hard-coded path to a `{verb -> (ActionList() stem, doc heading)}` registry, and registers `pan` and `audioCapture` too — closing the same class of drift `sliceActionList()` itself was created to prevent (#5102: a caller concluding a working action doesn't exist because the fallthrough error message omitted it).

- `documented_actions()` now counts only rows of a table whose header's first cell names "action", so `audioCapture`'s neighbouring "Capture points" table doesn't feed phantom actions in.
- The token regex allows digits, so `probeNr2Stereo` matches.
- `panActionList()` and `audioCaptureActionList()` are added as each verb's single source (used by the fallthrough error too), completing the trio with `sliceActionList()`.
- The `### pan` and `### audioCapture` doc sections gain proper `| action | ... |` tables covering every currently-advertised action.

This is split out of #5462 per the maintainer review there (item #3 of the suggested break-up — "a tooling improvement we'd take on its own merits").

**Scoped down from the original fork commit**: that branch's `pan`/`audioCapture` action lists already included `capture_audio analyze`, `pan span`, and `pan rate` — three of the new bridge-verb additions the review's blocker #6 explicitly calls out as needing a maintainer ruling before they land. Neither is implemented against current `main` either, so this PR's `panActionList()`/`audioCaptureActionList()` list only the actions `doPan()`/`doAudioCapture()` actually have today — the audit carries no forward reference to verbs this PR doesn't add. Happy to extend both lists in a follow-up once that RFC conversation happens.

## Constitution principle honored

N/A — tooling/doc-drift guard, no runtime behavior change beyond two error messages becoming accurate (see below).

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR`)
- [ ] Behavior verified on a real radio if applicable — n/a, doc-tooling + bridge error-message text only
- [x] Existing tests pass (CI) — `tools/test_gen_bridge_docs.py` (ctest `bridge_docs_subaction_audit`): `--check` passes clean on a clean tree and reports the 3-verb audit; deleting the `pan` `rfgain` row or the `audioCapture` `probeNr2Stereo` row makes `--check` exit 1 and name the missing verb + action. Existing `bridge_docs_check` still green.
- [x] Reproduction steps documented — see Summary; `HERMES.md §8` names the general problem class

Side effect worth flagging in review: the pre-existing `unknown pan action` error message was missing `float`/`dock` (it only ever listed `create|add|remove|close|center|rfgain`) — now fixed as part of routing it through the same single-source `panActionList()`.

## Checklist

- [x] Commits are signed
- [x] No new flat-key `AppSettings` calls
- [x] Code is clean-room
- [x] All meter UI uses `MeterSmoother` — n/a
- [x] Documentation updated if user-visible behavior changed — `docs/automation-bridge.md` updated in this PR
- [ ] Security-sensitive changes reference a GHSA if applicable — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)