### PR TITLE
fix(mcp): stop owned Windows apps without SIGKILL

### DIFF
--- a/tools/aether_mcp.py
+++ b/tools/aether_mcp.py
@@ -313,7 +313,20 @@ def _signal_owned_process(process, *, force=False):
     The child is launched with start_new_session=True, so it is a session
     leader (pgid == pid) and any helper subprocesses it spawns share that
     group; signalling the group reaps them too. Fall back to the single
-    process if the group is already gone or on Windows (no POSIX groups)."""
+    process if the group is already gone or on Windows (no POSIX groups).
+
+    The two platforms are NOT equivalent, and the fallback is weaker than it
+    looks. On Windows terminate()/kill() are TerminateProcess: no signal is
+    delivered, so a SIGTERM handler in the child never runs — including the
+    HL2 emergency unkey in src/core/backends/hl2/Hl2EmergencyStop.cpp, whose
+    SIGTERM/SIGINT registration is deliberately outside the #ifndef Q_OS_WIN.
+    TerminateProcess also does not reap descendants, so the group-reaping
+    property above is POSIX-only. This is not fixable at this seam:
+    CREATE_NEW_PROCESS_GROUP is set at launch, but CTRL_BREAK_EVENT only
+    reaches console applications, not a windowed Qt process. It is bounded in
+    practice because the app_instance launch path pins
+    AETHER_AUTOMATION_NO_TX=1 and drops AETHER_AUTOMATION_ALLOW_TX, so an
+    owned app cannot key through the bridge."""
     if sys.platform != "win32":
         sig = signal.SIGKILL if force else signal.SIGTERM
         try:

--- a/tools/aether_mcp.py
+++ b/tools/aether_mcp.py
@@ -307,7 +307,7 @@ def _remove_owned_socket(instance):
         pass  # app-owned socket cleanup is best-effort after process exit
 
 
-def _signal_owned_process(process, sig):
+def _signal_owned_process(process, *, force=False):
     """Signal the child's whole session, not just its PID.
 
     The child is launched with start_new_session=True, so it is a session
@@ -315,13 +315,14 @@ def _signal_owned_process(process, sig):
     group; signalling the group reaps them too. Fall back to the single
     process if the group is already gone or on Windows (no POSIX groups)."""
     if sys.platform != "win32":
+        sig = signal.SIGKILL if force else signal.SIGTERM
         try:
             os.killpg(os.getpgid(process.pid), sig)
             return
         except (ProcessLookupError, PermissionError, OSError):
             pass  # group already reaped, or racing exit — fall back below
     try:
-        (process.kill if sig == signal.SIGKILL else process.terminate)()
+        (process.kill if force else process.terminate)()
     except OSError:
         pass
 
@@ -333,11 +334,11 @@ def _stop_owned_app():
         return {"ok": True, "running": False}
     process = instance["process"]
     if process.poll() is None:
-        _signal_owned_process(process, signal.SIGTERM)
+        _signal_owned_process(process)
         try:
             process.wait(timeout=5)
         except subprocess.TimeoutExpired:
-            _signal_owned_process(process, signal.SIGKILL)
+            _signal_owned_process(process, force=True)
             try:
                 process.wait(timeout=5)
             except subprocess.TimeoutExpired:

--- a/tools/test_aether_mcp.py
+++ b/tools/test_aether_mcp.py
@@ -17,6 +17,7 @@ import os
 import sys
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import aether_mcp  # noqa: E402
@@ -301,11 +302,92 @@ def test_gesture_session():
         aether_mcp.Bridge = original_bridge
         aether_mcp.bridge_socket_path = original_sockpath
         os.environ.pop("AETHER_MCP_TOKEN", None)
+
+
+def test_owned_process_shutdown():
+    """No live process: Windows has no SIGKILL, including on the timeout path."""
+    original_sys = aether_mcp.sys
+    original_signal = aether_mcp.signal
+    original_owned = aether_mcp._owned_app
+    original_os = aether_mcp.os
+
+    class Process:
+        pid = 12345
+
+        def __init__(self, needs_kill=False, refuses_kill=False):
+            self.returncode = None
+            self.calls = []
+            self.needs_kill = needs_kill
+            self.refuses_kill = refuses_kill
+
+        def poll(self):
+            return self.returncode
+
+        def terminate(self):
+            self.calls.append("terminate")
+            if not self.needs_kill:
+                self.returncode = 1
+
+        def kill(self):
+            self.calls.append("kill")
+            if not self.refuses_kill:
+                self.returncode = 1
+
+        def wait(self, timeout=None):
+            if self.returncode is None:
+                raise aether_mcp.subprocess.TimeoutExpired("mock", timeout)
+            return self.returncode
+
+    try:
+        aether_mcp.sys = SimpleNamespace(platform="win32")
+        aether_mcp.signal = SimpleNamespace(SIGTERM=15)  # Deliberately no SIGKILL.
+        for needs_kill, refuses_kill in ((False, False), (True, False), (True, True)):
+            process = Process(needs_kill, refuses_kill)
+            aether_mcp._owned_app = {
+                "process": process, "socket": "mock-owned-pipe", "label": "mock",
+            }
+            result = aether_mcp._stop_owned_app()
+            expected = ["terminate", "kill"] if needs_kill else ["terminate"]
+            check(f"Windows shutdown sequence {needs_kill}/{refuses_kill}",
+                  process.calls == expected, str(process.calls))
+            check(f"Windows shutdown retains truthful ownership {needs_kill}/{refuses_kill}",
+                  result["running"] == refuses_kill
+                  and result["ok"] != refuses_kill
+                  and (aether_mcp._owned_app is not None) == refuses_kill, str(result))
+        group_calls = []
+        aether_mcp.sys = SimpleNamespace(platform="linux")
+        aether_mcp.signal = SimpleNamespace(SIGTERM=15, SIGKILL=9)
+        aether_mcp.os = SimpleNamespace(
+            getpgid=lambda pid: pid,
+            killpg=lambda pid, sig: group_calls.append((pid, sig)))
+        process = Process()
+        aether_mcp._signal_owned_process(process)
+        aether_mcp._signal_owned_process(process, force=True)
+        check("POSIX shutdown retains TERM/KILL process-group signaling",
+              group_calls == [(process.pid, 15), (process.pid, 9)] and not process.calls,
+              str(group_calls))
+
+        def missing_group(_pid):
+            raise ProcessLookupError("mock process group already exited")
+
+        aether_mcp.os.getpgid = missing_group
+        aether_mcp._signal_owned_process(process)
+        aether_mcp._signal_owned_process(process, force=True)
+        check("POSIX missing-group fallback retains terminate/kill",
+              process.calls == ["terminate", "kill"], str(process.calls))
+    finally:
+        aether_mcp._owned_app = original_owned
+        aether_mcp.signal = original_signal
+        aether_mcp.sys = original_sys
+        aether_mcp.os = original_os
+
+
 def test_secure_app_instance():
     """Fresh builds inherit the token only at runtime and are identity-checked."""
     aether_mcp._stop_owned_app()
     original_popen = aether_mcp.subprocess.Popen
     original_bridge = aether_mcp.Bridge
+    original_os = aether_mcp.os
     saved_env = {key: os.environ.get(key) for key in (
         "AETHER_MCP_TOKEN", "AETHER_MCP_SOCKET", "AETHER_AUTOMATION_ALLOW_TX")}
     popen_calls = []
@@ -377,6 +459,12 @@ def test_secure_app_instance():
 
     aether_mcp.subprocess.Popen = fake_popen
     aether_mcp.Bridge = _Bridge
+    # A mocked Popen PID must never resolve to a real host process group.
+    def no_process_group(_pid):
+        raise ProcessLookupError("mock process has no OS process group")
+
+    aether_mcp.os = SimpleNamespace(**vars(original_os))
+    aether_mcp.os.getpgid = no_process_group
     try:
         with tempfile.TemporaryDirectory() as temp_root:
             worktree = Path(temp_root) / "AetherSDR"
@@ -504,6 +592,7 @@ def test_secure_app_instance():
         aether_mcp._stop_owned_app()
         aether_mcp.subprocess.Popen = original_popen
         aether_mcp.Bridge = original_bridge
+        aether_mcp.os = original_os
         for key, value in saved_env.items():
             if value is None:
                 os.environ.pop(key, None)
@@ -687,6 +776,7 @@ if __name__ == "__main__":
     test_field_mapping()
     test_token_attached()
     test_gesture_session()
+    test_owned_process_shutdown()
     test_secure_app_instance()
     test_jsonrpc_robustness()
     test_robustness_tools()

--- a/tools/test_aether_mcp.py
+++ b/tools/test_aether_mcp.py
@@ -338,7 +338,17 @@ def test_owned_process_shutdown():
                 raise aether_mcp.subprocess.TimeoutExpired("mock", timeout)
             return self.returncode
 
+    def no_process_group(_pid):
+        raise ProcessLookupError("mock process has no OS process group")
+
     try:
+        # Stub os BEFORE the win32 loop, not after it. Process.pid is a fake
+        # that is entirely plausible on a real host, and this test exists to
+        # assert the platform guard — so it must not depend on that guard
+        # holding. If the guard ever regresses, a real process group would be
+        # signalled here, under the registered CTest.
+        aether_mcp.os = SimpleNamespace(**vars(original_os))
+        aether_mcp.os.getpgid = no_process_group
         aether_mcp.sys = SimpleNamespace(platform="win32")
         aether_mcp.signal = SimpleNamespace(SIGTERM=15)  # Deliberately no SIGKILL.
         for needs_kill, refuses_kill in ((False, False), (True, False), (True, True)):
@@ -357,9 +367,9 @@ def test_owned_process_shutdown():
         group_calls = []
         aether_mcp.sys = SimpleNamespace(platform="linux")
         aether_mcp.signal = SimpleNamespace(SIGTERM=15, SIGKILL=9)
-        aether_mcp.os = SimpleNamespace(
-            getpgid=lambda pid: pid,
-            killpg=lambda pid, sig: group_calls.append((pid, sig)))
+        aether_mcp.os = SimpleNamespace(**vars(original_os))
+        aether_mcp.os.getpgid = lambda pid: pid
+        aether_mcp.os.killpg = lambda pid, sig: group_calls.append((pid, sig))
         process = Process()
         aether_mcp._signal_owned_process(process)
         aether_mcp._signal_owned_process(process, force=True)
@@ -367,10 +377,7 @@ def test_owned_process_shutdown():
               group_calls == [(process.pid, 15), (process.pid, 9)] and not process.calls,
               str(group_calls))
 
-        def missing_group(_pid):
-            raise ProcessLookupError("mock process group already exited")
-
-        aether_mcp.os.getpgid = missing_group
+        aether_mcp.os.getpgid = no_process_group
         aether_mcp._signal_owned_process(process)
         aether_mcp._signal_owned_process(process, force=True)
         check("POSIX missing-group fallback retains terminate/kill",


### PR DESCRIPTION
## Summary

Fix `app_instance stop` on Windows. Python does not provide `signal.SIGKILL` there, but the old helper evaluated it even on the normal terminate path and raised `AttributeError`, leaving its owned test app running.

Pass a `force` flag internally: POSIX retains TERM/KILL process-group signaling; Windows uses the owned `Popen.terminate()` / `Popen.kill()` methods without referencing unsupported signal constants. Failed termination continues to report `running=true` and retain ownership.

This was found during the native Windows validation for #5591 and is intentionally separate from that AetherD feature.

| File | Scope |
| --- | --- |
| `tools/aether_mcp.py` | Nine-line platform-portability adjustment; no new launch, authentication or process-selection authority |
| `tools/test_aether_mcp.py` | Mock normal/forced/refused Windows shutdown, preserved POSIX behavior, and isolate fake PIDs from real process groups |

## Second fix: mock PIDs no longer reach real host process groups

Called out separately because it is the higher-consequence of the two changes
and the table above under-sells it. On `main`, `test_secure_app_instance`'s
`_Process.next_pid = 4200` reaches
`os.killpg(os.getpgid(4200), SIGTERM)` against the **real host** process group
before any mock method is called — under the registered CTest
`aether_mcp_field_mapping`. On a machine where PID 4200 exists, the test would
SIGTERM and then SIGKILL an unrelated process group, and would also mis-assert,
because the group signal "succeeds" so the mock's `returncode` never changes.
Stubbing `os.getpgid` to raise `ProcessLookupError` removes both problems.

## Review follow-ups (added in 9561641a)

- `_signal_owned_process`'s docstring now records that the Windows fallback is
  not equivalent to the POSIX path: `terminate()`/`kill()` are
  `TerminateProcess`, so no signal is delivered and a `SIGTERM` handler in the
  child never runs — including the HL2 emergency unkey, whose `SIGTERM`/`SIGINT`
  registration in `Hl2EmergencyStop.cpp` deliberately sits outside the
  `#ifndef Q_OS_WIN`. `TerminateProcess` also does not reap descendants. Not
  fixable at this seam (`CTRL_BREAK_EVENT` reaches console applications only,
  not a windowed Qt process), and bounded because the `app_instance` launch path
  pins `AETHER_AUTOMATION_NO_TX=1` and drops `AETHER_AUTOMATION_ALLOW_TX`.
- `test_owned_process_shutdown` stubbed `os` only *after* its win32 loop, so the
  test asserting the platform guard depended on that guard holding. The stub now
  precedes the loop, and both stubs use the `SimpleNamespace(**vars(os))` form so
  they degrade gracefully if `_signal_owned_process` grows another `os.*` call.
- Mutation evidence re-verified after the hardening: the test still fails against
  the base helper with `AttributeError: ... SIGKILL` and passes with the fix.

## Constitution principle honored

Principle XI — fixes are demonstrated. The new mock regression raises the original missing-`SIGKILL` error with the base helper and passes with this fix. Principle XII — tests must not resolve synthetic process IDs against the host's real process groups.

## Test plan

- [x] `python3 tools/test_aether_mcp.py` passes on macOS and Linux; Python 3.12 equivalent passes on Windows.
- [x] Before/after regression: the new Windows mock test demonstrably fails against the unchanged base helper with `AttributeError: ... SIGKILL`.
- [x] Native Windows MCP launch, authenticated Demo receive/reconnect checks, and owned stop pass using these exact helper bytes. OS process count is zero afterward. `exitCode=1` is Windows process termination, not a graceful GUI-exit assertion.
- [x] Mock failed-stop path retains ownership; POSIX process-group and fallback tests pass without signaling real processes.
- [x] Existing tokenless-launch refusal, no-TX pinning, exact identity validation and protocol tests still pass.
- [x] `git diff --check` passes; no C++ or build-system change.
- [x] Independent architecture check and security diff review completed with no reportable finding in either changed file; process/socket/token boundaries and pre-existing documentation discrepancies are recorded.
- [ ] PR CI passes — pending after publication.

The native check used fresh settings without saved radio endpoints, an ephemeral token, only `DEMO-0001`, and `AETHER_AUTOMATION_NO_TX=1`. No physical radio was connected or keyed. Normal desktop discovery was not disabled; Demo-only is not a discovery-isolation claim. No new socket test is added to the default graph.

## Checklist

- [x] Signed commit verified.
- [x] No settings, UI, dependency, default-value or CI-gate changes.
- [x] Clean-room source change; no proprietary binary inspection.
- [x] Scope/reproduction documented here; no `CHANGELOG.md` entry.

