### PR TITLE
feat(hl2): I/O Board accessory pin-state display

### DIFF
--- a/src/core/backends/RadioCapabilities.h
+++ b/src/core/backends/RadioCapabilities.h
@@ -861,6 +861,13 @@ struct RadioCapabilities {
     bool hasGpsHardware = false;
     bool gpsHardwareRequiresPresence = false; // family declaration is conditional per unit
 
+    // The radio can carry a separate I/O Board accessory (a distinct I2C
+    // peripheral from the HL2 itself, with its own register map) and expose
+    // its live pin states. True unconditionally for the HL2: polling is
+    // inert with nothing attached, the same reasoning that already makes the
+    // automatic band-filter path safe to run unconditionally.
+    bool hasIoBoardAccessory = false;
+
     // Vendor-specific capabilities, keyed by extension namespace. Clients that
     // don't understand a namespace ignore it; a backend never puts core-profile
     // fields here. Example: {"flex": {"multiFlex": true, "guiClientId": "…"}}.

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -568,6 +568,22 @@ Hl2Backend::Hl2Backend(QObject* parent) : IRadioBackend(parent)
 
     connect(m_metis, &MetisClient::telemetryUpdated, this,
             [this](const Hl2Telemetry& t) { publishTelemetry(t); });
+    // Routes a sendI2cRead() reply back to whichever ioboard.readInputPins/
+    // readOutputPins call is still outstanding — m_pendingI2cRequestId is
+    // reset to 0 here so the single-flight gate in invokeExtension() admits
+    // the next request. A requestId of 0 means a poll tick's caller chose
+    // not to hear back (fire-and-forget); nothing to route in that case.
+    connect(m_metis, &MetisClient::i2cResponseReceived, this,
+            [this](bool error, int data) {
+        const quint64 requestId = m_pendingI2cRequestId;
+        m_pendingI2cRequestId = 0;
+        if (requestId == 0)
+            return;
+        emit extensionResult(requestId, QVariantMap{
+            {QStringLiteral("error"), error},
+            {QStringLiteral("data"), data},
+        });
+    });
     // Mirror the drop counter onto this thread so healthSnapshot() can read it
     // without touching an object that lives on the I/O thread.
     connect(m_metis, &MetisClient::dropsUpdated, this,
@@ -1547,6 +1563,11 @@ RadioCapabilities Hl2Backend::capabilities() const
     c.hasDownwardExpander = false;
     c.hasAgcThreshold = true; // Host receiver DSP implements threshold/off gain.
 
+    // Unconditional, like the other HL2 hardware-presence flags above: the
+    // pin-state poll is inert with nothing attached, so there is no "do you
+    // have this board" precondition to check first.
+    c.hasIoBoardAccessory = true;
+
     // EMPTY: the HL2's receive filters are the host DSP's, and continuous.
     c.rxFilterWidthsHz = {};
     // The host modulator implements a continuous transmit passband.
@@ -2345,6 +2366,14 @@ void Hl2Backend::finishDspSetup(const DspSetupResult& result)
     // UI yet, so anything higher would be an un-commanded power level chosen by
     // a default. An operator raising it explicitly is the only way it should go up.
     setTxDriveLevel(0);
+
+    // I/O Board startup reset — the accessory's own README recommendation:
+    // "When your SDR program starts, write 1 to REG_CONTROL to set all
+    // registers back to zero," so stale data from a previous session or a
+    // different SDR program isn't acted on before the first real pin-state
+    // read (the I/O Board settings page's poll) arrives.
+    QMetaObject::invokeMethod(m_metis, "resetIoBoardRegisters", Qt::QueuedConnection);
+
     emit dspSetupFinished();
 
     // Initial slice/pan state is published from the linkUp handler above, once
@@ -4244,6 +4273,39 @@ void Hl2Backend::invokeExtension(const QString& ns, const QString& verb, quint64
                     {QStringLiteral("receivers"), rxList},
                 });
             }
+            return;
+        }
+        // The I/O Board's own pin-status poll (RadioSetupDialog's 1Hz
+        // auto-poll row): no bus/address/register args — this ONE known
+        // device's bus/address/register are this backend's own knowledge
+        // (MetisProtocol.h's kIoBoard* constants), not something the GUI
+        // layer should hold directly (RadioSetupDialog.cpp stays below the
+        // vendor-header seam; see tools/check_engine_boundary.py's EB3).
+        // Gated on a live session and on no OTHER I2C request already
+        // pending, so a stale reply can never be misrouted to whichever
+        // caller happens to ask next.
+        if (verb == QLatin1String("ioboard.readInputPins")) {
+            if (!m_metis || m_pendingI2cRequestId != 0) {
+                if (requestId != 0)
+                    emit extensionResult(requestId, QVariantMap{{QStringLiteral("error"), true}});
+                return;
+            }
+            m_pendingI2cRequestId = requestId;
+            QMetaObject::invokeMethod(m_metis, "sendI2cRead", Qt::QueuedConnection,
+                Q_ARG(int, 2), Q_ARG(int, hl2::kIoBoardI2cAddr),
+                Q_ARG(int, hl2::kIoBoardRegInputPins));
+            return;
+        }
+        if (verb == QLatin1String("ioboard.readOutputPins")) {
+            if (!m_metis || m_pendingI2cRequestId != 0) {
+                if (requestId != 0)
+                    emit extensionResult(requestId, QVariantMap{{QStringLiteral("error"), true}});
+                return;
+            }
+            m_pendingI2cRequestId = requestId;
+            QMetaObject::invokeMethod(m_metis, "sendI2cRead", Qt::QueuedConnection,
+                Q_ARG(int, 2), Q_ARG(int, hl2::kIoBoardI2cAddr),
+                Q_ARG(int, hl2::kIoBoardRegOutputPins));
             return;
         }
     }

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -304,6 +304,12 @@ private:
     // build before this one had.
     int m_freqCalPpb = 0;
     double m_freqCalScale = 1.0;
+    // The requestId of the I/O Board I2C transaction currently in flight, or
+    // 0 when none is — the real HPSDR I2C mechanism has no transaction id of
+    // its own, so this is what lets the eventual reply (MetisClient::
+    // i2cResponseReceived) find its way back to the right caller, and what
+    // ioboard.readInputPins/readOutputPins check before starting another.
+    quint64 m_pendingI2cRequestId = 0;
     // Identity of the connected radio (its MAC, from the connect request), so
     // the calibration loads and stores per radio rather than globally: it
     // describes one physical crystal. Empty until connectRadio().

--- a/src/core/backends/hl2/MetisClient.cpp
+++ b/src/core/backends/hl2/MetisClient.cpp
@@ -149,6 +149,17 @@ MetisClient::MetisClient(QObject* parent) : QObject(parent) {
                 "no IQ stream from the radio within %1 ms of start")
                     .arg(kConnectTimeoutMs));
     });
+
+    m_i2cTimeoutTimer = new QTimer(this);
+    m_i2cTimeoutTimer->setSingleShot(true);
+    m_i2cTimeoutTimer->setInterval(kI2cTimeoutMs);
+    connect(m_i2cTimeoutTimer, &QTimer::timeout, this, [this] {
+        if (!m_i2cJobs.awaiting())
+            return;
+        m_i2cJobs.complete();
+        emit i2cResponseReceived(/*error=*/true, /*data=*/0);
+        dispatchNextI2cJob();
+    });
 }
 
 MetisClient::~MetisClient()
@@ -690,6 +701,29 @@ void MetisClient::flushTxIq()
     m_txIq.clear();
 }
 
+void MetisClient::sendI2cRead(int bus, int deviceAddress, int control)
+{
+    const auto b = (bus == 2) ? I2cBus::Bus2 : I2cBus::Bus1;   // bus param is 1-based (matches the reference UI's "I2C 1"/"I2C 2")
+    m_i2cJobs.enqueue(ccI2cRead(b, static_cast<std::uint8_t>(deviceAddress),
+                                static_cast<std::uint8_t>(control)));
+    dispatchNextI2cJob();
+}
+
+void MetisClient::resetIoBoardRegisters()
+{
+    m_i2cJobs.enqueue(ccIoBoardReset());
+    dispatchNextI2cJob();
+}
+
+void MetisClient::dispatchNextI2cJob()
+{
+    const auto job = m_i2cJobs.dispatchNext();
+    if (!job)
+        return;
+    m_oneShot.push_back(*job);
+    m_i2cTimeoutTimer->start();
+}
+
 std::array<std::uint8_t, kUsbPacketSize> MetisClient::buildNextControlPacket()
 {
     static const Cc kCcAdc = ccAdcAssign();
@@ -917,6 +951,14 @@ void MetisClient::onReadyRead()
             if (const auto resp = parseEp6Response(bytes.data() + fs)) {
                 m_telemetry.apply(*resp);
                 telemetryChanged = true;
+                if (m_i2cJobs.awaiting()) {
+                    if (const auto i2c = decodeI2cResponse(*resp); i2c.matched) {
+                        m_i2cJobs.complete();
+                        m_i2cTimeoutTimer->stop();
+                        emit i2cResponseReceived(i2c.error, i2c.data);
+                        dispatchNextI2cJob();
+                    }
+                }
             }
         }
         // Coalesce to ~10 Hz: telemetry free-runs continuously, so a frame

--- a/src/core/backends/hl2/MetisClient.h
+++ b/src/core/backends/hl2/MetisClient.h
@@ -271,6 +271,30 @@ public:
     Q_INVOKABLE void setTxTestTone(double offsetHz, double amplitude);
     [[nodiscard]] bool txTestToneEnabled() const noexcept { return m_toneAmp > 0.0; }
 
+    // The generic, ACK'd I2C read — the I/O Board pin-state poll (below the
+    // vendor-header seam: RadioSetupDialog reaches this only through
+    // Hl2Backend's scoped ioboard.readInputPins/readOutputPins extension
+    // verbs, never with a caller-chosen bus/address/register of its own; see
+    // Hl2Backend::invokeExtension()). Funnels through ONE internal queue
+    // (m_i2cJobs) so a reply arriving between two overlapping calls always
+    // resolves to the call that is actually still outstanding — the real
+    // HPSDR I2C mechanism has no transaction id, matched purely by arrival
+    // order. See dispatchNextI2cJob().
+    //
+    // The AUTOMATIC N2ADR/KP4RX TX-frequency push (band following) is a
+    // DIFFERENT, write-only mechanism — setIoBoardTxFrequencyHz() — that
+    // deliberately does NOT set RQST and so never awaits an ACK, and so
+    // never needs this queue at all: see ccI2c2Write()'s own comment in
+    // MetisProtocol.h for why the two paths are kept separate.
+    Q_INVOKABLE void sendI2cRead(int bus, int deviceAddress, int control);
+    // The I/O Board's documented startup reset (ccIoBoardReset): write 1 to
+    // REG_CONTROL so stale register data from a previous session or a
+    // different SDR program can't be acted on before the first real
+    // TX-frequency push arrives. Goes through the generic ACK'd queue above
+    // (m_i2cJobs), since this is a one-shot connect-time write, not part of
+    // the per-tune frequency push.
+    Q_INVOKABLE void resetIoBoardRegisters();
+
 signals:
     void linkUp();                                                  // first EP6 seen
     void linkDown();                                               // stopped
@@ -302,6 +326,13 @@ signals:
     // No EP6 arrived within kConnectTimeoutMs of start() — the radio is off,
     // unreachable, or already streaming to a different client.
     void connectFailed(const QString& reason);
+    // A sendI2cRead() request was answered: `error` is either the radio's
+    // 0x3F "no such transaction" sentinel (decodeI2cResponse()) or the
+    // kI2cTimeoutMs timeout firing with nothing having answered — both look
+    // identical to a caller, which only needs to know the request did not
+    // succeed. `data` is the returned byte, meaningful only when error is
+    // false.
+    void i2cResponseReceived(bool error, int data);
 
 private slots:
     void onReadyRead();
@@ -325,6 +356,11 @@ private:
     // real C&C frame; a stream started before any C&C has landed emits ADC-idle
     // samples (Q pinned to zero) until one does.
     void sendPrimingBurst(int countPerBank);
+
+    // Sends the front of m_i2cJobs if nothing is currently awaiting an ACK.
+    // Called after every enqueue and after every completion (ACK or
+    // timeout) — see the class-level note on sendI2cRead().
+    void dispatchNextI2cJob();
 
     // EP2 cadence follows the frame geometry, not the EP6 arrival rate: the
     // radio consumes one EP2 frame per kTxSamplesPerPacket samples, so at 48 kHz
@@ -361,6 +397,15 @@ private:
     quint64 m_ep2Sent = 0;                // EP2 frames sent since m_ep2Clock
     qint64  m_ep2IntervalUs = 2625;       // derived from the sample rate
     bool    m_watchdogEnabled = true;     // gateware watchdog (anti-wedge)
+
+    // I2C request scheduling: pure, socket-free I2cJobQueue; this class only
+    // owns the timer and the actual send. In flight from the moment
+    // dispatchNextI2cJob() actually sends the front job until either onReadyRead()
+    // decodes a matching ACK or m_i2cTimeoutTimer fires — whichever comes first —
+    // at which point dispatchNextI2cJob() sends the next one.
+    I2cJobQueue m_i2cJobs;
+    QTimer* m_i2cTimeoutTimer = nullptr;
+    static constexpr int kI2cTimeoutMs = 500;
 
     QUdpSocket* m_socket = nullptr;
     QHostAddress m_host;

--- a/src/core/backends/hl2/MetisProtocol.cpp
+++ b/src/core/backends/hl2/MetisProtocol.cpp
@@ -241,6 +241,54 @@ std::optional<Ep6Response> parseEp6Response(const std::uint8_t* frame) noexcept
     return r;
 }
 
+Cc ccI2cRead(I2cBus bus, std::uint8_t deviceAddress, std::uint8_t control) noexcept
+{
+    const std::uint8_t addr = (bus == I2cBus::Bus1) ? kAddrI2cBus1 : kAddrI2cBus2;
+    const auto c0 = static_cast<std::uint8_t>(static_cast<std::uint8_t>(addr << 1) | 0x80);  // RQST
+    if (deviceAddress > 0x7F)
+        deviceAddress = static_cast<std::uint8_t>(deviceAddress >> 1);
+    // C1: read + stop. C2: stop-request flag | 7-bit device address.
+    return {c0, 0x07, static_cast<std::uint8_t>(0x80 | (deviceAddress & 0x7F)), control, 0x00};
+}
+
+Cc ccI2cWrite(I2cBus bus, std::uint8_t deviceAddress, std::uint8_t control, std::uint8_t data) noexcept
+{
+    const std::uint8_t addr = (bus == I2cBus::Bus1) ? kAddrI2cBus1 : kAddrI2cBus2;
+    const auto c0 = static_cast<std::uint8_t>(static_cast<std::uint8_t>(addr << 1) | 0x80);  // RQST
+    if (deviceAddress > 0x7F)
+        deviceAddress = static_cast<std::uint8_t>(deviceAddress >> 1);
+    // C1: write + stop. C2: stop-request flag | 7-bit device address.
+    return {c0, 0x06, static_cast<std::uint8_t>(0x80 | (deviceAddress & 0x7F)), control, data};
+}
+
+I2cResult decodeI2cResponse(const Ep6Response& r) noexcept
+{
+    I2cResult out;
+    if (!r.ack)
+        return out;                      // not a reply to any RQST
+    if (r.raddr == kI2cErrorRaddr) {
+        out.matched = true;
+        out.error = true;
+        return out;
+    }
+    if (r.raddr != kAddrI2cBus1 && r.raddr != kAddrI2cBus2)
+        return out;                      // an ACK for some other RQST
+    out.matched = true;
+    out.data = static_cast<std::uint8_t>(r.data & 0xFF);
+    return out;
+}
+
+// ccIoBoardTxFrequency() is defined above (the write-only I2C2 mechanism
+// upstream's HL2 IO-board band-following feature uses) — not redefined
+// here. ccIoBoardReset() below reuses that same fixed address
+// (kIoBoardI2cAddr) but goes through the generic ACK'd I2cBus::Bus2 write,
+// since it is a one-shot connect-time write, not part of the per-tune
+// frequency push.
+Cc ccIoBoardReset() noexcept
+{
+    return ccI2cWrite(I2cBus::Bus2, kIoBoardI2cAddr, kIoBoardRegControl, 0x01);
+}
+
 void Hl2Telemetry::apply(const Ep6Response& r) noexcept
 {
     ptt = r.ptt;

--- a/src/core/backends/hl2/MetisProtocol.h
+++ b/src/core/backends/hl2/MetisProtocol.h
@@ -4,6 +4,7 @@
 #include <complex>
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <optional>
 #include <span>
 #include <vector>
@@ -286,6 +287,25 @@ std::uint8_t ocFilterByteForHz(double hz) noexcept;
 // Human-readable name of an open-collector filter selection, for logging.
 const char* ocFilterName(std::uint8_t oc) noexcept;
 
+// ---- I/O Board accessory: raw I2C request/reply ----
+//
+// A SEPARATE I2C peripheral from the HL2 itself — unrelated to the J16
+// filter board above, which drives its I2C device by config-register bits
+// alone and reads nothing back. This is a genuine bidirectional transaction:
+// addr 0x3C (I2C bus 1) / 0x3D (I2C bus 2), RQST on the outgoing frame is C0
+// bit 7 — the SAME bit the incoming frame's ACK occupies (Ep6Response::ack
+// below) — and the radio's ACK-tagged reply echoes RADDR = 0x3C/0x3D in
+// C0[6:1], with 0x3F reserved to mean "transaction failed". Sourced from the
+// W5TSU fork of the MI0BOT Hermes-Lite-2 Thetis fork
+// (ChannelMaster/networkproto1.c, the I2C request-encode block around the
+// round-robin's I2C slot) — tier 3 on the source-precedence ladder; not
+// independently re-verified against the HL2 gateware RTL.
+inline constexpr std::uint8_t kAddrI2cBus1 = 0x3C;
+inline constexpr std::uint8_t kAddrI2cBus2 = 0x3D;
+inline constexpr int kI2cErrorRaddr = 0x3F;
+
+enum class I2cBus : std::uint8_t { Bus1 = 0, Bus2 = 1 };
+
 // A 5-byte Command & Control payload: C0 (register address) + C1..C4 (data).
 using Cc = std::array<std::uint8_t, 5>;
 
@@ -467,6 +487,99 @@ struct Ep6Response {
 // Decode the C&C bytes of one 512-byte EP6 frame. Returns nullopt if the frame
 // is not sync-framed.
 std::optional<Ep6Response> parseEp6Response(const std::uint8_t* frame) noexcept;
+
+// One-shot I2C read/write REQUEST. `deviceAddress` is the 7-bit I2C device
+// address (values above 0x7F are shifted right by one, matching the
+// reference implementation's own handling of an 8-bit-shifted address);
+// `control` is the target register on that device. Sets the RQST bit so the
+// radio's ACK-tagged reply can be correlated back by decodeI2cResponse().
+Cc ccI2cRead(I2cBus bus, std::uint8_t deviceAddress, std::uint8_t control) noexcept;
+Cc ccI2cWrite(I2cBus bus, std::uint8_t deviceAddress, std::uint8_t control, std::uint8_t data) noexcept;
+
+// Result of decoding an ACK-tagged EP6 response as an I2C reply.
+struct I2cResult {
+    // This response answers an I2C bus 1/2 RQST — false for every other kind
+    // of ACK reply (an unrelated extension's RQST, or a classic free-running
+    // frame), so a caller polling telemetry cannot mistake one for the other.
+    bool matched = false;
+    bool error = false;     // the radio reported the 0x3F "no such transaction" sentinel
+    std::uint8_t data = 0;  // the returned byte (DATA[7:0]) when matched && !error
+};
+I2cResult decodeI2cResponse(const Ep6Response& r) noexcept;
+
+// A FIFO of I2C jobs that lets at most one be "in flight" at a time — the
+// real HPSDR RQST/ACK mechanism has no transaction id, matched purely by
+// arrival order, so the wire tolerates exactly one outstanding I2C request
+// (oracle §5). Pure state machine: no Qt, no socket, no timer — MetisClient
+// owns the timeout timer and the actual send, and only asks this class WHEN
+// it's allowed to send the next one. Socket-free by design so the scheduling
+// behaviour is a deterministic CTest rather than something only a live fake
+// radio could exercise (see tests/tests.cmake's note on the retired
+// fake-radio fixtures: "deterministic assertions... extracted into
+// socket-free tests").
+class I2cJobQueue {
+public:
+    void enqueue(const Cc& job) { m_queue.push_back(job); }
+
+    // The job to send now, and marks one job in flight — or nullopt if
+    // something is already in flight (awaiting its ACK or timeout) or there
+    // is nothing queued.
+    std::optional<Cc> dispatchNext() noexcept
+    {
+        if (m_awaiting || m_queue.empty())
+            return std::nullopt;
+        const Cc job = m_queue.front();
+        m_queue.pop_front();
+        m_awaiting = true;
+        return job;
+    }
+
+    // The in-flight job is done — answered (ack) or given up on (timeout).
+    // Either way, dispatchNext() may now send the next one.
+    void complete() noexcept { m_awaiting = false; }
+
+    [[nodiscard]] bool awaiting() const noexcept { return m_awaiting; }
+    [[nodiscard]] bool empty() const noexcept { return m_queue.empty(); }
+    [[nodiscard]] std::size_t size() const noexcept { return m_queue.size(); }
+
+private:
+    std::deque<Cc> m_queue;
+    bool m_awaiting = false;
+};
+
+// ---- N2ADR/KP4RX I/O Board accessory: registers beyond the TX-frequency ones ----
+//
+// The address (kIoBoardI2cAddr) and the TX-frequency registers
+// (kIoBoardRegTxFreqMsb/Lsb, ccIoBoardTxFrequency()) are declared above,
+// alongside the write-only I2C2 mechanism that drives the automatic
+// band-following push (Hl2Backend::applyIoBoardFrequency()). What follows
+// here is this branch's OWN addition, layered on top for the GENERIC, ACK'd
+// I2C read/write mechanism (I2cBus/ccI2cRead/ccI2cWrite above): a live
+// pin-status poll. (A manual raw-address read/write panel is deliberately
+// NOT part of this slice — see the PR body for why.) Ground truth:
+// https://github.com/W5TSU/HL2IOBoard_KP4RX (i2c_registers.h, README "Table
+// of I2C Registers"), the operator's own hardware. Confirmed on I2C bus 2
+// (I2cBus::Bus2) against a real Thetis<->HL2 packet capture (a working
+// register-0 read of device 0x41 came back C0=0xFA, i.e. bus 2; the
+// identical request on bus 1 got no reply) — the same bus the write-only
+// path above uses.
+inline constexpr std::uint8_t kIoBoardRegControl = 5;  // write 1 to reset all registers to zero
+// Pin-status reads (RadioSetupDialog's I/O Board pin-state poll). Register 6
+// (REG_INPUT_PINS) is CONFIRMED against the same Thetis<->HL2 capture as the
+// bus-2 finding above: Thetis polls this exact register for live input-pin
+// status. Register 169 (REG_OUT_PINS) is the board firmware's own documented
+// value but has NOT been confirmed against a capture or real hardware read —
+// treat it as tier-2, not tier-3, until it is.
+inline constexpr std::uint8_t kIoBoardRegInputPins  = 6;    // confirmed via packet capture
+inline constexpr std::uint8_t kIoBoardRegOutputPins = 169;  // per firmware docs, unverified against hardware
+
+// The documented startup reset: write 1 to REG_CONTROL to clear stale
+// register data (e.g. a leftover band code from a previous session or a
+// different SDR program) before the first real TX-frequency push arrives.
+// Goes through the generic ACK'd I2cBus::Bus2 write (not the write-only
+// I2C2 path above), since this is a one-shot connect-time write, not part
+// of the throttled per-tune frequency push.
+Cc ccIoBoardReset() noexcept;
 
 // Everything the classic response cycle carries. Fields are std::optional
 // because each RADDR carries only part of it, so "not seen yet" stays

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -150,6 +150,18 @@ static const QString kCheckBoxIndicator =
     "QCheckBox::indicator:checked { border: 2px solid {{color.accent}}; background: {{color.background.2}}; }"
     "QCheckBox::indicator:disabled { border-color: {{color.background.2}}; background: {{color.background.0}}; }";
 
+// kCheckBoxIndicator's separate :checked and :disabled rules don't combine —
+// on a widget that's BOTH (a read-only, always-disabled indicator checkbox,
+// as opposed to every other checkbox in this dialog which is interactive),
+// the later :disabled rule wins the cascade on every property they both set,
+// so checked and unchecked render identically. Rather than touch the shared
+// constant every interactive checkbox relies on (where this combination
+// never arises), read-only indicator rows use this variant instead, which
+// adds the missing combined rule.
+static const QString kCheckBoxIndicatorReadOnly = kCheckBoxIndicator + QStringLiteral(
+    "QCheckBox::indicator:disabled:checked { "
+    "border: 2px solid {{color.accent}}; background: {{color.background.2}}; }");
+
 static constexpr int kInfoLeftLabelWidth = 112;
 static constexpr int kInfoRightLabelWidth = 160;
 
@@ -827,6 +839,21 @@ RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio,
         QStringLiteral("usb cable gpio bit bcd amplifier tuner accessory"), [this] { return buildUsbCablesTab(); });
     addPage(hardwareCategory, QStringLiteral("Peripherals"),
         QStringLiteral("controllers amplifier tuner antenna genius pgxl tgxl manual ip"), [this] { return buildPeripheralsTab(); });
+
+    // I/O Board accessory pin states. Gated on its own capability boolean,
+    // following the Calibration/APD precedent above — never a family
+    // check — and hidden immediately at construction since a reconnect to a
+    // non-HL2 radio must not leave an HL2-only page visible.
+    QTreeWidgetItem* ioBoardItem = addPage(hardwareCategory, QStringLiteral("I/O Board"),
+        QStringLiteral("i2c io board pin state accessory n2adr kp4rx"),
+        [this] { return buildIoBoardTab(); });
+    m_ioBoardPageIndex = m_pageIndexes.value(QStringLiteral("I/O Board"));
+    ioBoardItem->setHidden(!m_model->backendCapabilities().hasIoBoardAccessory);
+    connect(m_model, &RadioModel::capabilitiesChanged, this,
+            [this, ioBoardItem](bool, const RadioCapabilities&) {
+        ioBoardItem->setHidden(!m_model->backendCapabilities().hasIoBoardAccessory);
+    });
+
     addPage(onlineCategory, QStringLiteral("Appearance & Behavior"),
         QStringLiteral("themes colors display font vision contrast click wheel ui enhancements"), [this] { return buildUiEnhancementsTab(); });
     addPage(onlineCategory, QStringLiteral("SmartLink"),
@@ -889,13 +916,15 @@ RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio,
                 const bool apdRow = item == m_pageItems.value(m_apdPageIndex);
                 const bool calRow = item == m_pageItems.value(m_calibrationPageIndex);
                 const bool droopRow = item == m_pageItems.value(m_droopCalibrationPageIndex);
+                const bool ioBoardRow = item == m_pageItems.value(m_ioBoardPageIndex);
                 const bool gated =
                     (isFlexOnlyPage(item) && !isCapabilityPageAvailable(item))
                     || (isGpsPage(item)
                         && !isGpsSetupAvailable())
                     || (apdRow && !m_model->transmitModel().apdConfigurable())
                     || (calRow && !m_model->backendCapabilities().hostFrequencyCalibration)
-                    || (droopRow && !droopCalibrationAvailable(m_model->backend()));
+                    || (droopRow && !droopCalibrationAvailable(m_model->backend()))
+                    || (ioBoardRow && !m_model->backendCapabilities().hasIoBoardAccessory);
                 if (!gated) {
                     item->setHidden(!matches);
                 }
@@ -9577,6 +9606,127 @@ QWidget* RadioSetupDialog::buildQrzTab()
 
     root->addWidget(cache);
     root->addStretch();
+    return page;
+}
+
+// I/O Board: the separate I2C accessory board — NOT the J16 filter board, a
+// distinct peripheral with its own register map. This slice is the live
+// pin-state display only (5 input / 8 output pins, read-only, polled at
+// 1 Hz); a manual raw bus/address/register I2C panel is deliberately NOT
+// part of it — see the PR body for why — so there is nothing here an
+// operator can use to write to an arbitrary device on the bus.
+QWidget* RadioSetupDialog::buildIoBoardTab()
+{
+    auto* page = new QWidget;
+    auto* vbox = new QVBoxLayout(page);
+    vbox->setSpacing(8);
+    auto& theme = AetherSDR::ThemeManager::instance();
+
+    auto* enableCheck = new QCheckBox(QStringLiteral("Enable I/O Board polling"));
+    theme.applyStyleSheet(enableCheck,
+        QStringLiteral("QCheckBox { color: {{color.text.primary}}; font-size: 12px; spacing: 8px; }")
+        + kCheckBoxIndicator);
+    enableCheck->setAccessibleName(QStringLiteral("Enable I/O Board polling"));
+    enableCheck->setToolTip(QStringLiteral(
+        "Polls the I/O Board accessory's pin states once a second. "
+        "Leave off unless you have the I/O Board accessory attached."));
+    vbox->addWidget(enableCheck);
+
+    // ---- pin states: read-only, populated by the 1 Hz auto-poll below ----
+    auto* pinGroup = new QGroupBox(QStringLiteral("I/O Board Pin States"));
+    theme.applyStyleSheet(pinGroup, kGroupStyle);
+    auto* pinLayout = new QGridLayout(pinGroup);
+    pinLayout->setHorizontalSpacing(6);
+
+    QVector<QCheckBox*> inputPins, outputPins;
+    auto makeReadOnlyRow = [&theme](QGridLayout* grid, int row, const QString& label,
+                                    int count, QVector<QCheckBox*>& out) {
+        auto* lbl = new QLabel(label);
+        theme.applyStyleSheet(lbl, kLabelStyle);
+        grid->addWidget(lbl, row, 0);
+        for (int i = 0; i < count; ++i) {
+            auto* cb = new QCheckBox;
+            cb->setEnabled(false);   // reflects the last read; never operator-set directly
+            theme.applyStyleSheet(cb, kCheckBoxIndicatorReadOnly);
+            cb->setAccessibleName(QStringLiteral("%1 pin %2").arg(label).arg(i + 1));
+            grid->addWidget(cb, row, i + 1);
+            out.append(cb);
+        }
+    };
+    makeReadOnlyRow(pinLayout, 0, QStringLiteral("Input"), 5, inputPins);
+    makeReadOnlyRow(pinLayout, 1, QStringLiteral("Output"), 8, outputPins);
+    vbox->addWidget(pinGroup);
+    vbox->addStretch();
+
+    // extensionResult is per-CALL (requestId 0 == fire-and-forget); a real
+    // reply needs a live requestId, so this page mints its own counter rather
+    // than reusing 0 for every read it makes. Hl2Backend allows only one
+    // outstanding I2C request at a time, so remembering just the LAST call's
+    // purpose ("pin-in" vs "pin-out") is enough to route its eventual reply
+    // without a full request table.
+    auto nextRequestId = std::make_shared<quint64>(1);
+    auto pendingKind = std::make_shared<QString>(QStringLiteral("pin-in"));
+    // Connects to the CURRENT backend only — a family switch away from and
+    // back to an HL2 while this page is open would need a fresh connection
+    // this pass does not re-establish. Acceptable for now: reopening the
+    // dialog (or the page) after such a switch restores it.
+    if (IRadioBackend* backend = m_model->backend()) {
+        connect(backend, &IRadioBackend::extensionResult, this,
+                [inputPins, outputPins, pendingKind](quint64, const QVariant& result) {
+            const QVariantMap m = result.toMap();
+            if (m.value(QStringLiteral("error")).toBool())
+                return;   // leave the row at its last known-good state
+            const int data = m.value(QStringLiteral("data")).toInt();
+            if (*pendingKind == QStringLiteral("pin-in")) {
+                for (int i = 0; i < inputPins.size(); ++i)
+                    inputPins[i]->setChecked((data & (1 << i)) != 0);
+            } else {
+                for (int i = 0; i < outputPins.size(); ++i)
+                    outputPins[i]->setChecked((data & (1 << i)) != 0);
+            }
+        });
+    }
+
+    auto triggerReadInputPins = [this, nextRequestId, pendingKind] {
+        *pendingKind = QStringLiteral("pin-in");
+        m_model->invokeBackendExtension(QStringLiteral("hl2"),
+            QStringLiteral("ioboard.readInputPins"), (*nextRequestId)++, QVariant());
+    };
+    auto triggerReadOutputPins = [this, nextRequestId, pendingKind] {
+        *pendingKind = QStringLiteral("pin-out");
+        m_model->invokeBackendExtension(QStringLiteral("hl2"),
+            QStringLiteral("ioboard.readOutputPins"), (*nextRequestId)++, QVariant());
+    };
+
+    // Alternate input/output polls once a second. Alternating (never both
+    // queued in the same tick) is deliberate — only one I2C job's result is
+    // ever "current" via pendingKind, so firing both before the first's
+    // reply landed would let the second call's pendingKind write win and
+    // misroute the first reply to the wrong row. Hl2Backend's
+    // single-outstanding-request gate refuses a poll tick that lands while a
+    // manual read is still in flight; the next tick simply tries again a
+    // second later.
+    auto pollNextIsInput = std::make_shared<bool>(true);
+    auto* pinPollTimer = new QTimer(page);
+    pinPollTimer->setInterval(1000);
+    connect(pinPollTimer, &QTimer::timeout, this,
+            [triggerReadInputPins, triggerReadOutputPins, pollNextIsInput] {
+        if (*pollNextIsInput)
+            triggerReadInputPins();
+        else
+            triggerReadOutputPins();
+        *pollNextIsInput = !*pollNextIsInput;
+    });
+    connect(enableCheck, &QCheckBox::toggled, this,
+            [pinPollTimer, triggerReadInputPins](bool on) {
+        if (on) {
+            triggerReadInputPins();   // immediate first read, not a 1 s wait
+            pinPollTimer->start();
+        } else {
+            pinPollTimer->stop();
+        }
+    });
+
     return page;
 }
 

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -136,6 +136,10 @@ private:
     void     refreshApdSamplerCombo(const QString& txAnt);
     QWidget* buildUsbCablesTab();
     QWidget* buildPeripheralsTab();
+    // I/O Board accessory pin-state display. Gated on its own
+    // RadioCapabilities boolean rather than a family check, following the
+    // Calibration/APD precedent (see the constructor).
+    QWidget* buildIoBoardTab();
     QWidget* buildUiEnhancementsTab();
     // Phase 2 of GHSA-wfx7-w6p8-4jr2 (#2951) — Pinned Certificates list
     // (host, sha256 fingerprint, pinned date) with per-row Forget and a
@@ -262,6 +266,7 @@ private:
     // External APD page (visible only when the radio reports apd configurable=1)
     int                       m_apdPageIndex{-1};
     int                       m_calibrationPageIndex{-1};
+    int                       m_ioBoardPageIndex{-1};
     // Re-seeds the Calibration page from the LIVE backend value. The page is
     // built once per process (buildDeferredTab erases the builder) and the
     // dialog is a showOrRaisePersistent singleton, so without this the spinbox

--- a/tests/hl2_family_transition_test.cpp
+++ b/tests/hl2_family_transition_test.cpp
@@ -87,6 +87,8 @@ int main(int argc, char** argv)
           "#4449: HL2 host-modulates (PC runs the modulator, no on-radio jacks)");
     check(model.panStream() == nullptr,
           "HL2 owns no PanadapterStream");
+    check(model.backendCapabilities().hasIoBoardAccessory,
+          "HL2 advertises hasIoBoardAccessory (I/O Board settings page)");
 
     // ── The normalized RX-audio bus ────────────────────────────────────────
     //
@@ -209,6 +211,8 @@ int main(int argc, char** argv)
           "round-trip: Flex regains canReboot after HL2 -> Flex");
     check(model.panStream() != nullptr,
           "round-trip: Flex owns a PanadapterStream again");
+    check(!model.backendCapabilities().hasIoBoardAccessory,
+          "round-trip: the HL2-only I/O Board page does not survive onto a Flex");
     // A host-modulated claim must not survive into a family that DOES need a
     // real dax_tx stream, or the dialog would arm against a stream that was
     // never created and transmit a silent 111.6 s frame.

--- a/tests/hl2_metis_protocol_test.cpp
+++ b/tests/hl2_metis_protocol_test.cpp
@@ -730,6 +730,124 @@ int main()
               "all 40 bits reach the wire");
     }
 
+    // ---- I/O Board: generic ACK'd I2C request/reply (register 0x3C/0x3D) ----
+    {
+        const Cc readReq = ccI2cRead(I2cBus::Bus1, 0xD4, 0x0F);
+        check(readReq[0] == static_cast<std::uint8_t>((kAddrI2cBus1 << 1) | 0x80),
+              "I2C bus 1 read sets RQST (C0 bit 7) on the bus-1 register");
+        check(readReq[1] == 0x07, "I2C read is C1 = 0x07 (read + stop)");
+        check(readReq[2] == (0x80 | (0xD4 >> 1)),
+              "an 8-bit-shifted device address is normalized to 7 bits before C2");
+
+        const Cc writeReq = ccI2cWrite(I2cBus::Bus2, 0x50, 0x03, 0xAB);
+        check(writeReq[0] == static_cast<std::uint8_t>((kAddrI2cBus2 << 1) | 0x80),
+              "I2C bus 2 write sets RQST on the bus-2 register, distinct from bus 1");
+        check(writeReq[1] == 0x06, "I2C write is C1 = 0x06 (write + stop)");
+        check(writeReq[2] == (0x80 | 0x50), "a 7-bit device address passes through unshifted");
+        check(writeReq[3] == 0x03, "C3 carries the target register");
+        check(writeReq[4] == 0xAB, "C4 carries the write data");
+
+        // A successful bus-1 reply: ACK, RADDR = kAddrI2cBus1, data byte in C4.
+        std::uint8_t frame[8] = {0x7F, 0x7F, 0x7F, 0, 0, 0, 0, 0};
+        frame[3] = static_cast<std::uint8_t>((kAddrI2cBus1 << 1) | 0x80);
+        frame[7] = 0x42;   // C4 = returned byte
+        const auto resp = parseEp6Response(frame);
+        check(resp.has_value() && resp->ack, "constructed ACK frame decodes as ack=true");
+        const auto decoded = decodeI2cResponse(*resp);
+        check(decoded.matched && !decoded.error && decoded.data == 0x42,
+              "a bus-1 ACK reply decodes to matched, no error, byte 0x42");
+
+        // The error sentinel (RADDR = 0x3F).
+        std::uint8_t errFrame[8] = {0x7F, 0x7F, 0x7F, 0, 0, 0, 0, 0};
+        errFrame[3] = static_cast<std::uint8_t>((kI2cErrorRaddr << 1) | 0x80);
+        const auto errResp = parseEp6Response(errFrame);
+        const auto errDecoded = decodeI2cResponse(*errResp);
+        check(errDecoded.matched && errDecoded.error,
+              "the 0x3F sentinel decodes to matched + error, never a silent success");
+
+        // A classic free-running frame (ack=false) is not an I2C reply at all.
+        std::uint8_t classic[8] = {0x7F, 0x7F, 0x7F, 0x00, 0, 0, 0, 0};
+        const auto classicResp = parseEp6Response(classic);
+        check(!decodeI2cResponse(*classicResp).matched,
+              "a classic (non-ACK) frame never decodes as an I2C reply");
+
+        // An ACK for some OTHER RQST (not I2C) must not be misread as one.
+        std::uint8_t otherFrame[8] = {0x7F, 0x7F, 0x7F, 0, 0, 0, 0, 0};
+        otherFrame[3] = static_cast<std::uint8_t>((0x00 << 1) | 0x80);  // some unrelated RADDR
+        const auto otherResp = parseEp6Response(otherFrame);
+        check(!decodeI2cResponse(*otherResp).matched,
+              "an ACK for an unrelated RADDR is not mistaken for an I2C reply");
+    }
+
+    // ---- N2ADR/KP4RX I/O Board: startup reset ----
+    //
+    // ccIoBoardTxFrequency() itself is pinned in the "IO board transmit-
+    // frequency batch" block above (upstream's write-only I2C2 mechanism —
+    // see MetisProtocol.h's comment on why the automatic push and this
+    // reset use two different I2C paths). This block covers only what
+    // this branch adds: the documented startup reset, which goes through
+    // the GENERIC ACK'd I2cBus::Bus2 write since it is a one-shot
+    // connect-time write, not part of the per-tune push.
+    {
+        const Cc reset = ccIoBoardReset();
+        check(reset[0] == static_cast<std::uint8_t>((kAddrI2cBus2 << 1) | 0x80),
+              "the startup reset is also on I2C bus 2");
+        check(reset[2] == (0x80 | kIoBoardI2cAddr), "the startup reset targets the same fixed address");
+        check(reset[3] == kIoBoardRegControl, "the startup reset targets REG_CONTROL");
+        check(reset[4] == 0x01, "the startup reset writes 1 (per the firmware's documented reset convention)");
+    }
+
+    // ---- I2cJobQueue: MetisClient's I2C scheduling, pinned socket-free ----
+    //
+    // The real HPSDR I2C mechanism has no transaction id — the radio's ACK is
+    // matched purely by arrival order — so MetisClient must never have two
+    // requests in flight at once. This is the scheduling logic itself
+    // (dispatchNextI2cJob's gate), extracted out of MetisClient so it can be
+    // pinned here rather than only by a live fake-radio fixture (see
+    // tests/tests.cmake's note on the retired ones: "deterministic
+    // assertions... extracted into socket-free tests").
+    {
+        I2cJobQueue q;
+        check(q.empty() && !q.awaiting(), "a fresh queue starts empty and idle");
+        check(!q.dispatchNext().has_value(), "nothing to dispatch from an empty queue");
+
+        const Cc jobA = ccIoBoardReset();
+        const Cc jobB = ccI2cRead(I2cBus::Bus2, kIoBoardI2cAddr, kIoBoardRegInputPins);
+        const Cc jobC = ccI2cRead(I2cBus::Bus2, kIoBoardI2cAddr, kIoBoardRegOutputPins);
+        q.enqueue(jobA);
+        q.enqueue(jobB);
+        q.enqueue(jobC);
+        check(q.size() == 3, "three enqueued jobs are all held until dispatched");
+
+        // Only the FRONT job goes out, and the queue is marked awaiting —
+        // this is the one-outstanding-transaction gate itself.
+        const auto first = q.dispatchNext();
+        check(first.has_value() && (*first)[3] == jobA[3], "the first dispatch is job A, in FIFO order");
+        check(q.awaiting(), "dispatching marks the queue as awaiting a reply");
+        check(q.size() == 2, "the dispatched job left the queue");
+        check(!q.dispatchNext().has_value(),
+              "a second dispatch is refused while one is still outstanding — "
+              "never two I2C requests on the wire at once");
+
+        // The outstanding job completes (an ACK, or the timeout — this class
+        // does not care which): the next one may now go.
+        q.complete();
+        check(!q.awaiting(), "completing clears the in-flight flag");
+        const auto second = q.dispatchNext();
+        check(second.has_value() && (*second)[3] == jobB[3], "the second dispatch is job B, still FIFO order");
+
+        // A timeout (no ACK ever arrived) completes it exactly the same way
+        // a real ACK would — the queue does not distinguish, and must not
+        // wedge either way.
+        q.complete();
+        const auto third = q.dispatchNext();
+        check(third.has_value() && (*third)[3] == jobC[3], "the third dispatch is job C — a timeout unblocks the queue");
+        check(q.empty(), "all three jobs have now left the queue");
+
+        q.complete();
+        check(!q.dispatchNext().has_value(), "an empty, idle queue has nothing left to dispatch");
+    }
+
     if (g_failures == 0)
         std::fprintf(stderr, "hl2_metis_protocol_test: all checks passed\n");
     return g_failures == 0 ? 0 : 1;


### PR DESCRIPTION
## Summary

Adds a new 'I/O Board' settings page under Controllers & Hardware showing the N2ADR/KP4RX I/O Board accessory's live pin states (5 input / 8 output, read-only, polled at 1 Hz), gated on a new `hasIoBoardAccessory` `RadioCapabilities` boolean rather than a family check.

- `MetisProtocol.h/.cpp`: `I2cBus`, `ccI2cRead()`/`ccI2cWrite()`, `decodeI2cResponse()` — the generic, ACK'd I2C request/reply mechanism (distinct from the existing write-only I2C2 path the automatic TX-frequency band-following push already uses) — plus `I2cJobQueue`, a pure socket-free state machine enforcing the wire's real constraint: at most one I2C transaction outstanding at a time, since HPSDR's RQST/ACK has no transaction id and matches purely by arrival order.
- `MetisClient`: `sendI2cRead()`/`resetIoBoardRegisters()` `Q_INVOKABLE` methods, an `i2cResponseReceived` signal, a 500 ms timeout so a request to an absent device surfaces as an error rather than hanging, and a connect-time register reset (the accessory's own README: "write 1 to REG_CONTROL to set all registers back to zero" before the first real read/write).
- `Hl2Backend`: `hasIoBoardAccessory=true`, a single-outstanding-request gate, and two SCOPED extension verbs — `ioboard.readInputPins`/`readOutputPins` — that always target the one known device/register (`kIoBoardI2cAddr`, confirmed via a real Thetis↔HL2 packet capture for the input-pin register; the output-pin register is firmware-doc-only, honestly caveated as unverified against hardware). Neither verb takes a caller-chosen bus/address/register.

**Deliberately NOT in this PR:** a manual raw I2C read/write panel (arbitrary bus/address/register/data from the GUI). Your review on #5462 flagged that panel specifically as needing a ruling on blast radius (I2C bus 1 is the HL2's own internal peripherals, not just the accessory bus) before it ships upstream, and suggested splitting it from the pin-state display "so the useful half isn't held hostage." This PR is that useful half; the raw panel is a follow-up once that ruling exists.

This is split out of #5462 per the maintainer review there (item #10 of the suggested break-up), following #8 (misc-options, #5583) and #9 (filter board, #5584). Built standalone against plain upstream `main`.

## Constitution principle honored

Principle II — the capability is declared explicitly (`hasIoBoardAccessory`), gated per-radio rather than by family check, and recorded consistently through the seam (`Hl2Backend::capabilities()`, `hl2_family_transition_test.cpp`'s round-trip-clear assertion).

## Test plan

- [x] Local build passes (`cmake --build build`) — core library, and the full `AetherSDR` GUI target
- [ ] Behavior verified on a real radio (I have the accessory; will confirm the input-pin poll against real hardware before merge — the register is already packet-capture-confirmed, this would confirm the live read path end to end)
- [x] Existing tests pass (CI) — full local `ctest` suite: 398/398 passed
- [x] Reproduction steps documented if user-reported bug — N/A, new feature

`tests/hl2_metis_protocol_test.cpp` — `ccI2cRead()`/`ccI2cWrite()` wire encoding on both buses, `decodeI2cResponse()` on a matched reply / the 0x3F error sentinel / a classic free-running frame / an unrelated RQST's ACK, the startup reset's exact bytes, and `I2cJobQueue`'s FIFO + single-outstanding scheduling (enqueue, dispatch, refuse-while-awaiting, complete, dispatch next) including that a timeout unblocks it the same way a real ACK would.
`tests/hl2_family_transition_test.cpp` — `hasIoBoardAccessory` is true on HL2 and does not survive an HL2 → Flex round trip.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — this page holds no persisted settings; polling reflects live radio state only
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV). Register addresses cited per their own source-precedence tier in code comments (packet capture vs. firmware docs vs. reference-implementation source).
- [x] All meter UI uses `MeterSmoother` — N/A, this page has no meters
- [x] Documentation updated if user-visible behavior changed — the page is self-documenting via its own tooltip; no existing doc claims needed updating
- [ ] Security-sensitive changes reference a GHSA if applicable — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdKV31nczEeSagFyGrnmqS