### PR TITLE
refactor(hl2): centralise the AGC-ceiling dB conversion on Hl2DbReference

### DIFF
--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -2635,10 +2635,6 @@ void Hl2Backend::setSliceAgc(int sliceId, const QString& mode, int thresholdDb)
     // seedReceiverAgc); this makes the capture side agree with it.
     m_agcMode = r->agcMode;
     m_agcThresholdDb = r->agcThresholdDb;
-    // The shared signal-reference object tracks the same remembered value, so
-    // the LNA offset and the AGC ceiling — the two ends of the antenna→
-    // demodulator reference chain — are queryable from one place.
-    m_dbRef.setAgcThresholdOperatorUnits(r->agcThresholdDb);
     // WDSP IS TOLD WHAT THE RECEIVER NOW HOLDS, not what the caller asked for.
     // Deriving from `m` meant a refused mode still reached the DSP as
     // wdspAgcMode()'s medium fallback while r->agcMode, the applet echo and the

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -913,7 +913,7 @@ bool Hl2Backend::createPanadapter()
     dc.mode = modeFromString(r.mode);
     std::tie(dc.filterLowHz, dc.filterHighHz) = dspFilterHz(r);
     dc.agcMode = wdspAgcMode(r.agcMode);
-    dc.maximumAgcGainDb = r.agcThresholdDb * kAgcCeilingDbPerUnit;
+    dc.maximumAgcGainDb = Hl2DbReference::agcCeilingDbForThreshold(r.agcThresholdDb);
     bool ok = false;
     Hl2RxDsp* dsp = r.dsp;
     QMetaObject::invokeMethod(dsp, [dsp, &dc, &err, &ok] {
@@ -2051,7 +2051,7 @@ void Hl2Backend::beginDspSetup()
         // rather than as a restore bug, which is why the three sites should
         // look identical.
         dc.agcMode = wdspAgcMode(r.agcMode);
-        dc.maximumAgcGainDb = r.agcThresholdDb * kAgcCeilingDbPerUnit;
+        dc.maximumAgcGainDb = Hl2DbReference::agcCeilingDbForThreshold(r.agcThresholdDb);
         chains.push_back(r.dsp);
         configs.push_back(dc);
     }
@@ -2635,6 +2635,10 @@ void Hl2Backend::setSliceAgc(int sliceId, const QString& mode, int thresholdDb)
     // seedReceiverAgc); this makes the capture side agree with it.
     m_agcMode = r->agcMode;
     m_agcThresholdDb = r->agcThresholdDb;
+    // The shared signal-reference object tracks the same remembered value, so
+    // the LNA offset and the AGC ceiling — the two ends of the antenna→
+    // demodulator reference chain — are queryable from one place.
+    m_dbRef.setAgcThresholdOperatorUnits(r->agcThresholdDb);
     // WDSP IS TOLD WHAT THE RECEIVER NOW HOLDS, not what the caller asked for.
     // Deriving from `m` meant a refused mode still reached the DSP as
     // wdspAgcMode()'s medium fallback while r->agcMode, the applet echo and the
@@ -2643,7 +2647,8 @@ void Hl2Backend::setSliceAgc(int sliceId, const QString& mode, int thresholdDb)
     // surface nobody can see. It also fixes the empty-mode call (a
     // threshold-only change), which used to send medium over whatever mode the
     // receiver was actually running.
-    const double ceilingDb = r->agcThresholdDb * kAgcCeilingDbPerUnit;
+    const double ceilingDb =
+        Hl2DbReference::agcCeilingDbForThreshold(r->agcThresholdDb);
     if (r->dsp)
         QMetaObject::invokeMethod(r->dsp, "setAgc", Qt::QueuedConnection,
             Q_ARG(int, wdspAgcMode(r->agcMode)), Q_ARG(double, ceilingDb));
@@ -3200,7 +3205,7 @@ void Hl2Backend::applyPanBandwidth(double hz)
         // moved their AGC would have had it silently snap back to medium/39 dB
         // every time they zoomed.
         dc.agcMode = wdspAgcMode(r.agcMode);
-        dc.maximumAgcGainDb = r.agcThresholdDb * kAgcCeilingDbPerUnit;
+        dc.maximumAgcGainDb = Hl2DbReference::agcCeilingDbForThreshold(r.agcThresholdDb);
         std::string err;
         bool ok = false;
         Hl2RxDsp* dsp = r.dsp;
@@ -3231,7 +3236,8 @@ void Hl2Backend::applyPanBandwidth(double hz)
                 rc.mode = modeFromString(m_rx[k].mode);
                 std::tie(rc.filterLowHz, rc.filterHighHz) = dspFilterHz(m_rx[k]);
                 rc.agcMode = wdspAgcMode(m_rx[k].agcMode);
-                rc.maximumAgcGainDb = m_rx[k].agcThresholdDb * kAgcCeilingDbPerUnit;
+                rc.maximumAgcGainDb = Hl2DbReference::agcCeilingDbForThreshold(
+                    m_rx[k].agcThresholdDb);
                 std::string backErr;
                 bool backOk = false;
                 QMetaObject::invokeMethod(back, [back, &rc, &backErr, &backOk] {
@@ -5080,7 +5086,7 @@ void Hl2Backend::pushInitialState()
         // which is the rule the passband derivation guard exists to enforce.
         QMetaObject::invokeMethod(r.dsp, "setAgc", Qt::QueuedConnection,
             Q_ARG(int, wdspAgcMode(r.agcMode)),
-            Q_ARG(double, r.agcThresholdDb * kAgcCeilingDbPerUnit));
+            Q_ARG(double, Hl2DbReference::agcCeilingDbForThreshold(r.agcThresholdDb)));
         QMetaObject::invokeMethod(r.dsp, "setAudioMuted", Qt::QueuedConnection,
             Q_ARG(bool, false));
         // The notch axis, which is measured from the NCO and defaults to ZERO.

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -953,9 +953,9 @@ private:
 
     // Fraction of the half-span the slice may occupy before the NCO re-centres.
     // 0.8 leaves the outer 20% of each side for filter roll-off.
-    // Slice AGC threshold (0..100) -> WDSP gain ceiling in dB. 0.6 spans
-    // 0..60 dB; see the measurement in setSliceAgc().
-    static constexpr double kAgcCeilingDbPerUnit = 0.6;
+    // Slice AGC threshold (0..100) -> WDSP gain ceiling in dB lives on
+    // Hl2DbReference now (kAgcCeilingDbPerUnit / agcCeilingDbForThreshold) —
+    // one object owns the whole signal-reference chain. See setSliceAgc().
     static constexpr double kUsablePassbandFraction = 0.8;
     // Ceiling on host-mixed slice audio. N demodulated receivers are summed
     // here, so N loud slices can sum past full scale where one never could.

--- a/src/core/backends/hl2/Hl2DbReference.h
+++ b/src/core/backends/hl2/Hl2DbReference.h
@@ -40,10 +40,32 @@ namespace AetherSDR::hl2 {
 // -120 to about -140, because the default LNA gain is 20 dB. Neither number is
 // calibrated, so that shift bought nothing and would have looked to the
 // operator exactly like the regression this class exists to prevent.
+//
+// THE AGC THRESHOLD LIVES HERE TOO
+//
+// The operator's AGC-T (0..100 operator units) maps to WDSP's AGC gain ceiling
+// in dB by a single scale (kAgcCeilingDbPerUnit). That conversion was copied
+// into six call sites in Hl2Backend and is the same drift surface as the LNA
+// offset: all three numbers -- LNA gain, calibration offset, AGC ceiling --
+// describe one signal-reference chain from the antenna to the demodulator, so
+// they belong to one object with one conversion each. The LNA term is
+// radio-wide (one AD9866 behind every DDC), so the shared instance carries the
+// live value; the AGC-T value is per-receiver, so agcCeilingDbForThreshold()
+// is also exposed as a pure static for the per-receiver call sites.
 class Hl2DbReference {
 public:
     // Matches Hl2Backend/MetisClient's default LNA setting.
     static constexpr double kDefaultLnaGainDb = 20.0;
+
+    // Operator AGC-T units (0..100) -> WDSP AGC gain ceiling in dB. 0.6 dB per
+    // unit puts the slice model's default of 65 at 39 dB, measured clean on
+    // live hardware (Hl2RxDsp::Config::maximumAgcGainDb).
+    static constexpr double kAgcCeilingDbPerUnit = 0.6;
+    [[nodiscard]] static constexpr double agcCeilingDbForThreshold(
+        int operatorUnits) noexcept
+    {
+        return operatorUnits * kAgcCeilingDbPerUnit;
+    }
 
     // Gain we commanded on the AD9866 LNA, in dB.
     void setLnaGainDb(double db) noexcept { m_lnaGainDb = db; }
@@ -62,6 +84,23 @@ public:
     void setReferenceLnaGainDb(double db) noexcept { m_referenceLnaGainDb = db; }
     double referenceLnaGainDb() const noexcept { return m_referenceLnaGainDb; }
 
+    // The last operator-set AGC-T, in 0..100 units. The shared instance tracks
+    // it (HERMES.md §5 "flat memory" — one remembered pair) so the full
+    // signal-reference triplet is queryable from one place; per-receiver call
+    // sites that need a specific receiver's ceiling use the static above.
+    void setAgcThresholdOperatorUnits(int units) noexcept
+    {
+        m_agcThresholdOperatorUnits = units;
+    }
+    int agcThresholdOperatorUnits() const noexcept
+    {
+        return m_agcThresholdOperatorUnits;
+    }
+    double agcCeilingDb() const noexcept
+    {
+        return agcCeilingDbForThreshold(m_agcThresholdOperatorUnits);
+    }
+
     // The whole point: subtracting the gain we applied is what keeps a signal
     // of constant strength reading the same dBm across a gain change.
     double toDbm(double dbfs) const noexcept
@@ -79,6 +118,7 @@ private:
     double m_lnaGainDb = kDefaultLnaGainDb;
     double m_referenceLnaGainDb = kDefaultLnaGainDb;
     double m_fullScaleDbm = 0.0;
+    int m_agcThresholdOperatorUnits = 65;   // slice model's default
 };
 
 }  // namespace AetherSDR::hl2

--- a/src/core/backends/hl2/Hl2DbReference.h
+++ b/src/core/backends/hl2/Hl2DbReference.h
@@ -41,17 +41,14 @@ namespace AetherSDR::hl2 {
 // calibrated, so that shift bought nothing and would have looked to the
 // operator exactly like the regression this class exists to prevent.
 //
-// THE AGC THRESHOLD LIVES HERE TOO
+// THE AGC-CEILING CONVERSION LIVES HERE TOO
 //
 // The operator's AGC-T (0..100 operator units) maps to WDSP's AGC gain ceiling
 // in dB by a single scale (kAgcCeilingDbPerUnit). That conversion was copied
-// into six call sites in Hl2Backend and is the same drift surface as the LNA
-// offset: all three numbers -- LNA gain, calibration offset, AGC ceiling --
-// describe one signal-reference chain from the antenna to the demodulator, so
-// they belong to one object with one conversion each. The LNA term is
-// radio-wide (one AD9866 behind every DDC), so the shared instance carries the
-// live value; the AGC-T value is per-receiver, so agcCeilingDbForThreshold()
-// is also exposed as a pure static for the per-receiver call sites.
+// into six call sites in Hl2Backend -- the same drift surface as the LNA
+// offset, and part of the same antenna->demodulator signal-reference chain, so
+// it belongs here. It is a PURE STATIC: the AGC-T value itself is per-receiver
+// state that stays on Hl2Backend::Receiver; this object only owns the maths.
 class Hl2DbReference {
 public:
     // Matches Hl2Backend/MetisClient's default LNA setting.
@@ -84,23 +81,6 @@ public:
     void setReferenceLnaGainDb(double db) noexcept { m_referenceLnaGainDb = db; }
     double referenceLnaGainDb() const noexcept { return m_referenceLnaGainDb; }
 
-    // The last operator-set AGC-T, in 0..100 units. The shared instance tracks
-    // it (HERMES.md §5 "flat memory" — one remembered pair) so the full
-    // signal-reference triplet is queryable from one place; per-receiver call
-    // sites that need a specific receiver's ceiling use the static above.
-    void setAgcThresholdOperatorUnits(int units) noexcept
-    {
-        m_agcThresholdOperatorUnits = units;
-    }
-    int agcThresholdOperatorUnits() const noexcept
-    {
-        return m_agcThresholdOperatorUnits;
-    }
-    double agcCeilingDb() const noexcept
-    {
-        return agcCeilingDbForThreshold(m_agcThresholdOperatorUnits);
-    }
-
     // The whole point: subtracting the gain we applied is what keeps a signal
     // of constant strength reading the same dBm across a gain change.
     double toDbm(double dbfs) const noexcept
@@ -118,7 +98,6 @@ private:
     double m_lnaGainDb = kDefaultLnaGainDb;
     double m_referenceLnaGainDb = kDefaultLnaGainDb;
     double m_fullScaleDbm = 0.0;
-    int m_agcThresholdOperatorUnits = 65;   // slice model's default
 };
 
 }  // namespace AetherSDR::hl2

--- a/tests/hl2_dbref_test.cpp
+++ b/tests/hl2_dbref_test.cpp
@@ -62,6 +62,30 @@ int main()
     check(near(-13.0 + ref.offsetDb(), ref.toDbm(-13.0)),
           "offsetDb() and toDbm() agree (spectrum vs S-meter)");
 
+    // The AGC threshold conversion now lives on this object (Plan 4.4): one
+    // scale, one place, instead of `x * 0.6` copied into six Hl2Backend sites.
+    check(near(Hl2DbReference::agcCeilingDbForThreshold(65), 39.0),
+          "AGC-T 65 -> 39 dB ceiling (the slice model's default, measured on hardware)");
+    check(near(Hl2DbReference::agcCeilingDbForThreshold(0), 0.0),
+          "AGC-T 0 -> 0 dB");
+    check(near(Hl2DbReference::agcCeilingDbForThreshold(100), 60.0),
+          "AGC-T 100 -> 60 dB");
+
+    // The shared instance tracks the last operator-set threshold, so the full
+    // reference triplet (LNA gain, calibration offset, AGC ceiling) is
+    // readable from one object.
+    check(ref.agcThresholdOperatorUnits() == 65 && near(ref.agcCeilingDb(), 39.0),
+          "the object defaults to the slice-model threshold");
+    ref.setAgcThresholdOperatorUnits(40);
+    check(ref.agcThresholdOperatorUnits() == 40 && near(ref.agcCeilingDb(), 24.0),
+          "setAgcThresholdOperatorUnits() moves agcCeilingDb() with it");
+    // An AGC-T change does NOT touch the LNA offset — the two ends of the
+    // chain are independent values in one object, not a coupled pair.
+    const double offBefore = ref.offsetDb();
+    ref.setAgcThresholdOperatorUnits(90);
+    check(near(ref.offsetDb(), offBefore),
+          "changing the AGC threshold leaves the display offset untouched");
+
     if (g_failures == 0)
         std::fprintf(stderr, "hl2_dbref_test: all checks passed\n");
     return g_failures == 0 ? 0 : 1;

--- a/tests/hl2_dbref_test.cpp
+++ b/tests/hl2_dbref_test.cpp
@@ -62,29 +62,16 @@ int main()
     check(near(-13.0 + ref.offsetDb(), ref.toDbm(-13.0)),
           "offsetDb() and toDbm() agree (spectrum vs S-meter)");
 
-    // The AGC threshold conversion now lives on this object (Plan 4.4): one
-    // scale, one place, instead of `x * 0.6` copied into six Hl2Backend sites.
+    // The AGC-ceiling conversion now lives on this object as a pure static
+    // (Plan 4.4): one scale, one place, instead of `x * 0.6` copied into six
+    // Hl2Backend sites. The AGC-T value itself stays per-receiver on
+    // Hl2Backend::Receiver — this is just the maths.
     check(near(Hl2DbReference::agcCeilingDbForThreshold(65), 39.0),
           "AGC-T 65 -> 39 dB ceiling (the slice model's default, measured on hardware)");
     check(near(Hl2DbReference::agcCeilingDbForThreshold(0), 0.0),
           "AGC-T 0 -> 0 dB");
     check(near(Hl2DbReference::agcCeilingDbForThreshold(100), 60.0),
           "AGC-T 100 -> 60 dB");
-
-    // The shared instance tracks the last operator-set threshold, so the full
-    // reference triplet (LNA gain, calibration offset, AGC ceiling) is
-    // readable from one object.
-    check(ref.agcThresholdOperatorUnits() == 65 && near(ref.agcCeilingDb(), 39.0),
-          "the object defaults to the slice-model threshold");
-    ref.setAgcThresholdOperatorUnits(40);
-    check(ref.agcThresholdOperatorUnits() == 40 && near(ref.agcCeilingDb(), 24.0),
-          "setAgcThresholdOperatorUnits() moves agcCeilingDb() with it");
-    // An AGC-T change does NOT touch the LNA offset — the two ends of the
-    // chain are independent values in one object, not a coupled pair.
-    const double offBefore = ref.offsetDb();
-    ref.setAgcThresholdOperatorUnits(90);
-    check(near(ref.offsetDb(), offBefore),
-          "changing the AGC threshold leaves the display offset untouched");
 
     if (g_failures == 0)
         std::fprintf(stderr, "hl2_dbref_test: all checks passed\n");


### PR DESCRIPTION
## Summary

HERMES.md §13 T2-12 / §11.5: LNA gain, calibration offset and AGC ceiling all describe one signal-reference chain from the antenna to the demodulator, and each should have one conversion in one place. The LNA offset already lived on `Hl2DbReference`; the operator-AGC-T → WDSP-ceiling scale (`x * 0.6`) was copied into six `Hl2Backend` call sites with the constant duplicated on `Hl2Backend` itself.

This adds `Hl2DbReference::kAgcCeilingDbPerUnit` + a pure static `agcCeilingDbForThreshold(operatorUnits)` that all six sites now call.

A second commit removes instance state (`m_agcThresholdOperatorUnits` + three accessors) that a follow-up code review found had no production reader — the real call sites all use the pure static directly, since the AGC-T value itself is per-Receiver state that already lives on `Hl2Backend::Receiver`. Keeping the PR at this state (post-cleanup) rather than the class's original intermediate shape.

This is split out of #5462 per the maintainer review there (item #4 of the suggested break-up — "pure consolidation with a clear correctness story"). Scope note: the LNA term stays radio-wide (one AD9866 behind every DDC — `Hl2Backend`'s existing comment argues this deliberately), so this is consolidation of the *conversion*, not a per-receiver relocation of the whole object; the AGC-T *value* remains per-Receiver.

The original fork commit that did this cleanup (`a727666e`) also touched `Hl2RxDsp.cpp`/`WdspChannel.*`/`hl2_notch_seed_test.cpp` for an unrelated concern (the notch-gated FIR length latency fix) — that half is intentionally left out of this PR; it belongs with the item #5 split from the same review.

## Constitution principle honored

Principle VIII (one conversion, one place, for a value multiple call sites derive independently) — cited in the original HERMES.md write-up this consolidates.

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR`)
- [x] Behavior verified on a real radio if applicable — no behavior change; pure refactor of an existing, hardware-verified conversion (`AGC-T 65 -> 39 dB` matches the slice model's measured default)
- [x] Existing tests pass (CI) — `tests/hl2_dbref_test.cpp`: AGC-T 0/65/100 → 0/39/60 dB via the pure static; `hl2_dbref_test` run locally, all checks pass
- [x] Reproduction steps documented — n/a, refactor with no behavior change

## Checklist

- [x] Commits are signed
- [x] No new flat-key `AppSettings` calls
- [x] Code is clean-room
- [x] All meter UI uses `MeterSmoother` — n/a
- [x] Documentation updated if user-visible behavior changed — n/a, no user-visible change
- [ ] Security-sensitive changes reference a GHSA if applicable — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)