### PR TITLE
feat(hl2): authoritative mode list — real RTTY/DFM, refuse unlisted modes

### DIFF
--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <limits>
 
+#include "core/backends/hl2/Hl2ModeTable.h"
 #include "core/backends/hl2/Hl2RxDsp.h"
 #include "core/backends/hl2/Hl2TxDsp.h"
 #include "core/backends/hl2/Hl2BandMemoryPolicy.h"
@@ -188,46 +189,10 @@ int wdspAgcMode(const QString& mode) noexcept
     return 3;                                  // medium: WDSP's own default
 }
 
-WdspChannel::Mode modeFromString(const QString& mode) noexcept
-{
-    const QString u = mode.toUpper();
-    if (u == QLatin1String("LSB"))  return WdspChannel::Mode::Lsb;
-    if (u == QLatin1String("USB"))  return WdspChannel::Mode::Usb;
-    if (u == QLatin1String("DSB"))  return WdspChannel::Mode::Dsb;
-    if (u == QLatin1String("CWL"))  return WdspChannel::Mode::Cwl;
-    // "CW" is the upper-sideband CW mode name the rest of the app uses (it is
-    // what TciProtocol::tciToSmartSDR produces for TCI's `cw`, and what a Flex
-    // reports); "CWU" is the explicit spelling. Only CWU was listed, so plain CW
-    // fell through to the USB fallback below and was demodulated as SSB -- the
-    // mode indicator read CW while the passband and detector were not.
-    if (u == QLatin1String("CWU") || u == QLatin1String("CW"))
-        return WdspChannel::Mode::Cwu;
-    if (u == QLatin1String("FM") || u == QLatin1String("NFM"))
-        return WdspChannel::Mode::Fm;
-    if (u == QLatin1String("AM"))   return WdspChannel::Mode::Am;
-    if (u == QLatin1String("DIGU")) return WdspChannel::Mode::Digu;
-    if (u == QLatin1String("DIGL")) return WdspChannel::Mode::Digl;
-    if (u == QLatin1String("SAM"))  return WdspChannel::Mode::Sam;
-    if (u == QLatin1String("DRM"))  return WdspChannel::Mode::Drm;
-    if (u == QLatin1String("WBFM") || u == QLatin1String("WFM")) return WdspChannel::Mode::Wbfm;
-    return WdspChannel::Mode::Usb;
-}
-
-// Is `mode` a name modeFromString() genuinely maps (rather than falling back
-// to USB)? The restore boundary uses this so a corrupt document's mode string
-// is dropped instead of reaching Receiver::mode, the UI, and — via capture —
-// re-persisting itself (PR #4619 review, Ozy311).
-bool isKnownModeString(const QString& mode) noexcept
-{
-    static const QStringList kKnown = {
-        QStringLiteral("LSB"), QStringLiteral("USB"), QStringLiteral("DSB"),
-        QStringLiteral("CWL"), QStringLiteral("CWU"), QStringLiteral("CW"),
-        QStringLiteral("FM"),  QStringLiteral("NFM"), QStringLiteral("AM"),
-        QStringLiteral("DIGU"), QStringLiteral("DIGL"), QStringLiteral("SAM"),
-        QStringLiteral("DRM"), QStringLiteral("WBFM"), QStringLiteral("WFM"),
-    };
-    return kKnown.contains(mode.toUpper());
-}
+// modeFromString(), isKnownModeString(), wdspModeName() and
+// defaultPassbandForMode() now live in Hl2ModeTable.h so they are unit-testable
+// without a connected backend (tests/hl2_mode_table_test.cpp). Brought into this
+// TU's scope by the header's `using` below.
 
 // The same question for the AGC vocabulary, and it needs asking for the same
 // reason: wdspAgcMode() FALLS BACK to medium for anything it does not
@@ -244,50 +209,6 @@ bool isKnownAgcModeString(const QString& mode) noexcept
     const QString m = mode.trimmed().toLower();
     return m == QLatin1String("off") || m == QLatin1String("slow")
            || m == QLatin1String("med") || m == QLatin1String("fast");
-}
-
-// Default RX passband per mode, in Hz relative to the carrier. Sign carries the
-// sideband, matching SliceModel's convention (USB-family positive, LSB-family
-// negative, carrier-straddling modes symmetric) -- a table with the wrong sign
-// here would be silently "corrected" by SliceModel::normalizeFilterPolarity and
-// the mistake would never surface.
-//
-// The digital entries are deliberately the widest of the set. DIGU is the mode
-// WSJT-X selects, and it must pass the whole 3 kHz audio window the decoder
-// expects; a snug SSB passband would clip the top of the FT8 sub-band and drop
-// exactly the signals at the edges.
-std::pair<int, int> defaultPassbandForMode(const QString& mode) noexcept
-{
-    const QString u = mode.toUpper();
-    if (u == QLatin1String("USB"))  return {100, 2900};
-    if (u == QLatin1String("LSB"))  return {-2900, -100};
-    if (u == QLatin1String("DIGU")) return {150, 3000};
-    if (u == QLatin1String("DIGL")) return {-3000, -150};
-    // CW: 500 Hz CENTRED ON THE CARRIER, both sidebands, because in CW the
-    // operator-facing passband is measured from the signal and not from the
-    // audio it becomes. The pitch offset lives in the BFO (cwBfoHz) instead —
-    // see the note there — so CWU and CWL share one table entry and differ only
-    // in which way the BFO leans.
-    //
-    // This is the convention the rest of the app already assumes:
-    // VfoWidget::applyFilterPreset builds every CW preset as {-w/2, +w/2}
-    // ("centred on carrier — radio's BFO handles pitch offset"), and a Flex
-    // reports CW cuts the same way (FlexLib Slice.cs clamps them to
-    // ±12000 - CWPitch, which only makes sense for cuts measured from the
-    // carrier). Returning {350, 850} here put the passband skirt a whole pitch
-    // to the RIGHT of the marker on the panadapter and, worse, meant the
-    // gateware transmitted a CW carrier at the marker while the receiver
-    // listened 600 Hz above it.
-    if (u == QLatin1String("CWU") || u == QLatin1String("CW")
-        || u == QLatin1String("CWL")) return {-250, 250};
-    // Carrier-straddling modes: symmetric about the carrier, which the envelope
-    // and synchronous detectors both need.
-    if (u == QLatin1String("AM") || u == QLatin1String("SAM")) return {-4000, 4000};
-    if (u == QLatin1String("DSB")) return {-3000, 3000};
-    if (u == QLatin1String("FM") || u == QLatin1String("NFM")) return {-8000, 8000};
-    if (u == QLatin1String("WBFM") || u == QLatin1String("WFM")) return {-40000, 40000};
-    if (u == QLatin1String("DRM")) return {-5000, 5000};
-    return {150, 3000};   // matches modeFromString's USB fallback
 }
 
 // The CW BFO offset for `mode`, in Hz of audio: where a signal sitting exactly
@@ -5652,6 +5573,12 @@ void Hl2Backend::emitSliceState(int ddc)
     d.panId = ids->panId;
     d.frequency = r->sliceFreqHz / 1.0e6;   // MHz
     d.mode = r->mode;
+    // The backend is authoritative about which modes it supports (Plan 2): the
+    // VFO combo shows exactly this list instead of the Flex fallback set, so no
+    // mode can be selected that silently demodulates as something else, and
+    // D-STAR / DRM / FreeDV — which need a decoder or an audio path this raw-IQ
+    // backend does not have — are simply not offered.
+    d.modeList = hl2SupportedModes();
     d.filterLow = r->filterLowHz;
     d.filterHigh = r->filterHighHz;
     d.audioGain = qRound(r->audioGain * 100.0f);

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -191,8 +191,9 @@ int wdspAgcMode(const QString& mode) noexcept
 
 // modeFromString(), isKnownModeString(), wdspModeName() and
 // defaultPassbandForMode() now live in Hl2ModeTable.h so they are unit-testable
-// without a connected backend (tests/hl2_mode_table_test.cpp). Brought into this
-// TU's scope by the header's `using` below.
+// without a connected backend (tests/hl2_mode_table_test.cpp). This TU is inside
+// namespace AetherSDR::hl2, so the calls below resolve to the header's versions
+// with no `using`.
 
 // The same question for the AGC vocabulary, and it needs asking for the same
 // reason: wdspAgcMode() FALLS BACK to medium for anything it does not
@@ -5578,7 +5579,7 @@ void Hl2Backend::emitSliceState(int ddc)
     // mode can be selected that silently demodulates as something else, and
     // D-STAR / DRM / FreeDV — which need a decoder or an audio path this raw-IQ
     // backend does not have — are simply not offered.
-    d.modeList = hl2SupportedModes();
+    d.modeList = supportedModes();
     d.filterLow = r->filterLowHz;
     d.filterHigh = r->filterHighHz;
     d.audioGain = qRound(r->audioGain * 100.0f);

--- a/src/core/backends/hl2/Hl2ModeTable.h
+++ b/src/core/backends/hl2/Hl2ModeTable.h
@@ -23,10 +23,11 @@
 namespace AetherSDR::hl2 {
 
 // The set of modes the HL2 backend genuinely supports, published on every
-// SliceDelta so the VFO combo shows exactly these (no silent fall-through, and
-// no D-STAR / DRM / FreeDV entries the raw-IQ path cannot honour). "CW" is the
-// app-wide name for upper-sideband CW; CWL still works if sent explicitly.
-inline const QStringList& hl2SupportedModes()
+// SliceDelta so the VFO combo shows exactly these -- no silent fall-through,
+// and no D-STAR / DRM / FreeDV entries the raw-IQ path cannot honour (no AMBE
+// vocoder, no DRM decoder, no bus-B audio tap yet). "CW" is the app-wide name
+// for upper-sideband CW; CWL still works if sent explicitly.
+inline const QStringList& supportedModes()
 {
     static const QStringList kModes = {
         QStringLiteral("USB"),  QStringLiteral("LSB"),  QStringLiteral("CW"),
@@ -67,10 +68,14 @@ inline WdspChannel::Mode modeFromString(const QString& mode) noexcept
     if (u == QLatin1String("DIGL")) return WdspChannel::Mode::Digl;
     // RTTY: a narrow USB slice. The Baudot decode is client-side
     // (RttyDecoder, on rxDemodAudioReady), so WDSP just needs to hand it clean
-    // audio around the decoder's mark/space tones — see defaultPassbandForMode.
-    if (u == QLatin1String("RTTY")) return WdspChannel::Mode::Usb;
+    // audio around the decoder's mark/space tones -- see defaultPassbandForMode.
+    if (u == QLatin1String("RTTY")) {
+        return WdspChannel::Mode::Usb;
+    }
     if (u == QLatin1String("SAM"))  return WdspChannel::Mode::Sam;
-    if (u == QLatin1String("DRM"))  return WdspChannel::Mode::Drm;
+    // No DRM entry: WDSP's DRM mode only sets the demod up for an EXTERNAL DRM
+    // decoder, and there is none in the tree. It is not advertised and maps to
+    // the USB fallback if forced, rather than to a mode with nothing behind it.
     if (u == QLatin1String("WBFM") || u == QLatin1String("WFM")) {
         return WdspChannel::Mode::Wbfm;
     }
@@ -80,18 +85,20 @@ inline WdspChannel::Mode modeFromString(const QString& mode) noexcept
 // Is `mode` a name modeFromString() genuinely maps (rather than falling back to
 // USB)? The restore boundary uses this so a corrupt document's mode string is
 // dropped instead of reaching Receiver::mode, the UI, and -- via capture --
-// re-persisting itself (PR #4619 review, Ozy311).
+// re-persisting itself (PR #4619 review, Ozy311). It is the advertised set plus
+// the alias/legacy spellings modeFromString() also accepts but the combo does
+// not feature (explicit CW sidebands, double-sideband, wideband FM). No DRM:
+// there is no decoder, so a restored "DRM" is dropped like any other mode this
+// backend cannot honour.
 inline bool isKnownModeString(const QString& mode) noexcept
 {
-    static const QStringList kKnown = {
-        QStringLiteral("LSB"),  QStringLiteral("USB"),  QStringLiteral("DSB"),
-        QStringLiteral("CWL"),  QStringLiteral("CWU"),  QStringLiteral("CW"),
-        QStringLiteral("FM"),   QStringLiteral("NFM"),  QStringLiteral("DFM"),
-        QStringLiteral("AM"),   QStringLiteral("DIGU"), QStringLiteral("DIGL"),
-        QStringLiteral("RTTY"), QStringLiteral("SAM"),  QStringLiteral("DRM"),
+    static const QStringList kLegacySpellings = {
+        QStringLiteral("CWU"),  QStringLiteral("CWL"), QStringLiteral("DSB"),
         QStringLiteral("WBFM"), QStringLiteral("WFM"),
     };
-    return kKnown.contains(mode.toUpper());
+    const QString u = mode.toUpper();
+    return supportedModes().contains(u, Qt::CaseInsensitive)
+           || kLegacySpellings.contains(u);
 }
 
 // WdspChannel::Mode -> canonical name, for the `dsp.get` readback. The inverse
@@ -135,10 +142,12 @@ inline std::pair<int, int> defaultPassbandForMode(const QString& mode) noexcept
     if (u == QLatin1String("DIGU")) return {150, 3000};
     if (u == QLatin1String("DIGL")) return {-3000, -150};
     // RTTY: a narrow USB window over RttyDecoder's default mark (2125 Hz) and
-    // 170 Hz shift, wide enough for either polarity (space at 1955 or 2295) plus
-    // filter skirt. Narrow so an adjacent RTTY signal 300 Hz away does not bleed
-    // into the mark/space discriminator.
-    if (u == QLatin1String("RTTY")) return {1900, 2400};
+    // 170 Hz shift. 400 Hz spans the mark plus space in EITHER polarity (space
+    // at 1955 normal-reverse or 2295 normal) with a little filter skirt, and no
+    // more -- an adjacent RTTY signal a few hundred Hz off must not bleed into
+    // the mark/space discriminator. Wider than the shift itself (170 Hz) but far
+    // tighter than an SSB voice passband.
+    if (u == QLatin1String("RTTY")) return {1950, 2350};
     // CW: 500 Hz CENTRED ON THE CARRIER, both sidebands, because in CW the
     // operator-facing passband is measured from the signal and not from the
     // audio it becomes. The pitch offset lives in the BFO (cwBfoHz) instead --
@@ -161,7 +170,6 @@ inline std::pair<int, int> defaultPassbandForMode(const QString& mode) noexcept
     if (u == QLatin1String("FM") || u == QLatin1String("NFM")
         || u == QLatin1String("DFM")) return {-8000, 8000};
     if (u == QLatin1String("WBFM") || u == QLatin1String("WFM")) return {-40000, 40000};
-    if (u == QLatin1String("DRM")) return {-5000, 5000};
     return {150, 3000};   // matches modeFromString's USB fallback
 }
 

--- a/src/core/backends/hl2/Hl2ModeTable.h
+++ b/src/core/backends/hl2/Hl2ModeTable.h
@@ -1,0 +1,168 @@
+#pragma once
+
+#include <QLatin1String>
+#include <QString>
+#include <QStringList>
+
+#include <utility>
+
+#include "core/dsp/WdspChannel.h"
+
+// The HL2 RX mode table: operator mode string -> WDSP demod mode + default
+// passband, plus the restore-boundary guard and the inverse name map. Pulled
+// out of Hl2Backend.cpp's anon namespace so it is directly unit-testable
+// (tests/hl2_mode_table_test.cpp) without a connected-backend fixture.
+//
+// Plan 2: RTTY and DFM stop falling through to a plain USB passband. RTTY is a
+// filtered-SSB slice feeding the client-side RttyDecoder (its FSK front end
+// runs downstream on rxDemodAudioReady), so it demodulates as USB but with a
+// narrow passband centred on the decoder's mark/shift. DFM (FM data) is FM with
+// an FM-width passband — the wrong-demod SSB fallback made an FM-data signal
+// unlistenable and undecodable.
+
+namespace AetherSDR::hl2 {
+
+// The set of modes the HL2 backend genuinely supports, published on every
+// SliceDelta so the VFO combo shows exactly these (no silent fall-through, and
+// no D-STAR / DRM / FreeDV entries the raw-IQ path cannot honour). "CW" is the
+// app-wide name for upper-sideband CW; CWL still works if sent explicitly.
+inline const QStringList& hl2SupportedModes()
+{
+    static const QStringList kModes = {
+        QStringLiteral("USB"),  QStringLiteral("LSB"),  QStringLiteral("CW"),
+        QStringLiteral("AM"),   QStringLiteral("SAM"),  QStringLiteral("FM"),
+        QStringLiteral("NFM"),  QStringLiteral("DIGU"), QStringLiteral("DIGL"),
+        QStringLiteral("RTTY"), QStringLiteral("DFM"),
+    };
+    return kModes;
+}
+
+inline WdspChannel::Mode modeFromString(const QString& mode) noexcept
+{
+    const QString u = mode.toUpper();
+    if (u == QLatin1String("LSB"))  return WdspChannel::Mode::Lsb;
+    if (u == QLatin1String("USB"))  return WdspChannel::Mode::Usb;
+    if (u == QLatin1String("DSB"))  return WdspChannel::Mode::Dsb;
+    if (u == QLatin1String("CWL"))  return WdspChannel::Mode::Cwl;
+    // "CW" is the upper-sideband CW mode name the rest of the app uses (it is
+    // what TciProtocol::tciToSmartSDR produces for TCI's `cw`, and what a Flex
+    // reports); "CWU" is the explicit spelling. Only CWU was listed, so plain CW
+    // fell through to the USB fallback below and was demodulated as SSB -- the
+    // mode indicator read CW while the passband and detector were not.
+    if (u == QLatin1String("CWU") || u == QLatin1String("CW")) {
+        return WdspChannel::Mode::Cwu;
+    }
+    if (u == QLatin1String("FM") || u == QLatin1String("NFM")) {
+        return WdspChannel::Mode::Fm;
+    }
+    // DFM (FM data): FM demod, differing from NFM only in that program material
+    // is data and wants the passband flat. This backend has no de-emphasis
+    // toggle, so DFM demodulates identically to FM here — but that is FM, not
+    // the SSB the USB fallback used to give an FM-data signal.
+    if (u == QLatin1String("DFM")) {
+        return WdspChannel::Mode::Fm;
+    }
+    if (u == QLatin1String("AM"))   return WdspChannel::Mode::Am;
+    if (u == QLatin1String("DIGU")) return WdspChannel::Mode::Digu;
+    if (u == QLatin1String("DIGL")) return WdspChannel::Mode::Digl;
+    // RTTY: a narrow USB slice. The Baudot decode is client-side
+    // (RttyDecoder, on rxDemodAudioReady), so WDSP just needs to hand it clean
+    // audio around the decoder's mark/space tones — see defaultPassbandForMode.
+    if (u == QLatin1String("RTTY")) return WdspChannel::Mode::Usb;
+    if (u == QLatin1String("SAM"))  return WdspChannel::Mode::Sam;
+    if (u == QLatin1String("DRM"))  return WdspChannel::Mode::Drm;
+    if (u == QLatin1String("WBFM") || u == QLatin1String("WFM")) {
+        return WdspChannel::Mode::Wbfm;
+    }
+    return WdspChannel::Mode::Usb;
+}
+
+// Is `mode` a name modeFromString() genuinely maps (rather than falling back to
+// USB)? The restore boundary uses this so a corrupt document's mode string is
+// dropped instead of reaching Receiver::mode, the UI, and -- via capture --
+// re-persisting itself (PR #4619 review, Ozy311).
+inline bool isKnownModeString(const QString& mode) noexcept
+{
+    static const QStringList kKnown = {
+        QStringLiteral("LSB"),  QStringLiteral("USB"),  QStringLiteral("DSB"),
+        QStringLiteral("CWL"),  QStringLiteral("CWU"),  QStringLiteral("CW"),
+        QStringLiteral("FM"),   QStringLiteral("NFM"),  QStringLiteral("DFM"),
+        QStringLiteral("AM"),   QStringLiteral("DIGU"), QStringLiteral("DIGL"),
+        QStringLiteral("RTTY"), QStringLiteral("SAM"),  QStringLiteral("DRM"),
+        QStringLiteral("WBFM"), QStringLiteral("WFM"),
+    };
+    return kKnown.contains(mode.toUpper());
+}
+
+// WdspChannel::Mode -> canonical name, for the `dsp.get` readback. The inverse
+// of modeFromString() for the values it maps 1:1; the two CW and the two FM
+// spellings collapse to one name each, matching what the rest of the app uses.
+inline QString wdspModeName(WdspChannel::Mode mode) noexcept
+{
+    switch (mode) {
+    case WdspChannel::Mode::Lsb:  return QStringLiteral("LSB");
+    case WdspChannel::Mode::Usb:  return QStringLiteral("USB");
+    case WdspChannel::Mode::Dsb:  return QStringLiteral("DSB");
+    case WdspChannel::Mode::Cwl:  return QStringLiteral("CWL");
+    case WdspChannel::Mode::Cwu:  return QStringLiteral("CWU");
+    case WdspChannel::Mode::Fm:   return QStringLiteral("FM");
+    case WdspChannel::Mode::Am:   return QStringLiteral("AM");
+    case WdspChannel::Mode::Digu: return QStringLiteral("DIGU");
+    case WdspChannel::Mode::Spec: return QStringLiteral("SPEC");
+    case WdspChannel::Mode::Digl: return QStringLiteral("DIGL");
+    case WdspChannel::Mode::Sam:  return QStringLiteral("SAM");
+    case WdspChannel::Mode::Drm:  return QStringLiteral("DRM");
+    case WdspChannel::Mode::Wbfm: return QStringLiteral("WBFM");
+    }
+    return QStringLiteral("USB");
+}
+
+// Default RX passband per mode, in Hz relative to the carrier. Sign carries the
+// sideband, matching SliceModel's convention (USB-family positive, LSB-family
+// negative, carrier-straddling modes symmetric) -- a table with the wrong sign
+// here would be silently "corrected" by SliceModel::normalizeFilterPolarity and
+// the mistake would never surface.
+//
+// The digital entries are deliberately the widest of the set. DIGU is the mode
+// WSJT-X selects, and it must pass the whole 3 kHz audio window the decoder
+// expects; a snug SSB passband would clip the top of the FT8 sub-band and drop
+// exactly the signals at the edges.
+inline std::pair<int, int> defaultPassbandForMode(const QString& mode) noexcept
+{
+    const QString u = mode.toUpper();
+    if (u == QLatin1String("USB"))  return {100, 2900};
+    if (u == QLatin1String("LSB"))  return {-2900, -100};
+    if (u == QLatin1String("DIGU")) return {150, 3000};
+    if (u == QLatin1String("DIGL")) return {-3000, -150};
+    // RTTY: a narrow USB window over RttyDecoder's default mark (2125 Hz) and
+    // 170 Hz shift, wide enough for either polarity (space at 1955 or 2295) plus
+    // filter skirt. Narrow so an adjacent RTTY signal 300 Hz away does not bleed
+    // into the mark/space discriminator.
+    if (u == QLatin1String("RTTY")) return {1900, 2400};
+    // CW: 500 Hz CENTRED ON THE CARRIER, both sidebands, because in CW the
+    // operator-facing passband is measured from the signal and not from the
+    // audio it becomes. The pitch offset lives in the BFO (cwBfoHz) instead --
+    // see the note there -- so CWU and CWL share one table entry and differ only
+    // in which way the BFO leans.
+    //
+    // This is the convention the rest of the app already assumes:
+    // VfoWidget::applyFilterPreset builds every CW preset as {-w/2, +w/2}
+    // ("centred on carrier -- radio's BFO handles pitch offset"), and a Flex
+    // reports CW cuts the same way (FlexLib Slice.cs clamps them to
+    // +/-12000 - CWPitch, which only makes sense for cuts measured from the
+    // carrier).
+    if (u == QLatin1String("CWU") || u == QLatin1String("CW")
+        || u == QLatin1String("CWL")) return {-250, 250};
+    // Carrier-straddling modes: symmetric about the carrier, which the envelope
+    // and synchronous detectors both need.
+    if (u == QLatin1String("AM") || u == QLatin1String("SAM")) return {-4000, 4000};
+    if (u == QLatin1String("DSB")) return {-3000, 3000};
+    // FM and DFM (FM data) both take the FM-width window here.
+    if (u == QLatin1String("FM") || u == QLatin1String("NFM")
+        || u == QLatin1String("DFM")) return {-8000, 8000};
+    if (u == QLatin1String("WBFM") || u == QLatin1String("WFM")) return {-40000, 40000};
+    if (u == QLatin1String("DRM")) return {-5000, 5000};
+    return {150, 3000};   // matches modeFromString's USB fallback
+}
+
+}  // namespace AetherSDR::hl2

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -143,6 +143,23 @@ void SliceModel::tuneAndRecenter(double mhz)
 
 void SliceModel::setMode(const QString& mode)
 {
+    // The backend is authoritative about its mode set — Flex and HL2 publish
+    // SliceDelta::modeList, and on a raw-IQ radio a mode the demodulator does
+    // not implement would silently come out as something else (Plan 2, "no
+    // silent fall-through"). Refuse an operator/CAT/rigctl/TCI request for a
+    // mode the radio does not offer. An empty list means "unconstrained"
+    // (Sim, or a radio still mid-handshake). Status application goes through
+    // applyDelta(), which assigns m_mode directly and never reaches here, so
+    // this cannot reject the radio's own restored state (Principle II).
+    if (!m_modeList.isEmpty()
+        && !m_modeList.contains(mode, Qt::CaseInsensitive)) {
+        qWarning().noquote()
+            << "SliceModel: mode" << mode
+            << "is not offered by this radio (" << m_modeList.join(QLatin1Char('/'))
+            << "); ignoring";
+        return;
+    }
+
     const std::optional<DigitalVoiceModeId> requestedMode =
         DigitalVoiceModeRegistry::modeForRadioMode(mode);
     if (m_mode == mode) {

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -149,7 +149,7 @@ void SliceModel::setMode(const QString& mode)
     // silent fall-through"). Refuse an operator/CAT/rigctl/TCI request for a
     // mode the radio does not offer. An empty list means "unconstrained"
     // (Sim, or a radio still mid-handshake). Status application goes through
-    // applyDelta(), which assigns m_mode directly and never reaches here, so
+    // applyChanges(), which assigns m_mode directly and never reaches here, so
     // this cannot reject the radio's own restored state (Principle II).
     if (!m_modeList.isEmpty()
         && !m_modeList.contains(mode, Qt::CaseInsensitive)) {

--- a/tests/hl2_mode_table_test.cpp
+++ b/tests/hl2_mode_table_test.cpp
@@ -1,0 +1,102 @@
+// The HL2 RX mode table (Plan 2). Pins the operator-mode-string -> WDSP-mode +
+// passband map, the restore-boundary guard, and the authoritative supported
+// list. Pure: no connected backend, no WDSP channel.
+//
+// The property that matters: NOTHING falls silently through to a plain USB
+// passband. Every mode the backend advertises resolves to a real demod + a
+// passband that is not the {150, 3000} USB fallback, and D-STAR / DRM / FreeDV
+// are not advertised at all.
+
+#include "core/backends/hl2/Hl2ModeTable.h"
+
+#include <cstdio>
+
+using namespace AetherSDR::hl2;
+using Mode = WdspChannel::Mode;
+
+namespace {
+
+int failures = 0;
+
+void check(bool ok, const char* what)
+{
+    std::printf("%s %s\n", ok ? "PASS" : "FAIL", what);
+    if (!ok) {
+        ++failures;
+    }
+}
+
+bool isUsbFallbackPassband(const QString& mode)
+{
+    const auto pb = defaultPassbandForMode(mode);
+    return pb.first == 150 && pb.second == 3000;
+}
+
+} // namespace
+
+int main()
+{
+    // --- the supported list is exactly the raw-IQ-honourable set ------------
+    const QStringList supported = hl2SupportedModes();
+    check(supported.contains("RTTY") && supported.contains("DFM"),
+          "RTTY and DFM are advertised");
+    check(!supported.contains("DSTR") && !supported.contains("DRM")
+              && !supported.contains("FDVU") && !supported.contains("FDVL")
+              && !supported.contains("FREEDV") && !supported.contains("RADE"),
+          "D-STAR / DRM / FreeDV / RADE are NOT advertised");
+    for (const QString& m : supported) {
+        check(isKnownModeString(m),
+              qUtf8Printable(QStringLiteral("advertised mode %1 is a known mode string").arg(m)));
+        // USB and DIGU legitimately share the {150,3000} shape; every other
+        // advertised mode must have carved out its own entry rather than hit
+        // the fallback line.
+        check(!isUsbFallbackPassband(m) || m == "USB" || m == "DIGU",
+              qUtf8Printable(QStringLiteral("advertised mode %1 has its own passband, not the USB fallback").arg(m)));
+    }
+
+    // --- RTTY: filtered USB slice, narrow window over the decoder tones -----
+    check(modeFromString("RTTY") == Mode::Usb,
+          "RTTY demodulates as USB (the Baudot decode is client-side)");
+    {
+        const auto pb = defaultPassbandForMode("RTTY");
+        check(pb.first == 1900 && pb.second == 2400,
+              "RTTY passband is the narrow 1900..2400 window, not USB's 150..3000");
+        check((pb.second - pb.first) < 700,
+              "RTTY passband is narrow enough to reject an adjacent signal");
+    }
+    check(isKnownModeString("RTTY"), "RTTY survives the restore boundary");
+
+    // --- DFM: FM demod, FM-width passband (was SSB fallback) ---------------
+    check(modeFromString("DFM") == Mode::Fm,
+          "DFM demodulates as FM, not SSB");
+    {
+        const auto pb = defaultPassbandForMode("DFM");
+        check(pb == defaultPassbandForMode("FM"),
+              "DFM shares FM's passband");
+        check(pb.first < 0 && pb.second > 0,
+              "DFM passband straddles the carrier like FM");
+    }
+    check(isKnownModeString("DFM"), "DFM survives the restore boundary");
+
+    // --- regression: the modes that already worked still map the same ------
+    check(modeFromString("USB") == Mode::Usb && modeFromString("LSB") == Mode::Lsb
+              && modeFromString("CW") == Mode::Cwu && modeFromString("CWL") == Mode::Cwl
+              && modeFromString("AM") == Mode::Am && modeFromString("SAM") == Mode::Sam
+              && modeFromString("FM") == Mode::Fm && modeFromString("NFM") == Mode::Fm
+              && modeFromString("DIGU") == Mode::Digu && modeFromString("DIGL") == Mode::Digl
+              && modeFromString("DSB") == Mode::Dsb && modeFromString("DRM") == Mode::Drm
+              && modeFromString("WFM") == Mode::Wbfm,
+          "the pre-Plan-2 mode map is unchanged");
+    check(modeFromString("NONSENSE") == Mode::Usb,
+          "an unknown mode still falls back to USB (the last resort)");
+    check(!isKnownModeString("NONSENSE"),
+          "an unknown mode is not a known mode string");
+
+    // --- wdspModeName round-trips for the 1:1 values -----------------------
+    check(wdspModeName(Mode::Usb) == "USB" && wdspModeName(Mode::Cwu) == "CWU"
+              && wdspModeName(Mode::Fm) == "FM" && wdspModeName(Mode::Digl) == "DIGL",
+          "wdspModeName maps the enum back to canonical names");
+
+    std::printf("%s\n", failures == 0 ? "ALL PASS" : "SOME FAILED");
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/hl2_mode_table_test.cpp
+++ b/tests/hl2_mode_table_test.cpp
@@ -37,7 +37,7 @@ bool isUsbFallbackPassband(const QString& mode)
 int main()
 {
     // --- the supported list is exactly the raw-IQ-honourable set ------------
-    const QStringList supported = hl2SupportedModes();
+    const QStringList supported = supportedModes();
     check(supported.contains("RTTY") && supported.contains("DFM"),
           "RTTY and DFM are advertised");
     check(!supported.contains("DSTR") && !supported.contains("DRM")
@@ -58,11 +58,20 @@ int main()
     check(modeFromString("RTTY") == Mode::Usb,
           "RTTY demodulates as USB (the Baudot decode is client-side)");
     {
+        // The contract (Plan 2.2): a narrow window around the decoder's default
+        // mark (2125 Hz) / 170 Hz shift, wide enough for either polarity
+        // (space at 1955 or 2295) and no wider -- distinctly tighter than an
+        // SSB voice passband, so an adjacent RTTY signal does not bleed in.
+        constexpr int kMark = 2125;
+        constexpr int kShift = 170;
         const auto pb = defaultPassbandForMode("RTTY");
-        check(pb.first == 1900 && pb.second == 2400,
-              "RTTY passband is the narrow 1900..2400 window, not USB's 150..3000");
-        check((pb.second - pb.first) < 700,
-              "RTTY passband is narrow enough to reject an adjacent signal");
+        const int width = pb.second - pb.first;
+        check(!isUsbFallbackPassband("RTTY"),
+              "RTTY has its own passband, not the USB fallback");
+        check(pb.first <= (kMark - kShift) && pb.second >= (kMark + kShift),
+              "RTTY passband covers both mark and space in either polarity");
+        check(width > kShift && width <= 450,
+              "RTTY passband is wider than the shift but far tighter than SSB");
     }
     check(isKnownModeString("RTTY"), "RTTY survives the restore boundary");
 
@@ -78,13 +87,20 @@ int main()
     }
     check(isKnownModeString("DFM"), "DFM survives the restore boundary");
 
+    // --- DRM is firmly not a thing on this radio (no decoder anywhere) -----
+    check(modeFromString("DRM") == Mode::Usb,
+          "DRM is no longer mapped — it falls back to USB if forced");
+    check(isUsbFallbackPassband("DRM"), "DRM gets no dedicated passband");
+    check(!isKnownModeString("DRM"),
+          "a restored DRM slice is dropped, not honoured");
+
     // --- regression: the modes that already worked still map the same ------
     check(modeFromString("USB") == Mode::Usb && modeFromString("LSB") == Mode::Lsb
               && modeFromString("CW") == Mode::Cwu && modeFromString("CWL") == Mode::Cwl
               && modeFromString("AM") == Mode::Am && modeFromString("SAM") == Mode::Sam
               && modeFromString("FM") == Mode::Fm && modeFromString("NFM") == Mode::Fm
               && modeFromString("DIGU") == Mode::Digu && modeFromString("DIGL") == Mode::Digl
-              && modeFromString("DSB") == Mode::Dsb && modeFromString("DRM") == Mode::Drm
+              && modeFromString("DSB") == Mode::Dsb
               && modeFromString("WFM") == Mode::Wbfm,
           "the pre-Plan-2 mode map is unchanged");
     check(modeFromString("NONSENSE") == Mode::Usb,

--- a/tests/hl2_tci_signaling_test.cpp
+++ b/tests/hl2_tci_signaling_test.cpp
@@ -28,6 +28,7 @@
 #include "TestSettingsProfile.h"
 #include "core/AudioEngine.h"
 #include "core/backends/hl2/Hl2Backend.h"
+#include "core/backends/hl2/Hl2ModeTable.h"
 #include "core/RadioDiscovery.h"
 #include "core/TciProtocol.h"
 #include "core/TciServer.h"
@@ -501,10 +502,12 @@ static void testModeDefaultPassband()
 
     int low = 0, high = 0;
     int deltas = 0;
+    QStringList modeList;
     QObject::connect(&backend, &IRadioBackend::sliceChanged, &backend,
                      [&](int, const SliceDelta& d) {
         if (d.filterLow)  low  = *d.filterLow;
         if (d.filterHigh) high = *d.filterHigh;
+        if (d.modeList)   modeList = *d.modeList;
         ++deltas;
     });
 
@@ -514,6 +517,18 @@ static void testModeDefaultPassband()
     const int cwWidth = high - low;
     check(cwWidth > 0 && cwWidth <= 900,
           "CWU gets a CW-width passband, not the SSB default");
+
+    // Plan 2: every slice delta carries the backend's authoritative mode list,
+    // so the VFO combo shows exactly the raw-IQ-honourable set — RTTY and DFM
+    // are in it; D-STAR / DRM / FreeDV are not.
+    check(modeList == hl2::supportedModes(),
+          "the slice delta carries the authoritative mode list");
+    check(modeList.contains(QStringLiteral("RTTY"))
+              && modeList.contains(QStringLiteral("DFM"))
+              && !modeList.contains(QStringLiteral("DSTR"))
+              && !modeList.contains(QStringLiteral("DRM"))
+              && !modeList.contains(QStringLiteral("FDVU")),
+          "the list adds RTTY/DFM and omits D-STAR/DRM/FreeDV");
 
     // "CW" is the spelling TciProtocol produces for TCI's `cw` and the one a
     // Flex reports; only "CWU" was recognised, so plain CW silently landed on

--- a/tests/slice_model_mode_list_guard_test.cpp
+++ b/tests/slice_model_mode_list_guard_test.cpp
@@ -1,0 +1,95 @@
+// Plan 2.4: SliceModel::setMode() refuses a mode the radio does not offer.
+//
+// Once a backend publishes SliceDelta::modeList (Flex always, HL2 as of
+// Plan 2), an operator / CAT / rigctl / TCI request for a mode outside that
+// list must be rejected rather than passed to a demodulator that will silently
+// substitute something else. Status application (applyChanges) must be
+// unaffected — it assigns the mode directly and is how a restored slice mode
+// arrives (Principle II).
+
+#include "models/SliceModel.h"
+#include "core/backends/SliceDelta.h"
+
+#include <QCoreApplication>
+#include <QStringList>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int failures = 0;
+
+void check(bool ok, const char* what)
+{
+    std::printf("%s %s\n", ok ? "PASS" : "FAIL", what);
+    if (!ok) {
+        ++failures;
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    // An empty mode list means "unconstrained" — the guard refuses nothing.
+    // (Use a non-digital-voice mode: DSTR/FreeDV also go through the
+    // DigitalVoiceModeRegistry, which has its own rejection path.)
+    {
+        SliceModel s(1);
+        s.setMode(QStringLiteral("DSB"));
+        check(s.mode() == QLatin1String("DSB"),
+              "no published list -> the mode-list guard refuses nothing");
+    }
+
+    // With a published list, only listed modes are accepted (case-insensitive).
+    {
+        SliceModel s(1);
+        SliceDelta d;
+        d.modeList = QStringList{QStringLiteral("USB"), QStringLiteral("LSB"),
+                                 QStringLiteral("CW"), QStringLiteral("RTTY"),
+                                 QStringLiteral("DFM")};
+        s.applyChanges(d);
+
+        s.setMode(QStringLiteral("RTTY"));
+        check(s.mode() == QLatin1String("RTTY"), "a listed mode is accepted");
+
+        s.setMode(QStringLiteral("usb"));
+        check(s.mode() == QLatin1String("usb"),
+              "a listed mode is accepted case-insensitively");
+
+        const QString before = s.mode();
+        // Non-digital-voice unlisted modes — these isolate the mode-list guard
+        // (DSTR/FreeDV would also be stopped by the DV registry).
+        s.setMode(QStringLiteral("DSB"));
+        check(s.mode() == before, "an unlisted non-DV mode (DSB) is refused");
+        s.setMode(QStringLiteral("WFM"));
+        check(s.mode() == before, "an unlisted non-DV mode (WFM) is refused");
+        s.setMode(QStringLiteral("DRM"));
+        check(s.mode() == before, "an unlisted mode (DRM) is refused");
+        // And the digital-voice ones the raw-IQ backend cannot honour.
+        s.setMode(QStringLiteral("DSTR"));
+        check(s.mode() == before, "an unlisted digital-voice mode (DSTR) is refused");
+    }
+
+    // Status application bypasses the guard: a restored slice mode outside the
+    // currently-known list still lands (the backend is telling us, not asking).
+    {
+        SliceModel s(1);
+        SliceDelta list;
+        list.modeList = QStringList{QStringLiteral("USB"), QStringLiteral("CW")};
+        s.applyChanges(list);
+
+        SliceDelta restored;
+        restored.mode = QStringLiteral("DSB");
+        s.applyChanges(restored);
+        check(s.mode() == QLatin1String("DSB"),
+              "applyChanges() sets a mode the guard would have refused");
+    }
+
+    std::printf("%s\n", failures == 0 ? "ALL PASS" : "SOME FAILED");
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -859,6 +859,14 @@ target_include_directories(hl2_noise_blanker_test PRIVATE src)
 target_link_libraries(hl2_noise_blanker_test PRIVATE aethercore Qt6::Core Qt6::Test)
 add_test(NAME hl2_noise_blanker_test COMMAND hl2_noise_blanker_test)
 
+# The HL2 RX mode table (Plan 2): operator mode -> WDSP mode + passband, the
+# restore-boundary guard, and the authoritative supported-mode list. Header-only
+# (Hl2ModeTable.h); pure Core, no WDSP channel.
+add_executable(hl2_mode_table_test tests/hl2_mode_table_test.cpp)
+target_include_directories(hl2_mode_table_test PRIVATE src)
+target_link_libraries(hl2_mode_table_test PRIVATE Qt6::Core)
+add_test(NAME hl2_mode_table_test COMMAND hl2_mode_table_test)
+
 # AM/SAM come back from WDSP's envelope detector with the carrier as a DC
 # pedestal; the blocker on the audio output must strip it without touching the
 # modes that were already zero-mean, and without its corner creeping up into

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1066,6 +1066,17 @@ target_include_directories(slice_model_squelch_memory_test PRIVATE src)
 target_link_libraries(slice_model_squelch_memory_test PRIVATE Qt6::Core Qt6::Test)
 add_test(NAME slice_model_squelch_memory_test COMMAND slice_model_squelch_memory_test)
 
+# Plan 2.4: setMode() refuses a mode outside the backend's published modeList;
+# applyChanges() (status) is unaffected.
+add_executable(slice_model_mode_list_guard_test
+    tests/slice_model_mode_list_guard_test.cpp
+    src/models/SliceModel.cpp
+    src/core/DigitalVoiceModeRegistry.cpp
+)
+target_include_directories(slice_model_mode_list_guard_test PRIVATE src)
+target_link_libraries(slice_model_mode_list_guard_test PRIVATE Qt6::Core Qt6::Test)
+add_test(NAME slice_model_mode_list_guard_test COMMAND slice_model_mode_list_guard_test)
+
 # ThemeManager — RFC #3076 Phase 1.  Verifies the built-in default-dark
 # theme loads from Qt resources, scalar tokens resolve, missing tokens
 # don't crash, and the stylesheet template resolver substitutes correctly.


### PR DESCRIPTION
## Summary

Fixes #5580. The HL2 sent no `mode_list`, so the VFO combo showed the Flex fallback set and RTTY / DFM / D-STAR all fell silently through to a plain USB passband — the mode label said one thing and the demodulator did another.

- `modeFromString()`, `isKnownModeString()`, `wdspModeName()` and `defaultPassbandForMode()` move from `Hl2Backend.cpp`'s anon namespace into a header (`Hl2ModeTable.h`) so they're unit-testable without a connected backend.
- **RTTY**: `modeFromString("RTTY")` → `Usb` (the Baudot decode is the client-side `RttyDecoder`, already wired to `rxDemodAudioReady` and auto-started on the "RTTY" mode string), with a narrow 1950–2350 Hz passband centered on the decoder's mark and covering its space in either polarity, instead of the 150–3000 Hz USB fallback.
- **DFM** (FM data): `modeFromString("DFM")` → `Fm` with the FM-width passband. It was demodulating as SSB. No de-emphasis toggle exists here, so DFM == NFM for now — but that's FM, not SSB.
- `Hl2Backend::emitSliceState` publishes `SliceDelta::modeList = supportedModes()` (`{USB,LSB,CW,AM,SAM,FM,NFM,DIGU,DIGL,RTTY,DFM}`) on every slice update, the same path `FlexBackend` uses. `VfoWidget` already consumes it, so the combo now shows exactly this list. D-STAR/DRM/FreeDV are firmly not advertised (no AMBE/no decoder/no bus-B audio path — DRM is fully removed, not just unadvertised, so a restored "DRM" slice is now dropped like any other unhonorable mode); RADE stays under its existing non-Flex decline.
- `SliceModel::setMode()` now returns early (with a `qWarning` naming the offered set) when the request is not in a non-empty `m_modeList`, case-insensitively — the final piece of "no silent fall-through": once a backend publishes a real mode list, an operator/CAT/rigctl/TCI request outside it must be rejected, not demodulated as something else. One chokepoint covers every intent path. An empty list means "unconstrained" (Sim, or a radio still mid-handshake). Status restore uses `applyChanges()`, which assigns the mode directly and never reaches `setMode()`, so a restored slice mode outside the currently-known list still lands (Principle II).
- Follow-up code-review pass: braces on the new RTTY control flow, `isKnownModeString()`'s known-list now derives from `supportedModes()` + a short legacy-spellings list instead of a second hand-synced copy, and `hl2_tci_signaling_test` (a live `Hl2Backend`) asserts an emitted `SliceDelta` carries `supportedModes()` with RTTY/DFM in and D-STAR/DRM/FreeDV out.

This is split out of #5462 per the maintainer review there (item #6 of the suggested break-up).

## Constitution principle honored

Principle II (a radio's own restored state is never rejected — `applyChanges()` bypasses the new guard) and the "no silent fall-through" truthfulness standard this codebase already applies elsewhere (cited directly in the original commit message this PR carries forward).

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR`)
- [ ] Behavior verified on a real radio if applicable — verified on hardware (Hermes-Lite 2) in the original combined branch prior to the maintainer-requested split; happy to re-verify against this exact branch if wanted before merge.
- [x] Existing tests pass (CI) — `hl2_mode_table_test` (RTTY → Usb + narrow window; DFM → Fm + FM passband; both survive `isKnownModeString`; DRM removed entirely; unknown mode falls back to USB), `slice_model_mode_list_guard_test` (no list → nothing refused; a listed mode incl. lowercase accepted; DSB/WFM/DRM/D-STAR refused with `m_mode` unchanged; `applyChanges()` of an unlisted mode still lands), `hl2_tci_signaling_test`, `hl2_dsp_readback_test` — all pass locally.
- [x] Reproduction steps documented — see #5580 and Summary above

## Checklist

- [x] Commits are signed
- [x] No new flat-key `AppSettings` calls
- [x] Code is clean-room
- [x] All meter UI uses `MeterSmoother` — n/a
- [x] Documentation updated if user-visible behavior changed — the mode combo's visible content is self-describing (it shows exactly what `modeList` advertises); no separate doc page describes the HL2 mode set today
- [ ] Security-sensitive changes reference a GHSA if applicable — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)