### PR TITLE
feat(aetherd): coordinate primary desktop TX intent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -791,6 +791,7 @@ set(CORE_SOURCES
     src/core/CwSidetoneQAudioSink.cpp
     src/core/CwxLocalKeyer.cpp
     src/core/IambicKeyer.cpp
+    src/core/TxCoordinator.cpp
     src/core/SpectralNR.cpp
     src/core/MonoDspStereoAdapter.cpp
     src/core/PanadapterStream.cpp
@@ -950,6 +951,7 @@ set(MODEL_SOURCES
     src/models/Nr2SettingsModel.cpp
     src/models/Rn2SettingsModel.cpp
     src/models/RadioModel.cpp
+    src/models/RadioModel_TxCoordinator.cpp
     src/models/DeclaredBands.cpp
     src/models/RadioSession.cpp
     src/models/ModelCapabilities.cpp

--- a/docs/aetherd-stage4-tx-coordinator.md
+++ b/docs/aetherd-stage4-tx-coordinator.md
@@ -1,0 +1,119 @@
+# Stage 4: engine TX coordinator and primary desktop paths
+
+This is the first Stage 4 increment of RFC #3849, after the receive-control
+milestone (#5563). It does **not** enable daemon transmission or complete the
+RFC's multi-client TX arbiter.
+
+## Authority and ownership
+
+`TxCoordinator` lives in `libaethercore`. Trusted engine composition registers
+opaque actor handles with a transmit policy. Handles belong to one coordinator;
+client strings, `PttSource` values and handles from another coordinator cannot
+mint authority. Mutations are confined to the coordinator's owning thread.
+
+There are at most 64 live actor registrations. An operation has one owner,
+an opaque identity and a cancellation fence. Repeated acquisition by that owner
+keeps the operation and its original duration limit; another actor is refused.
+Zero maximum duration preserves the existing unbounded local-operator workflow.
+The optional bounded policy is tested in isolation but is not granted to daemon
+clients by this increment.
+
+Cancellation, revocation and expiry invalidate key-on delivery before invoking
+the stop callback. Recovery is published before that callback and remains an
+admission barrier even if the callback acknowledges synchronously. A stale
+operation cannot acknowledge or complete another operation. Connection reset
+also invalidates queued cleanup, including when a transport object survives.
+An idle cleanup fence can permit key-up delivery but cannot acquire, complete
+or acknowledge an owned operation.
+
+`RadioModel` registers one **transitional desktop compatibility actor**. Existing
+desktop, CAT, TCI, MIDI, keyer and bridge calls still share their existing entry
+points. This does not establish individual client identity. `PttSource` remains
+display/preflight metadata, never the owner or a permission grant.
+
+## Primary paths
+
+| Intent | Engine route |
+| --- | --- |
+| MOX/PTT | TransmitModel admission, RadioModel, `IRadioBackend::setKeying` |
+| TUNE / two-tone | TransmitModel admission, RadioModel, `IRadioBackend::setTune` |
+| Internal ATU | TransmitModel admission, RadioModel, `IRadioBackend::setAtu` |
+| Straight key / paddle / timed CW / CW PTT | RadioModel admission and existing backend or NetCW transport |
+| CWX text, characters and macros | Actual-send admission before commands or local-keyer delivery |
+
+MOX, TUNE and ATU no longer emit parallel raw keying commands from
+`TransmitModel`. Flex encodes the same FlexLib 4.2.18 commands behind its typed
+backend methods. The receive-only backend, receive-only mode, pan inhibit and
+existing operator preflight checks remain in force. Key-up, bypass and abort
+are not subject to key-on permission checks.
+
+Admission precedes optimistic model state. The resulting fence is checked
+again after synchronous notifications. Intent epochs prevent a reentrant new
+key from being followed by the preceding intent's stale key-up. This does not
+turn local intent into radio readback: existing Flex interlock, Icom PTT
+readback and command-edge fallback provenance are unchanged.
+
+The compatibility actor tracks active primary intent kinds. CWX queue drain
+does not end a separately held MOX intent. QSK interlock gaps do not release
+the CWX batch. CWX clear/reset fences remaining segments and late replies
+through its existing drain epoch as well as the engine operation.
+
+## Normal release versus cancellation
+
+Normal PTT release retains Quindar outro and RADE end-of-over sequencing.
+Each deferred release carries its original atomic cancellation fence. New
+key-on, explicit stop, reset or destruction invalidates it. Duplicate releases
+do not truncate an in-flight outro. Release execution stays on the owning
+thread; workers may inspect the fence but cannot mutate the model through it.
+
+RADE completion carries the original request ID. Its queued audio-gate closure
+and delayed PTT release check the original release fence. Re-engagement during
+EOO also has an explicit intent notification, because optimistic MOX can remain
+true throughout that interval and emit no state edge. The hardware/interlock
+fallback may finish its own audio tail but gains no authority to release a
+later carrier.
+
+NetCW retains the existing timestamp, packet-count, dedup index, four UDP
+copies and TCP backstop. Each UDP copy captures the original transport and
+checks its fence at terminal dispatch. Normal key-up retains the operation
+until the final queued key-up copy reaches that transport, so a short element
+does not lose its already-queued key-down. This is transport completion, not
+proof of RF reception or radio-idle state.
+
+Disconnect, forced disconnect and backend replacement cancel before transport
+reuse. Session admission closes before any cancellation, pending-command reply
+or model-removal notification, even when no operation was active. It stays
+closed through the disconnect gap and reopens only on the new connection edge.
+Stop cleanup remains in recovery until transport loss/teardown is
+acknowledged. Destruction does not call presentation observers while the
+aggregate is partially destroyed.
+
+## Deliberate limits and next increment
+
+The daemon still advertises no TX permission or method. No credential
+provisioning, remote listener, TLS policy, device discovery or transmit default
+is changed. The bridge's existing permission gate and watchdog remain intact.
+
+Desktop compatibility completion ends a local intent, **not** a qualified
+radio-idle claim. It must not be reused to authorize another client's TX.
+The next increment must propagate per-client actors through all integration
+and audio producers, bind bounded actor expiry to engine scheduling, complete
+qualified stop/readback recovery and fence remaining queued audio/wire paths.
+Only after that coverage is demonstrated can daemon TX grants be considered.
+The separately tracked CW/TUNE UX interlock in #5513 is not replaced here.
+
+## Verification boundary
+
+`tx_coordinator_test` exercises actor isolation, duration, revocation, recovery,
+stale handles, thread affinity, reentrancy and cleanup-only authority.
+`tx_operation_integration_test` drives production model entry points with an
+injected backend and terminal packet writer. It does not start a radio peer,
+bind a socket, discover hardware or transmit RF. It covers typed dispatch,
+refusals, deferred release, replacement, reentrant intent, Quindar, CWX and
+queued NetCW delivery. Existing model, ATU, Icom, CAT/TUNE, applet and bridge
+watchdog tests remain part of the targeted regression set.
+
+Native Demo/MCP checks with TX disabled can establish launch, identity,
+receive-path and refusal behavior. They cannot establish over-the-air CW
+timing, an amplifier's response, or RADE RF tail quality; those require
+separately authorized hardware verification.

--- a/docs/aetherd-stage4-tx-coordinator.md
+++ b/docs/aetherd-stage4-tx-coordinator.md
@@ -53,10 +53,32 @@ key from being followed by the preceding intent's stale key-up. This does not
 turn local intent into radio readback: existing Flex interlock, Icom PTT
 readback and command-edge fallback provenance are unchanged.
 
+Direct `TransmitModel::setMox(true)` now runs the same source-aware preflight
+as the operator PTT path, before optimistic state or admission. This intentionally
+closes the former direct-call bypass: non-DAX voice MOX needs an assigned TX
+slice. A connection attempt is not a connected session; admission stays closed
+until connection completion. Tests of dispatch use an injected backend with
+the explicit slice/admission prerequisites instead of an unanswered connection.
+
 The compatibility actor tracks active primary intent kinds. CWX queue drain
 does not end a separately held MOX intent. QSK interlock gaps do not release
 the CWX batch. CWX clear/reset fences remaining segments and late replies
 through its existing drain epoch as well as the engine operation.
+Unsupported radio-side CWX and tunerless ATU are refused before acquisition.
+Terminal ATU status closes local intent even when an in-progress report was
+missed; synchronous status observers cannot use that old completion to end a
+new ATU command. This status has no operation ID and is not qualified readback
+for multi-client arbitration.
+
+CWX rejection or invalid reply cancels the current batch and disarms its drain
+watch; stale replies are fenced by both epoch and operation. Cancelled speed
+expansion restores the base WPM without sending later text. Neutral radio-side
+text dispatch happens before sidetone notification, so a rejected batch does
+not start a misleading local playback. Non-Flex acceptance completes the local
+handoff after all segments, not RF transmission. An unsynced Flex macro likewise
+completes only its local handoff: its text length is unknown, so it cannot arm
+the indexed drain watch. Both remain explicitly unsuitable as another client's
+TX-admission evidence.
 
 ## Normal release versus cancellation
 
@@ -74,11 +96,16 @@ fallback may finish its own audio tail but gains no authority to release a
 later carrier.
 
 NetCW retains the existing timestamp, packet-count, dedup index, four UDP
-copies and TCP backstop. Each UDP copy captures the original transport and
-checks its fence at terminal dispatch. Normal key-up retains the operation
-until the final queued key-up copy reaches that transport, so a short element
+copies and TCP backstop. UDP copies, the TCP backstop and the no-stream TCP
+fallback capture the original transport and check their fences at dispatch.
+Normal key-up retains the operation until both participating transport queues
+consume it (including the final UDP copy), so a short element
 does not lose its already-queued key-down. This is transport completion, not
 proof of RF reception or radio-idle state.
+Iambic producer-thread input captures a session generation before queueing onto
+the model; reset/reconnect and the scheduled-time floor reject old-session edges
+before either Flex or non-Flex delivery. This is session isolation, not yet
+per-producer authorization within a shared desktop operation.
 
 Disconnect, forced disconnect and backend replacement cancel before transport
 reuse. Session admission closes before any cancellation, pending-command reply
@@ -112,6 +139,9 @@ bind a socket, discover hardware or transmit RF. It covers typed dispatch,
 refusals, deferred release, replacement, reentrant intent, Quindar, CWX and
 queued NetCW delivery. Existing model, ATU, Icom, CAT/TUNE, applet and bridge
 watchdog tests remain part of the targeted regression set.
+The private test-only terminal writers in `PanadapterStream` and
+`RadioConnection` allow these queue tests to exercise production dispatch without
+initializing sockets or substituting synthetic radio firmware.
 
 Native Demo/MCP checks with TX disabled can establish launch, identity,
 receive-path and refusal behavior. They cannot establish over-the-air CW

--- a/docs/aetherd-stage4-tx-coordinator.md
+++ b/docs/aetherd-stage4-tx-coordinator.md
@@ -44,7 +44,10 @@ display/preflight metadata, never the owner or a permission grant.
 MOX, TUNE and ATU no longer emit parallel raw keying commands from
 `TransmitModel`. Flex encodes the same FlexLib 4.2.18 commands behind its typed
 backend methods. The receive-only backend, receive-only mode, pan inhibit and
-existing operator preflight checks remain in force. Key-up, bypass and abort
+existing operator preflight checks remain in force. Admission refusals carry a
+distinct operator message and notification key per `Refusal` reason; only
+`Recovering` is reachable while a single desktop actor exists, but the per-client
+actors of the next increment make the rest reachable. Key-up, bypass and abort
 are not subject to key-on permission checks.
 
 Admission precedes optimistic model state. The resulting fence is checked
@@ -112,8 +115,15 @@ reuse. Session admission closes before any cancellation, pending-command reply
 or model-removal notification, even when no operation was active. It stays
 closed through the disconnect gap and reopens only on the new connection edge.
 Stop cleanup remains in recovery until transport loss/teardown is
-acknowledged. Destruction does not call presentation observers while the
-aggregate is partially destroyed.
+acknowledged. Every stop source therefore needs a matching acknowledgment: an
+unacknowledged stop keeps admission closed for the rest of the session. `reset()`
+is the only production stop source in this increment and the disconnect/teardown
+paths acknowledge it; `cancel()`, `revoke()`, `expire()` and `emergencyStop()`
+have no production callers yet, so the increment that gives one of them a caller
+must land its acknowledgment path in the same change. A refusal that reaches the
+coordinator outside a disconnect gap is logged, because the session latch
+short-circuits the normal case before admission is attempted. Destruction does
+not call presentation observers while the aggregate is partially destroyed.
 
 ## Deliberate limits and next increment
 

--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -1779,6 +1779,10 @@ void PanadapterStream::unregisterIqStream(quint32 streamId)
 
 void PanadapterStream::sendToRadio(const QByteArray& packet)
 {
+    if (m_packetSinkForTest) {
+        m_packetSinkForTest(packet);
+        return;
+    }
     if (m_radioAddress.isNull() || m_radioPort == 0) {
         static int dropCount = 0;
         if (++dropCount <= 5)

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -15,6 +15,7 @@
 #include <QMutex>
 #include <QMutexLocker>
 #include <atomic>
+#include <functional>
 
 namespace AetherSDR {
 
@@ -39,6 +40,9 @@ class OpusCodec;
 
 class PanadapterStream : public QObject {
     Q_OBJECT
+    friend class TxOperationIntegrationTestAccess;
+    // Inject the terminal transport in socket-free queue/cancellation tests.
+    std::function<void(const QByteArray&)> m_packetSinkForTest;
 
 public:
     static constexpr int VITA49_HEADER_BYTES = 28;

--- a/src/core/RADEEngine.cpp
+++ b/src/core/RADEEngine.cpp
@@ -211,11 +211,12 @@ void RADEEngine::resetTx()
 #endif
 }
 
-void RADEEngine::setEooRequested(bool requested)
+void RADEEngine::setEooRequested(bool requested, quint64 requestId)
 {
 #ifdef HAVE_RADE
     if (m_eooRequested == requested) return;
     m_eooRequested = requested;
+    m_eooRequestId = requestId;
     if (requested) {
         qCDebug(lcRade) << "RADEEngine: EOO requested — draining pipeline...";
         // Trigger a feed with empty audio to kick the drain logic if no more mic audio is coming
@@ -223,6 +224,7 @@ void RADEEngine::setEooRequested(bool requested)
     }
 #else
     Q_UNUSED(requested);
+    Q_UNUSED(requestId);
 #endif
 }
 
@@ -383,7 +385,7 @@ void RADEEngine::feedTxAudio(const QByteArray& pcm)
 
         m_eooSent = true;
         m_eooFinished = true;
-        emit eooFinished();
+        emit eooFinished(m_eooRequestId);
         qCDebug(lcRade) << "RADEEngine: EOO transmission complete — eooFinished emitted";
     }
 #else

--- a/src/core/RADEEngine.h
+++ b/src/core/RADEEngine.h
@@ -57,7 +57,7 @@ public slots:
     // Request End-of-Over (EOO) transmission. Once requested, the engine
     // will finish processing any queued voice audio, then append the EOO
     // frame and a short silence tail before stopping.
-    void setEooRequested(bool requested);
+    void setEooRequested(bool requested, quint64 requestId = 0);
 
     // Set the operator callsign to embed in the EOO frame. Must be called
     // before the first PTT press. Thread-safe: may be called from any thread.
@@ -69,7 +69,7 @@ public slots:
 signals:
     void rxSpeechReady(const QByteArray& pcm);   // Decoded speech, 24kHz stereo int16
     void txModemReady(const QByteArray& pcm);     // Encoded modem, 24kHz stereo int16
-    void eooFinished();                           // Emitted after EOO frame and silence tail sent
+    void eooFinished(quint64 requestId); // original request, after EOO and silence tail
     void syncChanged(bool synced);
     void snrChanged(float snrDb);
     void freqOffsetChanged(float hz);
@@ -84,6 +84,7 @@ private:
     bool                 m_synced{false};
 
     bool                 m_eooRequested{false};
+    quint64              m_eooRequestId{0};
     bool                 m_eooSent{false};
     bool                 m_eooFinished{false};
 

--- a/src/core/RadioConnection.cpp
+++ b/src/core/RadioConnection.cpp
@@ -338,6 +338,10 @@ void RadioConnection::gracefulDisconnect(quint32 handle,
 
 void RadioConnection::writeCommand(quint32 seq, const QString& command)
 {
+    if (m_commandSinkForTest) {
+        m_commandSinkForTest(seq, command);
+        return;
+    }
     if (m_syntheticDemo) {
         if (!isConnected()) return;
         // Keepalive: RadioModel pings the radio and force-disconnects after 5

--- a/src/core/RadioConnection.h
+++ b/src/core/RadioConnection.h
@@ -26,6 +26,8 @@ enum class ConnectionState {
 // Call init() after moveToThread() to create the socket and timer.
 class RadioConnection : public QObject {
     Q_OBJECT
+    friend class TxOperationIntegrationTestAccess;
+    std::function<void(quint32, const QString&)> m_commandSinkForTest;
 
 public:
     explicit RadioConnection(QObject* parent = nullptr);

--- a/src/core/TxCoordinator.cpp
+++ b/src/core/TxCoordinator.cpp
@@ -1,0 +1,224 @@
+#include "TxCoordinator.h"
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+
+namespace AetherSDR {
+
+bool TxCoordinator::Operation::permitsDispatch(qint64 now) const
+{
+    if (!m_state || m_state->cancelled.load(std::memory_order_acquire)
+        || now < m_state->startedMs) {
+        return false;
+    }
+    // Subtract only after validating nonnegative, ordered clock values. Avoid
+    // deadline addition, which overflows for a large trusted-clock test input.
+    return m_state->maximumMs == 0
+        || now - m_state->startedMs < m_state->maximumMs;
+}
+
+bool TxCoordinator::Operation::sameOperation(const Operation& other) const
+{
+    return m_state && m_state == other.m_state;
+}
+
+bool TxCoordinator::Operation::permitsCleanup() const
+{
+    if (!m_state) {
+        return false;
+    }
+    const std::shared_ptr<Identity> identity = m_state->actor->coordinator.lock();
+    return identity && identity->generation.load(std::memory_order_acquire) == m_state->generation;
+}
+
+TxCoordinator::TxCoordinator(StopHandler stopHandler)
+    : m_thread(QThread::currentThread())
+    , m_identity(std::make_shared<Identity>())
+    , m_stopHandler(std::move(stopHandler))
+{
+}
+
+TxCoordinator::~TxCoordinator()
+{
+    // The owner performs reset while its backend is alive. Destruction is a
+    // final fence only: callbacks into a partially destroyed owner are unsafe.
+    if (m_active.m_state) {
+        m_active.m_state->cancelled.store(true, std::memory_order_release);
+    }
+    if (m_stopping.m_state) {
+        m_stopping.m_state->cancelled.store(true, std::memory_order_release);
+    }
+}
+
+bool TxCoordinator::onThread() const
+{
+    return QThread::currentThread() == m_thread;
+}
+
+bool TxCoordinator::validActor(const Actor& actor) const
+{
+    return actor.m_state && !actor.m_state->revoked
+        && actor.m_state->coordinator.lock() == m_identity;
+}
+
+TxCoordinator::Actor TxCoordinator::registerActor(ActorPolicy policy)
+{
+    if (!onThread() || policy.maximumOperationMs < 0 || !m_stopHandler) {
+        return {};
+    }
+    std::erase_if(m_actors, [](const std::weak_ptr<ActorState>& actor) {
+        const std::shared_ptr<ActorState> state = actor.lock();
+        return !state || state->revoked;
+    });
+    if (m_actors.size() >= kMaximumActors) {
+        return {};
+    }
+    Actor actor;
+    actor.m_state = std::make_shared<ActorState>(ActorState{m_identity, policy, false});
+    m_actors.push_back(actor.m_state);
+    return actor;
+}
+
+TxCoordinator::Admission TxCoordinator::acquire(const Actor& actor, qint64 now)
+{
+    if (!onThread()) {
+        return {{}, Refusal::WrongThread};
+    }
+    if (!validActor(actor) || now < 0) {
+        return {{}, Refusal::InvalidActor};
+    }
+    if (!actor.m_state->policy.mayTransmit) {
+        return {{}, Refusal::Denied};
+    }
+    expire(now);
+    // stopHandler may synchronously revoke the requesting actor.
+    if (!validActor(actor)) {
+        return {{}, Refusal::InvalidActor};
+    }
+    if (m_stopping.m_state || m_inStopHandler) {
+        return {{}, Refusal::Recovering};
+    }
+    if (m_active.m_state) {
+        if (m_active.m_state->actor != actor.m_state) {
+            return {{}, Refusal::Busy};
+        }
+        return {m_active, Refusal::None};
+    }
+    if (m_identity->generation.load() == std::numeric_limits<quint64>::max()) {
+        return {{}, Refusal::Recovering};
+    }
+    m_active.m_state = std::make_shared<OperationState>();
+    m_active.m_state->actor = actor.m_state;
+    m_active.m_state->startedMs = now;
+    m_active.m_state->maximumMs = actor.m_state->policy.maximumOperationMs;
+    m_active.m_state->generation = ++m_identity->generation;
+    return {m_active, Refusal::None};
+}
+
+bool TxCoordinator::owns(const Actor& actor, const Operation& operation) const
+{
+    return onThread() && validActor(actor) && m_active.sameOperation(operation)
+        && m_active.m_state->actor == actor.m_state;
+}
+
+TxCoordinator::Operation TxCoordinator::cleanupFence() const
+{
+    if (!onThread()) {
+        return {};
+    }
+    Operation fence;
+    fence.m_state = std::make_shared<OperationState>();
+    fence.m_state->actor = std::make_shared<ActorState>(ActorState{m_identity, {}, true});
+    fence.m_state->cancelled.store(true, std::memory_order_release);
+    fence.m_state->generation = m_identity->generation.load(std::memory_order_acquire);
+    return fence;
+}
+
+bool TxCoordinator::complete(const Operation& operation)
+{
+    if (!onThread() || !m_active.sameOperation(operation)) {
+        return false;
+    }
+    m_active.m_state->cancelled.store(true, std::memory_order_release);
+    m_active = {};
+    return true;
+}
+
+void TxCoordinator::stop(StopReason reason)
+{
+    if (!m_active.m_state) {
+        return;
+    }
+    m_stopping = m_active;
+    m_active = {};
+    m_stopping.m_state->cancelled.store(true, std::memory_order_release);
+    // Publish recovery state before invoking user code. Reentrant requests may
+    // not acquire and get unkeyed by cleanup for the preceding operation.
+    const Operation stopping = m_stopping;
+    m_inStopHandler = true;
+    m_stopHandler(stopping, reason);
+    m_inStopHandler = false;
+}
+
+bool TxCoordinator::cancel(const Actor& actor, const Operation& operation)
+{
+    if (!owns(actor, operation)) {
+        return false;
+    }
+    stop(StopReason::OwnerCancelled);
+    return true;
+}
+
+void TxCoordinator::revoke(const Actor& actor)
+{
+    if (!onThread() || !validActor(actor)) {
+        return;
+    }
+    actor.m_state->revoked = true;
+    if (m_active.m_state && m_active.m_state->actor == actor.m_state) {
+        stop(StopReason::ActorRevoked);
+    }
+}
+
+void TxCoordinator::expire(qint64 now)
+{
+    if (onThread() && m_active.m_state && !m_active.permitsDispatch(now)) {
+        stop(StopReason::Expired);
+    }
+}
+
+void TxCoordinator::reset()
+{
+    if (onThread()) {
+        stop(StopReason::Reset);
+        // A transport can survive a reconnect. Fence old queued key-ups too,
+        // before that same socket is ever reused for a new radio connection.
+        if (m_identity->generation.load() < std::numeric_limits<quint64>::max()) {
+            ++m_identity->generation;
+        }
+    }
+}
+
+void TxCoordinator::emergencyStop()
+{
+    if (onThread()) {
+        stop(StopReason::Emergency);
+    }
+}
+
+bool TxCoordinator::acknowledgeStopped(const Operation& operation)
+{
+    if (!onThread() || !m_stopping.sameOperation(operation)) {
+        return false;
+    }
+    m_stopping = {};
+    return true;
+}
+
+bool TxCoordinator::recovering() const
+{
+    return onThread() && bool(m_stopping.m_state);
+}
+
+} // namespace AetherSDR

--- a/src/core/TxCoordinator.h
+++ b/src/core/TxCoordinator.h
@@ -79,6 +79,16 @@ public:
     void emergencyStop();
     // The stop handler must arrange qualified readback or transport completion
     // before acknowledging recovery. Merely requesting unkey is not proof.
+    //
+    // INVARIANT: every stop source needs a matching acknowledgment, because an
+    // unacknowledged stop keeps admission closed forever — recovering() stays
+    // true and every later acquire() is refused Recovering. Today the only
+    // production stop source is reset(), and teardownBackend()/onDisconnected()
+    // acknowledge it, so the barrier always clears with the session. cancel(),
+    // revoke(), expire() and emergencyStop() have no production callers yet;
+    // whichever increment gives one of them a caller has to land its
+    // acknowledgment path in the same change, not after it. RadioModel logs a
+    // warning when it hits this refusal outside a disconnect gap.
     [[nodiscard]] bool acknowledgeStopped(const Operation& operation);
     [[nodiscard]] bool owns(const Actor& actor, const Operation& operation) const;
     [[nodiscard]] bool recovering() const;

--- a/src/core/TxCoordinator.h
+++ b/src/core/TxCoordinator.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <QThread>
+#include <QtGlobal>
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <vector>
+
+namespace AetherSDR {
+
+// Engine-local authority, not a protocol credential or a PttSource. Only
+// trusted composition code registers actors. Neither handle is constructible
+// from client-supplied IDs; handles from another coordinator are rejected.
+class TxCoordinator final {
+    struct ActorState;
+    struct OperationState;
+
+public:
+    class Actor {
+    public:
+        Actor() = default;
+    private:
+        friend class TxCoordinator;
+        std::shared_ptr<ActorState> m_state;
+    };
+
+    class Operation {
+    public:
+        Operation() = default;
+        // Transport workers may only read this cancellation fence. Admission,
+        // completion and all model access remain on the engine owning thread.
+        [[nodiscard]] bool permitsDispatch(qint64 monotonicMs) const;
+        // A queued key-up may outlive normal completion, but never a new
+        // operation, connection reset, or coordinator destruction.
+        [[nodiscard]] bool permitsCleanup() const;
+        [[nodiscard]] bool sameOperation(const Operation& other) const;
+    private:
+        friend class TxCoordinator;
+        std::shared_ptr<OperationState> m_state;
+    };
+
+    struct ActorPolicy {
+        bool mayTransmit{false};
+        // Zero means no new timeout for an existing local operator workflow.
+        // A bounded actor cannot extend a transmission by repeating acquire().
+        qint64 maximumOperationMs{0};
+    };
+
+    enum class Refusal { None, WrongThread, InvalidActor, Denied, Busy, Recovering };
+    struct Admission {
+        Operation operation;
+        Refusal refusal{Refusal::InvalidActor};
+        [[nodiscard]] bool accepted() const { return refusal == Refusal::None; }
+    };
+
+    enum class StopReason { OwnerCancelled, ActorRevoked, Expired, Reset, Emergency };
+    using StopHandler = std::function<void(const Operation&, StopReason)>;
+    static constexpr int kMaximumActors = 64;
+
+    explicit TxCoordinator(StopHandler stopHandler);
+    ~TxCoordinator();
+    TxCoordinator(const TxCoordinator&) = delete;
+    TxCoordinator& operator=(const TxCoordinator&) = delete;
+
+    [[nodiscard]] Actor registerActor(ActorPolicy policy);
+    [[nodiscard]] Admission acquire(const Actor& actor, qint64 monotonicMs);
+    // Stop-only delivery fence, including when no operation was acquired.
+    // It conveys no key-on, ownership, completion or acknowledgment authority.
+    [[nodiscard]] Operation cleanupFence() const;
+    // Normal completion is for an already-stopped operation. Cancellation
+    // invalidates queued work first, then calls the engine's immediate stop.
+    [[nodiscard]] bool complete(const Operation& operation);
+    [[nodiscard]] bool cancel(const Actor& actor, const Operation& operation);
+    void revoke(const Actor& actor);
+    void expire(qint64 monotonicMs);
+    void reset();
+    void emergencyStop();
+    // The stop handler must arrange qualified readback or transport completion
+    // before acknowledging recovery. Merely requesting unkey is not proof.
+    [[nodiscard]] bool acknowledgeStopped(const Operation& operation);
+    [[nodiscard]] bool owns(const Actor& actor, const Operation& operation) const;
+    [[nodiscard]] bool recovering() const;
+
+private:
+    struct Identity {
+        std::atomic<quint64> generation{0};
+    };
+    struct ActorState {
+        std::weak_ptr<Identity> coordinator;
+        ActorPolicy policy;
+        bool revoked{false};
+    };
+    struct OperationState {
+        std::shared_ptr<ActorState> actor;
+        std::atomic<bool> cancelled{false};
+        qint64 startedMs{0};
+        qint64 maximumMs{0};
+        quint64 generation{0};
+    };
+
+    [[nodiscard]] bool onThread() const;
+    [[nodiscard]] bool validActor(const Actor& actor) const;
+    void stop(StopReason reason);
+
+    QThread* const m_thread;
+    std::shared_ptr<Identity> m_identity;
+    std::vector<std::weak_ptr<ActorState>> m_actors;
+    Operation m_active;
+    Operation m_stopping;
+    StopHandler m_stopHandler;
+    bool m_inStopHandler{false};
+};
+
+} // namespace AetherSDR

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -466,6 +466,25 @@ void FlexBackend::setKeying(bool key)
     send(QStringLiteral("xmit %1").arg(key ? 1 : 0));
 }
 
+void FlexBackend::setTune(bool on, int tunePowerPercent)
+{
+    // FlexLib 4.2.18 Radio.TXTune. Power is a separate radio setting; do not
+    // re-send it here. Host-modulating backends need it on this same verb.
+    Q_UNUSED(tunePowerPercent);
+    send(QStringLiteral("transmit tune %1").arg(on ? 1 : 0));
+}
+
+void FlexBackend::setAtu(bool start)
+{
+    // FlexLib 4.2.18 Radio.ATUTuneStart / ATUTuneBypass.
+    send(start ? QStringLiteral("atu start") : QStringLiteral("atu bypass"));
+}
+
+void FlexBackend::abortCwText()
+{
+    send(QStringLiteral("cwx clear"));
+}
+
 void FlexBackend::invokeExtension(const QString& ns, const QString& verb,
                                   quint64 requestId, const QVariant& arg)
 {

--- a/src/core/backends/flex/FlexBackend.h
+++ b/src/core/backends/flex/FlexBackend.h
@@ -71,6 +71,9 @@ public:
     void setNotchesEnabled(bool on) override;
     void sendSliceWaveformCommand(int sliceId, const QString& command);
     void setKeying(bool key) override;
+    void setTune(bool on, int tunePowerPercent = -1) override;
+    void setAtu(bool start) override;
+    void abortCwText() override;
     void invokeExtension(const QString& ns, const QString& verb,
                          quint64 requestId, const QVariant& arg = {}) override;
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1809,8 +1809,12 @@ private:
     QMetaObject::Connection m_radeDaxReconcileConn;  // RADE slice dax= change → move the Rade hold
     QMetaObject::Connection m_freedvMoxConn;
     QMetaObject::Connection m_radeMoxFallbackConn;
+    QMetaObject::Connection m_radePttIntentConn;
     QString m_lastRadeRxCallsign;
     bool m_radeEooPending{false};
+    TransmitModel::PttRelease m_radePttRelease;
+    quint64 m_radeEooRequestId{0};
+    std::shared_ptr<std::atomic<bool>> m_radeFallbackReleaseFence;
     bool m_radeTxActive{false};
     void activateRADE(int sliceId);
     void deactivateRADE();

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -726,8 +726,6 @@ void MainWindow::deactivateRADE()
     }
     m_radioModel.transmitModel().invalidatePttRelease();
     m_radePttRelease = {};
-    m_radeEooPending = false;
-    m_radeTxActive = false;
     syncKiwiSdrTransmitMute();
 
     m_audio->setRadeMode(false);

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -465,24 +465,32 @@ void MainWindow::activateRADE(int sliceId)
     // Layer 1 — PttOffHook: catches MOX button (TxApplet) and TciServer callers
     // that go through TransmitModel::requestPttOff(). Fires BEFORE setMox(false),
     // so the radio stays in TX while EOO is generated and sent.
-    m_radioModel.transmitModel().setPttOffHook([this]() {
-        if (m_radeEooPending) {
+    m_radioModel.transmitModel().setPttOffHook([this](TransmitModel::PttRelease release) {
+        if (m_radeEooPending && m_radePttRelease.current()) {
             qCDebug(lcRade) << "MainWindow: PttOffHook — EOO already pending, ignoring duplicate";
             return;
         }
+        m_radePttRelease = release;
+        const quint64 requestId = ++m_radeEooRequestId;
         m_radeEooPending = true;
         syncKiwiSdrTransmitMute();
         qCDebug(lcRade) << "MainWindow: PttOffHook — intercepted requestPttOff, deferring for RADE EOO";
-        QMetaObject::invokeMethod(m_radeEngine, [this]() {
-            m_radeEngine->setEooRequested(true);
+        QMetaObject::invokeMethod(m_radeEngine, [engine = m_radeEngine, release, requestId]() {
+            if (release.current()) {
+                engine->setEooRequested(true, requestId);
+            }
         }, Qt::QueuedConnection);
     });
 
     // Layer 2 — eooFinished: once EOO audio is queued in AudioEngine, close the
     // audio gate (after EOO packets) then wait for the full EOO playout before
     // dropping the carrier. EOO=144ms + silence=60ms + margin=50ms = 254ms.
-    connect(m_radeEngine, &RADEEngine::eooFinished, this, [this]() {
-        if (!m_radeEooPending) {
+    connect(m_radeEngine, &RADEEngine::eooFinished, this, [this](quint64 requestId) {
+        if (requestId != m_radeEooRequestId) {
+            return;
+        }
+        const TransmitModel::PttRelease release = m_radePttRelease;
+        if (!m_radeEooPending || !release.current()) {
             qCDebug(lcRade) << "MainWindow: eooFinished — no pending PTT release (EOO triggered without an intercepted unkey; no carrier to release)";
             return;
         }
@@ -493,8 +501,10 @@ void MainWindow::activateRADE(int sliceId)
         // Post setTransmitting(false) AFTER the queued txModemReady(eoo/silence)
         // signals so the audio gate closes only after EOO is in the UDP send buffer.
         if (m_audio)
-            QMetaObject::invokeMethod(m_audio, [this]() {
-                m_audio->setTransmitting(false);
+            QMetaObject::invokeMethod(m_audio, [audio = m_audio, release]() {
+                if (release.current()) {
+                    audio->setTransmitting(false);
+                }
             }, Qt::QueuedConnection);
 
         constexpr int kEooPlaybackMs = RADEEngine::kEooFrameMs
@@ -502,9 +512,9 @@ void MainWindow::activateRADE(int sliceId)
                                      + RADEEngine::kEooTransportMarginMs;
         qCDebug(lcRade) << "MainWindow: RADE eooFinished — deferring xmit 0 by"
                         << kEooPlaybackMs << "ms for EOO playback";
-        QTimer::singleShot(kEooPlaybackMs, this, [this]() {
+        QTimer::singleShot(kEooPlaybackMs, this, [release]() {
             qCDebug(lcRade) << "MainWindow: RADE EOO playback timer expired — releasing radio PTT";
-            m_radioModel.setTransmit(false);
+            release.release();
         });
     });
 
@@ -513,23 +523,45 @@ void MainWindow::activateRADE(int sliceId)
     // tx=true: new over starting — clear pending flag and reset engine EOO state.
     // tx=false + !pending + isTransmitting: unintercepted unkey — request EOO as
     //   best-effort (radio may already be in RX, but at least the app won't hang).
+    const auto beginOver = [this] {
+        if (!m_radeEngine || !m_radeEngine->isActive()
+            || (m_radeTxActive && !m_radeEooPending)) {
+            return;
+        }
+        ++m_radeEooRequestId;
+        if (m_radeFallbackReleaseFence) {
+            m_radeFallbackReleaseFence->store(false, std::memory_order_release);
+        }
+        m_radeEooPending = false;
+        m_radeTxActive = true;
+        syncKiwiSdrTransmitMute();
+        QMetaObject::invokeMethod(m_radeEngine, [engine = m_radeEngine]() {
+            engine->resetTx();
+        }, Qt::QueuedConnection);
+        qCDebug(lcRade) << "MainWindow: MOX asserted — RADE TX state reset for new over";
+    };
+    // A re-engage during EOO may leave optimistic MOX true and emit no state
+    // edge at all. Its explicit intent still has to restart the encoder.
+    m_radePttIntentConn = connect(&m_radioModel, &RadioModel::localTransmitEngaged, this, beginOver);
     m_radeMoxFallbackConn = connect(&m_radioModel.transmitModel(), &TransmitModel::moxChanged,
-            this, [this](bool tx) {
+            this, [this, beginOver](bool tx) {
         if (!m_radeEngine || !m_radeEngine->isActive()) return;
         if (tx) {
-            m_radeEooPending = false;
-            m_radeTxActive = true;
-            syncKiwiSdrTransmitMute();
-            QMetaObject::invokeMethod(m_radeEngine, [this]() {
-                m_radeEngine->resetTx();
-            }, Qt::QueuedConnection);
-            qCDebug(lcRade) << "MainWindow: MOX asserted — RADE TX state reset for new over";
+            beginOver();
         } else if (!m_radeEooPending && m_radeTxActive) {
             qCDebug(lcRade) << "MainWindow: moxChanged(false) fallback — unintercepted PTT release, requesting EOO";
             m_radeEooPending = true;
+            // The radio already unkeyed. Finish the old audio pipeline only;
+            // there is no carrier-release authority to borrow from a later TX.
+            m_radeFallbackReleaseFence = std::make_shared<std::atomic<bool>>(true);
+            const std::shared_ptr<std::atomic<bool>> fence = m_radeFallbackReleaseFence;
+            m_radePttRelease = {[fence] { return fence->load(std::memory_order_acquire); }, {}};
+            const quint64 requestId = ++m_radeEooRequestId;
             syncKiwiSdrTransmitMute();
-            QMetaObject::invokeMethod(m_radeEngine, [this]() {
-                m_radeEngine->setEooRequested(true);
+            QMetaObject::invokeMethod(m_radeEngine, [engine = m_radeEngine, fence, requestId]() {
+                if (fence->load(std::memory_order_acquire)) {
+                    engine->setEooRequested(true, requestId);
+                }
             }, Qt::QueuedConnection);
         }
     });
@@ -681,6 +713,19 @@ void MainWindow::deactivateRADE()
 
     m_radioModel.transmitModel().clearPttOffHook();
     disconnect(m_radeMoxFallbackConn);
+    disconnect(m_radePttIntentConn);
+    const TransmitModel::PttRelease pendingRelease = m_radePttRelease;
+    m_radeEooPending = false;
+    m_radeTxActive = false;
+    // Leaving RADE during a pending tail must release that tail's own carrier,
+    // not abandon it or borrow a newer transmission's authority.
+    pendingRelease.release();
+    ++m_radeEooRequestId;
+    if (m_radeFallbackReleaseFence) {
+        m_radeFallbackReleaseFence->store(false, std::memory_order_release);
+    }
+    m_radioModel.transmitModel().invalidatePttRelease();
+    m_radePttRelease = {};
     m_radeEooPending = false;
     m_radeTxActive = false;
     syncKiwiSdrTransmitMute();

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -1231,12 +1231,8 @@ void MainWindow::wireRadioModel()
                     << " down=" << down
                     << " schedMs=" << cwTraceMsAt(when);
             }
-            QMetaObject::invokeMethod(this, [this, down, when]() {
-                const quint64 traceId = m_lastCwPaddleTraceId.load(std::memory_order_relaxed);
-                const quint64 sourceMs = m_lastCwPaddleSourceMs.load(std::memory_order_relaxed);
-                m_radioModel.sendCwKeyEdge(down, QStringLiteral("cw:iambic-keyer"),
-                                           traceId, sourceMs, when);
-            }, Qt::QueuedConnection);
+            m_radioModel.queueCwKeyEdge(down, QStringLiteral("cw:iambic-keyer"),
+                                       traceId, sourceMs, when);
         });
         m_iambicKeyer->setOnPaddleEvent([this](bool dit, bool dah) {
             // The radio's break-in setting decides whether key edges produce

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -1266,6 +1266,28 @@ void MainWindow::wireRadioModel()
     }
 
     // TX/RX transition → audio source switching
+    connect(&m_radioModel.transmitModel(), &TransmitModel::pttReleaseCancelled,
+            this, [this] {
+#ifdef HAVE_RADE
+        ++m_radeEooRequestId;
+        if (m_radeFallbackReleaseFence) {
+            m_radeFallbackReleaseFence->store(false, std::memory_order_release);
+        }
+        m_radePttRelease = {};
+        m_radeEooPending = false;
+        m_radeTxActive = false;
+        if (m_radeEngine) {
+            QMetaObject::invokeMethod(m_radeEngine, [engine = m_radeEngine] {
+                engine->resetTx();
+            }, Qt::QueuedConnection);
+        }
+#endif
+        // Cancellation must not wait for EOO, even when optimistic MOX was
+        // already false and neither of the state-edge handlers below fires.
+        if (m_audio) {
+            m_audio->setTransmitting(false);
+        }
+    });
     connect(&m_radioModel.transmitModel(), &TransmitModel::moxChanged,
             this, [this](bool tx) {
         // Keep TX audio source strictly aligned with the local MOX edge for all
@@ -1306,7 +1328,8 @@ void MainWindow::wireRadioModel()
                 // when this fires (RadioModel emits it synchronously with moxChanged).
                 // Suppress now; eooFinished posts setTransmitting(false) to the
                 // AudioEngine queue after the EOO packets.
-                if (m_radeSliceId >= 0 && m_radeEngine && m_radeEngine->isActive()) {
+                if (m_radeSliceId >= 0 && m_radeEngine && m_radeEngine->isActive()
+                    && m_radeEooPending && m_radePttRelease.current()) {
                     qCDebug(lcRade) << "MainWindow: txAudioGateChanged(false) suppressed — RADE EOO pending";
                 } else {
                     m_audio->setTransmitting(false);

--- a/src/models/CwxModel.cpp
+++ b/src/models/CwxModel.cpp
@@ -2,6 +2,8 @@
 #include "core/LogManager.h"
 #include <QDebug>
 #include <QMap>
+#include <QScopeGuard>
+#include <limits>
 
 namespace AetherSDR {
 
@@ -120,15 +122,26 @@ void CwxModel::emitExpandedSend(const QVector<SpeedSegment>& segs, const Transmi
     }
 
     int cmdWpm = m_speed;
+    const int epoch = m_drainEpoch;
+    const auto restoreSpeed = qScopeGuard([this, &cmdWpm, epoch] {
+        // This is cleanup, not a fresh keying intent. Every early return must
+        // restore the base speed too. An epoch change means clearBuffer already
+        // restored it, or the original session has gone away; don't write into
+        // a replacement batch/session from this old stack frame.
+        if (epoch == m_drainEpoch && cmdWpm != m_speed) {
+            ++m_pendingWpmEchoes;
+            emit commandReady(QString("cwx wpm %1").arg(m_speed));
+        }
+    });
     for (int i = 0; i < segs.size(); ++i) {
         if (!permit()) {
             return;
         }
         const SpeedSegment& seg = segs[i];
         if (seg.wpm != cmdWpm) {
-            emit commandReady(QString("cwx wpm %1").arg(seg.wpm));
             ++m_pendingWpmEchoes;   // swallow this transient's echo (#272)
             cmdWpm = seg.wpm;
+            emit commandReady(QString("cwx wpm %1").arg(seg.wpm));
         }
         if (!permit()) {
             return;
@@ -149,14 +162,28 @@ void CwxModel::emitExpandedSend(const QVector<SpeedSegment>& segs, const Transmi
         if (!permit()) {
             return;
         }
-        if (!seg.text.isEmpty())
-            emit transmissionRequested(seg.text, seg.wpm);
+        if (!seg.text.isEmpty() && !notifyTransmission(seg.text, seg.wpm, permit)) {
+            return;
+        }
     }
-    // Restore authoritative WPM if transient changes were made
-    if (permit() && cmdWpm != m_speed) {
-        emit commandReady(QString("cwx wpm %1").arg(m_speed));
-        ++m_pendingWpmEchoes;   // swallow the restore's echo too (#272)
+}
+
+bool CwxModel::notifyTransmission(const QString& text, int wpm, const TransmissionPermit& permit)
+{
+    if (!permit()) {
+        return false;
     }
+    if (m_textSender && !m_textSender(text, wpm)) {
+        if (permit()) {
+            clearBuffer();
+        }
+        return false;
+    }
+    if (!permit()) {
+        return false;
+    }
+    emit transmissionRequested(text, wpm);
+    return permit();
 }
 
 void CwxModel::send(const QString& text)
@@ -169,10 +196,13 @@ void CwxModel::send(const QString& text)
         return;
     }
     if (!m_speedModifiersEnabled) {
-        emit transmissionRequested(text, m_speed);
-        return;
+        notifyTransmission(text, m_speed, permit);
+    } else {
+        emitExpandedSend(expandSpeedModifiers(text, m_speed, m_speedStep), permit);
     }
-    emitExpandedSend(expandSpeedModifiers(text, m_speed, m_speedStep), permit);
+    if (permit()) {
+        emit transmissionDispatched(m_drainEpoch, false);
+    }
 }
 
 void CwxModel::sendChar(const QString& ch)
@@ -191,8 +221,8 @@ void CwxModel::sendChar(const QString& ch)
     emit replyCommandReady(
         QString("cwx send \"%1\" %2").arg(encoded).arg(m_nextBlock++),
         m_drainEpoch, ch.length());
-    if (permit()) {
-        emit transmissionRequested(ch, m_speed);
+    if (notifyTransmission(ch, m_speed, permit)) {
+        emit transmissionDispatched(m_drainEpoch, false);
     }
 }
 
@@ -209,11 +239,12 @@ void CwxModel::sendMacro(int idx)
         // first seconds after connect) — fall back to radio-side expansion so an
         // early F-key press still transmits instead of silently keying nothing.
         // The radio is authoritative for stored macros (Principle II).
-        // Caveat: this fire-and-forget path can't arm the reply-driven drain
-        // watch (no client-side char count), so a macro keyed before sync
-        // completes relies on the radio's own break-in for TX release. It's a
-        // narrow first-few-seconds window; keying something beats keying nothing.
+        // No client-side character count exists, so this can only complete
+        // local dispatch, never claim that the radio has finished transmitting.
         emit commandReady(QString("cwx macro send %1").arg(idx));
+        if (permit()) {
+            emit transmissionDispatched(m_drainEpoch, true);
+        }
         return;
     }
     // Expand speed modifiers client-side via cwx send blocks rather than
@@ -222,6 +253,9 @@ void CwxModel::sendMacro(int idx)
     // the unified path ensures + / - prefixes are never forwarded to the
     // radio where they would be misread as prosigns (AR / hyphen).
     emitExpandedSend(expandSpeedModifiers(text, m_speed, m_speedStep), permit);
+    if (permit()) {
+        emit transmissionDispatched(m_drainEpoch, false);
+    }
 }
 
 void CwxModel::saveMacro(int idx, const QString& text)
@@ -288,6 +322,7 @@ void CwxModel::handleSendReply(int resultCode, const QString& body, int epoch, i
         return;
     if (resultCode != 0) {
         qCWarning(lcCw) << "CwxModel: cwx send failed, result=" << resultCode;
+        clearBuffer();
         return;
     }
     // Body format is "<radio_index>,<block>" per FlexLib CWX.cs:54-83.
@@ -296,6 +331,7 @@ void CwxModel::handleSendReply(int resultCode, const QString& body, int epoch, i
     const int radioIndex = indexStr.toInt(&ok);
     if (!ok || radioIndex < 0) {
         qCWarning(lcCw) << "CwxModel: failed to parse radio_index from reply body:" << body;
+        clearBuffer();
         return;
     }
     // radio_index is the FIRST-char (insertion-start) queue position of this
@@ -303,8 +339,11 @@ void CwxModel::handleSendReply(int resultCode, const QString& body, int epoch, i
     // is radio_index + nChars - 1. Verified on FLEX-6500 fw 4.2.20.41343 (see
     // handleSendReply() doc in the header). nChars is always >= 1 for a real
     // send; guard defensively so an empty batch can't retract the index. (#3949)
-    if (nChars < 1)
+    if (nChars < 1 || radioIndex > std::numeric_limits<int>::max() - (nChars - 1)) {
+        qCWarning(lcCw) << "CwxModel: invalid character count in send reply";
+        clearBuffer();
         return;
+    }
     const int endIndex = radioIndex + nChars - 1;
     // Only ever advance the watch, never retract it. cwx send replies on the
     // single command socket are normally ordered, but if two back-to-back

--- a/src/models/CwxModel.cpp
+++ b/src/models/CwxModel.cpp
@@ -99,7 +99,17 @@ CwxModel::expandSpeedModifiers(const QString& text, int baseWpm, int step)
     return segs;
 }
 
-void CwxModel::emitExpandedSend(const QVector<SpeedSegment>& segs)
+CwxModel::TransmissionPermit CwxModel::admitTransmission()
+{
+    const TransmissionPermit permit = m_transmissionAdmission ? m_transmissionAdmission() : TransmissionPermit{};
+    if (m_transmissionAdmission && (!permit || !permit())) {
+        return {};
+    }
+    const int epoch = m_drainEpoch;
+    return [this, permit, epoch] { return epoch == m_drainEpoch && (!permit || permit()); };
+}
+
+void CwxModel::emitExpandedSend(const QVector<SpeedSegment>& segs, const TransmissionPermit& permit)
 {
     // Find last segment with non-empty text — that block's cwx send goes via
     // replyCommandReady so RadioModel can capture the radio_index and detect
@@ -111,11 +121,17 @@ void CwxModel::emitExpandedSend(const QVector<SpeedSegment>& segs)
 
     int cmdWpm = m_speed;
     for (int i = 0; i < segs.size(); ++i) {
+        if (!permit()) {
+            return;
+        }
         const SpeedSegment& seg = segs[i];
         if (seg.wpm != cmdWpm) {
             emit commandReady(QString("cwx wpm %1").arg(seg.wpm));
             ++m_pendingWpmEchoes;   // swallow this transient's echo (#272)
             cmdWpm = seg.wpm;
+        }
+        if (!permit()) {
+            return;
         }
         QString encoded = seg.text;
         encoded.replace(' ', QChar(0x7f));
@@ -130,11 +146,14 @@ void CwxModel::emitExpandedSend(const QVector<SpeedSegment>& segs)
             else
                 emit commandReady(cmd);
         }
+        if (!permit()) {
+            return;
+        }
         if (!seg.text.isEmpty())
             emit transmissionRequested(seg.text, seg.wpm);
     }
     // Restore authoritative WPM if transient changes were made
-    if (cmdWpm != m_speed) {
+    if (permit() && cmdWpm != m_speed) {
         emit commandReady(QString("cwx wpm %1").arg(m_speed));
         ++m_pendingWpmEchoes;   // swallow the restore's echo too (#272)
     }
@@ -145,16 +164,24 @@ void CwxModel::send(const QString& text)
     if (text.isEmpty()) {
         return;
     }
+    const TransmissionPermit permit = admitTransmission();
+    if (!permit) {
+        return;
+    }
     if (!m_speedModifiersEnabled) {
         emit transmissionRequested(text, m_speed);
         return;
     }
-    emitExpandedSend(expandSpeedModifiers(text, m_speed, m_speedStep));
+    emitExpandedSend(expandSpeedModifiers(text, m_speed, m_speedStep), permit);
 }
 
 void CwxModel::sendChar(const QString& ch)
 {
     if (ch.isEmpty()) return;
+    const TransmissionPermit permit = admitTransmission();
+    if (!permit) {
+        return;
+    }
     QString encoded = ch;
     encoded.replace(' ', QChar(0x7f));
     // Live-mode chars go via the reply path (not fire-and-forget commandReady)
@@ -164,12 +191,18 @@ void CwxModel::sendChar(const QString& ch)
     emit replyCommandReady(
         QString("cwx send \"%1\" %2").arg(encoded).arg(m_nextBlock++),
         m_drainEpoch, ch.length());
-    emit transmissionRequested(ch, m_speed);
+    if (permit()) {
+        emit transmissionRequested(ch, m_speed);
+    }
 }
 
 void CwxModel::sendMacro(int idx)
 {
     if (idx < 1 || idx > 12) return;
+    const TransmissionPermit permit = admitTransmission();
+    if (!permit) {
+        return;
+    }
     const QString text = m_macros[idx - 1];
     if (text.isEmpty()) {
         // Local copy not yet synced (the macroN= status is still pending in the
@@ -188,7 +221,7 @@ void CwxModel::sendMacro(int idx)
     // single cwx send identical in effect to the radio-side expansion, but
     // the unified path ensures + / - prefixes are never forwarded to the
     // radio where they would be misread as prosigns (AR / hyphen).
-    emitExpandedSend(expandSpeedModifiers(text, m_speed, m_speedStep));
+    emitExpandedSend(expandSpeedModifiers(text, m_speed, m_speedStep), permit);
 }
 
 void CwxModel::saveMacro(int idx, const QString& text)

--- a/src/models/CwxModel.h
+++ b/src/models/CwxModel.h
@@ -3,6 +3,7 @@
 #include <QObject>
 #include <QString>
 #include <QVector>
+#include <functional>
 
 namespace AetherSDR {
 
@@ -38,6 +39,12 @@ public:
     // recognised as stale and ignored rather than re-arming the watch. (#3949)
     int   drainEpoch()  const { return m_drainEpoch; }
     QString macro(int idx) const;  // 0-based (0=F1, 11=F12)
+
+    // Actual-send operation fence, separate from a UI's read-only can-send
+    // predicate. Checking whether a button is enabled must never acquire TX.
+    using TransmissionPermit = std::function<bool()>;
+    using TransmissionAdmission = std::function<TransmissionPermit()>;
+    void setTransmissionAdmission(TransmissionAdmission admission) { m_transmissionAdmission = std::move(admission); }
 
     // Actions
     void send(const QString& text);      // Send mode: full string
@@ -114,7 +121,9 @@ signals:
     void queueEmpty();                   // radio CWX buffer drained — TX teardown required
 
 private:
-    void emitExpandedSend(const QVector<SpeedSegment>& segs);
+    TransmissionPermit admitTransmission();
+    void emitExpandedSend(const QVector<SpeedSegment>& segs, const TransmissionPermit& permit);
+    TransmissionAdmission m_transmissionAdmission;
 
     int     m_speed{20};
     int     m_delay{5};

--- a/src/models/CwxModel.h
+++ b/src/models/CwxModel.h
@@ -45,6 +45,10 @@ public:
     using TransmissionPermit = std::function<bool()>;
     using TransmissionAdmission = std::function<TransmissionPermit()>;
     void setTransmissionAdmission(TransmissionAdmission admission) { m_transmissionAdmission = std::move(admission); }
+    // Optional neutral backend dispatch. False rejects the batch before the
+    // sidetone notification; the radio-specific command path stays separate.
+    using TextSender = std::function<bool(const QString&, int)>;
+    void setTextSender(TextSender sender) { m_textSender = std::move(sender); }
 
     // Actions
     void send(const QString& text);      // Send mode: full string
@@ -118,12 +122,17 @@ signals:
     // self-contained even if speed changes mid-transmission.
     void transmissionRequested(const QString& text, int wpm);
     void transmissionCancelled();        // erase / clearBuffer / interrupt
+    // All synchronous sends in this batch have been handed off. This is NOT
+    // radio-idle evidence. untrackedMacro has no client-side drain index.
+    void transmissionDispatched(int epoch, bool untrackedMacro);
     void queueEmpty();                   // radio CWX buffer drained — TX teardown required
 
 private:
     TransmissionPermit admitTransmission();
     void emitExpandedSend(const QVector<SpeedSegment>& segs, const TransmissionPermit& permit);
+    bool notifyTransmission(const QString& text, int wpm, const TransmissionPermit& permit);
     TransmissionAdmission m_transmissionAdmission;
+    TextSender m_textSender;
 
     int     m_speed{20};
     int     m_delay{5};

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -9531,6 +9531,11 @@ void RadioModel::rebuildBackendForFamily(const QString& family)
 bool RadioModel::rebuildBackendForTest(const QString& family)
 {
     rebuildBackendForFamily(family);
+    // Same reason as setBackendForTest(): the rebuild tears the old backend
+    // down, which closes admission for the dying session, and no onConnected()
+    // edge follows a test-injected backend to reopen it. Without this a test
+    // taking this path sees every TX intent silently refused.
+    m_txSessionClosing = false;
     return m_backend != nullptr;
 }
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1,4 +1,5 @@
 #include "RadioModel.h"
+#include <QPointer>
 #include "core/GuiClientIdentityPolicy.h"
 #include "AntennaAliasStore.h"
 #include "BandDefs.h"
@@ -1228,6 +1229,14 @@ void RadioModel::setupBackend(const QString& family)
                 if (delta.mox)
                     publishBackendTransmitEdge(*delta.mox);
                 m_transmitModel.applyChanges(delta);
+                if (delta.atuStatusRaw && (m_txActivities & static_cast<unsigned>(TxActivity::Atu))) {
+                    if (m_transmitModel.atuStatus() == ATUStatus::InProgress) {
+                        m_atuOperationObserved = true;
+                    } else if (m_atuOperationObserved && m_transmitModel.atuStatus() != ATUStatus::None
+                               && m_transmitModel.atuStatus() != ATUStatus::NotStarted) {
+                        endLocalTxActivity(TxActivity::Atu);
+                    }
+                }
                 if (delta.cwSpeed && !usesFlexCommandPlane()) {
                     m_cwxModel.adoptSpeed(*delta.cwSpeed);
                 }
@@ -1827,6 +1836,7 @@ void RadioModel::wireBackendReceiverState()
 
 void RadioModel::teardownBackend()
 {
+    resetTxOperations();
     ++m_backendReceiverGeneration;
     // Answer, then drop, every command still waiting on the backend that is
     // about to die. The generation guard on commandResponse means a reply
@@ -1865,6 +1875,7 @@ void RadioModel::teardownBackend()
     // reaches that path — see hasWsprTxStream().
     m_wsprTxSeamAudioArmed = false;
     m_backend.reset();
+    (void)m_txCoordinator.acknowledgeStopped(m_txOperation);
     m_connection = nullptr;
     m_panStream = nullptr;
     // Backend pan ids are only meaningful to the backend that issued them, so
@@ -2005,7 +2016,27 @@ void RadioModel::evaluateTxFilterAudioLoss(float scFilt1, float scFilt2)
 
 RadioModel::RadioModel(QObject* parent)
     : QObject(parent)
+    , m_txCoordinator([this](const TxCoordinator::Operation& operation,
+                            TxCoordinator::StopReason reason) { stopTxOperation(operation, reason); })
 {
+    m_desktopTxActor = m_txCoordinator.registerActor({true, 0});
+    m_transmitModel.setKeyingAdmission([this](TransmitModel::KeyingIntent intent, bool on) -> TransmitModel::KeyingPermit {
+        if (!on) {
+            const TxCoordinator::Operation fence = m_txCoordinator.cleanupFence();
+            return [fence] { return fence.permitsCleanup(); };
+        }
+        bool admitted = false;
+        switch (intent) {
+        case TransmitModel::KeyingIntent::Mox: admitted = beginLocalTxActivity(TxActivity::Mox); break;
+        case TransmitModel::KeyingIntent::Tune: admitted = beginLocalTxActivity(TxActivity::Tune); break;
+        case TransmitModel::KeyingIntent::Atu: admitted = beginLocalTxActivity(TxActivity::Atu); break;
+        }
+        if (!admitted) {
+            return {};
+        }
+        const TxCoordinator::Operation operation = m_txOperation;
+        return [operation] { return operation.permitsDispatch(txMonotonicMs()); };
+    });
     // Register the typed seam-delta payloads so IRadioBackend's normalized
     // signals survive a queued connection. Today decode*Status runs synchronously
     // on this thread (AutoConnection → DirectConnection, no metatype needed), but
@@ -2253,31 +2284,25 @@ RadioModel::RadioModel(QObject* parent)
         if (m_backend && !usesFlexCommandPlane())
             m_backend->setTxMonitor(on, level);
     });
-    // The ATU START keys the transmitter on a radio with a real tuner
-    // (IRadioBackend::setAtu), so it sits behind the same gate as MOX, TUNE and
-    // CW keying below: transmit-incapable backend, receive-only mode, and the
-    // pan TX inhibit. Until #5558 only the Flex wire-text copy of this intent
-    // was gated (the commandReady handler), and that text is dropped on every
-    // family without a Flex command plane — so on Icom the cycle ran
-    // regardless. Gated to non-Flex families for the same reason TUNE is: the
-    // wire text already carries the Flex intent through its own gate, and a
-    // second refusal here would notify twice.
-    //
-    // BYPASS is unconditional. A refused start must never leave the tuner
-    // un-bypassable, and bypass keys nothing.
+    // Primary keying intents have one typed route on every backend. Admission
+    // happens before the model changes optimistic state; there is no parallel
+    // Flex-text copy to bypass the coordinator or issue a duplicate command.
+    // BYPASS remains unconditional, including after a refused start (#5558).
     connect(&m_transmitModel, &TransmitModel::atuCommandIssued, this,
             [this](bool start) {
-        if (!m_backend || usesFlexCommandPlane()) {
-            return;
+        const quint64 commandEpoch = ++m_atuCommandEpoch;
+        const TxCoordinator::Operation operation = m_txOperation;
+        if (start) {
+            m_transmitModel.noteActivePttSource(TransmitModel::PttSource::Atu);
+            armInterlockNotification(TransmitModel::PttSource::Atu);
+            applyTuneInhibit();
         }
-        // Match the wire-text gate key so one refused intent produces one notice.
-        if (start
-            && (!refuseKeyOnTransmitIncapableBackend()
-                || !refuseKeyInReceiveOnlyMode()
-                || transmitStartBlockedByInhibit(QStringLiteral("tune-start")))) {
-            return;
+        if (m_backend && (!start || operation.permitsDispatch(txMonotonicMs()))) {
+            m_backend->setAtu(start);
         }
-        m_backend->setAtu(start);
+        if (!start && commandEpoch == m_atuCommandEpoch) {
+            endLocalTxActivity(TxActivity::Atu);
+        }
     });
     connect(&m_transmitModel, &TransmitModel::speechProcessorCommandIssued, this,
             [this](bool on, int level) {
@@ -2285,58 +2310,26 @@ RadioModel::RadioModel(QObject* parent)
             m_backend->setSpeechProcessor(on, level);
     });
 
-    // Keying and tune from the GUI.
-    //
-    // These paths never reached a non-Flex backend: the MOX button goes through
-    // TransmitModel::setMox, which emits the Flex text command "xmit 1" and
-    // nothing else, and TUNE emits "transmit tune 1" the same way. Only the
-    // automation bridge's key verb went through setTransmit() and therefore
-    // through the seam — which is exactly why keying worked under test and did
-    // nothing when the operator pressed MOX.
-    //
-    // Gated to non-Flex families ON PURPOSE: for Flex the text command above
-    // already keys the radio, and routing this as well would send "xmit 1"
-    // twice.
     connect(&m_transmitModel, &TransmitModel::moxCommandIssued, this,
             [this](bool on) {
-        if (m_backend && m_family != QLatin1String("flex")) {
-            if (on && !(refuseKeyOnTransmitIncapableBackend()
-                        && refuseKeyInReceiveOnlyMode()))
-                return;
-            m_backend->setKeying(on);
-            // The MOX button and the PTT coordinator key here, NOT through
-            // setTransmit(), so the raw-TX edge has to be published on this path
-            // too — otherwise a TCI client watching an operator-initiated
-            // transmit sees nothing. See publishBackendTransmitEdge().
-            publishCommandedBackendTransmitEdge(on);
-        }
+        setTransmit(on, m_transmitModel.activePttSource());
     });
     connect(&m_transmitModel, &TransmitModel::tuneCommandIssued, this,
             [this](bool on) {
-        if (m_backend && m_family != QLatin1String("flex")) {
-            if (on && !(refuseKeyOnTransmitIncapableBackend()
-                        && refuseKeyInReceiveOnlyMode())) {
-                // Un-latch TUNE as well. m_tune was already set optimistically
-                // (TransmitModel::startTune), and the button's toggle reads it,
-                // so leaving it set would strand TUNE "on" against a radio that
-                // never keyed. The re-entry through this same slot carries
-                // on=false and so skips the guard.
-                m_transmitModel.stopTune();
-                return;
-            }
-            // Hand the backend the operator's TUNE power. A host-modulated
-            // backend has no other path to it — see IRadioBackend::setTune().
+        const quint64 commandEpoch = ++m_tuneCommandEpoch;
+        const TxCoordinator::Operation operation = m_txOperation;
+        if (on) {
+            armInterlockNotification(m_transmitModel.activePttSource());
+            applyTuneInhibit();
+        }
+        if (m_backend && (!on || operation.permitsDispatch(txMonotonicMs()))) {
             m_backend->setTune(on, m_transmitModel.tunePower());
-            // A tune carrier is a transmission. Hl2Backend::setTune() calls
-            // setKeying(), so the radio is on the air — the raw-TX edge has to
-            // be published here for the same reason it is on the MOX path, and
-            // for one more that is specific to tune: TciServer's
-            // "already transmitting" guard reads isRadioTransmitting(), so
-            // leaving it false let a TCI client key ON TOP of a live tune
-            // carrier, and that client's unkey then dropped the key while tune
-            // still believed it owned it. A TCI-driven amplifier also never saw
-            // trx:true for the carrier operators most often tune INTO an amp.
-            publishCommandedBackendTransmitEdge(on);
+            if (commandEpoch == m_tuneCommandEpoch) {
+                publishCommandedBackendTransmitEdge(on);
+            }
+        }
+        if (!on && commandEpoch == m_tuneCommandEpoch) {
+            endLocalTxActivity(TxActivity::Tune);
         }
     });
 
@@ -2412,12 +2405,10 @@ RadioModel::RadioModel(QObject* parent)
     });
 
     m_transmitModel.setPttPreflight([this](TransmitModel::PttSource source) {
-        m_pendingTransmitPreflightSource = source;
         return localPttInterlockMessage(source);
     });
     connect(&m_transmitModel, &TransmitModel::pttBlocked,
             this, [this](const QString& message) {
-        m_pendingTransmitPreflightSource = TransmitModel::PttSource::Mox;
         const QString panId = txSlice() ? txSlice()->panId() : QString();
         emitInterlockNotification(
             message,
@@ -2463,50 +2454,6 @@ RadioModel::RadioModel(QObject* parent)
             }
         }
 
-        static const QRegularExpression xmitRe(R"(^xmit\s+([01])\s*$)", QRegularExpression::CaseInsensitiveOption);
-        const auto match = xmitRe.match(trimmed);
-        if (match.hasMatch()) {
-            const bool tx = (match.captured(1) == "1");
-            if (tx) {
-                if (transmitStartBlockedByInhibit(QStringLiteral("xmit"))) {
-                    m_pendingTransmitPreflightSource =
-                        TransmitModel::PttSource::Mox;
-                    m_txRequested = false;
-                    return;
-                }
-                armInterlockNotification(m_pendingTransmitPreflightSource);
-                m_pendingTransmitPreflightSource = TransmitModel::PttSource::Mox;
-            }
-            m_txRequested = tx;
-            if (!tx && m_txAudioGate) {
-                m_txAudioGate = false;
-                emit txAudioGateChanged(false);
-            }
-        }
-        if (cmd == "transmit tune 1" || cmd == "atu start") {
-            if (transmitStartBlockedByInhibit(QStringLiteral("tune-start"))) {
-                return;
-            }
-            if (cmd == "atu start") {
-                // Attribute the whole interlock cycle before dispatch. ATU and
-                // interlock statuses are independent asynchronous planes, so
-                // gating only on TUNE_IN_PROGRESS can briefly start (or
-                // prematurely resume) the operator-over timer when those
-                // statuses arrive out of order.
-                //
-                // Tag here, AFTER the inhibit gate above, and NOT in
-                // TransmitModel::atuStart() (which — unlike startTune — has no
-                // runPttPreflight of its own). Tagging before the gate would
-                // leave a stale Atu source on a blocked ATU, which a following
-                // bare hardware/VOX key (no source-bearing entry point) would
-                // inherit and be wrongly excluded from the operator TX timer.
-                m_transmitModel.noteActivePttSource(
-                    TransmitModel::PttSource::Atu);
-            }
-            armInterlockNotification(m_pendingTransmitPreflightSource);
-            m_pendingTransmitPreflightSource = TransmitModel::PttSource::Mox;
-            applyTuneInhibit();
-        }
         sendCmd(cmd);
     });
 
@@ -2545,6 +2492,13 @@ RadioModel::RadioModel(QObject* parent)
     connect(&m_tnfModel, &TnfModel::notchesEnabledRequested, this, [this](bool on){
         if (m_backend)
             m_backend->setNotchesEnabled(on);
+    });
+    m_cwxModel.setTransmissionAdmission([this]() -> CwxModel::TransmissionPermit {
+        if (!beginLocalTxActivity(TxActivity::Cwx)) {
+            return {};
+        }
+        const TxCoordinator::Operation operation = m_txOperation;
+        return [operation] { return operation.permitsDispatch(txMonotonicMs()); };
     });
     connect(&m_cwxModel, &CwxModel::commandReady, this, [this](const QString& cmd){
         // Non-Flex text keyers consume the neutral transmissionRequested /
@@ -2587,6 +2541,7 @@ RadioModel::RadioModel(QObject* parent)
             && backendCapabilities().hasRadioSideCwKeyer) {
             m_backend->abortCwText();
         }
+        endLocalTxActivity(TxActivity::Cwx);
     });
     // Final cwx send of each macro/text block goes via replyCommandReady so we
     // can capture the radio_index from the reply.  CwxModel::handleSendReply
@@ -2621,7 +2576,10 @@ RadioModel::RadioModel(QObject* parent)
         if (!m_cwxDrainArmed) return;
         m_cwxDrainArmed = false;
         m_cwxActive = false;
-        m_transmitModel.setMox(false);
+        endLocalTxActivity(TxActivity::Cwx);
+        if (m_txActivities == 0) {
+            m_transmitModel.setMox(false);
+        }
     });
     // DVK commands are reply-aware (#3377): capture the verb + slot id so
     // the response code routes back to DvkModel, which forwards non-zero
@@ -2716,6 +2674,22 @@ RadioModel::RadioModel(QObject* parent)
 
 RadioModel::~RadioModel()
 {
+    // Observers may already be tearing down. Cleanup must reach the backend
+    // without calling presentation slots from a partially destroyed aggregate.
+    blockSignals(true);
+    m_transmitModel.blockSignals(true);
+    m_cwxModel.blockSignals(true);
+    if (m_backend) {
+        if (m_txActivities & static_cast<unsigned>(TxActivity::Tune)) {
+            m_backend->setTune(false, m_transmitModel.tunePower());
+        }
+        if (m_txActivities & static_cast<unsigned>(TxActivity::Atu)) {
+            m_backend->setAtu(false);
+        }
+        if (m_txActivities & static_cast<unsigned>(TxActivity::Cwx)) {
+            m_backend->abortCwText();
+        }
+    }
     // Disconnect RadioModel's own connections to the wire objects BEFORE they
     // are torn down, to prevent use-after-free (ASAN). (#502) The objects are
     // still alive here — the backend owns them and destroys them next. The WAN
@@ -4064,6 +4038,7 @@ bool RadioModel::wakeIcomRadio(int modelId, int address, QString* error)
 
 void RadioModel::disconnectFromRadio()
 {
+    resetTxOperations();
     cancelRadioWake();
     m_intentionalDisconnect = true;
     m_rebootInProgress = false;
@@ -4118,6 +4093,7 @@ void RadioModel::rejectPresentedWanCert()
 
 void RadioModel::forceDisconnect()
 {
+    resetTxOperations();
     // Close TCP/TLS without setting m_intentionalDisconnect so the UI can
     // start the normal unexpected-disconnect reconnect path.
     m_connectAttemptActive = false;  // this attempt is over; the retry re-arms it (#4912)
@@ -4552,6 +4528,7 @@ bool RadioModel::forwardNonFlexCwKeying(bool down)
 
 void RadioModel::setTransmit(bool tx, TransmitModel::PttSource source)
 {
+    const TxCoordinator::Operation cleanup = tx ? TxCoordinator::Operation{} : m_txCoordinator.cleanupFence();
     if (tx) {
         // F2 (#4448): refuse keying on a backend that cannot transmit. The
         // guard is a capability test, not a family test — HL2 is TX-capable
@@ -4582,6 +4559,10 @@ void RadioModel::setTransmit(bool tx, TransmitModel::PttSource source)
             m_transmitModel.setTransmitting(false);
             return;
         }
+        if (!beginLocalTxActivity(TxActivity::Mox)) {
+            return;
+        }
+        m_transmitModel.invalidatePttRelease();
         armInterlockNotification(source);
         // Record who initiated this key-up so the status-bar TX timer can tell
         // an operator MOX/PTT from a TCI-hardware or DAX transmit (#tx-timer).
@@ -4591,14 +4572,22 @@ void RadioModel::setTransmit(bool tx, TransmitModel::PttSource source)
     // Track local intent so we can keep TX gating aligned with user/PTT edges
     // while radio interlock transitions through intermediate states.
     m_txRequested = tx;
+    const TxCoordinator::Operation operation = m_txOperation;
+    const quint64 commandEpoch = ++m_txCommandEpoch;
 
     // Optimistic edge gating:
     // - TX on: start immediately to keep modem waveform aligned with PTT edge.
     // - TX off: stop immediately to avoid "stuck TX tail" during UNKEY_REQUESTED.
     m_transmitModel.setTransmitting(tx);
+    if (commandEpoch != m_txCommandEpoch) {
+        return;
+    }
     if (!tx && m_txAudioGate) {
         m_txAudioGate = false;
         emit txAudioGateChanged(false);
+    }
+    if (!tx && commandEpoch == m_txCommandEpoch) {
+        m_transmitModel.cancelPttRelease();
     }
 
     if (tx) {
@@ -4607,6 +4596,7 @@ void RadioModel::setTransmit(bool tx, TransmitModel::PttSource source)
         // Put the radio-authoritative selection ahead of xmit on our command
         // stream so D-STAR is emitted only when that selected slice is DSTR.
         syncDigitalVoiceTxSelection(true);
+        emit localTransmitEngaged();
     }
     // Key through the SEAM, not with a raw Flex command. This used to be
     // sendCmd("xmit N"), which meant IRadioBackend::setKeying had no callers at
@@ -4616,10 +4606,19 @@ void RadioModel::setTransmit(bool tx, TransmitModel::PttSource source)
     // Behaviour for Flex is unchanged: FlexBackend::setKeying sends the exact
     // same "xmit N" through the same sink, and the only extra gate on that path
     // matches "display pan set ", not "xmit".
+    if (commandEpoch != m_txCommandEpoch
+        || (tx ? !operation.permitsDispatch(txMonotonicMs()) : !cleanup.permitsCleanup())) {
+        return;
+    }
     if (m_backend)
         m_backend->setKeying(tx);
 
-    publishCommandedBackendTransmitEdge(tx);
+    if (commandEpoch == m_txCommandEpoch) {
+        publishCommandedBackendTransmitEdge(tx);
+    }
+    if (!tx && commandEpoch == m_txCommandEpoch) {
+        endLocalTxActivity(TxActivity::Mox);
+    }
 }
 
 void RadioModel::publishCommandedBackendTransmitEdge(bool tx)
@@ -4836,6 +4835,12 @@ QString RadioModel::audioCompressionParam() const
 void RadioModel::sendCwKey(bool down, const QString& debugSource,
                            quint64 debugTraceId, quint64 debugSourceMs)
 {
+    if (down && !beginLocalTxActivity(TxActivity::CwKey)) {
+        return;
+    }
+    const quint64 deliveryEpoch = ++m_cwKeyDeliveryEpoch;
+    const TxCoordinator::Operation operation = m_txOperation;
+    bool deferred = false;
     // Send only the key edge — the radio's break-in setting decides whether
     // it transmits.  With break_in=1 (QSK), `cw key 1` triggers TX and
     // break_in_delay holds the relay between elements.  With break_in=0,
@@ -4847,13 +4852,20 @@ void RadioModel::sendCwKey(bool down, const QString& debugSource,
             return;
         }
     } else {
-        sendNetCwCommand(QString("cw key %1").arg(down ? 1 : 0),
-                         debugSource, debugTraceId, debugSourceMs);
+        deferred = sendNetCwCommand(QString("cw key %1").arg(down ? 1 : 0),
+                         debugSource, debugTraceId, debugSourceMs, {}, [this, down, operation, deliveryEpoch] {
+            if (!down && deliveryEpoch == m_cwKeyDeliveryEpoch && operation.sameOperation(m_txOperation)) {
+                endLocalTxActivity(TxActivity::CwKey);
+            }
+        });
     }
     const bool prev = m_cwKeyActive;
     m_cwKeyActive = down;
     if (prev != down)
         emit cwKeyDownChanged(down);
+    if (!down && !deferred) {
+        endLocalTxActivity(TxActivity::CwKey);
+    }
 }
 
 void RadioModel::sendCwPaddle(bool dit, bool dah, const QString& debugSource,
@@ -4872,11 +4884,24 @@ void RadioModel::sendCwPaddle(bool dit, bool dah, const QString& debugSource,
 void RadioModel::sendCwPtt(bool on, const QString& debugSource,
                            quint64 debugTraceId, quint64 debugSourceMs)
 {
+    if (on && !beginLocalTxActivity(TxActivity::CwPtt)) {
+        return;
+    }
+    const quint64 deliveryEpoch = ++m_cwPttDeliveryEpoch;
+    const TxCoordinator::Operation operation = m_txOperation;
+    bool deferred = false;
     if (m_backend && !usesFlexCommandPlane()) {
         m_backend->setKeying(on);
     } else {
-        sendNetCwCommand(on ? QStringLiteral("cw ptt 1") : QStringLiteral("cw ptt 0"),
-                         debugSource, debugTraceId, debugSourceMs);
+        deferred = sendNetCwCommand(on ? QStringLiteral("cw ptt 1") : QStringLiteral("cw ptt 0"),
+                         debugSource, debugTraceId, debugSourceMs, {}, [this, on, operation, deliveryEpoch] {
+            if (!on && deliveryEpoch == m_cwPttDeliveryEpoch && operation.sameOperation(m_txOperation)) {
+                endLocalTxActivity(TxActivity::CwPtt);
+            }
+        });
+    }
+    if (!on && !deferred) {
+        endLocalTxActivity(TxActivity::CwPtt);
     }
 }
 
@@ -4884,6 +4909,12 @@ void RadioModel::sendCwKeyEdge(bool down, const QString& debugSource,
                                quint64 debugTraceId, quint64 debugSourceMs,
                                std::chrono::steady_clock::time_point scheduledAt)
 {
+    if (down && !beginLocalTxActivity(TxActivity::CwKey)) {
+        return;
+    }
+    const quint64 deliveryEpoch = ++m_cwKeyDeliveryEpoch;
+    const TxCoordinator::Operation operation = m_txOperation;
+    bool deferred = false;
     if (m_backend && !usesFlexCommandPlane()) {
         // `scheduledAt` stops here on this branch: setCwKeying() carries no
         // timestamp, so a non-Flex backend applies the edge at forward time
@@ -4894,8 +4925,12 @@ void RadioModel::sendCwKeyEdge(bool down, const QString& debugSource,
             return;
         }
     } else {
-        sendNetCwCommand(QString("cw key %1").arg(down ? 1 : 0),
-                         debugSource, debugTraceId, debugSourceMs, scheduledAt);
+        deferred = sendNetCwCommand(QString("cw key %1").arg(down ? 1 : 0),
+                         debugSource, debugTraceId, debugSourceMs, scheduledAt, [this, down, operation, deliveryEpoch] {
+            if (!down && deliveryEpoch == m_cwKeyDeliveryEpoch && operation.sameOperation(m_txOperation)) {
+                endLocalTxActivity(TxActivity::CwKey);
+            }
+        });
     }
     // Deliberately no cwKeyDownChanged here.  This is the local iambic
     // keyer's path, and its producer already drove the sidetone gate at the
@@ -4907,6 +4942,9 @@ void RadioModel::sendCwKeyEdge(bool down, const QString& debugSource,
     // for a spurious blip (#4976).  m_cwKeyActive is still tracked: it feeds
     // the TX-ownership interlock alongside m_cwxActive.
     m_cwKeyActive = down;
+    if (!down && !deferred) {
+        endLocalTxActivity(TxActivity::CwKey);
+    }
 }
 
 // ── NetCW stream — VITA-49 UDP delivery with redundant sends ────────────────
@@ -4946,9 +4984,10 @@ QByteArray RadioModel::buildNetCwPacket(const QByteArray& payload)
     return pkt;
 }
 
-void RadioModel::sendNetCwCommand(const QString& baseCmd, const QString& debugSource,
+bool RadioModel::sendNetCwCommand(const QString& baseCmd, const QString& debugSource,
                                   quint64 debugTraceId, quint64 debugSourceMs,
-                                  std::chrono::steady_clock::time_point scheduledAt)
+                                 std::chrono::steady_clock::time_point scheduledAt,
+                                 std::function<void()> delivered)
 {
     if (m_netCwStreamId == 0) {
         // No netcw stream — fall back to TCP immediate
@@ -4965,7 +5004,7 @@ void RadioModel::sendNetCwCommand(const QString& baseCmd, const QString& debugSo
                 << " cmd=\"" << fallbackCmd << "\"";
         }
         sendCmd(fallbackCmd);
-        return;
+        return false;
     }
 
     // Build the full command with timing metadata and dedup index
@@ -5110,34 +5149,41 @@ void RadioModel::sendNetCwCommand(const QString& baseCmd, const QString& debugSo
             << " bytes=" << bytes;
     };
 
-    QMetaObject::invokeMethod(m_panStream, [this, packet0, logUdpSend]() {
-        logUdpSend(0, 0, packet0.size());
-        m_panStream->sendToRadio(packet0);
-    }, Qt::QueuedConnection);
-
-    QTimer::singleShot(5, this, [this, packet1, logUdpSend]() {
-        QMetaObject::invokeMethod(m_panStream, [this, packet1, logUdpSend]() {
-            logUdpSend(1, 5, packet1.size());
-            m_panStream->sendToRadio(packet1);
+    // Capture the original transport AND operation. A delayed copy must not
+    // borrow a replacement backend (or a newer owner's key) after reconnect.
+    // Check again on the worker, not merely before queueing the thread hop.
+    const bool keying = baseCmd.endsWith(QLatin1String(" 1"));
+    const TxCoordinator::Operation operation = keying ? m_txOperation : m_txCoordinator.cleanupFence();
+    const QPointer<PanadapterStream> stream = m_panStream;
+    const QPointer<RadioModel> receiver = this;
+    const auto sendCopy = [stream, operation, keying, logUdpSend, receiver, delivered](const QByteArray& packet, int copy, int delay) {
+        if (!stream) {
+            return;
+        }
+        QMetaObject::invokeMethod(stream, [stream, operation, keying, packet, copy, delay, logUdpSend, receiver, delivered] {
+            if (!stream || (keying ? !operation.permitsDispatch(txMonotonicMs()) : !operation.permitsCleanup())) {
+                return;
+            }
+            logUdpSend(copy, delay, packet.size());
+            stream->sendToRadio(packet);
+            // Normal key-up is not cancellation. Keep its operation alive
+            // until queued key-downs and the final key-up copy have reached
+            // this worker; otherwise a short element can lose its down edge.
+            if (copy == 3 && !keying && receiver && delivered) {
+                QMetaObject::invokeMethod(receiver, delivered, Qt::QueuedConnection);
+            }
         }, Qt::QueuedConnection);
-    });
-    QTimer::singleShot(10, this, [this, packet2, logUdpSend]() {
-        QMetaObject::invokeMethod(m_panStream, [this, packet2, logUdpSend]() {
-            logUdpSend(2, 10, packet2.size());
-            m_panStream->sendToRadio(packet2);
-        }, Qt::QueuedConnection);
-    });
-    QTimer::singleShot(15, this, [this, packet3, logUdpSend]() {
-        QMetaObject::invokeMethod(m_panStream, [this, packet3, logUdpSend]() {
-            logUdpSend(3, 15, packet3.size());
-            m_panStream->sendToRadio(packet3);
-        }, Qt::QueuedConnection);
-    });
+    };
+    sendCopy(packet0, 0, 0);
+    QTimer::singleShot(5, this, [sendCopy, packet1] { sendCopy(packet1, 1, 5); });
+    QTimer::singleShot(10, this, [sendCopy, packet2] { sendCopy(packet2, 2, 10); });
+    QTimer::singleShot(15, this, [sendCopy, packet3] { sendCopy(packet3, 3, 15); });
 
     // FlexLib sends the same decorated netcw command over TCP after the UDP
     // copies.  With the 16-bit timestamp format above, the radio can dedupe
     // by index=N and the TCP path provides a reliable delivery backstop.
     sendCmd(fullCmd);
+    return true;
 }
 
 void RadioModel::cwAutoTune(int sliceId, bool intermittent)
@@ -6382,6 +6428,7 @@ void RadioModel::onBackendSpectrumFrame(int panId, const QByteArray& frame)
 
 void RadioModel::onConnected()
 {
+    m_txSessionClosing = false;
     qCDebug(lcProtocol) << "RadioModel: connected (family=" << m_family << ")";
     m_connectAttemptActive = false;  // the attempt landed (#4912)
     m_reconnectTimer.stop();
@@ -6545,6 +6592,7 @@ void RadioModel::pruneStaleSessionModels(quint64 generation)
 
 void RadioModel::dropAllSessionModelsForFamilySwitch()
 {
+    resetTxOperations();
     // Live models (present if the switch happens without a clean disconnect).
     const QList<SliceModel*> liveSlices = m_slices;
     m_slices.clear();
@@ -7370,6 +7418,8 @@ void RadioModel::restoreTuneInhibit()
 
 void RadioModel::onDisconnected()
 {
+    resetTxOperations();
+    (void)m_txCoordinator.acknowledgeStopped(m_txOperation);
     qCDebug(lcProtocol) << "RadioModel: disconnected";
     m_guiClientRegistrationState.reset();
 
@@ -7405,7 +7455,6 @@ void RadioModel::onDisconnected()
     m_lastInterlockNotificationKey.clear();
     m_lastInterlockNotificationMs = 0;
     m_interlockNotificationArmedUntilMs = 0;
-    m_pendingTransmitPreflightSource = TransmitModel::PttSource::Mox;
     m_interlockNotificationSource = TransmitModel::PttSource::Mox;
     m_digitalVoiceTxSliceId = -1;
     m_lastDigitalVoiceTxSelectionKey.clear();
@@ -9372,6 +9421,9 @@ void RadioModel::setBackendForTest(std::unique_ptr<IRadioBackend> backend,
     m_backend = std::move(backend);
     m_family = family;
     wireBackendReceiverState();
+    // Injected backends bypass onConnected(), but replacement must still drain
+    // the old session before test callers can exercise the new one.
+    m_txSessionClosing = false;
 }
 
 void RadioModel::rebuildBackendForFamily(const QString& family)

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1222,23 +1222,9 @@ void RadioModel::setupBackend(const QString& family)
     // synchronously from the matching decode*Status() calls in the status
     // handlers (main-thread AutoConnection → DirectConnection).
     connect(m_backend.get(), &IRadioBackend::transmitChanged, this,
-            [this](const TransmitDelta& delta) {
-                // A backend-reported MOX edge is radio state, not local intent.
-                // Keep it out of TransmitModel::moxChanged, whose consumers
-                // own this client's audio, DAX, recorder and serial PTT.
-                if (delta.mox)
-                    publishBackendTransmitEdge(*delta.mox);
-                m_transmitModel.applyChanges(delta);
-                if (delta.atuStatusRaw && (m_txActivities & static_cast<unsigned>(TxActivity::Atu))) {
-                    if (m_transmitModel.atuStatus() == ATUStatus::InProgress) {
-                        m_atuOperationObserved = true;
-                    } else if (m_atuOperationObserved && m_transmitModel.atuStatus() != ATUStatus::None
-                               && m_transmitModel.atuStatus() != ATUStatus::NotStarted) {
-                        endLocalTxActivity(TxActivity::Atu);
-                    }
-                }
-                if (delta.cwSpeed && !usesFlexCommandPlane()) {
-                    m_cwxModel.adoptSpeed(*delta.cwSpeed);
+            [this, generation](const TransmitDelta& delta) {
+                if (generation == m_backendReceiverGeneration) {
+                    applyBackendTransmitDelta(delta);
                 }
             });
     connect(m_backend.get(), &IRadioBackend::keyingStateConfirmed,
@@ -2522,11 +2508,12 @@ RadioModel::RadioModel(QObject* parent)
             m_transmitModel.setCwSpeed(wpm);
         }
     });
-    connect(&m_cwxModel, &CwxModel::transmissionRequested, this,
-            [this](const QString& text, int wpm) {
-        if (!m_backend || usesFlexCommandPlane()
-            || !backendCapabilities().hasRadioSideCwKeyer) {
-            return;
+    m_cwxModel.setTextSender([this](const QString& text, int wpm) {
+        if (usesFlexCommandPlane()) {
+            return true;
+        }
+        if (!m_backend || !backendCapabilities().hasRadioSideCwKeyer) {
+            return false;
         }
         Q_UNUSED(wpm);
         const QString rejection = m_backend->sendCwText(text);
@@ -2535,13 +2522,38 @@ RadioModel::RadioModel(QObject* parent)
                 tr("CW text not sent: %1").arg(rejection),
                 MessageSeverity::Warning);
         }
+        return rejection.isEmpty();
     });
     connect(&m_cwxModel, &CwxModel::transmissionCancelled, this, [this] {
+        const TxCoordinator::Operation operation = m_txOperation;
+        const int epoch = m_cwxModel.drainEpoch();
+        m_cwxActive = false;
+        m_cwxDrainArmed = false;
         if (m_backend && !usesFlexCommandPlane()
             && backendCapabilities().hasRadioSideCwKeyer) {
             m_backend->abortCwText();
         }
-        endLocalTxActivity(TxActivity::Cwx);
+        if (operation.sameOperation(m_txOperation) && epoch == m_cwxModel.drainEpoch()) {
+            endLocalTxActivity(TxActivity::Cwx);
+        }
+    });
+    connect(&m_cwxModel, &CwxModel::transmissionDispatched, this,
+            [this](int epoch, bool untrackedMacro) {
+        if (epoch != m_cwxModel.drainEpoch()) {
+            return;
+        }
+        if (!usesFlexCommandPlane() || untrackedMacro) {
+            // CI-V has no text-progress readback, and an unsynced Flex macro
+            // has no client-side end index. Complete only the local handoff.
+            // This must never become another client's radio-idle authority.
+            if (untrackedMacro && m_cwxDrainArmed) {
+                // An unknown-length tail appended to a tracked batch makes
+                // that old end index incomplete. Don't let it cut off the tail.
+                m_cwxDrainArmed = false;
+                m_cwxModel.resetDrainWatch();
+            }
+            endLocalTxActivity(TxActivity::Cwx);
+        }
     });
     // Final cwx send of each macro/text block goes via replyCommandReady so we
     // can capture the radio_index from the reply.  CwxModel::handleSendReply
@@ -2557,8 +2569,12 @@ RadioModel::RadioModel(QObject* parent)
         // m_cwxDrainArmed is owned solely by the CWX send/drain lifecycle, so
         // the queueEmpty release below survives QSK break-in flicker. (#3949)
         m_cwxDrainArmed = true;
-        sendCmd(cmd, [this, epoch, nChars](int respVal, const QString& body){
-            m_cwxModel.handleSendReply(respVal, body, epoch, nChars);
+        const TxCoordinator::Operation operation = m_txOperation;
+        sendCmd(cmd, [this, operation, epoch, nChars](int respVal, const QString& body){
+            if (operation.sameOperation(m_txOperation)
+                && operation.permitsDispatch(txMonotonicMs())) {
+                m_cwxModel.handleSendReply(respVal, body, epoch, nChars);
+            }
         });
     });
     // When the radio signals its CWX buffer is drained, release TX. (#2450)
@@ -4506,6 +4522,30 @@ bool RadioModel::refuseKeyWithInterlock(const QString& message, const QString& k
     return false;
 }
 
+void RadioModel::applyBackendTransmitDelta(const TransmitDelta& delta)
+{
+    const TxCoordinator::Operation operation = m_txOperation;
+    const quint64 atuEpoch = m_atuCommandEpoch;
+    // Backend MOX is radio state, not local intent; don't echo it into the
+    // signal that drives this client's audio, DAX, recorder and serial PTT.
+    if (delta.mox) {
+        publishBackendTransmitEdge(*delta.mox);
+    }
+    m_transmitModel.applyChanges(delta);
+    if (delta.atuStatusRaw && operation.sameOperation(m_txOperation)
+        && atuEpoch == m_atuCommandEpoch
+        && (m_txActivities & static_cast<unsigned>(TxActivity::Atu))) {
+        const ATUStatus status = m_transmitModel.atuStatus();
+        if (status != ATUStatus::InProgress && status != ATUStatus::None
+            && status != ATUStatus::NotStarted) {
+            endLocalTxActivity(TxActivity::Atu);
+        }
+    }
+    if (delta.cwSpeed && !usesFlexCommandPlane()) {
+        m_cwxModel.adoptSpeed(*delta.cwSpeed);
+    }
+}
+
 bool RadioModel::forwardNonFlexCwKeying(bool down)
 {
     if (!m_backend) {
@@ -4989,6 +5029,8 @@ bool RadioModel::sendNetCwCommand(const QString& baseCmd, const QString& debugSo
                                  std::chrono::steady_clock::time_point scheduledAt,
                                  std::function<void()> delivered)
 {
+    const bool keying = baseCmd.endsWith(QLatin1String(" 1"));
+    const TxCoordinator::Operation operation = keying ? m_txOperation : m_txCoordinator.cleanupFence();
     if (m_netCwStreamId == 0) {
         // No netcw stream — fall back to TCP immediate
         const QString fallbackCmd = baseCmd.contains("cw key")
@@ -5003,8 +5045,7 @@ bool RadioModel::sendNetCwCommand(const QString& baseCmd, const QString& debugSo
                 << " source=" << (debugSource.isEmpty() ? QStringLiteral("unknown") : debugSource)
                 << " cmd=\"" << fallbackCmd << "\"";
         }
-        sendCmd(fallbackCmd);
-        return false;
+        return sendNetCwTcp(fallbackCmd, operation, keying, std::move(delivered));
     }
 
     // Build the full command with timing metadata and dedup index
@@ -5152,15 +5193,22 @@ bool RadioModel::sendNetCwCommand(const QString& baseCmd, const QString& debugSo
     // Capture the original transport AND operation. A delayed copy must not
     // borrow a replacement backend (or a newer owner's key) after reconnect.
     // Check again on the worker, not merely before queueing the thread hop.
-    const bool keying = baseCmd.endsWith(QLatin1String(" 1"));
-    const TxCoordinator::Operation operation = keying ? m_txOperation : m_txCoordinator.cleanupFence();
     const QPointer<PanadapterStream> stream = m_panStream;
     const QPointer<RadioModel> receiver = this;
-    const auto sendCopy = [stream, operation, keying, logUdpSend, receiver, delivered](const QByteArray& packet, int copy, int delay) {
+    // Complete normal key-up only after BOTH transport queues have consumed
+    // the edge. Otherwise the faster UDP queue can invalidate a short TCP down.
+    const int parts = (stream ? 1 : 0) + ((m_connection || m_wanConn) ? 1 : 0);
+    const auto pending = std::make_shared<int>(parts);
+    const auto partDelivered = [pending, delivered] {
+        if (--*pending == 0 && delivered) {
+            delivered();
+        }
+    };
+    const auto sendCopy = [stream, operation, keying, logUdpSend, receiver, partDelivered](const QByteArray& packet, int copy, int delay) {
         if (!stream) {
             return;
         }
-        QMetaObject::invokeMethod(stream, [stream, operation, keying, packet, copy, delay, logUdpSend, receiver, delivered] {
+        QMetaObject::invokeMethod(stream, [stream, operation, keying, packet, copy, delay, logUdpSend, receiver, partDelivered] {
             if (!stream || (keying ? !operation.permitsDispatch(txMonotonicMs()) : !operation.permitsCleanup())) {
                 return;
             }
@@ -5169,8 +5217,8 @@ bool RadioModel::sendNetCwCommand(const QString& baseCmd, const QString& debugSo
             // Normal key-up is not cancellation. Keep its operation alive
             // until queued key-downs and the final key-up copy have reached
             // this worker; otherwise a short element can lose its down edge.
-            if (copy == 3 && !keying && receiver && delivered) {
-                QMetaObject::invokeMethod(receiver, delivered, Qt::QueuedConnection);
+            if (copy == 3 && !keying && receiver) {
+                QMetaObject::invokeMethod(receiver, partDelivered, Qt::QueuedConnection);
             }
         }, Qt::QueuedConnection);
     };
@@ -5182,7 +5230,44 @@ bool RadioModel::sendNetCwCommand(const QString& baseCmd, const QString& debugSo
     // FlexLib sends the same decorated netcw command over TCP after the UDP
     // copies.  With the 16-bit timestamp format above, the radio can dedupe
     // by index=N and the TCP path provides a reliable delivery backstop.
-    sendCmd(fullCmd);
+    sendNetCwTcp(fullCmd, operation, keying, partDelivered);
+    return parts != 0;
+}
+
+bool RadioModel::sendNetCwTcp(const QString& command, const TxCoordinator::Operation& operation,
+                            bool keying, std::function<void()> delivered)
+{
+    const QPointer<RadioModel> receiver = this;
+    const auto notifyDelivered = [receiver, keying, delivered] {
+        if (!keying && receiver && delivered) {
+            QMetaObject::invokeMethod(receiver, delivered, Qt::QueuedConnection);
+        }
+    };
+    const auto permitted = [operation, keying] {
+        return keying ? operation.permitsDispatch(txMonotonicMs()) : operation.permitsCleanup();
+    };
+    if (m_wanConn) {
+        // WAN's TLS writer is synchronous on the model's thread, unlike LAN.
+        // Capture its identity and check authority immediately at that writer.
+        const QPointer<WanConnection> connection = m_wanConn;
+        if (connection && permitted()) {
+            connection->sendCommand(command);
+            notifyDelivered();
+        }
+        return true;
+    }
+    const QPointer<RadioConnection> connection = m_connection;
+    if (!connection) {
+        return false;
+    }
+    const quint32 seq = m_seqCounter.fetch_add(1);
+    QMetaObject::invokeMethod(connection, [connection, seq, command, permitted, notifyDelivered] {
+        if (!connection || !permitted()) {
+            return;
+        }
+        connection->writeCommand(seq, command);
+        notifyDelivered();
+    }, Qt::QueuedConnection);
     return true;
 }
 
@@ -6428,6 +6513,8 @@ void RadioModel::onBackendSpectrumFrame(int panId, const QByteArray& frame)
 
 void RadioModel::onConnected()
 {
+    m_cwInputSession.fetch_add(1, std::memory_order_release);
+    m_cwInputNotBefore = std::chrono::steady_clock::now();
     m_txSessionClosing = false;
     qCDebug(lcProtocol) << "RadioModel: connected (family=" << m_family << ")";
     m_connectAttemptActive = false;  // the attempt landed (#4912)

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -30,6 +30,7 @@
 #include "TnfModel.h"
 #include "SpotModel.h"
 #include "CwxModel.h"
+#include "core/TxCoordinator.h"
 #include "DvkModel.h"
 #include "UsbCableModel.h"
 #include "DaxIqModel.h"
@@ -810,6 +811,9 @@ public:
     void acceptPresentedWanCert();
     void rejectPresentedWanCert();
     void setTransmit(bool tx, TransmitModel::PttSource source = TransmitModel::PttSource::Mox);
+    // Snapshot for engine-owned deferred release. This is not a credential or
+    // an invitation to borrow whichever operation happens to be current later.
+    TxCoordinator::Operation transmitOperation() const { return m_txOperation; }
     void setDigitalVoiceTxSlice(int sliceId);
     QString audioCompressionParam() const;        // "none" or "opus" based on settings
     void sendCwKey(bool down, const QString& debugSource = {},
@@ -1216,6 +1220,9 @@ signals:
     void txAudioGateChanged(bool transmitting);
     // Raw interlock TX state (regardless of ownership — for DAX passthrough).
     void radioTransmittingChanged(bool transmitting);
+    // Accepted local PTT intent, including re-engage during a deferred tail.
+    // Not radio readback: never use this to publish observed transmit state.
+    void localTransmitEngaged();
     // A backend's explicit keyed-state readback, including unchanged answers
     // hidden by the change-gated radioTransmittingChanged signal.
     void radioTransmitConfirmed(bool transmitting);
@@ -1687,6 +1694,7 @@ public:
 
 private:
     friend class RadioModelSliceLifecycleTestAccess;
+    friend class TxOperationIntegrationTestAccess;
     void wireBackendReceiverState();
     bool dispatchSliceLifecycleCommand(const QString& command, ResponseCallback callback = {});
     quint64 m_backendReceiverGeneration = 0;
@@ -1733,6 +1741,26 @@ private:
     qint64 m_lastAudioMs{0};
     TunerModel       m_tunerModel;
     TransmitModel    m_transmitModel;
+    // Transitional desktop actor: existing integrations still enter through
+    // the desktop methods. Per-client authority is a subsequent Stage 4 step;
+    // no daemon client can register or obtain this actor.
+    TxCoordinator m_txCoordinator;
+    TxCoordinator::Actor m_desktopTxActor;
+    TxCoordinator::Operation m_txOperation;
+    enum class TxActivity : unsigned { Mox = 1, Tune = 2, Atu = 4, CwKey = 8, CwPtt = 16, Cwx = 32 };
+    unsigned m_txActivities{0};
+    bool m_txSessionClosing{false};
+    bool m_atuOperationObserved{false};
+    quint64 m_txCommandEpoch{0};
+    quint64 m_tuneCommandEpoch{0};
+    quint64 m_atuCommandEpoch{0};
+    quint64 m_cwKeyDeliveryEpoch{0};
+    quint64 m_cwPttDeliveryEpoch{0};
+    static qint64 txMonotonicMs();
+    bool beginLocalTxActivity(TxActivity activity);
+    void endLocalTxActivity(TxActivity activity);
+    void stopTxOperation(const TxCoordinator::Operation& operation, TxCoordinator::StopReason reason);
+    void resetTxOperations();
     EqualizerModel   m_equalizerModel;
     TnfModel         m_tnfModel;
     SpotModel        m_spotModel;
@@ -1749,9 +1777,10 @@ private:
     int      m_netCwIndex{1};           // sequential dedup index
     QElapsedTimer m_netCwClock;          // 16-bit relative ms clock for time=0x....
     qint64   m_netCwLastSendMs{-1};
-    void sendNetCwCommand(const QString& cmd, const QString& debugSource = {},
+    bool sendNetCwCommand(const QString& cmd, const QString& debugSource = {},
                           quint64 debugTraceId = 0, quint64 debugSourceMs = 0,
-                          std::chrono::steady_clock::time_point scheduledAt = {});
+                          std::chrono::steady_clock::time_point scheduledAt = {},
+                          std::function<void()> delivered = {});
     QByteArray buildNetCwPacket(const QByteArray& payload);
 
     QString     m_name;
@@ -1821,7 +1850,6 @@ private:
     QString     m_lastInterlockNotificationKey;
     qint64      m_lastInterlockNotificationMs{0};
     qint64      m_interlockNotificationArmedUntilMs{0};
-    TransmitModel::PttSource m_pendingTransmitPreflightSource{TransmitModel::PttSource::Mox};
     TransmitModel::PttSource m_interlockNotificationSource{TransmitModel::PttSource::Mox};
     int         m_digitalVoiceTxSliceId{-1};
     QString     m_lastDigitalVoiceTxSelectionKey;

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -841,6 +841,11 @@ public:
     void sendCwKeyEdge(bool down, const QString& debugSource = {},
                        quint64 debugTraceId = 0, quint64 debugSourceMs = 0,
                        std::chrono::steady_clock::time_point scheduledAt = {});
+    // Producer-thread entry: capture the session before queueing onto the model.
+    // Old queued iambic edges cannot borrow the replacement radio's authority.
+    void queueCwKeyEdge(bool down, const QString& debugSource,
+                       quint64 debugTraceId, quint64 debugSourceMs,
+                       std::chrono::steady_clock::time_point scheduledAt);
     void cwAutoTune(int sliceId, bool intermittent); // int=1 start loop, int=0 stop
     void cwAutoTuneOnce(int sliceId);                // one-shot (no int= param)
     bool addSlice();           // Create a new slice on the active panadapter
@@ -1750,17 +1755,21 @@ private:
     enum class TxActivity : unsigned { Mox = 1, Tune = 2, Atu = 4, CwKey = 8, CwPtt = 16, Cwx = 32 };
     unsigned m_txActivities{0};
     bool m_txSessionClosing{false};
-    bool m_atuOperationObserved{false};
     quint64 m_txCommandEpoch{0};
     quint64 m_tuneCommandEpoch{0};
     quint64 m_atuCommandEpoch{0};
     quint64 m_cwKeyDeliveryEpoch{0};
     quint64 m_cwPttDeliveryEpoch{0};
+    std::atomic<quint64> m_cwInputSession{0};
+    std::chrono::steady_clock::time_point m_cwInputNotBefore{};
     static qint64 txMonotonicMs();
     bool beginLocalTxActivity(TxActivity activity);
     void endLocalTxActivity(TxActivity activity);
     void stopTxOperation(const TxCoordinator::Operation& operation, TxCoordinator::StopReason reason);
     void resetTxOperations();
+    void applyBackendTransmitDelta(const TransmitDelta& delta);
+    bool sendNetCwTcp(const QString& command, const TxCoordinator::Operation& operation,
+                     bool keying, std::function<void()> delivered);
     EqualizerModel   m_equalizerModel;
     TnfModel         m_tnfModel;
     SpotModel        m_spotModel;

--- a/src/models/RadioModel_TxCoordinator.cpp
+++ b/src/models/RadioModel_TxCoordinator.cpp
@@ -1,4 +1,5 @@
 #include "RadioModel.h"
+#include "core/LogManager.h"
 
 #include <chrono>
 
@@ -36,8 +37,43 @@ bool RadioModel::beginLocalTxActivity(TxActivity activity)
     }
     const TxCoordinator::Admission admission = m_txCoordinator.acquire(m_desktopTxActor, txMonotonicMs());
     if (!admission.accepted()) {
-        emitInterlockNotification(tr("Transmit cleanup is still in progress."),
-                                  QStringLiteral("tx-coordinator-recovering"));
+        // One message per reason. Only Recovering is reachable while a single
+        // desktop actor exists, but the others become reachable as soon as a
+        // per-client actor does, and "cleanup is in progress" would then be a
+        // wrong explanation rather than a vague one.
+        QString message;
+        QString key;
+        switch (admission.refusal) {
+        case TxCoordinator::Refusal::Recovering:
+            message = tr("Transmit cleanup is still in progress.");
+            key = QStringLiteral("tx-coordinator-recovering");
+            break;
+        case TxCoordinator::Refusal::Busy:
+            message = tr("Another client is transmitting.");
+            key = QStringLiteral("tx-coordinator-busy");
+            break;
+        case TxCoordinator::Refusal::Denied:
+            message = tr("This client is not permitted to transmit.");
+            key = QStringLiteral("tx-coordinator-denied");
+            break;
+        case TxCoordinator::Refusal::InvalidActor:
+        case TxCoordinator::Refusal::WrongThread:
+        case TxCoordinator::Refusal::None:
+            message = tr("Transmit is unavailable.");
+            key = QStringLiteral("tx-coordinator-unavailable");
+            break;
+        }
+        // m_txSessionClosing short-circuits above, so a Recovering refusal here
+        // is a stop that was never acknowledged rather than a normal disconnect
+        // gap. That is a permanent admission latch, so say so instead of
+        // leaving it to be diagnosed from a silent refusal. See
+        // TxCoordinator::acknowledgeStopped().
+        if (admission.refusal == TxCoordinator::Refusal::Recovering) {
+            qCWarning(lcProtocol)
+                << "RadioModel: TX refused — coordinator stop is unacknowledged;"
+                << "admission stays closed until the session ends";
+        }
+        emitInterlockNotification(message, key);
         return false;
     }
     m_txOperation = admission.operation;

--- a/src/models/RadioModel_TxCoordinator.cpp
+++ b/src/models/RadioModel_TxCoordinator.cpp
@@ -1,0 +1,103 @@
+#include "RadioModel.h"
+
+#include <chrono>
+
+namespace AetherSDR {
+
+qint64 RadioModel::txMonotonicMs()
+{
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+bool RadioModel::beginLocalTxActivity(TxActivity activity)
+{
+    if (m_txSessionClosing) {
+        emitInterlockNotification(tr("Transmit is unavailable while the radio disconnects."),
+                                  QStringLiteral("tx-session-closing"));
+        return false;
+    }
+    if (!m_backend || !refuseKeyOnTransmitIncapableBackend()
+        || !refuseKeyInReceiveOnlyMode()) {
+        return false;
+    }
+    const QString gate = activity == TxActivity::Tune || activity == TxActivity::Atu
+        ? QStringLiteral("tune-start")
+        : activity == TxActivity::Mox ? QStringLiteral("xmit") : QStringLiteral("cw-key");
+    if (transmitStartBlockedByInhibit(gate)) {
+        return false;
+    }
+    const TxCoordinator::Admission admission = m_txCoordinator.acquire(m_desktopTxActor, txMonotonicMs());
+    if (!admission.accepted()) {
+        emitInterlockNotification(tr("Transmit cleanup is still in progress."),
+                                  QStringLiteral("tx-coordinator-recovering"));
+        return false;
+    }
+    m_txOperation = admission.operation;
+    if (activity == TxActivity::Atu && !(m_txActivities & static_cast<unsigned>(TxActivity::Atu))) {
+        m_atuOperationObserved = false;
+    }
+    m_txActivities |= static_cast<unsigned>(activity);
+    return true;
+}
+
+void RadioModel::endLocalTxActivity(TxActivity activity)
+{
+    if (activity == TxActivity::Atu) {
+        m_atuOperationObserved = false;
+    }
+    m_txActivities &= ~static_cast<unsigned>(activity);
+    if (m_txActivities == 0) {
+        // Existing desktop sequencers explicitly end their local intent. This
+        // fences pending work; it is NOT a claim that the radio is observed RX.
+        // Do not use this compatibility completion to authorize another
+        // client's TX. Per-client admission/readback is the next Stage 4 step.
+        (void)m_txCoordinator.complete(m_txOperation);
+    }
+}
+
+void RadioModel::stopTxOperation(const TxCoordinator::Operation& operation,
+                               TxCoordinator::StopReason reason)
+{
+    Q_UNUSED(reason);
+    // TxCoordinator has already invalidated the keying fence and entered
+    // recovery. All cleanup below is key-up/bypass/abort; never re-admit it.
+    m_transmitModel.cancelPttRelease();
+    const unsigned activities = m_txActivities;
+    if (activities & static_cast<unsigned>(TxActivity::Cwx)) {
+        m_cwxModel.clearBuffer();
+    }
+    if (activities & static_cast<unsigned>(TxActivity::CwKey)) {
+        sendCwKey(false);
+    }
+    if (activities & static_cast<unsigned>(TxActivity::CwPtt)) {
+        sendCwPtt(false);
+    }
+    if (activities & static_cast<unsigned>(TxActivity::Tune)) {
+        m_transmitModel.stopTune();
+    }
+    if (activities & static_cast<unsigned>(TxActivity::Atu)) {
+        m_transmitModel.atuBypass();
+    }
+    if (activities != 0) {
+        setTransmit(false);
+    }
+    m_txActivities = 0;
+    m_txOperation = operation;
+    // No acknowledgment here: queued stop commands are not stopped-radio
+    // evidence. The lifecycle caller acknowledges only after transport loss.
+}
+
+void RadioModel::resetTxOperations()
+{
+    // Even an idle coordinator must refuse new intent while the session dies.
+    // Close admission BEFORE cancellation/reply/model notifications can reenter
+    // us; operation recovery alone only covers a previously active operation.
+    m_txSessionClosing = true;
+    m_transmitModel.cancelPttRelease();
+    m_txCoordinator.reset();
+    m_cwxModel.resetDrainWatch();
+    m_txActivities = 0;
+}
+
+} // namespace AetherSDR

--- a/src/models/RadioModel_TxCoordinator.cpp
+++ b/src/models/RadioModel_TxCoordinator.cpp
@@ -21,6 +21,13 @@ bool RadioModel::beginLocalTxActivity(TxActivity activity)
         || !refuseKeyInReceiveOnlyMode()) {
         return false;
     }
+    const RadioCapabilities caps = backendCapabilities();
+    if ((activity == TxActivity::Cwx && !caps.hasRadioSideCwKeyer)
+        || (activity == TxActivity::Atu && !caps.hasTuner)) {
+        emitInterlockNotification(tr("This radio does not support the requested transmit operation."),
+                                  QStringLiteral("tx-operation-unsupported"));
+        return false;
+    }
     const QString gate = activity == TxActivity::Tune || activity == TxActivity::Atu
         ? QStringLiteral("tune-start")
         : activity == TxActivity::Mox ? QStringLiteral("xmit") : QStringLiteral("cw-key");
@@ -34,18 +41,12 @@ bool RadioModel::beginLocalTxActivity(TxActivity activity)
         return false;
     }
     m_txOperation = admission.operation;
-    if (activity == TxActivity::Atu && !(m_txActivities & static_cast<unsigned>(TxActivity::Atu))) {
-        m_atuOperationObserved = false;
-    }
     m_txActivities |= static_cast<unsigned>(activity);
     return true;
 }
 
 void RadioModel::endLocalTxActivity(TxActivity activity)
 {
-    if (activity == TxActivity::Atu) {
-        m_atuOperationObserved = false;
-    }
     m_txActivities &= ~static_cast<unsigned>(activity);
     if (m_txActivities == 0) {
         // Existing desktop sequencers explicitly end their local intent. This
@@ -94,10 +95,25 @@ void RadioModel::resetTxOperations()
     // Close admission BEFORE cancellation/reply/model notifications can reenter
     // us; operation recovery alone only covers a previously active operation.
     m_txSessionClosing = true;
+    m_cwInputSession.fetch_add(1, std::memory_order_release);
+    m_cwInputNotBefore = std::chrono::steady_clock::now();
     m_transmitModel.cancelPttRelease();
     m_txCoordinator.reset();
     m_cwxModel.resetDrainWatch();
     m_txActivities = 0;
+}
+
+void RadioModel::queueCwKeyEdge(bool down, const QString& source, quint64 traceId,
+                              quint64 sourceMs, std::chrono::steady_clock::time_point scheduledAt)
+{
+    const quint64 session = m_cwInputSession.load(std::memory_order_acquire);
+    QMetaObject::invokeMethod(this, [this, session, down, source, traceId, sourceMs, scheduledAt] {
+        if (session != m_cwInputSession.load(std::memory_order_acquire)
+            || m_txSessionClosing || scheduledAt < m_cwInputNotBefore) {
+            return;
+        }
+        sendCwKeyEdge(down, source, traceId, sourceMs, scheduledAt);
+    }, Qt::QueuedConnection);
 }
 
 } // namespace AetherSDR

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -1012,6 +1012,8 @@ TransmitModel::PttRelease TransmitModel::capturePttRelease()
             [this, ownerThread = thread()] {
                 if (QThread::currentThread() == ownerThread) {
                     setMox(false);
+                } else {
+                    qCWarning(lcProtocol) << "PTT release refused off the model owning thread";
                 }
             }};
 }

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -3,6 +3,7 @@
 #include "core/LogManager.h"
 #include <QDebug>
 #include <QTimer>
+#include <QThread>
 
 namespace AetherSDR {
 
@@ -10,8 +11,14 @@ TransmitModel::TransmitModel(QObject* parent)
     : QObject(parent)
 {}
 
+TransmitModel::~TransmitModel()
+{
+    invalidatePttRelease();
+}
+
 void TransmitModel::resetState()
 {
+    cancelPttRelease();
     m_apdEnabled = false;
     m_apdConfigurable = false;
     m_apdEqActive = false;
@@ -336,6 +343,11 @@ void TransmitModel::startTune(PttSource source)
     }
     if (!runPttPreflight(source, false))
         return;
+    const KeyingPermit permit = m_keyingAdmission ? m_keyingAdmission(KeyingIntent::Tune, true) : KeyingPermit{};
+    if (m_keyingAdmission && (!permit || !permit())) {
+        return;
+    }
+    const quint64 intentEpoch = ++m_tuneIntentEpoch;
 
     // Tag the initiating source so the status-bar operator TX timer can exclude
     // local TUNE carriers as well as TCI/DAX-initiated tune (the radio reports
@@ -355,8 +367,9 @@ void TransmitModel::startTune(PttSource source)
         m_tune = true;
         emit tuneChanged(true);
     }
-    emit commandReady("transmit tune 1");
-    emit tuneCommandIssued(true);
+    if (intentEpoch == m_tuneIntentEpoch && (!permit || permit())) {
+        emit tuneCommandIssued(true);
+    }
 }
 
 void TransmitModel::startTwoToneTune(PttSource source)
@@ -366,15 +379,24 @@ void TransmitModel::startTwoToneTune(PttSource source)
     }
     if (!runPttPreflight(source, false))
         return;
+    const KeyingPermit permit = m_keyingAdmission ? m_keyingAdmission(KeyingIntent::Tune, true) : KeyingPermit{};
+    if (m_keyingAdmission && (!permit || !permit())) {
+        return;
+    }
+    const quint64 intentEpoch = ++m_tuneIntentEpoch;
 
     m_activePttSource = source;   // exclude local/TCI/DAX tune (see startTune, #4131)
     setTuneMode("two_tone");
+    if (intentEpoch != m_tuneIntentEpoch || (permit && !permit())) {
+        return;
+    }
     if (!m_tune) {
         m_tune = true;
         emit tuneChanged(true);
     }
-    emit commandReady("transmit tune 1");
-    emit tuneCommandIssued(true);
+    if (intentEpoch == m_tuneIntentEpoch && (!permit || permit())) {
+        emit tuneCommandIssued(true);
+    }
 }
 
 void TransmitModel::toggleTwoToneTune()
@@ -394,25 +416,41 @@ void TransmitModel::toggleTwoToneTune()
 
 void TransmitModel::stopTune()
 {
+    const quint64 intentEpoch = ++m_tuneIntentEpoch;
+    const KeyingPermit permit = m_keyingAdmission ? m_keyingAdmission(KeyingIntent::Tune, false) : KeyingPermit{};
     if (m_tune) {
         m_tune = false;
         emit tuneChanged(false);
     }
-    emit commandReady("transmit tune 0");
-    emit tuneCommandIssued(false);
+    if (intentEpoch == m_tuneIntentEpoch && (!permit || permit())) {
+        emit tuneCommandIssued(false);
+    }
 }
 
 void TransmitModel::setMox(bool on)
 {
+    if (on && !runPttPreflight(m_activePttSource)) {
+        return;
+    }
+    const KeyingPermit permit = m_keyingAdmission ? m_keyingAdmission(KeyingIntent::Mox, on) : KeyingPermit{};
+    if (on && m_keyingAdmission && (!permit || !permit())) {
+        return;
+    }
+    const quint64 intentEpoch = ++m_moxIntentEpoch;
+    invalidatePttRelease();
     // Optimistic MOX edge gating keeps UI/audio aligned with user intent.
     // Interlock status from the radio will still reconcile final state.
     if (m_transmitting != on) {
         m_transmitting = on;
         emit transmittingChanged(on);
+        if (intentEpoch != m_moxIntentEpoch || m_transmitting != on || (permit && !permit())) {
+            return;
+        }
         emit moxChanged(on);
     }
-    emit commandReady(QString("xmit %1").arg(on ? 1 : 0));
-    emit moxCommandIssued(on);
+    if (intentEpoch == m_moxIntentEpoch && (!permit || permit())) {
+        emit moxCommandIssued(on);
+    }
 }
 
 void TransmitModel::setTransmitting(bool tx)
@@ -420,6 +458,9 @@ void TransmitModel::setTransmitting(bool tx)
     if (tx == m_transmitting) return;
     m_transmitting = tx;
     emit transmittingChanged(tx);
+    if (m_transmitting != tx) {
+        return;
+    }
     // Keep moxChanged for backward compat — CW decoder gate and QSO recorder
     // currently gate on this signal and need interlock-driven TX edges too.
     emit moxChanged(tx);
@@ -427,13 +468,15 @@ void TransmitModel::setTransmitting(bool tx)
 
 void TransmitModel::atuStart()
 {
-    emit commandReady("atu start");
+    const KeyingPermit permit = m_keyingAdmission ? m_keyingAdmission(KeyingIntent::Atu, true) : KeyingPermit{};
+    if (m_keyingAdmission && (!permit || !permit())) {
+        return;
+    }
     emit atuCommandIssued(true);
 }
 
 void TransmitModel::atuBypass()
 {
-    emit commandReady("atu bypass");
     emit atuCommandIssued(false);
 }
 
@@ -937,19 +980,63 @@ void TransmitModel::cancelPendingQuindarOff()
     m_quindarOutroInFlight = false;
 }
 
-void TransmitModel::dispatchMoxOff()
+void TransmitModel::invalidatePttRelease()
 {
-    if (m_pttOffHook) {
-        m_pttOffHook();
+    if (m_pttReleaseFence) {
+        m_pttReleaseFence->store(false, std::memory_order_release);
+        m_pttReleaseFence.reset();
+    }
+}
+
+void TransmitModel::cancelPttRelease()
+{
+    const quint64 intentEpoch = ++m_moxIntentEpoch;
+    ++m_tuneIntentEpoch;
+    invalidatePttRelease();
+    cancelPendingQuindarOff();
+    if (m_quindarTone) {
+        m_quindarTone->forceIdle();
+    }
+    emit quindarActiveChanged(false);
+    if (intentEpoch == m_moxIntentEpoch) {
+        emit pttReleaseCancelled();
+    }
+}
+
+TransmitModel::PttRelease TransmitModel::capturePttRelease()
+{
+    invalidatePttRelease();
+    m_pttReleaseFence = std::make_shared<std::atomic<bool>>(true);
+    const std::shared_ptr<std::atomic<bool>> fence = m_pttReleaseFence;
+    return {[fence] { return fence->load(std::memory_order_acquire); },
+            [this, ownerThread = thread()] {
+                if (QThread::currentThread() == ownerThread) {
+                    setMox(false);
+                }
+            }};
+}
+
+void TransmitModel::dispatchMoxOff(const PttRelease& release)
+{
+    if (!release.current()) {
         return;
     }
-    setMox(false);
+    if (m_pttOffHook) {
+        m_pttOffHook(release);
+        return;
+    }
+    release.release();
 }
 
 void TransmitModel::requestPttOn(PttSource source)
 {
     if (!runPttPreflight(source))
         return;
+    const KeyingPermit permit = m_keyingAdmission ? m_keyingAdmission(KeyingIntent::Mox, true) : KeyingPermit{};
+    if (m_keyingAdmission && (!permit || !permit())) {
+        return;
+    }
+    invalidatePttRelease();
 
     // Remember who asked to key so the status-bar TX timer can exclude
     // TCI-hardware and DAX transmits (both surface as source=SW at the radio).
@@ -988,11 +1075,17 @@ void TransmitModel::requestPttOn(PttSource source)
             emit quindarActiveChanged(false);
         });
     }
-    setMox(true);
+    if (!permit || permit()) {
+        setMox(true);
+    }
 }
 
 void TransmitModel::requestPttOff(PttSource /*source*/)
 {
+    if (m_pttReleaseFence && m_pttReleaseFence->load(std::memory_order_acquire)) {
+        return; // a duplicate release must not truncate an in-flight normal tail
+    }
+    const PttRelease release = capturePttRelease();
     auto* tone = m_quindarTone;
 
     // No Quindar, no phone mode, or already shutting down → straight
@@ -1002,7 +1095,7 @@ void TransmitModel::requestPttOff(PttSource /*source*/)
         || tone->phase() == ClientQuindarTone::Phase::Idle
         || m_quindarOutroInFlight) {
         cancelPendingQuindarOff();
-        dispatchMoxOff();
+        dispatchMoxOff(release);
         return;
     }
 
@@ -1010,22 +1103,29 @@ void TransmitModel::requestPttOff(PttSource /*source*/)
     // tone gets transmitted before the radio unkeys.  Outro duration
     // is style-dependent and computed from current settings.
     tone->startOutro();
-    m_quindarOutroInFlight = true;
     emit quindarActiveChanged(true);
+    if (!release.current()) {
+        return;
+    }
     const int outroMs = std::max(50, tone->currentOutroDurationMs());
 
     cancelPendingQuindarOff();
+    m_quindarOutroInFlight = true;
     m_pendingMoxOffTimer = new QTimer(this);
     m_pendingMoxOffTimer->setSingleShot(true);
     m_pendingMoxOffTimer->setInterval(outroMs);
-    connect(m_pendingMoxOffTimer, &QTimer::timeout, this, [this]() {
+    connect(m_pendingMoxOffTimer, &QTimer::timeout, this, [this, release, timer = m_pendingMoxOffTimer]() {
         // If a re-engage happened during the outro window the timer
         // would have been cancelled; if we're here, the outro fully
         // completed and it's safe to flip MOX off.
+        timer->deleteLater();
+        if (timer != m_pendingMoxOffTimer) {
+            return;
+        }
         m_pendingMoxOffTimer = nullptr;
         m_quindarOutroInFlight = false;
         emit quindarActiveChanged(false);
-        dispatchMoxOff();
+        dispatchMoxOff(release);
     });
     m_pendingMoxOffTimer->start();
 }

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -9,6 +9,8 @@
 #include "core/backends/TransmitDelta.h"
 
 #include <functional>
+#include <atomic>
+#include <memory>
 
 class QTimer;
 
@@ -40,6 +42,7 @@ class TransmitModel : public QObject {
 
 public:
     explicit TransmitModel(QObject* parent = nullptr);
+    ~TransmitModel() override;
 
     // ── Transmit getters ────────────────────────────────────────────────────
     int     rfPower()       const { return m_rfPower; }
@@ -236,12 +239,27 @@ public:
     using PttPreflight = std::function<QString(PttSource)>;
     void setPttPreflight(PttPreflight preflight);
 
-    // Pre-unkey hook: when set, requestPttOff() calls hook() instead of
-    // setMox(false) directly. Hook MUST eventually release PTT via setTransmit(false).
-    // Designed for RADE EOO intercept.
-    using PttOffHook = std::function<void()>;
+    enum class KeyingIntent { Mox, Tune, Atu };
+    // Installed by the engine. Admission precedes optimistic state and every
+    // keying signal; a standalone model has no transport to authorize.
+    using KeyingPermit = std::function<bool()>;
+    using KeyingAdmission = std::function<KeyingPermit(KeyingIntent, bool)>;
+    void setKeyingAdmission(KeyingAdmission admission) { m_keyingAdmission = std::move(admission); }
+
+    // A deferred release owns its original cancellation fence. A new key-on,
+    // explicit stop, reset or destruction invalidates it, including on audio
+    // workers. Never reconstruct a release from the then-current operation.
+    struct PttRelease {
+        std::function<bool()> isCurrent;
+        std::function<void()> finish;
+        bool current() const { return isCurrent && isCurrent(); }
+        void release() const { if (current() && finish) { finish(); } }
+    };
+    using PttOffHook = std::function<void(PttRelease)>;
     void setPttOffHook(PttOffHook hook);
     void clearPttOffHook();
+    void invalidatePttRelease();
+    void cancelPttRelease();
 
     void atuStart();
     void atuBypass();
@@ -317,12 +335,11 @@ signals:
     // reuse that same signal rather than a duplicate. #4449 recovery.)
     // Keying and tune as INTENT rather than as a Flex command string.
     //
-    // setMox() and startTune() emit "xmit N" / "transmit tune N" through
-    // commandReady, which is a Flex TCP command and reaches a backend with no
-    // command channel not at all. These carry the same intent for backends that
-    // key through IRadioBackend. RadioModel routes them only for non-Flex
-    // families, so Flex keeps its single command and does not key twice.
+    // All backends receive these through RadioModel's coordinator and typed
+    // seam. Keying is never duplicated through commandReady.
     void moxCommandIssued(bool on);
+    // Immediate teardown/cancellation, distinct from a normal tail request.
+    void pttReleaseCancelled();
     void tuneCommandIssued(bool on);
     void hostModulationChanged(bool on);
     void hasTunerChanged(bool present);
@@ -412,15 +429,20 @@ private:
     bool isPhoneModeForQuindar() const;
     bool runPttPreflight(PttSource source, bool resyncMoxOnBlock = true);
     void cancelPendingQuindarOff();
-    void dispatchMoxOff();
+    void dispatchMoxOff(const PttRelease& release);
+    PttRelease capturePttRelease();
 
     // PTT coordinator state (#2262)
     class ClientQuindarTone* m_quindarTone{nullptr};
     TxModeGetter             m_txModeGetter;
     PttPreflight             m_pttPreflight;
+    KeyingAdmission          m_keyingAdmission;
     QTimer*                  m_pendingMoxOffTimer{nullptr};
     bool                     m_quindarOutroInFlight{false};
     PttOffHook               m_pttOffHook;
+    std::shared_ptr<std::atomic<bool>> m_pttReleaseFence;
+    quint64 m_moxIntentEpoch{0};
+    quint64 m_tuneIntentEpoch{0};
 
     // APD state
     bool m_apdEnabled{false};

--- a/tests/atu_seam_gate_test.cpp
+++ b/tests/atu_seam_gate_test.cpp
@@ -9,8 +9,7 @@
 //   1. a blocked start dispatches NOTHING to the backend;
 //   2. a permitted start dispatches EXACTLY ONCE;
 //   3. bypass is dispatched regardless of the gate.
-// Flex is covered too: its ATU travels as wire text through the existing
-// gate, so the seam verb must not fire there at all.
+// Flex is covered too: all families now take the same typed seam exactly once.
 
 #include "TestSettingsProfile.h"
 #include "models/RadioModel.h"
@@ -162,13 +161,13 @@ static void panInhibitBlocksStart()
     check(f.backend->atuStarts == 1, "inhibit lifted: start dispatches once");
 }
 
-static void flexStaysOnTheWirePath()
+static void flexUsesTheSameTypedPath()
 {
     Fixture f(QStringLiteral("flex"), /*canTransmit=*/true);
     f.radio.transmitModel().atuStart();
     f.radio.transmitModel().atuBypass();
-    check(f.backend->atuStarts == 0 && f.backend->atuBypasses == 0,
-          "flex: the seam verb is never used (ATU travels as wire text)");
+    check(f.backend->atuStarts == 1 && f.backend->atuBypasses == 1,
+          "flex: the same typed seam dispatches each intent exactly once");
 }
 
 int main(int argc, char** argv)
@@ -180,7 +179,7 @@ int main(int argc, char** argv)
     receiveOnlyBackendBlocksStart();
     receiveOnlyModeBlocksStart();
     panInhibitBlocksStart();
-    flexStaysOnTheWirePath();
+    flexUsesTheSameTypedPath();
     std::printf("%d failure(s)\n", failures);
     return failures == 0 ? 0 : 1;
 }

--- a/tests/automation_tx_watchdog_test.cpp
+++ b/tests/automation_tx_watchdog_test.cpp
@@ -85,9 +85,17 @@ void pump(int ms)
 bool sawForceUnkey(const QStringList& commands)
 {
     return std::ranges::any_of(commands, [](const QString& command) {
-        return command == QStringLiteral("xmit 0")
-            || command == QStringLiteral("transmit tune 0");
+        return command == QStringLiteral("intent:mox:off")
+            || command == QStringLiteral("intent:tune:off");
     });
+}
+
+void recordKeyingIntents(RadioModel& radio, QStringList& commands)
+{
+    QObject::connect(&radio.transmitModel(), &AetherSDR::TransmitModel::moxCommandIssued,
+                     &radio, [&commands](bool on) { commands << (on ? "intent:mox:on" : "intent:mox:off"); });
+    QObject::connect(&radio.transmitModel(), &AetherSDR::TransmitModel::tuneCommandIssued,
+                     &radio, [&commands](bool on) { commands << (on ? "intent:tune:on" : "intent:tune:off"); });
 }
 
 // (1) TX permission enabled, but a local feature (WSPR in production) keys
@@ -96,6 +104,7 @@ void testEnabledBridgeDoesNotUnkeyManualTransmit()
 {
     RadioModel radio;
     QStringList commands;
+    recordKeyingIntents(radio, commands);
     QObject::connect(&radio.transmitModel(),
                      &AetherSDR::TransmitModel::commandReady,
                      [&commands](const QString& command) {
@@ -122,6 +131,7 @@ void testBridgeActionDoesNotAdoptPreExistingTransmit()
 {
     RadioModel radio;
     QStringList commands;
+    recordKeyingIntents(radio, commands);
     QObject::connect(&radio.transmitModel(),
                      &AetherSDR::TransmitModel::commandReady,
                      [&commands](const QString& command) {
@@ -158,6 +168,7 @@ void testBridgeActionOnIdleRadioIsPoliced()
 {
     RadioModel radio;
     QStringList commands;
+    recordKeyingIntents(radio, commands);
     QObject::connect(&radio.transmitModel(),
                      &AetherSDR::TransmitModel::commandReady,
                      [&commands](const QString& command) {

--- a/tests/hl2_tci_signaling_test.cpp
+++ b/tests/hl2_tci_signaling_test.cpp
@@ -71,6 +71,21 @@ static RadioInfo flexInfo()
     return i;
 }
 
+// The TX-signaling contract is independent of connection establishment. Use
+// the production backend seam without opening a Metis transport or pretending
+// an unanswered TEST-NET connection is a completed radio session.
+static void prepareTxFixture(RadioModel& model)
+{
+    model.setBackendForTest(std::make_unique<hl2::Hl2Backend>(), QStringLiteral("hl2"));
+    if (!model.automationApplySliceFixture(0, QStringLiteral("A")) || !model.slice(0)) {
+        qFatal("Could not install the TX slice fixture");
+    }
+    SliceDelta delta;
+    delta.txSlice = true;
+    delta.mode = QStringLiteral("USB");
+    model.slice(0)->applyChanges(delta);
+}
+
 // Grants access to the private predicate that gates every DAX arrangement in
 // TciServer. Declared as a friend in TciServer.h.
 //
@@ -135,13 +150,12 @@ public:
 static void testTransmitEdgeIsPublished()
 {
     RadioModel model;
-    model.connectToRadio(hl2Info());
+    prepareTxFixture(model);
 
     QSignalSpy edges(&model, &RadioModel::radioTransmittingChanged);
 
     // Exactly the call TciServer::handleTrxRequest makes for a WSJT-X key.
-    // PttSource::Dax is what lets it through the local interlock preflight with
-    // no slice assigned, so this reaches the seam on a link-less model.
+    // The injected model has the explicit prerequisites to reach the seam.
     model.setTransmit(true, TransmitModel::PttSource::Dax);
     check(edges.size() == 1, "HL2 key publishes one radioTransmittingChanged");
     check(!edges.isEmpty() && edges.first().first().toBool(),
@@ -167,7 +181,7 @@ static void testTransmitEdgeIsPublished()
 static void testMoxPathPublishesTheSameEdge()
 {
     RadioModel model;
-    model.connectToRadio(hl2Info());
+    prepareTxFixture(model);
 
     QSignalSpy edges(&model, &RadioModel::radioTransmittingChanged);
 
@@ -188,13 +202,11 @@ static void testMoxPathPublishesTheSameEdge()
 static void testTunePathPublishesTheSameEdge()
 {
     RadioModel model;
-    model.connectToRadio(hl2Info());
+    prepareTxFixture(model);
 
     QSignalSpy edges(&model, &RadioModel::radioTransmittingChanged);
 
-    // PttSource::Dax for the same reason the key test uses it: it is the one
-    // source localPttInterlockMessage() lets through with no TX slice assigned,
-    // and TCI/DAX-initiated tune is a real path (see TransmitModel::startTune).
+    // TCI/DAX-initiated tune is a real path (see TransmitModel::startTune).
     model.transmitModel().startTune(TransmitModel::PttSource::Dax);
     check(edges.size() == 1 && edges.first().first().toBool(),
           "HL2 TUNE-on publishes radioTransmittingChanged(true)");
@@ -215,11 +227,15 @@ static void testFlexEdgeStaysInterlockOwned()
     model.connectToRadio(flexInfo());
 
     QSignalSpy edges(&model, &RadioModel::radioTransmittingChanged);
+    QSignalSpy moxCommands(&model.transmitModel(), &TransmitModel::moxCommandIssued);
     model.setTransmit(true, TransmitModel::PttSource::Dax);
+    model.transmitModel().noteActivePttSource(TransmitModel::PttSource::Dax);
     model.transmitModel().setMox(true);
     model.transmitModel().startTune(TransmitModel::PttSource::Dax);
     check(edges.isEmpty(),
           "Flex publishes no raw-TX edge from a command; interlock owns it");
+    check(moxCommands.size() == 1,
+          "Flex MOX assertion reaches command dispatch, not a preflight refusal");
 }
 
 // ── Which command plane the radio speaks ──────────────────────────────────
@@ -274,7 +290,7 @@ static void testRefusedKeyPublishesNoTransmitEdge()
     qunsetenv("AETHER_AUTOMATION_ALLOW_TX");
 
     RadioModel model;
-    model.connectToRadio(hl2Info());
+    prepareTxFixture(model);
     check(!model.backendCapabilities().canTransmit,
           "fixture precondition: the HL2 transmit gate is closed");
 

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -4054,6 +4054,21 @@ target_compile_definitions(memory_csv_compat_test PRIVATE
 target_link_libraries(memory_csv_compat_test PRIVATE Qt6::Core)
 add_test(NAME memory_csv_compat_test COMMAND memory_csv_compat_test)
 
+# Socket-free engine ownership/cancellation policy; no radio or peer process.
+add_executable(tx_coordinator_test
+    tests/tx_coordinator_test.cpp
+    src/core/TxCoordinator.cpp
+)
+target_include_directories(tx_coordinator_test PRIVATE src)
+target_link_libraries(tx_coordinator_test PRIVATE Qt6::Core)
+add_test(NAME tx_coordinator_test COMMAND tx_coordinator_test)
+
+# Socket-free: production models with injected backend command recorders.
+add_executable(tx_operation_integration_test tests/tx_operation_integration_test.cpp)
+target_include_directories(tx_operation_integration_test PRIVATE src tests)
+target_link_libraries(tx_operation_integration_test PRIVATE aethercore Qt6::Core)
+add_test(NAME tx_operation_integration_test COMMAND tx_operation_integration_test)
+
 add_executable(transmit_model_apd_test
     tests/transmit_model_apd_test.cpp
     src/models/TransmitModel.cpp
@@ -4852,6 +4867,7 @@ target_link_libraries(CAT_Flex_test PRIVATE Qt6::Core Qt6::Network)
 # Conditional targets are guarded with if(TARGET ...).
 set(AETHER_SETTINGS_CONSUMERS
     atu_seam_gate_test
+    tx_operation_integration_test
     backend_slice_lifecycle_test
     client_display_settings_test
     rx_applet_squelch_reconciliation_test

--- a/tests/transmit_model_test.cpp
+++ b/tests/transmit_model_test.cpp
@@ -40,6 +40,10 @@ int main(int argc, char** argv)
     QStringList blockedMessages;
     QObject::connect(&tx, &TransmitModel::commandReady,
                      [&commands](const QString& cmd) { commands.append(cmd); });
+    QObject::connect(&tx, &TransmitModel::tuneCommandIssued,
+                     [&commands](bool on) { commands.append(on ? "intent:tune:on" : "intent:tune:off"); });
+    QObject::connect(&tx, &TransmitModel::moxCommandIssued,
+                     [&commands](bool on) { commands.append(on ? "intent:mox:on" : "intent:mox:off"); });
     QObject::connect(&tx, &TransmitModel::pttBlocked,
                      [&blockedMessages](const QString& message) { blockedMessages.append(message); });
 
@@ -146,7 +150,7 @@ int main(int argc, char** argv)
     tx.startTwoToneTune();
     ok &= expect(commands == QStringList({
                      "transmit set tune_mode=two_tone",
-                     "transmit tune 1",
+                     "intent:tune:on",
                  })
                      && tx.activePttSource() == TransmitModel::PttSource::Tune,
                  "two-tone tune sets mode and tags the tune source before starting");
@@ -155,7 +159,7 @@ int main(int argc, char** argv)
     commands.clear();
     tx.toggleTwoToneTune();
     ok &= expect(commands == QStringList({
-                     "transmit tune 0",
+                     "intent:tune:off",
                      "transmit set tune_mode=single_tone",
                  }),
                  "two-tone tune toggle stops and restores single-tone mode");
@@ -165,13 +169,13 @@ int main(int argc, char** argv)
     tx.toggleTwoToneTune();
     ok &= expect(commands == QStringList({
                      "transmit set tune_mode=two_tone",
-                     "transmit tune 1",
+                     "intent:tune:on",
                  }),
                  "two-tone tune toggle starts two-tone when not tuning");
 
     commands.clear();
     tx.startTune();
-    ok &= expect(commands == QStringList({"transmit tune 1"})
+    ok &= expect(commands == QStringList({"intent:tune:on"})
                      && tx.activePttSource() == TransmitModel::PttSource::Tune,
                  "single-tone tune tags the tune source before starting");
 
@@ -401,7 +405,7 @@ int main(int argc, char** argv)
     tx.setTxModeGetter([] { return QStringLiteral("USB"); });
     commands.clear();
     tx.requestPttOn(TransmitModel::PttSource::Wspr);
-    ok &= expect(commands == QStringList({"xmit 1"})
+    ok &= expect(commands == QStringList({"intent:mox:on"})
                  && quindar.phase() == ClientQuindarTone::Phase::Idle,
                  "WSPR PTT bypasses Quindar signaling");
 

--- a/tests/tx_applet_power_reconciliation_test.cpp
+++ b/tests/tx_applet_power_reconciliation_test.cpp
@@ -223,7 +223,7 @@ void testAtuSuccessTogglesToBypass()
     if (!atu)
         return;
 
-    QSignalSpy commandSpy(&model, &TransmitModel::commandReady);
+    QSignalSpy commandSpy(&model, &TransmitModel::atuCommandIssued);
     TransmitDelta matched;
     matched.transmitFreq = 14.100;
     matched.atuEnabled = true;
@@ -232,7 +232,7 @@ void testAtuSuccessTogglesToBypass()
     atu->click();
     report("successful same-frequency ATU click requests bypass",
            !commandSpy.isEmpty()
-               && commandSpy.takeLast().at(0).toString() == QStringLiteral("atu bypass"));
+               && !commandSpy.takeLast().at(0).toBool());
 
     TransmitDelta bypassed;
     bypassed.atuEnabled = false;
@@ -242,7 +242,7 @@ void testAtuSuccessTogglesToBypass()
     atu->click();
     report("bypassed ATU click starts a fresh tune",
            !commandSpy.isEmpty()
-               && commandSpy.takeLast().at(0).toString() == QStringLiteral("atu start"));
+               && commandSpy.takeLast().at(0).toBool());
 }
 
 void testAtuCapabilityUsesThreeVisibleStates()
@@ -278,6 +278,7 @@ void testAtuCapabilityUsesThreeVisibleStates()
                && inactiveSuccessStyle == inactiveMemoryStyle);
 
     QSignalSpy commandSpy(&model, &TransmitModel::commandReady);
+    QSignalSpy atuIntents(&model, &TransmitModel::atuCommandIssued);
     model.setHasTuner(false);
     model.setHasTunerMemories(false);
     QApplication::processEvents();
@@ -293,7 +294,7 @@ void testAtuCapabilityUsesThreeVisibleStates()
                && memory->styleSheet() != inactiveMemoryStyle);
     atu->click();
     mem->click();
-    report("unavailable tuner controls emit no commands", commandSpy.isEmpty());
+    report("unavailable tuner controls emit no commands", commandSpy.isEmpty() && atuIntents.isEmpty());
     report("unavailable tuner controls explain the state",
            atu->toolTip()
                    == QStringLiteral("Antenna tuner controls are unavailable for this radio")
@@ -366,12 +367,13 @@ void testTuneAvailability()
         return;
     }
     QSignalSpy commands(&model, &TransmitModel::commandReady);
+    QSignalSpy tuneIntents(&model, &TransmitModel::tuneCommandIssued);
     model.setTuneAvailable(false);
     report("unsupported Tune button is disabled", !tune->isEnabled());
     model.startTune();
     model.startTwoToneTune();
     report("both Tune paths refuse without commands or optimistic state",
-           commands.isEmpty() && !model.isTuning());
+           commands.isEmpty() && tuneIntents.isEmpty() && !model.isTuning());
     model.setTuneAvailable(true);
     report("capable mode restores Tune", tune->isEnabled());
     model.startTune();

--- a/tests/tx_coordinator_test.cpp
+++ b/tests/tx_coordinator_test.cpp
@@ -1,0 +1,209 @@
+#include "core/TxCoordinator.h"
+
+#include <QCoreApplication>
+#include <QThread>
+
+#include <cstdio>
+#include <limits>
+#include <memory>
+#include <vector>
+
+using AetherSDR::TxCoordinator;
+
+namespace {
+int failures = 0;
+void check(bool condition, const char* message)
+{
+    std::printf("[%s] %s\n", condition ? "PASS" : "FAIL", message);
+    failures += !condition;
+}
+
+void ownershipAndRecovery()
+{
+    int stops = 0;
+    TxCoordinator::Operation stopped;
+    TxCoordinator::Actor competitor;
+    TxCoordinator* callbackCoordinator = nullptr;
+    TxCoordinator coordinator([&](const TxCoordinator::Operation& operation,
+                                 TxCoordinator::StopReason) {
+        ++stops;
+        stopped = operation;
+        check(!operation.permitsDispatch(100), "stop invalidates delivery before callback");
+        check(callbackCoordinator->acquire(competitor, 100).refusal == TxCoordinator::Refusal::Recovering,
+              "reentrant competing start cannot race stop cleanup");
+    });
+    callbackCoordinator = &coordinator;
+    const TxCoordinator::Actor owner = coordinator.registerActor({true, 0});
+    competitor = coordinator.registerActor({true, 0});
+    const TxCoordinator::Actor observer = coordinator.registerActor({false, 0});
+    check(coordinator.acquire({}, 0).refusal == TxCoordinator::Refusal::InvalidActor,
+          "default actor has no authority");
+    check(coordinator.acquire(observer, 0).refusal == TxCoordinator::Refusal::Denied,
+          "authenticated actor without transmit permission cannot acquire");
+    const TxCoordinator::Admission first = coordinator.acquire(owner, 0);
+    check(first.accepted() && first.operation.permitsDispatch(0), "owner acquires usable operation");
+    check(stops == 0, "acquiring never dispatches stop or keying");
+    check(coordinator.acquire(competitor, 1).refusal == TxCoordinator::Refusal::Busy,
+          "second actor cannot take the owner slot");
+    check(coordinator.acquire(owner, 2).operation.sameOperation(first.operation),
+          "repeated start retains the existing operation");
+    check(!coordinator.cancel(competitor, first.operation), "nonowner cannot stop owner");
+    check(!coordinator.complete({}), "invalid handle cannot finish another operation");
+    check(coordinator.cancel(owner, first.operation) && stops == 1,
+          "owner cancellation dispatches one stop");
+    check(!coordinator.cancel(owner, first.operation) && stops == 1,
+          "duplicate cancellation is inert");
+    check(!coordinator.acknowledgeStopped({}), "unrelated stop acknowledgment cannot clear recovery");
+    check(coordinator.acknowledgeStopped(stopped), "matching qualified stop acknowledgment clears recovery");
+    const TxCoordinator::Admission next = coordinator.acquire(competitor, 101);
+    check(next.accepted(), "next actor can acquire after recovery");
+    check(!coordinator.complete(first.operation), "late old completion cannot stop new owner");
+    check(!coordinator.acknowledgeStopped(stopped), "late old acknowledgment is inert");
+    check(next.operation.permitsDispatch(102), "new owner survives old callbacks");
+    check(coordinator.complete(next.operation), "already-stopped operation completes normally");
+    check(!next.operation.permitsDispatch(103), "normal completion fences queued work");
+    check(next.operation.permitsCleanup(), "normal completion retains queued key-up cleanup");
+    check(coordinator.acquire(owner, 104).accepted(), "new owner starts after normal completion");
+    check(!next.operation.permitsCleanup(), "old queued key-up cannot unkey a newer operation");
+    check(stops == 1, "normal completion never sends an extra unkey");
+}
+
+void expiryAndRevocation()
+{
+    int stops = 0;
+    TxCoordinator::Operation stopped;
+    TxCoordinator::StopReason reason = TxCoordinator::StopReason::Reset;
+    TxCoordinator coordinator([&](const TxCoordinator::Operation& operation,
+                                 TxCoordinator::StopReason why) {
+        ++stops;
+        stopped = operation;
+        reason = why;
+    });
+    const TxCoordinator::Actor bounded = coordinator.registerActor({true, 20});
+    const TxCoordinator::Actor other = coordinator.registerActor({true, 0});
+    const TxCoordinator::Admission first = coordinator.acquire(bounded, 100);
+    check(first.operation.permitsDispatch(119), "bounded operation survives before deadline");
+    check(!first.operation.permitsDispatch(120), "transport fence rejects exact deadline before timer runs");
+    check(coordinator.acquire(bounded, 119).accepted(), "repeat admission before deadline succeeds");
+    coordinator.expire(120);
+    check(stops == 1 && reason == TxCoordinator::StopReason::Expired,
+          "repeat acquisition cannot extend maximum continuous duration");
+    coordinator.expire(121);
+    check(stops == 1, "expired operation stops only once");
+    check(coordinator.acknowledgeStopped(stopped), "expiry recovery acknowledged");
+    const TxCoordinator::Admission second = coordinator.acquire(bounded, 122);
+    coordinator.revoke(other);
+    check(second.operation.permitsDispatch(123) && stops == 1,
+          "revoking another actor does not affect owner");
+    coordinator.revoke(bounded);
+    check(stops == 2 && reason == TxCoordinator::StopReason::ActorRevoked,
+          "owner revocation cancels active transmission");
+    check(!second.operation.permitsDispatch(123), "revocation fences pending output");
+    check(coordinator.acknowledgeStopped(stopped), "revocation recovery acknowledged");
+    check(coordinator.acquire(bounded, 124).refusal == TxCoordinator::Refusal::InvalidActor,
+          "revoked actor cannot reacquire");
+}
+
+void lifetimeAndIdentity()
+{
+    TxCoordinator::Operation stale;
+    TxCoordinator::Actor staleActor;
+    {
+        TxCoordinator coordinator([](const auto&, auto) {});
+        staleActor = coordinator.registerActor({true, 0});
+        stale = coordinator.acquire(staleActor, 0).operation;
+    }
+    check(!stale.permitsDispatch(1), "coordinator destruction fences retained worker handles");
+    TxCoordinator other([](const auto&, auto) {});
+    check(other.acquire(staleActor, 1).refusal == TxCoordinator::Refusal::InvalidActor,
+          "actor from destroyed or different coordinator cannot be adopted");
+    const TxCoordinator::Actor actor = other.registerActor({true, 0});
+    const TxCoordinator::Admission operation = other.acquire(actor, 0);
+    check(operation.operation.permitsDispatch(std::numeric_limits<qint64>::max()),
+          "ordinary local operation has no newly imposed timeout");
+    other.reset();
+    check(!operation.operation.permitsDispatch(1), "connection reset invalidates old work");
+    check(!operation.operation.permitsCleanup(), "connection reset invalidates old key-ups too");
+    check(other.recovering(), "reset remains fail closed until cleanup is acknowledged");
+    check(other.acknowledgeStopped(operation.operation), "reset cleanup tied to exact old operation");
+    const TxCoordinator::Admission next = other.acquire(actor, 2);
+    check(!next.operation.sameOperation(operation.operation), "new connection uses new operation identity");
+    other.emergencyStop();
+    check(!next.operation.permitsDispatch(3), "emergency stop invalidates active operation");
+}
+
+void limitsAndThread()
+{
+    TxCoordinator coordinator([](const auto&, auto) {});
+    check(coordinator.acquire(coordinator.registerActor({true, -1}), 0).refusal
+              == TxCoordinator::Refusal::InvalidActor, "negative time policy is rejected");
+    std::vector<TxCoordinator::Actor> actors;
+    for (int i = 0; i < TxCoordinator::kMaximumActors; ++i) {
+        actors.push_back(coordinator.registerActor({true, 0}));
+    }
+    check(coordinator.acquire(coordinator.registerActor({true, 0}), 0).refusal
+              == TxCoordinator::Refusal::InvalidActor, "actor registry is bounded");
+    coordinator.revoke(actors.front());
+    const TxCoordinator::Actor replacement = coordinator.registerActor({true, 0});
+    check(coordinator.acquire(replacement, 0).accepted(), "revocation frees a registration slot");
+    std::unique_ptr<QThread> thread(QThread::create([&] {
+        check(coordinator.acquire(replacement, 1).refusal == TxCoordinator::Refusal::WrongThread,
+              "off-thread admission fails in release builds");
+        coordinator.emergencyStop();
+    }));
+    thread->start();
+    thread->wait();
+    check(coordinator.acquire(replacement, 2).accepted(), "off-thread mutation did not change state");
+
+    TxCoordinator large([](const auto&, auto) {});
+    const auto bounded = large.registerActor({true, 20});
+    const auto result = large.acquire(bounded, std::numeric_limits<qint64>::max() - 10);
+    check(result.operation.permitsDispatch(std::numeric_limits<qint64>::max()),
+          "large clock values do not overflow deadline addition");
+    check(!result.operation.permitsDispatch(-1), "backwards or invalid clock fails closed");
+}
+
+void acknowledgedCallbackCannotReenter()
+{
+    TxCoordinator::Actor actor;
+    TxCoordinator* callbackCoordinator = nullptr;
+    TxCoordinator coordinator([&](const TxCoordinator::Operation& operation,
+                                 TxCoordinator::StopReason) {
+        check(callbackCoordinator->acknowledgeStopped(operation), "synchronous stop may acknowledge cleanup");
+        check(callbackCoordinator->acquire(actor, 2).refusal == TxCoordinator::Refusal::Recovering,
+              "acknowledgment cannot admit new work inside old stop handler");
+    });
+    callbackCoordinator = &coordinator;
+    actor = coordinator.registerActor({true, 0});
+    const TxCoordinator::Operation before = coordinator.acquire(actor, 0).operation;
+    coordinator.reset();
+    const TxCoordinator::Admission after = coordinator.acquire(actor, 3);
+    check(after.accepted() && after.operation.permitsCleanup(),
+          "reset cannot invalidate a reentrant new operation");
+    check(!before.permitsCleanup(), "reset fences the old generation after synchronous cleanup");
+}
+
+void stopOnlyFences()
+{
+    TxCoordinator coordinator([](const auto&, auto) {});
+    const TxCoordinator::Operation fence = coordinator.cleanupFence();
+    check(fence.permitsCleanup() && !fence.permitsDispatch(0), "idle cleanup fence cannot authorize key-on");
+    check(!coordinator.complete(fence) && !coordinator.acknowledgeStopped(fence),
+          "cleanup fence grants no ownership or recovery authority");
+    const TxCoordinator::Actor actor = coordinator.registerActor({true, 0});
+    check(coordinator.acquire(actor, 0).accepted(), "owner starts after idle cleanup fence");
+    check(!fence.permitsCleanup(), "idle queued key-up cannot affect a newer operation");
+}
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    ownershipAndRecovery();
+    expiryAndRevocation();
+    lifetimeAndIdentity();
+    limitsAndThread();
+    acknowledgedCallbackCannotReenter();
+    stopOnlyFences();
+    return failures ? 1 : 0;
+}

--- a/tests/tx_operation_integration_test.cpp
+++ b/tests/tx_operation_integration_test.cpp
@@ -24,6 +24,7 @@ public:
         radio.applyBackendTransmitDelta(delta);
     }
     static bool cwxDrainArmed(const RadioModel& radio) { return radio.m_cwxDrainArmed; }
+    static bool txSessionClosing(const RadioModel& radio) { return radio.m_txSessionClosing; }
     static void injectTcp(RadioModel& radio, RadioConnection& connection, QStringList& commands)
     {
         connection.m_commandSinkForTest = [&commands](quint32, const QString& command) { commands << command; };
@@ -596,6 +597,33 @@ void queuedCwSessionAndTcpFences()
               "reset fences queued TCP fallback/backstop and UDP before their final writers");
     }
 }
+// Both test-injection entry points tear the old backend down, which closes
+// admission for the dying session. Neither is followed by an onConnected()
+// edge, so each has to drain the latch itself or every later TX intent in that
+// test is silently refused and reads as a product bug.
+void testInjectionReopensAdmission()
+{
+    {
+        Fixture f;
+        check(!TxOperationIntegrationTestAccess::txSessionClosing(f.radio),
+              "setBackendForTest reopens admission after tearing the old backend down");
+        f.radio.disconnectFromRadio();
+        check(TxOperationIntegrationTestAccess::txSessionClosing(f.radio),
+              "disconnect closes admission for the dying session");
+        auto replacement = std::make_unique<RecordingBackend>(f.commands);
+        replacement->connected = true;
+        f.radio.setBackendForTest(std::move(replacement), QStringLiteral("replacement"));
+        check(!TxOperationIntegrationTestAccess::txSessionClosing(f.radio),
+              "a replacement injected after disconnect reopens admission");
+    }
+    {
+        Fixture f;
+        f.radio.disconnectFromRadio();
+        check(f.radio.rebuildBackendForTest(QStringLiteral("flex"))
+                  && !TxOperationIntegrationTestAccess::txSessionClosing(f.radio),
+              "rebuildBackendForTest reopens admission like setBackendForTest");
+    }
+}
 } // namespace
 
 int main(int argc, char** argv)
@@ -617,5 +645,6 @@ int main(int argc, char** argv)
     flexCwxLifecycle();
     queuedNetCwEdges();
     queuedCwSessionAndTcpFences();
+    testInjectionReopensAdmission();
     return failures ? 1 : 0;
 }

--- a/tests/tx_operation_integration_test.cpp
+++ b/tests/tx_operation_integration_test.cpp
@@ -1,0 +1,433 @@
+// Socket-free production-path tests. Only an injected transport recorder is
+// used; no radio, peer, listener, discovery or transmitter is opened.
+#include "TestSettingsProfile.h"
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+#include "core/backends/flex/FlexBackend.h"
+#include "core/ClientQuindarTone.h"
+#include "core/PanadapterStream.h"
+
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QTimer>
+#include <cstdio>
+#include <memory>
+#include <limits>
+
+using namespace AetherSDR;
+
+namespace AetherSDR {
+class TxOperationIntegrationTestAccess {
+public:
+    static void teardownWithPendingReply(RadioModel& radio, RadioModel::ResponseCallback callback)
+    {
+        radio.m_pendingCallbacks.insert(1234, std::move(callback));
+        radio.teardownBackend();
+    }
+    static void injectNetCwTransport(RadioModel& radio, PanadapterStream& stream,
+                                    std::function<void(const QByteArray&)> sink)
+    {
+        // No init(), start(), sockets, or synthetic firmware. Only replace
+        // the final writer and drive the real public CW methods/scheduler.
+        stream.m_packetSinkForTest = std::move(sink);
+        radio.m_family = QStringLiteral("flex");
+        radio.m_panStream = &stream;
+        radio.m_netCwStreamId = 0x12345678;
+    }
+};
+} // namespace AetherSDR
+
+namespace {
+int failures = 0;
+void check(bool condition, const char* message)
+{
+    std::printf("[%s] %s\n", condition ? "PASS" : "FAIL", message);
+    failures += !condition;
+}
+
+class RecordingBackend final : public IRadioBackend {
+public:
+    RadioCapabilities caps;
+    bool connected{false};
+    QStringList* commands;
+    explicit RecordingBackend(QStringList& record) : commands(&record)
+    {
+        caps.canTransmit = true;
+        caps.hasRadioSideCwKeyer = true;
+        caps.hasTuner = true;
+    }
+    RadioCapabilities capabilities() const override { return caps; }
+    bool isConnected() const override { return connected; }
+    void connectRadio(const RadioConnectRequest&) override {}
+    void disconnectRadio() override {}
+    void setSliceFrequency(int, double) override {}
+    void setSliceMode(int, const QString&) override {}
+    void setSliceFilter(int, int, int) override {}
+    void setSliceAgc(int, const QString&, int) override {}
+    void setPanCenter(const QString&, double, PanCenterIntent) override {}
+    void setKeying(bool on) override { *commands << (on ? "mox:on" : "mox:off"); }
+    void setTune(bool on, int) override { *commands << (on ? "tune:on" : "tune:off"); }
+    void setAtu(bool on) override { *commands << (on ? "atu:on" : "atu:off"); }
+    void setCwKeying(bool on, bool, int) override { *commands << (on ? "cw:on" : "cw:off"); }
+    QString sendCwText(const QString& text) override { *commands << "cwx:" + text; return {}; }
+    void abortCwText() override { *commands << "cwx:abort"; }
+    void invokeExtension(const QString&, const QString&, quint64, const QVariant&) override {}
+};
+
+struct Fixture {
+    // Recorder outlives the RadioModel's backend and its shutdown cleanup.
+    QStringList commands;
+    RadioModel radio;
+    RecordingBackend* backend;
+    Fixture()
+    {
+        auto owned = std::make_unique<RecordingBackend>(commands);
+        backend = owned.get();
+        radio.setBackendForTest(std::move(owned), QStringLiteral("test"));
+        if (!radio.automationApplySliceFixture(0, QStringLiteral("A")) || !radio.slice(0)) {
+            qFatal("Could not install the disconnected slice fixture");
+        }
+        SliceDelta delta;
+        delta.txSlice = true;
+        delta.mode = QStringLiteral("USB");
+        delta.panId = QStringLiteral("0x40000000");
+        radio.slice(0)->applyChanges(delta);
+        backend->connected = true;
+        radio.transmitModel().setTxModeGetter([] { return QStringLiteral("USB"); });
+        commands.clear();
+    }
+};
+
+void primaryRoutes()
+{
+    Fixture f;
+    TransmitModel& tx = f.radio.transmitModel();
+    QStringList rawKeying;
+    QObject::connect(&tx, &TransmitModel::commandReady, &f.radio, [&](const QString& command) {
+        if (command.startsWith("xmit ") || command.startsWith("transmit tune ")
+            || command == "atu start" || command == "atu bypass") {
+            rawKeying << command;
+        }
+    });
+    tx.setMox(true);
+    const TxCoordinator::Operation first = f.radio.transmitOperation();
+    check(first.permitsDispatch(std::numeric_limits<qint64>::max()) && first.permitsCleanup(),
+          "MOX acquires a live engine operation without a new operator timeout");
+    tx.setMox(false);
+    check(!first.permitsDispatch(std::numeric_limits<qint64>::max()), "explicit MOX release fences queued key-on");
+    tx.startTune();
+    tx.stopTune();
+    tx.startTwoToneTune();
+    tx.stopTune();
+    tx.atuStart();
+    tx.atuBypass();
+    f.radio.sendCwKey(true);
+    f.radio.sendCwKey(false);
+    f.radio.sendCwPtt(true);
+    f.radio.sendCwPtt(false);
+    check(f.commands == QStringList({"mox:on", "mox:off", "tune:on", "tune:off",
+          "tune:on", "tune:off", "atu:on", "atu:off", "cw:on", "cw:off", "mox:on", "mox:off"}),
+          "every primary intent dispatches once through its typed backend verb");
+    check(rawKeying.isEmpty(), "no duplicate keying escapes via raw model command text");
+}
+
+void refusedStartsAndUnconditionalStops()
+{
+    Fixture f;
+    f.backend->caps.canTransmit = false;
+    TransmitModel& tx = f.radio.transmitModel();
+    tx.setMox(true);
+    tx.requestPttOn(TransmitModel::PttSource::Mox);
+    tx.startTune();
+    tx.startTwoToneTune();
+    tx.atuStart();
+    f.radio.setTransmit(true);
+    f.radio.sendCwKey(true);
+    f.radio.sendCwPaddle(true, false);
+    f.radio.sendCwPtt(true);
+    f.radio.sendCwKeyEdge(true);
+    f.radio.cwxModel().send("CQ");
+    f.radio.cwxModel().sendChar("E");
+    f.radio.cwxModel().sendMacro(1);
+    check(f.commands.isEmpty(), "RX-only backend refuses every primary start including CW/CWX");
+    check(!tx.isTransmitting() && !tx.isTuning(), "refusal cannot leave optimistic TX or TUNE latched");
+    tx.setMox(false);
+    tx.stopTune();
+    tx.atuBypass();
+    f.radio.sendCwKey(false);
+    f.radio.sendCwPtt(false);
+    f.radio.cwxModel().clearBuffer();
+    check(f.commands == QStringList({"mox:off", "tune:off", "atu:off", "cw:off", "mox:off", "cwx:abort"}),
+          "key-up, bypass and clear remain available after capability loss");
+}
+
+void delayedReleaseAndReplacement()
+{
+    Fixture f;
+    TransmitModel& tx = f.radio.transmitModel();
+    TransmitModel::PttRelease release;
+    int cancellations = 0;
+    const QMetaObject::Connection cancelled = QObject::connect(&tx, &TransmitModel::pttReleaseCancelled,
+        &f.radio, [&] { ++cancellations; });
+    tx.setPttOffHook([&](TransmitModel::PttRelease captured) { release = captured; });
+    tx.requestPttOn(TransmitModel::PttSource::Mox);
+    tx.requestPttOff(TransmitModel::PttSource::Mox);
+    check(release.current() && f.commands == QStringList({"mox:on"}), "normal release waits for its tail");
+    const TransmitModel::PttRelease old = release;
+    tx.requestPttOn(TransmitModel::PttSource::Mox);
+    const qsizetype before = f.commands.size();
+    old.release();
+    check(!old.current() && f.commands.size() == before && tx.isTransmitting(),
+          "old RADE-style completion cannot unkey a re-engaged transmission");
+    tx.requestPttOff(TransmitModel::PttSource::Mox);
+    release.release();
+    check(!tx.isTransmitting() && f.commands.back() == "mox:off", "current normal tail releases once");
+
+    tx.requestPttOn(TransmitModel::PttSource::Mox);
+    tx.requestPttOff(TransmitModel::PttSource::Mox);
+    const TxCoordinator::Operation operation = f.radio.transmitOperation();
+    auto replacement = std::make_unique<RecordingBackend>(f.commands);
+    f.radio.setBackendForTest(std::move(replacement), QStringLiteral("replacement"));
+    f.commands.clear();
+    release.release();
+    check(!operation.permitsCleanup() && !release.current() && f.commands.isEmpty(),
+          "backend replacement fences old operation and delayed release before reuse");
+    check(cancellations > 0, "replacement notifies immediate audio/tail cancellation independently of state edges");
+    tx.clearPttOffHook();
+    QObject::disconnect(cancelled);
+}
+
+void flexEncoding()
+{
+    QStringList commands;
+    FlexBackend backend;
+    backend.setCommandSink([&](const QString& command) { commands << command; });
+    backend.setKeying(true);
+    backend.setKeying(false);
+    backend.setTune(true, 10);
+    backend.setTune(false, 10);
+    backend.setAtu(true);
+    backend.setAtu(false);
+    check(commands == QStringList({"xmit 1", "xmit 0", "transmit tune 1", "transmit tune 0", "atu start", "atu bypass"}),
+          "Flex seam preserves exact FlexLib 4.2.18 keying command forms");
+}
+
+void teardownAdmission()
+{
+    for (bool initiallyActive : {false, true}) {
+        Fixture f;
+        TransmitModel& tx = f.radio.transmitModel();
+        if (initiallyActive) {
+            tx.setMox(true);
+        }
+        bool replied = false;
+        TxCoordinator::Operation callbackOperation;
+        TxOperationIntegrationTestAccess::teardownWithPendingReply(f.radio,
+            [&](int code, const QString&) {
+                replied = code != 0;
+                f.commands.clear();
+                tx.setMox(true);
+                tx.startTune();
+                tx.atuStart();
+                f.radio.sendCwKey(true);
+                f.radio.sendCwPtt(true);
+                f.radio.cwxModel().send("CQ");
+                callbackOperation = f.radio.transmitOperation();
+                check(f.commands.isEmpty(),
+                      "backend teardown reply cannot re-admit any primary key-on intent");
+            });
+        check(replied, "teardown still answers the pending command with failure");
+        check(!callbackOperation.permitsDispatch(std::numeric_limits<qint64>::max()),
+              "teardown cannot leave a live operation after its backend dies");
+    }
+}
+
+void disconnectAdmission()
+{
+    for (bool force : {false, true}) {
+        Fixture f;
+        TransmitModel& tx = f.radio.transmitModel();
+        tx.setPttOffHook([](TransmitModel::PttRelease) {});
+        tx.requestPttOn(TransmitModel::PttSource::Mox);
+        tx.requestPttOff(TransmitModel::PttSource::Mox);
+        bool cancelled = false;
+        const QMetaObject::Connection cancellation = QObject::connect(
+            &tx, &TransmitModel::pttReleaseCancelled, &f.radio, [&] {
+                cancelled = true;
+                tx.atuStart();
+            });
+        f.commands.clear();
+        if (force) {
+            f.radio.forceDisconnect();
+        } else {
+            f.radio.disconnectFromRadio();
+        }
+        check(cancelled && !f.commands.contains("atu:on"),
+              "disconnect closes admission before deferred-release cancellation observers run");
+        QObject::disconnect(cancellation);
+        tx.clearPttOffHook();
+        f.commands.clear();
+        // The recorder deliberately still reports connected: real transports
+        // can take an event-loop turn or more to deliver their disconnect edge.
+        tx.atuStart();
+        f.radio.sendCwPtt(true);
+        check(f.commands.isEmpty(), "no new TX intent is admitted during the disconnect gap");
+
+        auto replacement = std::make_unique<RecordingBackend>(f.commands);
+        replacement->connected = true;
+        f.radio.setBackendForTest(std::move(replacement), QStringLiteral("replacement"));
+        f.commands.clear();
+        tx.atuStart();
+        check(f.commands == QStringList({"atu:on"}),
+              "a fully installed replacement can admit a fresh operation");
+        tx.atuBypass();
+    }
+}
+
+void reentrantIntents()
+{
+    Fixture f;
+    TransmitModel& tx = f.radio.transmitModel();
+    int engaged = 0;
+    QObject::connect(&f.radio, &RadioModel::localTransmitEngaged, &f.radio, [&] { ++engaged; });
+    tx.setMox(true);
+    bool restart = true;
+    const QMetaObject::Connection connection = QObject::connect(&tx, &TransmitModel::transmittingChanged,
+        &f.radio, [&](bool on) {
+            if (!on && restart) {
+                restart = false;
+                tx.setMox(true);
+            }
+        });
+    f.commands.clear();
+    tx.setMox(false);
+    check(f.commands == QStringList({"mox:on"}) && tx.isTransmitting() && engaged == 2,
+          "reentrant key-on supersedes the old key-up without a stale off command");
+    QObject::disconnect(connection);
+    tx.setMox(false);
+
+    tx.startTune();
+    const QMetaObject::Connection tune = QObject::connect(&tx, &TransmitModel::tuneChanged,
+        &f.radio, [&](bool on) { if (!on) { tx.startTune(); } });
+    f.commands.clear();
+    tx.stopTune();
+    check(f.commands == QStringList({"tune:on"}) && tx.isTuning(),
+          "a stale TUNE-off cannot stop a reentrant new TUNE intent");
+    QObject::disconnect(tune);
+    tx.stopTune();
+
+    tx.setMox(true);
+    const QMetaObject::Connection observedMox = QObject::connect(&f.radio, &RadioModel::radioTransmittingChanged,
+        &f.radio, [&](bool on) { if (!on) { tx.setMox(true); } });
+    tx.setMox(false);
+    check(tx.isTransmitting() && f.radio.transmitOperation().permitsDispatch(std::numeric_limits<qint64>::max()),
+          "command-edge observer re-engage retains the new MOX operation after old cleanup returns");
+    QObject::disconnect(observedMox);
+    tx.setMox(false);
+
+    tx.startTune();
+    const QMetaObject::Connection observedTune = QObject::connect(&f.radio, &RadioModel::radioTransmittingChanged,
+        &f.radio, [&](bool on) { if (!on) { tx.startTune(); } });
+    tx.stopTune();
+    check(tx.isTuning() && f.radio.transmitOperation().permitsDispatch(std::numeric_limits<qint64>::max()),
+          "command-edge observer re-engage retains the new TUNE operation after old cleanup returns");
+    QObject::disconnect(observedTune);
+    tx.stopTune();
+}
+
+void quindarNormalRelease()
+{
+    ClientQuindarTone tone;
+    tone.prepare(24000.0);
+    tone.setEnabled(true);
+    tone.setDurationMs(100);
+    Fixture f;
+    TransmitModel& tx = f.radio.transmitModel();
+    tx.setQuindarTone(&tone);
+    tx.requestPttOn(TransmitModel::PttSource::Mox);
+    tx.requestPttOff(TransmitModel::PttSource::Mox);
+    tx.requestPttOff(TransmitModel::PttSource::Mox);
+    check(f.commands == QStringList({"mox:on"}), "duplicate PTT-off does not truncate Quindar outro");
+    QEventLoop loop;
+    QTimer::singleShot(180, &loop, &QEventLoop::quit);
+    loop.exec();
+    check(f.commands == QStringList({"mox:on", "mox:off"}), "Quindar normal tail releases exactly once");
+
+    tx.requestPttOn(TransmitModel::PttSource::Mox);
+    tx.requestPttOff(TransmitModel::PttSource::Mox);
+    tx.requestPttOn(TransmitModel::PttSource::Mox);
+    const qsizetype before = f.commands.size();
+    QTimer::singleShot(180, &loop, &QEventLoop::quit);
+    loop.exec();
+    check(f.commands.size() == before && tx.isTransmitting(), "Quindar re-engage cancels old deferred unkey");
+    tx.setMox(false);
+}
+
+void cwxCancellationFence()
+{
+    CwxModel cwx;
+    int sends = 0;
+    bool cleared = false;
+    QObject::connect(&cwx, &CwxModel::commandReady, &cwx, [&](const QString& command) {
+        if (!cleared && command.startsWith("cwx send")) {
+            cleared = true;
+            cwx.clearBuffer();
+        }
+    });
+    QObject::connect(&cwx, &CwxModel::transmissionRequested, &cwx,
+                     [&](const QString&, int) { ++sends; });
+    cwx.send("CQ +TEST DE CALL");
+    check(cleared && sends == 0, "CWX cancellation fences remaining segments and local keyer delivery");
+}
+
+void queuedNetCwEdges()
+{
+    QList<QByteArray> packets;
+    PanadapterStream stream;
+    Fixture f;
+    TxOperationIntegrationTestAccess::injectNetCwTransport(f.radio, stream,
+        [&](const QByteArray& packet) { packets << packet; });
+    f.radio.sendCwKeyEdge(true);
+    const TxCoordinator::Operation operation = f.radio.transmitOperation();
+    f.radio.sendCwKeyEdge(false);
+    check(packets.isEmpty() && operation.permitsDispatch(std::numeric_limits<qint64>::max()),
+          "normal CW key-up retains authority until already-queued edges have drained");
+    QEventLoop loop;
+    QTimer::singleShot(60, &loop, &QEventLoop::quit);
+    loop.exec();
+    int downs = 0;
+    int ups = 0;
+    for (const QByteArray& packet : packets) {
+        downs += packet.mid(28).startsWith("cw key 1 ");
+        ups += packet.mid(28).startsWith("cw key 0 ");
+    }
+    check(downs == 4 && ups == 4, "short CW element retains all four down/up copies through queued delivery");
+    check(!operation.permitsDispatch(std::numeric_limits<qint64>::max()),
+          "CW operation completes after the final queued key-up reaches the transport");
+
+    packets.clear();
+    f.radio.sendCwKeyEdge(true);
+    f.radio.forceDisconnect();
+    QTimer::singleShot(60, &loop, &QEventLoop::quit);
+    loop.exec();
+    check(packets.isEmpty(), "disconnect cancels even the first queued NetCW copy before transport dispatch");
+}
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile settings(QStringLiteral("tx-operation-integration"));
+    if (!settings.isValid()) { return 1; }
+    QCoreApplication app(argc, argv);
+    primaryRoutes();
+    refusedStartsAndUnconditionalStops();
+    delayedReleaseAndReplacement();
+    flexEncoding();
+    teardownAdmission();
+    disconnectAdmission();
+    reentrantIntents();
+    quindarNormalRelease();
+    cwxCancellationFence();
+    queuedNetCwEdges();
+    return failures ? 1 : 0;
+}

--- a/tests/tx_operation_integration_test.cpp
+++ b/tests/tx_operation_integration_test.cpp
@@ -19,6 +19,17 @@ using namespace AetherSDR;
 namespace AetherSDR {
 class TxOperationIntegrationTestAccess {
 public:
+    static void transmitDelta(RadioModel& radio, const TransmitDelta& delta)
+    {
+        radio.applyBackendTransmitDelta(delta);
+    }
+    static bool cwxDrainArmed(const RadioModel& radio) { return radio.m_cwxDrainArmed; }
+    static void injectTcp(RadioModel& radio, RadioConnection& connection, QStringList& commands)
+    {
+        connection.m_commandSinkForTest = [&commands](quint32, const QString& command) { commands << command; };
+        radio.m_family = QStringLiteral("flex");
+        radio.m_connection = &connection;
+    }
     static void teardownWithPendingReply(RadioModel& radio, RadioModel::ResponseCallback callback)
     {
         radio.m_pendingCallbacks.insert(1234, std::move(callback));
@@ -49,6 +60,7 @@ class RecordingBackend final : public IRadioBackend {
 public:
     RadioCapabilities caps;
     bool connected{false};
+    QString cwRejection;
     QStringList* commands;
     explicit RecordingBackend(QStringList& record) : commands(&record)
     {
@@ -69,7 +81,7 @@ public:
     void setTune(bool on, int) override { *commands << (on ? "tune:on" : "tune:off"); }
     void setAtu(bool on) override { *commands << (on ? "atu:on" : "atu:off"); }
     void setCwKeying(bool on, bool, int) override { *commands << (on ? "cw:on" : "cw:off"); }
-    QString sendCwText(const QString& text) override { *commands << "cwx:" + text; return {}; }
+    QString sendCwText(const QString& text) override { *commands << "cwx:" + text; return cwRejection; }
     void abortCwText() override { *commands << "cwx:abort"; }
     void invokeExtension(const QString&, const QString&, quint64, const QVariant&) override {}
 };
@@ -380,6 +392,123 @@ void cwxCancellationFence()
     check(cleared && sends == 0, "CWX cancellation fences remaining segments and local keyer delivery");
 }
 
+void cwxCompletionAndRefusal()
+{
+    {
+        Fixture f;
+        f.backend->caps.hasRadioSideCwKeyer = false;
+        f.radio.cwxModel().send("CQ");
+        check(f.commands.isEmpty() && !f.radio.transmitOperation().permitsCleanup(),
+              "unsupported CWX refuses before acquiring an operation");
+    }
+    for (const bool reject : {false, true}) {
+        Fixture f;
+        if (reject) {
+            f.backend->cwRejection = QStringLiteral("test rejection");
+        }
+        int notifications = 0;
+        QObject::connect(&f.radio.cwxModel(), &CwxModel::transmissionRequested, &f.radio,
+                         [&](const QString&, int) { ++notifications; });
+        f.radio.cwxModel().send("CQ +TEST DE CALL");
+        check(!f.radio.transmitOperation().permitsDispatch(std::numeric_limits<qint64>::max()),
+              "radio-side CWX closes local dispatch after acceptance or rejection");
+        check(reject ? notifications == 0 : notifications > 1,
+              "rejected CWX neither announces sidetone nor sends later segments");
+        if (!reject) {
+            check(f.commands.filter("cwx:").size() == notifications,
+                  "accepted CWX retains admission through every segment");
+        }
+    }
+    {
+        Fixture f;
+        f.backend->caps.hasTuner = false;
+        f.radio.transmitModel().atuStart();
+        check(!f.commands.contains("atu:on")
+                  && !f.radio.transmitOperation().permitsDispatch(std::numeric_limits<qint64>::max()),
+              "tunerless ATU refuses before acquiring an operation");
+    }
+    for (const bool observedProgress : {false, true}) {
+        Fixture f;
+        f.radio.transmitModel().atuStart();
+        const TxCoordinator::Operation operation = f.radio.transmitOperation();
+        TransmitDelta delta;
+        if (observedProgress) {
+            delta.atuStatusRaw = QStringLiteral("TUNE_IN_PROGRESS");
+            TxOperationIntegrationTestAccess::transmitDelta(f.radio, delta);
+        }
+        delta.atuStatusRaw = QStringLiteral("TUNE_SUCCESSFUL");
+        TxOperationIntegrationTestAccess::transmitDelta(f.radio, delta);
+        check(!operation.permitsDispatch(std::numeric_limits<qint64>::max()),
+              "terminal ATU status completes local intent even if in-progress was missed");
+    }
+}
+
+void cwxFailureAndSpeedRestore()
+{
+    for (const int failure : {0, 1, 2, 3}) {
+        CwxModel cwx;
+        int cancelled = 0;
+        QObject::connect(&cwx, &CwxModel::transmissionCancelled, &cwx, [&] { ++cancelled; });
+        const int epoch = cwx.drainEpoch();
+        cwx.handleSendReply(0, "10,1", epoch, 3);
+        cwx.handleSendReply(failure == 0 ? 1 : 0,
+                           failure == 1 ? "bad" : failure == 3 ? "2147483647,1" : "10,1",
+                           epoch, failure == 2 ? 0 : 3);
+        check(cancelled == 1 && cwx.cwxEndIndex() == -1 && cwx.drainEpoch() != epoch,
+              "rejected, malformed, empty or overflowing reply cancels the current CWX batch");
+        cwx.handleSendReply(1, {}, epoch, 1);
+        check(cancelled == 1, "stale rejected reply cannot cancel a replacement CWX batch");
+    }
+    CwxModel cwx;
+    bool allowed = true;
+    QStringList commands;
+    cwx.setTransmissionAdmission([&] { return [&] { return allowed; }; });
+    QObject::connect(&cwx, &CwxModel::commandReady, &cwx, [&](const QString& command) {
+        commands << command;
+        if (command == "cwx wpm 23") {
+            allowed = false;
+        }
+    });
+    cwx.send("+CQ");
+    check(commands == QStringList({"cwx wpm 23", "cwx wpm 20"}),
+          "cancelled expansion restores base WPM without sending more text");
+}
+
+void flexCwxLifecycle()
+{
+    QStringList tcp;
+    RadioConnection connection;
+    Fixture f;
+    TxOperationIntegrationTestAccess::injectTcp(f.radio, connection, tcp);
+    f.radio.cwxModel().sendMacro(1);
+    check(!f.radio.transmitOperation().permitsDispatch(std::numeric_limits<qint64>::max()),
+          "unsynced Flex macro closes local handoff without claiming a drain observation");
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::MetaCall);
+    check(tcp.contains("cwx macro send 1"), "unsynced macro preserves radio-side expansion");
+
+    f.radio.cwxModel().send("CQ");
+    const TxCoordinator::Operation operation = f.radio.transmitOperation();
+    const int epoch = f.radio.cwxModel().drainEpoch();
+    check(TxOperationIntegrationTestAccess::cwxDrainArmed(f.radio)
+              && operation.permitsDispatch(std::numeric_limits<qint64>::max()),
+          "known Flex text keeps its operation until drain or failure");
+    f.radio.cwxModel().handleSendReply(1, {}, epoch, 2);
+    check(!TxOperationIntegrationTestAccess::cwxDrainArmed(f.radio)
+              && !operation.permitsDispatch(std::numeric_limits<qint64>::max()),
+          "Flex reply failure disarms drain and releases the exact local activity");
+    f.radio.cwxModel().send("NEW");
+    const TxCoordinator::Operation replacement = f.radio.transmitOperation();
+    f.radio.cwxModel().handleSendReply(1, {}, epoch, 2);
+    check(replacement.permitsDispatch(std::numeric_limits<qint64>::max())
+              && TxOperationIntegrationTestAccess::cwxDrainArmed(f.radio),
+          "old failed reply cannot release a replacement Flex CWX operation");
+    f.radio.cwxModel().handleSendReply(0, "10,1", f.radio.cwxModel().drainEpoch(), 3);
+    f.radio.cwxModel().sendMacro(2);
+    check(!TxOperationIntegrationTestAccess::cwxDrainArmed(f.radio)
+              && f.radio.cwxModel().cwxEndIndex() == -1,
+          "unknown-length macro tail cannot be truncated by an earlier batch's drain index");
+}
+
 void queuedNetCwEdges()
 {
     QList<QByteArray> packets;
@@ -412,6 +541,61 @@ void queuedNetCwEdges()
     loop.exec();
     check(packets.isEmpty(), "disconnect cancels even the first queued NetCW copy before transport dispatch");
 }
+
+void queuedCwSessionAndTcpFences()
+{
+    {
+        Fixture f;
+        const auto when = std::chrono::steady_clock::now();
+        f.radio.queueCwKeyEdge(true, "test", 0, 0, when);
+        f.radio.queueCwKeyEdge(false, "test", 0, 0, when);
+        f.radio.forceDisconnect();
+        auto replacement = std::make_unique<RecordingBackend>(f.commands);
+        f.radio.setBackendForTest(std::move(replacement), QStringLiteral("test"));
+        f.radio.sendCwKeyEdge(true);
+        const TxCoordinator::Operation fresh = f.radio.transmitOperation();
+        const qsizetype before = f.commands.size();
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::MetaCall);
+        check(f.commands.size() == before && fresh.permitsDispatch(std::numeric_limits<qint64>::max()),
+              "queued old-session iambic down/up cannot key or unkey a replacement operation");
+        f.radio.queueCwKeyEdge(false, "test", 0, 0, std::chrono::steady_clock::now());
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::MetaCall);
+        check(f.commands.last() == "cw:off" && !fresh.permitsDispatch(std::numeric_limits<qint64>::max()),
+              "fresh-session queued iambic release still reaches the backend");
+    }
+    for (const bool withUdp : {false, true}) {
+        QStringList tcp;
+        QList<QByteArray> udp;
+        RadioConnection connection;
+        PanadapterStream stream;
+        Fixture f;
+        TxOperationIntegrationTestAccess::injectTcp(f.radio, connection, tcp);
+        if (withUdp) {
+            TxOperationIntegrationTestAccess::injectNetCwTransport(f.radio, stream,
+                [&](const QByteArray& packet) { udp << packet; });
+        }
+        f.radio.sendCwKeyEdge(true);
+        const TxCoordinator::Operation operation = f.radio.transmitOperation();
+        f.radio.sendCwKeyEdge(false);
+        check(tcp.isEmpty() && operation.permitsDispatch(std::numeric_limits<qint64>::max()),
+              "short NetCW element retains authority until queued TCP delivery");
+        QEventLoop loop;
+        QTimer::singleShot(60, &loop, &QEventLoop::quit);
+        loop.exec();
+        check(tcp.size() == 2 && tcp.first().contains(withUdp ? "cw key 1 " : "cw key immediate 1")
+                  && tcp.last().contains(withUdp ? "cw key 0 " : "cw key immediate 0")
+                  && !operation.permitsDispatch(std::numeric_limits<qint64>::max()),
+              "TCP fallback/backstop delivers normal down/up and completes the matching operation");
+        tcp.clear();
+        udp.clear();
+        f.radio.sendCwKeyEdge(true);
+        f.radio.forceDisconnect();
+        QTimer::singleShot(60, &loop, &QEventLoop::quit);
+        loop.exec();
+        check(tcp.filter("cw key").isEmpty() && udp.isEmpty(),
+              "reset fences queued TCP fallback/backstop and UDP before their final writers");
+    }
+}
 } // namespace
 
 int main(int argc, char** argv)
@@ -428,6 +612,10 @@ int main(int argc, char** argv)
     reentrantIntents();
     quindarNormalRelease();
     cwxCancellationFence();
+    cwxCompletionAndRefusal();
+    cwxFailureAndSpeedRestore();
+    flexCwxLifecycle();
     queuedNetCwEdges();
+    queuedCwSessionAndTcpFences();
     return failures ? 1 : 0;
 }


### PR DESCRIPTION
## Summary

Related to #3849. First Stage 4 increment after #5563: add an engine-local `TxCoordinator` and route primary desktop transmit intents through it. This does **not** complete the multi-client arbiter or enable daemon transmission.

- Opaque actor/operation handles, bounded actor registration, cancellation fences, stop recovery, and stale-operation rejection in `libaethercore`.
- MOX/PTT, TUNE/two-tone, ATU, CW and actual-send CWX admission before dispatch; fixed Flex command encoding stays behind the backend seam.
- Preserve normal Quindar/RADE release sequencing while fencing obsolete completion callbacks and queued NetCW work.
- Close admission before disconnect/teardown notifications, including when initially idle. Integrated with the backend lifetime changes in #5573 without removing its generation checks or pending-reply failure delivery.

### Scope and limits

| Area | Change |
| --- | --- |
| Engine/models | Ownership, primary admission, cancellation and lifecycle guards |
| Flex/NetCW/RADE | Typed existing command forms and original-operation fences |
| GUI wiring | Carry deferred-release identity; no layout, theme or default changes |
| Tests/build/docs | Two new socket-free tests, existing typed-intent assertions, explicit contract and remaining work |

There is still **one transitional desktop compatibility actor**, not a separate principal per CAT/TCI/MIDI/bridge client. Local completion is not qualified RF-idle evidence. Per-client propagation, scheduled expiry, qualified stop/readback recovery and remaining queued audio/wire coverage are the next increment. Daemon TX grants/methods remain absent. #5513's separate CW/TUNE UX interlock is not replaced.

The independent Python MCP Windows shutdown repair found while testing is excluded from this PR and submitted separately as #5592. No `CHANGELOG.md`, CI gate expansion, new dependencies or discovery defaults.

## Constitution principle honored

Principle VI — transmit-on-intent: admission precedes optimistic state and transport delivery; cancellation invalidates the operation before cleanup can re-enter. Principle XI — fixes are demonstrated: regression tests fail before the corresponding guard and pass with it restored.

## Test plan

The initial PR head (`136caa31`) was validated with the same source manifest on all three platforms, integrated on `c692c75eb9f31aac151e943b9f88e6298007c6c5`:

| Platform | App + daemon | Focused CTests | Native automation bridge/MCP |
| --- | --- | --- | --- |
| macOS ARM64, Qt 6.11.2 | Pass, RADE enabled | 18/18, 26.92 s | Pass, Cocoa |
| Linux AArch64 VM, Qt 6.8.2 | Pass, RADE enabled | 18/18, 12.05 s | Pass, X11 |
| Windows VM, MSVC x64, Qt 6.8.3 | Pass, RADE enabled | 18/18, 15.82 s | Pass, Windows desktop |

Windows is an x64 build running in an ARM64 VM, not an ARM64-native binary claim. macOS CMake host/system and final binaries verified ARM64, with no RNNoise x86 sources.

The focused set covers coordinator/operation integration, transmit model, ATU gate, CWX drain/modifiers, Icom PTT authority, CAT tune policy, bridge watchdog, TX applet reconciliation, control codec/authorization/receive/telemetry/frequency, backend family switching/affinity and ANAN P2 protocol.

Native MCP used fresh settings, ephemeral authentication, only `DEMO-0001`, and `AETHER_AUTOMATION_NO_TX=1`: two tune/disconnect/reconnect cycles at 14.230/14.235 MHz; PTT/ATU refused; CWX unavailable; all transmit-state flags false. The harness explicitly waits for Demo slice creation after the connection edge. All owned test processes were terminated and checked; this is not a graceful GUI shutdown claim. Windows used the separately repaired MCP helper.

Socket/test disclosure: both new tests are socket-free, using production models and an injected terminal packet writer. The existing automation watchdog test exercises our own local server; no new peer/server test was added. No physical radio was connected or keyed, and no daemon discovery flag was enabled. The native desktop retains its normal discovery behavior, so these checks do not establish discovery-disabled operation. Fresh settings contain no saved radio or routed endpoint. RF timing, amplifier behavior and RADE over-the-air tail quality still require separately authorized hardware validation.

Review found and fixed teardown callback re-entry while idle, stale reentrant MOX/TUNE releases, and an MSVC test-lambda portability issue. The new teardown regression was run against the missing guard and failed, then passed after restoring the fix. Final independent security diff review completed with no reportable findings across all 27 changed files.

Manifest freshness, strict test registration, frozen CI gate, whitespace and strict engine-boundary checks passed (legacy boundary warnings only).

- [x] Initial-head local builds and focused tests passed on all three platforms; see follow-up limits below.
- [ ] Real-radio behavior verified — intentionally not exercised; see limits above.
- [ ] PR CI passes — pending after publication.
- [x] Regression/reproduction evidence documented.

## Checklist

- [x] Signed commit, exact reviewed tree verified after publication.
- [x] No new flat-key `AppSettings` calls.
- [x] Clean-room implementation; no proprietary binary inspection.
- [x] No meter UI changes.
- [x] Contract and limitations documented in `docs/aetherd-stage4-tx-coordinator.md`.
- [x] No GHSA applies to this new increment; no known outstanding security finding from review.

## Review-fix follow-up — 807b7835

Addressed the review findings in a signed follow-up commit:

- Fence queued iambic input across session replacement, and fence the original TCP connection/operation at both NetCW fallback and backstop writers. Normal key-up joins participating UDP/TCP queue completions.
- Refuse unsupported radio-side CWX and tunerless ATU before acquisition; close non-Flex text acceptance/rejection and unsynced Flex macro local handoffs without claiming RF idle.
- Cancel/disarm failed, malformed, invalid-count or overflowing CWX replies; ignore stale replies; restore base WPM on cancelled expansion; disarm an incomplete old drain index before an unknown macro tail.
- Accept terminal ATU status without a prior progress report, guarded against synchronous replacement intent. Add the off-thread PTT-release diagnostic and remove duplicate RADE assignments.

**Intentional public-method behavior:** direct `TransmitModel::setMox(true)` keeps the source-aware preflight before optimistic state/admission. Non-DAX voice MOX requires a TX slice; an unanswered connection attempt is not a completed session. The existing HL2 signaling test now injects the production backend plus a USB TX slice for its TX cases. The Flex case asserts actual MOX command emission to prevent vacuous success.

Fresh follow-up validation: macOS ARM64 app + daemon built with RADE enabled; **18/18 focused CTests passed (23.02 s)**, including `hl2_tci_signaling_test`. The latter was run with explicit operator approval after disclosing its remaining TEST-NET transport attempts (192.0.2.1/.2, no peer). Its four changed TX cases and all new regression cases are socket-free. This follow-up set adds HL2 signaling and does not rerun the original set's automation watchdog target.

Native Mac Demo/MCP repeated both receive cycles, identity checks and TX refusals with fresh settings, ephemeral authentication and NO_TX; the owned test process was stopped and confirmed gone. **Windows/Linux were not rerun for this follow-up patch**; their table above records the original head, not these fixes. Cross-platform PR CI is pending for the new head.

A combined mutation run disabling six guard classes produced ten failing assertions (ATU capability/completion, CWX reply cleanup/WPM, old-session iambic input and TCP fences); restoring the guards returned the final set to green. The strengthened unsupported-CWX acquisition assertion was not separately remutated. Manifest, strict registration, frozen CI gate, whitespace and strict engine-boundary checks passed. A fresh security diff scan of all 13 follow-up files completed with no reportable findings.

The terminal test writers in `PanadapterStream` and `RadioConnection` are private, default-unset members accessible to the named test friend; they let tests reach production queue dispatch without initializing sockets. No externally accessible setter was added. The two new registered tests remain outside the frozen PR gate and run in the default unfiltered main/full-suite and sanitizer lanes. No CI gate expansion.

Retained the existing design-note path (the naming suggestion was cosmetic). The standalone CWX cancellation test was verified on the original and fixed heads; its optional admission hook already preserves the command-only fixture, while production RadioModel installs mandatory admission. The shared-desktop-actor, no-daemon-TX and no-qualified-RF-idle limits remain unchanged.
