### PR TITLE
fix(gui): guard nested dialog lifetimes and audit safe menu owners

### DIFF
--- a/docs/gui-nested-loop-lifetime-audit.md
+++ b/docs/gui-nested-loop-lifetime-audit.md
@@ -1,0 +1,123 @@
+# GUI nested-loop lifetime audit (#5568)
+
+Baseline: `c692c75eb9f31aac151e943b9f88e6298007c6c5`. This audit follows
+parented stack `QMenu` / `QDialog` candidates, their derived dialogs and message
+helpers, and the state used after their nested event loops. It extends #5567;
+it does not claim that every reentrant signal in the application is safe.
+
+## Ownership rule
+
+A parented stack widget is unsafe when its parent can be destroyed while
+`exec()` runs: QObject deletes the child, although its storage belongs to the
+calling stack. A heap child held through `ScopedChildWidget` preserves scoped
+cleanup and permits parent deletion. That alone does not protect the caller:
+post-loop owner, model and child-widget accesses need survival/identity checks,
+and table items must be copied or resolved again.
+
+`MainWindow::showOrRaisePersistent()` sets `WA_DeleteOnClose` before showing
+utility dialogs. Closing one during a child loop is therefore a real deletion
+route. In contrast, the main window's destructor runs after the outer
+application event loop returns; it is not evidence of deletion during a menu.
+Workspace removal first evicts ordinary applet containers, and floating
+container close does not delete them. `ContainerManager::destroyContainer()`
+has no production caller outside its own recursive implementation at this
+baseline. Those facts distinguish ordinary applets from a transient parented
+directly to a workspace window.
+
+## Direct stack-menu/dialog inventory
+
+The following baseline inventory comes from `git grep` for explicit parented
+`QMenu` and `QDialog` local declarations under `src/gui`. Line numbers refer to
+the baseline, so they remain reproducible after this patch.
+
+| Baseline site | Disposition and reason |
+| --- | --- |
+| `AppletPanel.cpp:1208` | Retained: ordinary applet ownership and workspace eviction keep the parent alive. |
+| `Ax25HfPacketDecodeDialog.cpp:4263` | Retained: persistent hide-on-close dialog; it is not delete-on-close. |
+| `ClientChainWidget.cpp:688` | Retained: chain/editor is retained by its strip; ordinary strip close hides it. |
+| `ClientEqEditorCanvas.cpp:229` | Retained: EQ editor belongs to the retained chain. |
+| `ConnectionPanel.cpp:1915` | Menu retained: panel belongs to MainWindow. Discovery can replace list items while the menu/nickname prompt runs; resolve the row again by family and serial. |
+| `CopyAssistController.cpp:1008` | Retained: settings window is retained by the ordinary applet/controller, with no close-time deletion route found. |
+| `CrossNeedleMeterApplet.cpp:174` | Retained: ordinary applet ownership. |
+| `CwxPanel.cpp:773` | Menu retained: panel belongs to MainWindow. Copy the bubble text before the loop because history clearing can delete the bubble. |
+| `DxClusterDialog.cpp:2515` | Scoped menu: Spot Hub is delete-on-close. |
+| `LpMeterApplet.cpp:386` | Retained: ordinary applet ownership. |
+| `MainWindow.cpp:4538` | Retained: MainWindow survives this dialog loop. |
+| `MidiMappingDialog.cpp:678` | Scoped manual-binding dialog and post-loop owner/manager/child checks. MIDI mapping is delete-on-close. |
+| `MiniPanApplet.cpp:83` | Retained: ordinary applet ownership. |
+| `NetSchedulerDialog.cpp:173` | Scoped editor, copied capture callback and stable schedule IDs across loops. Double-click opening is deferred until the table event returns. Scheduler is delete-on-close. |
+| `NetworkDiagnosticsDialog.cpp:1387` | Scoped menu and persistent selected-row indexes. Diagnostics is delete-on-close and the log model can change. |
+| `RxApplet.cpp:454` | Scoped TX-antenna menu with original-slice survival/identity check. Ordinary owner deletion is not claimed as a production route; slice rebinding is the stale-intent hazard. |
+| `RxApplet.cpp:1064` | AGC menu retained: ordinary applet ownership; the callback uses current calibration state. |
+| `RxApplet.cpp:3235` | Scoped custom-filter dialog/menu and original slice/preset-button checks. Actions are connected with the preset button as context so a rebuilt preset cannot retain a callback. |
+| `SettingsBrowserDialog.cpp:666,799` | Scoped document viewer and Add Key; browser is delete-on-close. Double-click opening is deferred one event turn so Qt's table handler finishes before its table can be deleted. |
+| `StripChainWidget.cpp:688` | Retained: retained strip owns the chain. |
+| `StripRxChainWidget.cpp:593` | Retained: retained strip owns the chain. |
+| `TciApplet.cpp:157` | Retained: ordinary applet ownership. |
+| `ThemeEditorDialog.cpp:1035` | Scoped menu, owner/theme identity check and row relookup; preserves selection and scroll position. Theme Editor is delete-on-close. |
+| `TxApplet.cpp:808,852` | Menus retained: ordinary applet ownership. |
+
+## Derived dialogs and helpers
+
+Qt 6.11.2's [static message-box implementation](https://github.com/qt/qtbase/blob/v6.11.2/src/widgets/dialogs/qmessagebox.cpp)
+creates a stack `QMessageBox` inside `showNewMessageBox`. Its parent lifetime
+therefore matters even when our call site only says `QMessageBox::warning`.
+The [static input-dialog implementation](https://github.com/qt/qtbase/blob/v6.11.2/src/widgets/dialogs/qinputdialog.cpp)
+uses a guarded heap allocation; it still leaves the caller responsible for
+post-loop accesses. File/color pickers likewise require caller survival checks.
+
+| Site / owner | Disposition |
+| --- | --- |
+| Shared `FramelessMessageBox::showMessage` | Scoped allocation; callers receive cancellation when the parent destroys the box. |
+| Settings Browser confirmations/export | Owner checks after confirmation/picker; the Add Key child must also survive a second confirmation. |
+| MIDI import/export | Scoped file pickers/messages and owner, manager and editor survival checks; snapshot exported bindings before the picker. |
+| Net Scheduler import/export/remove | Scoped messages, owner checks after pickers, and ID relookup before changing a schedule. |
+| Radio Setup TX acknowledgment / Kiwi picker / CSV transfer | Scoped exact dialog constructors and owner/child/manager guards. Closing the acknowledgment does not persist TX permission. |
+| Waveforms notices/removal / file selection | Scoped `PersistentDialog` helpers and caller survival checks. |
+| Memory import/export/removal | Scoped notices and confirmations, owner/model checks and guarded asynchronous completion notices. |
+| Profile Manager / Profile Import-Export | Scoped notices/confirmations and owner/model/transfer/picker checks. |
+| BNR license in `AetherDspWidget` | Scoped confirmation; DSP window is delete-on-close. Return false if it disappears. |
+| Theme Editor operations / token-editor notice | Scoped messages and post-picker/input survival checks; preserve confirmation defaults. |
+| Spot Hub color/file selection / FreeDV notice | Caller and child survival checks and scoped message; Spot Hub is delete-on-close. |
+| Network Diagnostics save log | Check owner/table after the file picker. |
+| AGC calibration NR notice | Scoped warning; calibration window is delete-on-close. |
+| ATU pre-tune warnings | Scoped boxes and owner checks, preserving Cancel as default. `TxApplet::openPreTuneDialog` explicitly sets delete-on-close. |
+| Ulanzi mapper missing-polkit notice | Scoped warning; mapper is delete-on-close. This path is Linux-only. |
+| TX clear-memory confirmation | Scoped box and model identity check. Its parent is `this->window()`: workspace deletion can delete the box even though the applet container is evicted intact. |
+| Spectrum background-image picker | Scoped QFileDialog and surviving-spectrum check. The picker can belong directly to a removable workspace or floating spectrum window. |
+| MainWindow-owned Shortcut / SWR license / support helpers | Retained: no nested-loop MainWindow destruction route. |
+| AX.25, ordinary amplifier applet, Aetherial strip messages | Retained: hide/evict-and-keep owner lifetime. |
+| Legacy `GradientEditorDialog` | No production construction found; shared `GradientStrip` is used by TokenEditorWidget. No speculative conversion. |
+
+## Verification boundaries
+
+Socket-free tests exercise real Settings Browser Add Key, document viewer and
+shared warning paths, with the production delete-on-close flag and a timer that
+closes the owner while the child runs. The original source fails with an ASan
+bad-free in `QObjectPrivate::deleteChildren`; the fixed GUI sources pass.
+AddressSanitizer instruments the test, SettingsBrowserDialog and
+FramelessMessageBox; Qt and the linked engine library are not instrumented.
+
+The Rx component test separately injects owner destruction and slice rebinding;
+it does not claim a production applet-deletion route. Paired accepted-dialog
+cases require one write to the live original slice and zero writes after rebind.
+The scoped-widget test checks parent deletion and forwarded constructor values against the direct Qt constructor, including platform-specific title behavior. Net Scheduler Add and actual table double-click Edit both close the delete-on-close parent while the editor is active.
+
+Native macOS verification used a fresh `AETHER_SETTINGS_DIR`,
+`AETHER_AUTOMATION_NO_TX=1` and the explicit `connect local serial DEMO-0001`
+selector. For both Settings Browser / Add Key and Net Scheduler / Add Net,
+`invoke` opened the child, `grab` captured it, and `close` targeted the parent
+while the child loop was active. A subsequent `dumpTree` contained neither
+parent nor child, `ping` remained successful, and the radio snapshot still
+reported Demo with `transmitting=false`. Closing MainWindow then produced an
+actual process exit status of **0**; the app lock was released.
+
+The full macOS build passed with RADE enabled, ARM64 host/system/executable,
+and no RNNoise x86 sources. Nine focused CTests passed: settings browser,
+scoped widget, GUI nested lifetime, RX squelch reconciliation, TX power
+reconciliation, theme manager, theme seed, MIDI settings and ATU pre-tune
+centers. The GUI ASan suite passed all eight cases; removing the custom-filter
+slice/button guard in a scratch copy failed the rebound case with a stale
+write, while the live acceptance control still passed. No new socket test or
+per-PR CI gate was added. These samples do not claim native coverage of every
+dialog, a full ASan engine build, or the Linux-only polkit notice.

--- a/docs/gui-nested-loop-lifetime-audit.md
+++ b/docs/gui-nested-loop-lifetime-audit.md
@@ -49,7 +49,7 @@ the baseline, so they remain reproducible after this patch.
 | `NetworkDiagnosticsDialog.cpp:1387` | Scoped menu and persistent selected-row indexes. Diagnostics is delete-on-close and the log model can change. |
 | `RxApplet.cpp:454` | Scoped TX-antenna menu with original-slice survival/identity check. Ordinary owner deletion is not claimed as a production route; slice rebinding is the stale-intent hazard. |
 | `RxApplet.cpp:1064` | AGC menu retained: ordinary applet ownership; the callback uses current calibration state. |
-| `RxApplet.cpp:3235` | Scoped custom-filter dialog/menu and original slice/preset-button checks. Actions are connected with the preset button as context so a rebuilt preset cannot retain a callback. |
+| `RxApplet.cpp:3235` | Scoped custom-filter dialog/menu and original slice/preset-button checks. Actions are connected with the preset button as context so a rebuilt preset cannot retain a callback. The menu itself was **parentless** (`QMenu menu;`) at the baseline, so it was never the invalid-free case #5568 warns against conflating by grep; it is parented here only to give the nested dialog scoped cleanup. Re-parenting adds no styling: `RxApplet`'s sole widget-level stylesheet is `QSlider::sub-page` (`RxApplet.cpp:306`), which a `QMenu` cannot match. |
 | `SettingsBrowserDialog.cpp:666,799` | Scoped document viewer and Add Key; browser is delete-on-close. Double-click opening is deferred one event turn so Qt's table handler finishes before its table can be deleted. |
 | `StripChainWidget.cpp:688` | Retained: retained strip owns the chain. |
 | `StripRxChainWidget.cpp:593` | Retained: retained strip owns the chain. |
@@ -73,6 +73,8 @@ post-loop accesses. File/color pickers likewise require caller survival checks.
 | MIDI import/export | Scoped file pickers/messages and owner, manager and editor survival checks; snapshot exported bindings before the picker. |
 | Net Scheduler import/export/remove | Scoped messages, owner checks after pickers, and ID relookup before changing a schedule. |
 | Radio Setup TX acknowledgment / Kiwi picker / CSV transfer | Scoped exact dialog constructors and owner/child/manager guards. Closing the acknowledgment does not persist TX permission. |
+| Radio Setup reboot / firmware browse+upload / recording directory / slice colour / forget-all SmartLink certificates | Scoped boxes and owner, model and child guards. `RadioSetupDialog` is shown through `showOrRaisePersistent()` (`MainWindow.cpp:3395`), so it is delete-on-close and every one of these resumed into `this` or a child. The three `QMessageBox::` statics were the stack-allocated `showNewMessageBox` case, not merely stale pointers. Reboot, firmware upload and cert clearing keep `Cancel`/`No` as the default. |
+| Radio Setup automation-bridge bind failure | Retained: nothing runs after the notice. |
 | Waveforms notices/removal / file selection | Scoped `PersistentDialog` helpers and caller survival checks. |
 | Memory import/export/removal | Scoped notices and confirmations, owner/model checks and guarded asynchronous completion notices. |
 | Profile Manager / Profile Import-Export | Scoped notices/confirmations and owner/model/transfer/picker checks. |
@@ -101,7 +103,13 @@ FramelessMessageBox; Qt and the linked engine library are not instrumented.
 The Rx component test separately injects owner destruction and slice rebinding;
 it does not claim a production applet-deletion route. Paired accepted-dialog
 cases require one write to the live original slice and zero writes after rebind.
-The scoped-widget test checks parent deletion and forwarded constructor values against the direct Qt constructor, including platform-specific title behavior. Net Scheduler Add and actual table double-click Edit both close the delete-on-close parent while the editor is active.
+The scoped-widget test checks parent deletion and forwarded constructor values
+against the direct Qt constructor under the same parent, including
+platform-specific title behavior. The shared-warning case additionally asserts
+that a box whose parent dies mid-loop reports `NoButton` rather than a pressed
+button: `SettingsBrowserDialog::addKey()` and `deleteSelected()` only write to
+the store on `Yes`, so that return value is the barrier against a post-teardown
+write, not a detail. Net Scheduler Add and actual table double-click Edit both close the delete-on-close parent while the editor is active.
 
 Native macOS verification used a fresh `AETHER_SETTINGS_DIR`,
 `AETHER_AUTOMATION_NO_TX=1` and the explicit `connect local serial DEMO-0001`

--- a/src/gui/AetherDspWidget.cpp
+++ b/src/gui/AetherDspWidget.cpp
@@ -6,6 +6,7 @@
 #include "models/Rn2SettingsModel.h"
 #include "GuardedSlider.h"
 #include "Theme.h"
+#include "ScopedChildWidget.h"
 
 #include <QRegularExpression>
 #include <QSet>
@@ -1301,7 +1302,9 @@ bool AetherDspWidget::ensureBnrLicenseAccepted()
     if (NvidiaBnrSettings::licenseAccepted())
         return true;
 
-    QMessageBox box(this);
+    const QPointer<AetherDspWidget> self(this);
+    ScopedChildWidget<QMessageBox> boxOwner(this);
+    QMessageBox& box = *boxOwner.get();
     box.setWindowTitle(tr("NVIDIA Software License — BNR"));
     box.setIcon(QMessageBox::Information);
     box.setTextFormat(Qt::RichText);
@@ -1321,6 +1324,9 @@ bool AetherDspWidget::ensureBnrLicenseAccepted()
     auto* acceptBtn = box.addButton(tr("Accept"), QMessageBox::AcceptRole);
     box.addButton(tr("Decline"), QMessageBox::RejectRole);
     box.exec();
+    if (!self || !boxOwner) {
+        return false;
+    }
     if (box.clickedButton() == acceptBtn) {
         NvidiaBnrSettings::setLicenseAccepted(true);
         return true;

--- a/src/gui/AgcCalibrationDialog.cpp
+++ b/src/gui/AgcCalibrationDialog.cpp
@@ -9,6 +9,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMessageBox>
+#include "ScopedChildWidget.h"
 #include <QPainter>
 #include <QPainterPath>
 #include <QPushButton>
@@ -395,15 +396,14 @@ void AgcCalibrationDialog::onStartStop()
     // The user can disable NR and try again. Mirrors the quiet-spot guard
     // pattern in the engine and matches the in-hint warning text.
     if (nrSuppressesCalibration()) {
-        QMessageBox::warning(
-            this,
-            QStringLiteral("Disable NR for AGC-T calibration"),
+        ScopedChildWidget<QMessageBox> boxOwner(
+            QMessageBox::Warning, QStringLiteral("Disable NR for AGC-T calibration"),
             QStringLiteral(
                 "Noise Reduction is active and is crushing the audio noise "
                 "floor that the AGC knee detector measures. Turn off any of "
                 "NR / NR2 / RN2 / NR4 / DFNR / MNR / BNR, then try Auto Sweep "
-                "again."),
-            QMessageBox::Ok);
+                "again."), QMessageBox::Ok, this);
+        boxOwner.get()->exec();
         return;
     }
     m_curve->clear();

--- a/src/gui/AtuPreTuneDialog.cpp
+++ b/src/gui/AtuPreTuneDialog.cpp
@@ -19,6 +19,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMessageBox>
+#include "ScopedChildWidget.h"
 #include <QPushButton>
 #include <QScrollArea>
 #include <QStackedWidget>
@@ -488,6 +489,7 @@ QVector<double> AtuPreTuneDialog::centersForBand(const BandRow& row) const
 
 void AtuPreTuneDialog::onStartClicked()
 {
+    const QPointer<AtuPreTuneDialog> self(this);
     if (!m_radio) {
         reject();
         return;
@@ -558,15 +560,20 @@ void AtuPreTuneDialog::onStartClicked()
     // checked).
     if (m_points.size() > kMaxPointsSoftCap) {
         const int estSecs = m_points.size() * kSecondsPerPointEstimate;
-        const auto reply = QMessageBox::warning(this,
-            "Large Pre-Tune Sweep",
+        ScopedChildWidget<QMessageBox> boxOwner(
+            QMessageBox::Warning, "Large Pre-Tune Sweep",
             QString("Selected bands total %1 points "
                     "(estimated %2 min %3 s of intermittent TX).\n\n"
                     "Continue?")
                 .arg(m_points.size())
                 .arg(estSecs / 60)
                 .arg(estSecs % 60, 2, 10, QChar('0')),
-            QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Cancel);
+            QMessageBox::Ok | QMessageBox::Cancel, this);
+        boxOwner.get()->setDefaultButton(QMessageBox::Cancel);
+        const int reply = boxOwner.get()->exec();
+        if (!self || !boxOwner) {
+            return;
+        }
         if (reply != QMessageBox::Ok) return;
     }
 
@@ -577,13 +584,18 @@ void AtuPreTuneDialog::onStartClicked()
     if (m_mode == Mode::Auto && m_radio) {
         const int tunePower = m_radio->transmitModel().tunePower();
         if (tunePower > kAutoModeTunePowerWarnW) {
-            const auto reply = QMessageBox::warning(this,
-                "High Tune Power",
+            ScopedChildWidget<QMessageBox> boxOwner(
+                QMessageBox::Warning, "High Tune Power",
                 QString("Tune power is %1 W — higher than the recommended "
                         "%2 W ceiling for unattended Auto mode.\n\n"
                         "Continue?")
                     .arg(tunePower).arg(kAutoModeTunePowerWarnW),
-                QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Cancel);
+                QMessageBox::Ok | QMessageBox::Cancel, this);
+            boxOwner.get()->setDefaultButton(QMessageBox::Cancel);
+            const int reply = boxOwner.get()->exec();
+            if (!self || !boxOwner) {
+                return;
+            }
             if (reply != QMessageBox::Ok) return;
         }
     }

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -1942,12 +1942,20 @@ void ConnectionPanel::showRadioContextMenu(const QPoint& pos)
 
     // Reflect the change immediately: re-label this row from the saved setting
     // rather than waiting for the next discovery sweep.
-    RadioInfo updated = radio;
-    updated.nickname =
-        hl2::Hl2Discovery::effectiveNickname(radio.family, radio.serial,
-                                             radio.model);
-    m_radios[row] = updated;
-    item->setText(formatLocalRadioLabel(updated));
+    // Discovery may remove or reorder rows while either nested loop runs.
+    // Resolve the radio again instead of retaining a QListWidgetItem pointer.
+    for (int i = 0; i < m_radios.size(); ++i) {
+        RadioInfo& updated = m_radios[i];
+        if (updated.family != radio.family || updated.serial != radio.serial) {
+            continue;
+        }
+        updated.nickname = hl2::Hl2Discovery::effectiveNickname(
+            updated.family, updated.serial, updated.model);
+        if (QListWidgetItem* currentItem = m_radioList->item(i)) {
+            currentItem->setText(formatLocalRadioLabel(updated));
+        }
+        break;
+    }
 }
 
 void ConnectionPanel::onRadioDiscovered(const RadioInfo& radio)

--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -770,6 +770,8 @@ bool AetherSDR::CwxPanel::eventFilter(QObject* obj, QEvent* event)
     if (auto* bubble = dynamic_cast<CwxBubble*>(obj)) {
         if (event->type() == QEvent::ContextMenu) {
             auto* ce = static_cast<QContextMenuEvent*>(event);
+            // History can be cleared while the nested menu loop runs.
+            const QString resend = bubble->rawText();
             QMenu menu(this);
             AetherSDR::ThemeManager::instance().applyStyleSheet(&menu, "QMenu { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid {{color.background.2}}; }"
                 "QMenu::item:selected { background: {{color.accent}}; color: {{color.background.spectrum}}; }"
@@ -781,7 +783,7 @@ bool AetherSDR::CwxPanel::eventFilter(QObject* obj, QEvent* event)
             if (chosen == resendAction) {
                 // Resend the raw text (modifiers intact) so per-word speeds
                 // are preserved rather than re-keyed at base WPM. (#272)
-                resendText(bubble->rawText());
+                resendText(resend);
             } else if (chosen == clearAction) {
                 clearHistory();
             }

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -1,4 +1,5 @@
 #include "DxClusterDialog.h"
+#include "ScopedChildWidget.h"
 #include "DxClusterStartupCommandsDialog.h"
 #include "FlowLayout.h"
 // For MessageMaxLength — the two surfaces share FreeDvMyMessage, so they
@@ -39,12 +40,25 @@
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QMessageBox>
+#include <QPointer>
 #include <QRegularExpression>
 #include <QSignalBlocker>
 #include <QTimer>
 #include "core/ThemeManager.h"
 
 namespace AetherSDR {
+
+namespace {
+
+QColor getColorForLiveParent(const QColor& initial, DxClusterDialog* parent,
+                            const QString& title)
+{
+    const QPointer<DxClusterDialog> parentGuard(parent);
+    const QColor color = QColorDialog::getColor(initial, parent, title);
+    return parentGuard ? color : QColor();
+}
+
+} // namespace
 
 // GuardedSlider variant that resets to a stored default on left
 // double-click.  Used for the Filter Match Window slider (#2609) so
@@ -956,7 +970,7 @@ void DxClusterDialog::buildClusterTab(QTabWidget* tabs)
         "QPushButton { background: %1; border: 2px solid #405060; border-radius: 3px; }"
         "QPushButton:hover { border-color: #c8d8e8; }").arg(dxcColor.name()));
     connect(dxcColorBtn, &QPushButton::clicked, this, [this, dxcColorBtn] {
-        QColor c = QColorDialog::getColor(
+        QColor c = getColorForLiveParent(
             QColor(AppSettings::instance().value("DxClusterSpotColor", "#D2B48C").toString()),
             this, "DX Cluster Spot Color");
         if (c.isValid()) {
@@ -1158,7 +1172,7 @@ void DxClusterDialog::buildRbnTab(QTabWidget* tabs)
         "QPushButton { background: %1; border: 2px solid #405060; border-radius: 3px; }"
         "QPushButton:hover { border-color: #c8d8e8; }").arg(rbnColor.name()));
     connect(rbnColorBtn, &QPushButton::clicked, this, [this, rbnColorBtn] {
-        QColor c = QColorDialog::getColor(
+        QColor c = getColorForLiveParent(
             QColor(AppSettings::instance().value("RbnSpotColor", "#4488FF").toString()),
             this, "RBN Spot Color");
         if (c.isValid()) {
@@ -1315,7 +1329,7 @@ void DxClusterDialog::buildWsjtxTab(QTabWidget* tabs)
     m_wsjtxColorCQ->setFixedSize(18, 18);
     m_wsjtxColorCQ->setStyleSheet(swatchStyle(cqColor));
     connect(m_wsjtxColorCQ, &QPushButton::clicked, this, [this, swatchStyle] {
-        QColor c = QColorDialog::getColor(QColor(AppSettings::instance().value("WsjtxColorCQ", "#00FF00").toString()), this, "CQ Spot Color");
+        QColor c = getColorForLiveParent(QColor(AppSettings::instance().value("WsjtxColorCQ", "#00FF00").toString()), this, "CQ Spot Color");
         if (c.isValid()) {
             m_wsjtxColorCQ->setStyleSheet(swatchStyle(c));
             AppSettings::instance().setValue("WsjtxColorCQ", c.name());
@@ -1341,7 +1355,7 @@ void DxClusterDialog::buildWsjtxTab(QTabWidget* tabs)
     m_wsjtxColorPOTA->setFixedSize(18, 18);
     m_wsjtxColorPOTA->setStyleSheet(swatchStyle(potaColor));
     connect(m_wsjtxColorPOTA, &QPushButton::clicked, this, [this, swatchStyle] {
-        QColor c = QColorDialog::getColor(QColor(AppSettings::instance().value("WsjtxColorPOTA", "#00FFFF").toString()), this, "CQ POTA Spot Color");
+        QColor c = getColorForLiveParent(QColor(AppSettings::instance().value("WsjtxColorPOTA", "#00FFFF").toString()), this, "CQ POTA Spot Color");
         if (c.isValid()) {
             m_wsjtxColorPOTA->setStyleSheet(swatchStyle(c));
             AppSettings::instance().setValue("WsjtxColorPOTA", c.name());
@@ -1367,7 +1381,7 @@ void DxClusterDialog::buildWsjtxTab(QTabWidget* tabs)
     m_wsjtxColorCallingMe->setFixedSize(18, 18);
     m_wsjtxColorCallingMe->setStyleSheet(swatchStyle(callingMeColor));
     connect(m_wsjtxColorCallingMe, &QPushButton::clicked, this, [this, swatchStyle] {
-        QColor c = QColorDialog::getColor(QColor(AppSettings::instance().value("WsjtxColorCallingMe", "#FF0000").toString()), this, "Calling Me Spot Color");
+        QColor c = getColorForLiveParent(QColor(AppSettings::instance().value("WsjtxColorCallingMe", "#FF0000").toString()), this, "Calling Me Spot Color");
         if (c.isValid()) {
             m_wsjtxColorCallingMe->setStyleSheet(swatchStyle(c));
             AppSettings::instance().setValue("WsjtxColorCallingMe", c.name());
@@ -1392,7 +1406,7 @@ void DxClusterDialog::buildWsjtxTab(QTabWidget* tabs)
     m_wsjtxColorDefault->setFixedSize(18, 18);
     m_wsjtxColorDefault->setStyleSheet(swatchStyle(defaultColor));
     connect(m_wsjtxColorDefault, &QPushButton::clicked, this, [this, swatchStyle] {
-        QColor c = QColorDialog::getColor(QColor(AppSettings::instance().value("WsjtxColorDefault", "#FFFFFF").toString()), this, "Default Spot Color");
+        QColor c = getColorForLiveParent(QColor(AppSettings::instance().value("WsjtxColorDefault", "#FFFFFF").toString()), this, "Default Spot Color");
         if (c.isValid()) {
             m_wsjtxColorDefault->setStyleSheet(swatchStyle(c));
             AppSettings::instance().setValue("WsjtxColorDefault", c.name());
@@ -1671,7 +1685,7 @@ void DxClusterDialog::buildPotaTab(QTabWidget* tabs)
         "QPushButton { background: %1; border: 2px solid #405060; border-radius: 3px; }"
         "QPushButton:hover { border-color: #c8d8e8; }").arg(potaColor.name()));
     connect(potaColorBtn, &QPushButton::clicked, this, [this, potaColorBtn] {
-        QColor c = QColorDialog::getColor(
+        QColor c = getColorForLiveParent(
             QColor(AppSettings::instance().value("PotaSpotColor", "#FFFF00").toString()),
             this, "POTA Spot Color");
         if (c.isValid()) {
@@ -1848,7 +1862,7 @@ void DxClusterDialog::buildEiBiTab(QTabWidget* tabs)
     };
     updateColorBtnStyle(eibiColor.name());
     connect(eibiColorBtn, &QPushButton::clicked, this, [this, updateColorBtnStyle] {
-        QColor c = QColorDialog::getColor(
+        QColor c = getColorForLiveParent(
             QColor(AppSettings::instance().value("EiBiSpotColor", "#8aa8c0").toString()),
             this, "EiBi Spot Color");
         if (c.isValid()) {
@@ -2048,7 +2062,7 @@ void DxClusterDialog::buildN1mmTab(QTabWidget* tabs)
             colorBtn, swatchTemplate.arg(statusColor(spec).name()));
         connect(colorBtn, &QPushButton::clicked, this,
                 [this, colorBtn, swatchTemplate, statusColor, specPtr] {
-            QColor c = QColorDialog::getColor(statusColor(*specPtr), this, "N1MM Status Color");
+            QColor c = getColorForLiveParent(statusColor(*specPtr), this, "N1MM Status Color");
             if (c.isValid()) {
                 ThemeManager::instance().applyStyleSheet(
                     colorBtn, swatchTemplate.arg(c.name()));
@@ -2201,13 +2215,24 @@ void DxClusterDialog::buildFreeDvTab(QTabWidget* tabs)
             }
 
             if (callsign.isEmpty() || grid.isEmpty()) {
-                QMessageBox::warning(this, "FreeDV Reporter",
-                    "Please set both a callsign and a grid square before "
-                    "enabling reporter broadcasting.\n\n"
-                    "Reporter broadcasts to a public, community-shared map; "
-                    "blank or placeholder values would pollute it.");
-                QSignalBlocker block(m_fdvReportCheck);
-                m_fdvReportCheck->setChecked(false);
+                const QPointer<DxClusterDialog> self(this);
+                const QPointer<QCheckBox> reportCheck(m_fdvReportCheck);
+                ScopedChildWidget<QMessageBox> warningOwner(this);
+                QMessageBox& warning = *warningOwner.get();
+                warning.setIcon(QMessageBox::Warning);
+                warning.setWindowTitle("FreeDV Reporter");
+                warning.setText("Please set both a callsign and a grid square before "
+                                "enabling reporter broadcasting.\n\n"
+                                "Reporter broadcasts to a public, community-shared map; "
+                                "blank or placeholder values would pollute it.");
+                warning.setStandardButtons(QMessageBox::Ok);
+                warning.exec();
+                if (!self || !reportCheck || self->m_fdvReportCheck != reportCheck.data()
+                    || !warningOwner) {
+                    return;
+                }
+                QSignalBlocker block(reportCheck);
+                reportCheck->setChecked(false);
                 return;
             }
         }
@@ -2353,7 +2378,7 @@ void DxClusterDialog::buildFreeDvTab(QTabWidget* tabs)
         "QPushButton { background: %1; border: 2px solid #405060; border-radius: 3px; }"
         "QPushButton:hover { border-color: #c8d8e8; }").arg(freedvColor.name()));
     connect(freedvColorBtn, &QPushButton::clicked, this, [this, freedvColorBtn] {
-        QColor c = QColorDialog::getColor(
+        QColor c = getColorForLiveParent(
             QColor(AppSettings::instance().value("FreeDvSpotColor", "#FF8C00").toString()),
             this, "FreeDV Spot Color");
         if (c.isValid()) {
@@ -2512,7 +2537,8 @@ void DxClusterDialog::buildSpotListTab(QTabWidget* tabs)
                        QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)));
             s.save();
         };
-        QMenu menu(this);
+        ScopedChildWidget<QMenu> menuOwner(this);
+        QMenu& menu = *menuOwner.get();
         KeepMenuOpenOnToggle keepOpen;
         menu.installEventFilter(&keepOpen);
         for (const auto& tc : kToggleCols) {
@@ -2872,7 +2898,7 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
     colorBtn->setFixedSize(24, 24);
     updateSwatch(colorBtn, spotColor);
     connect(colorBtn, &QPushButton::clicked, this, [this, colorBtn, updateSwatch, save, spotColor]() mutable {
-        QColor c = QColorDialog::getColor(spotColor, this, "Spot Text Color");
+        QColor c = getColorForLiveParent(spotColor, this, "Spot Text Color");
         if (c.isValid()) {
             spotColor = c;
             updateSwatch(colorBtn, c);
@@ -2911,7 +2937,7 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
     bgColorBtn->setFixedSize(24, 24);
     updateSwatch(bgColorBtn, bgColor);
     connect(bgColorBtn, &QPushButton::clicked, this, [this, bgColorBtn, updateSwatch, save, bgColor]() mutable {
-        QColor c = QColorDialog::getColor(bgColor, this, "Spot Background Color");
+        QColor c = getColorForLiveParent(bgColor, this, "Spot Background Color");
         if (c.isValid()) {
             bgColor = c;
             updateSwatch(bgColorBtn, c);
@@ -3044,7 +3070,7 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
             QColor* colPtr = sw.colPtr;
             connect(btn, &QPushButton::clicked, this, [this, btn, key, colPtr, updateSwatch, save]() {
                 const QColor cur = colPtr ? *colPtr : QColor(Qt::gray);
-                QColor c = QColorDialog::getColor(cur, this, "Pick Colour");
+                QColor c = getColorForLiveParent(cur, this, "Pick Colour");
                 if (!c.isValid()) return;
                 if (colPtr) *colPtr = c;
                 updateSwatch(btn, c);
@@ -3064,15 +3090,19 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
         // Wire browse button — always arms the file watcher automatically so
         // spot colours update whenever the user exports a new log (#logbook-autoreload).
         connect(browseBtn, &QPushButton::clicked, this, [this, adifPathLabel, save](bool) {
+            const QPointer<DxClusterDialog> self(this);
+            const QPointer<QLabel> pathLabel(adifPathLabel);
             const QString path = QFileDialog::getOpenFileName(
                 this, "Select ADIF Log File", QDir::homePath(),
                 "ADIF Log Files (*.adi *.adif);;All Files (*)");
-            if (path.isEmpty()) return;
-            adifPathLabel->setText(QFileInfo(path).fileName());
+            if (!self || !pathLabel || path.isEmpty()) {
+                return;
+            }
+            pathLabel->setText(QFileInfo(path).fileName());
             save("DxccAdifFilePath", path);
-            if (m_dxccProvider) {
-                m_dxccProvider->importAdifFile(path);   // importStarted → "Updating…" via signal below
-                m_dxccProvider->setAutoReload(true, path);  // always watch after selection
+            if (self->m_dxccProvider) {
+                self->m_dxccProvider->importAdifFile(path);   // importStarted → "Updating…" via signal below
+                self->m_dxccProvider->setAutoReload(true, path);  // always watch after selection
             }
         });
 
@@ -3177,7 +3207,7 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
             QColor* colPtr = sw.colPtr;
             connect(btn, &QPushButton::clicked, this,
                     [this, btn, key, colPtr, updateSwatch, save]() {
-                QColor c = QColorDialog::getColor(*colPtr, this, "Pick Colour");
+                QColor c = getColorForLiveParent(*colPtr, this, "Pick Colour");
                 if (!c.isValid()) return;
                 *colPtr = c;
                 updateSwatch(btn, c);

--- a/src/gui/DxClusterStartupCommandsDialog.cpp
+++ b/src/gui/DxClusterStartupCommandsDialog.cpp
@@ -1,5 +1,6 @@
 #include "DxClusterStartupCommandsDialog.h"
 #include "core/AppSettings.h"
+#include "ScopedChildWidget.h"
 
 #include <QHBoxLayout>
 #include <QLabel>
@@ -83,10 +84,17 @@ DxClusterStartupCommandsDialog::DxClusterStartupCommandsDialog(
 void DxClusterStartupCommandsDialog::edit(
     const QString& title, const QString& appSettingsKey, QWidget* parent)
 {
-    DxClusterStartupCommandsDialog dlg(title, appSettingsKey, parent);
-    if (dlg.exec() != QDialog::Accepted) return;
+    const QString titleCopy = title;
+    const QString appSettingsKeyCopy = appSettingsKey;
+    ScopedChildWidget<DxClusterStartupCommandsDialog> dialogOwner(
+        titleCopy, appSettingsKeyCopy, parent);
+    DxClusterStartupCommandsDialog* const dialog = dialogOwner.get();
+    const int result = dialog->exec();
+    if (!dialogOwner || result != QDialog::Accepted) {
+        return;
+    }
     auto& s = AppSettings::instance();
-    s.setValue(appSettingsKey, dlg.m_edit->toPlainText());
+    s.setValue(appSettingsKeyCopy, dialog->m_edit->toPlainText());
     s.save();
 }
 

--- a/src/gui/FramelessMessageBox.cpp
+++ b/src/gui/FramelessMessageBox.cpp
@@ -1,4 +1,5 @@
 #include "FramelessMessageBox.h"
+#include "ScopedChildWidget.h"
 
 #include "FramelessResizer.h"
 #include "FramelessWindowTitleBar.h"
@@ -81,7 +82,8 @@ QMessageBox::StandardButton FramelessMessageBox::showMessage(
     Icon icon, QWidget* parent, const QString& title, const QString& text,
     StandardButtons buttons, StandardButton defaultButton)
 {
-    FramelessMessageBox box(parent);
+    ScopedChildWidget<FramelessMessageBox> boxOwner(parent);
+    FramelessMessageBox& box = *boxOwner.get();
     box.setIcon(icon);
     box.setWindowTitle(title);
     box.setText(text);

--- a/src/gui/ImageFileDialog.cpp
+++ b/src/gui/ImageFileDialog.cpp
@@ -1,4 +1,5 @@
 #include "ImageFileDialog.h"
+#include "ScopedChildWidget.h"
 
 #include <QButtonGroup>
 #include <QDialog>
@@ -259,7 +260,8 @@ private:
 
 QString getBackgroundImagePath(QWidget* parent, const QString& caption)
 {
-    QFileDialog dlg(parent, caption, QString(), buildImageFilter());
+    ScopedChildWidget<QFileDialog> dialogOwner(parent, caption, QString(), buildImageFilter());
+    QFileDialog& dlg = *dialogOwner.get();
     dlg.setFileMode(QFileDialog::ExistingFile);
     dlg.setOption(QFileDialog::DontUseNativeDialog, true);
     dlg.setAcceptMode(QFileDialog::AcceptOpen);
@@ -401,8 +403,10 @@ QString getBackgroundImagePath(QWidget* parent, const QString& caption)
                           [previewLabel](const QString& path) { previewLabel->setPreviewPath(path); });
     }
 
-    if (dlg.exec() != QDialog::Accepted)
+    const int result = dlg.exec();
+    if (!dialogOwner || result != QDialog::Accepted) {
         return {};
+    }
     return dlg.selectedFiles().value(0, QString());
 }
 

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -4746,9 +4746,12 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             sw, &SpectrumWidget::setWfBlankerThreshold,
             Qt::UniqueConnection);
     connect(menu, &SpectrumOverlayMenu::backgroundImageRequested,
-            this, [sw] {
+            sw, [sw] {
+        const QPointer<SpectrumWidget> spectrum(sw);
         const QString path = getBackgroundImagePath(sw->window(), "Choose Background Image");
-        if (path.isEmpty()) return;
+        if (!spectrum || path.isEmpty()) {
+            return;
+        }
         sw->setBackgroundImage(path);
         auto& s = AppSettings::instance();
         s.setValue(sw->settingsKey("BackgroundImage"), path);

--- a/src/gui/MemoryDialog.cpp
+++ b/src/gui/MemoryDialog.cpp
@@ -7,6 +7,7 @@
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
 #include "core/RadioConnection.h"
+#include "ScopedChildWidget.h"
 
 #include <QCoreApplication>
 #include <QDateTime>
@@ -44,6 +45,18 @@
 namespace AetherSDR {
 
 namespace {
+
+void showMemoryMessage(QWidget* parent, QMessageBox::Icon icon,
+                       const QString& title, const QString& text)
+{
+    ScopedChildWidget<QMessageBox> boxOwner(parent);
+    QMessageBox& box = *boxOwner.get();
+    box.setIcon(icon);
+    box.setWindowTitle(title);
+    box.setText(text);
+    box.setStandardButtons(QMessageBox::Ok);
+    box.exec();
+}
 
 class MemoryTableItem : public QTableWidgetItem {
 public:
@@ -1013,12 +1026,14 @@ void MemoryDialog::onAdd()
 
 void MemoryDialog::onExport()
 {
+    const QPointer<MemoryDialog> self(this);
+    const QPointer<RadioModel> modelGuard(m_model);
     const QString filterProfile = m_filterCombo->currentData().toString();
     const QList<MemoryCsvRecord> records =
         currentExportRecords(m_model->memories(), filterProfile);
 
     if (records.isEmpty()) {
-        QMessageBox::information(this, "Export Memories",
+        showMemoryMessage(this, QMessageBox::Information, "Export Memories",
                                  filterProfile.isEmpty()
                                      ? "There are no memories to export."
                                      : "There are no memories in the current filter to export.");
@@ -1030,13 +1045,14 @@ void MemoryDialog::onExport()
         "Export Memories",
         defaultExportFilePath(),
         "CSV Files (*.csv)");
-    if (path.isEmpty())
+    if (!self || !modelGuard || self->m_model != modelGuard.data() || path.isEmpty()) {
         return;
+    }
 
     const QByteArray csv = MemoryCsvCompat::serialize(records);
     const MemoryCsvParseResult validation = MemoryCsvCompat::parse(csv);
     if (!validation.ok()) {
-        QMessageBox::warning(this, "Export Memories",
+        showMemoryMessage(this, QMessageBox::Warning, "Export Memories",
                              QString("The generated SmartSDR CSV failed validation:\n%1")
                                  .arg(validation.errors.join('\n')));
         return;
@@ -1044,27 +1060,27 @@ void MemoryDialog::onExport()
 
     QSaveFile file(path);
     if (!file.open(QIODevice::WriteOnly)) {
-        QMessageBox::warning(this, "Export Memories",
+        showMemoryMessage(this, QMessageBox::Warning, "Export Memories",
                              QString("Couldn't open %1 for writing.")
                                  .arg(QDir::toNativeSeparators(path)));
         return;
     }
 
     if (file.write(csv) != csv.size()) {
-        QMessageBox::warning(this, "Export Memories",
+        showMemoryMessage(this, QMessageBox::Warning, "Export Memories",
                              QString("Couldn't write the SmartSDR CSV to %1.")
                                  .arg(QDir::toNativeSeparators(path)));
         return;
     }
 
     if (!file.commit()) {
-        QMessageBox::warning(this, "Export Memories",
+        showMemoryMessage(this, QMessageBox::Warning, "Export Memories",
                              QString("Couldn't save %1.")
                                  .arg(QDir::toNativeSeparators(path)));
         return;
     }
 
-    QMessageBox::information(this, "Export Memories",
+    showMemoryMessage(this, QMessageBox::Information, "Export Memories",
                              QString("Exported %1 memories to %2.")
                                  .arg(records.size())
                                  .arg(QDir::toNativeSeparators(QFileInfo(path).fileName())));
@@ -1074,17 +1090,20 @@ void MemoryDialog::onImport()
 {
     if (!m_model->memoriesWritable())
         return;
+    const QPointer<MemoryDialog> self(this);
+    const QPointer<RadioModel> modelGuard(m_model);
     const QString path = QFileDialog::getOpenFileName(
         this,
         "Import Memories",
         QDir::home().filePath("Documents"),
         "CSV Files (*.csv)");
-    if (path.isEmpty())
+    if (!self || !modelGuard || self->m_model != modelGuard.data() || path.isEmpty()) {
         return;
+    }
 
     QFile file(path);
     if (!file.open(QIODevice::ReadOnly)) {
-        QMessageBox::warning(this, "Import Memories",
+        showMemoryMessage(this, QMessageBox::Warning, "Import Memories",
                              QString("Couldn't open %1 for reading.")
                                  .arg(QDir::toNativeSeparators(path)));
         return;
@@ -1110,12 +1129,14 @@ void MemoryDialog::onImport()
 
     const QPointer<MemoryDialog> dialogGuard(this);
     auto showSummary = [dialogGuard, state]() {
-        if (!dialogGuard)
+        if (!dialogGuard) {
             return;
+        }
 
         dialogGuard->populateTable();
 
-        QMessageBox summary(dialogGuard);
+        ScopedChildWidget<QMessageBox> summaryOwner(dialogGuard.data());
+        QMessageBox& summary = *summaryOwner.get();
         summary.setWindowTitle("Import Memories");
         summary.setIcon(state->issues.isEmpty() ? QMessageBox::Information : QMessageBox::Warning);
         summary.setText(QString("Imported %1 %2 from %3 (%4 format).")
@@ -1131,7 +1152,7 @@ void MemoryDialog::onImport()
             summary.setDetailedText(state->issues.join('\n'));
         }
         summary.exec();
-        if (dialogGuard)
+        if (dialogGuard && summaryOwner)
             dialogGuard->focusTableOnCurrentRow();
     };
 
@@ -1166,8 +1187,9 @@ void MemoryDialog::onImport()
     };
     const auto runNext = QSharedPointer<std::function<void()>>::create();
     *runNext = [model, dialogGuard, state, runNext, showSummary, progressGuard, advanceProgress]() {
-        if (!dialogGuard)
+        if (!dialogGuard) {
             return;
+        }
 
         if (state->nextRecord >= state->records.size()) {
             if (progressGuard) {
@@ -1197,8 +1219,9 @@ void MemoryDialog::onImport()
 
         model->sendCmdPublic("memory create",
             [model, dialogGuard, state, runNext, rowLabel, update, advanceProgress](int code, const QString& body) {
-            if (!dialogGuard)
+            if (!dialogGuard) {
                 return;
+            }
 
             if (code != 0) {
                 state->issues << formatImportIssue(
@@ -1225,8 +1248,9 @@ void MemoryDialog::onImport()
             model->sendCmdPublic(
                 QString("memory set %1 %2").arg(idx).arg(update.commandSuffix),
                 [model, dialogGuard, state, runNext, rowLabel, update, idx, advanceProgress](int setCode, const QString& setBody) {
-                if (!dialogGuard)
+                if (!dialogGuard) {
                     return;
+                }
 
                 if (setCode == 0) {
                     model->handleMemoryStatus(idx, update.kvs);
@@ -1243,8 +1267,9 @@ void MemoryDialog::onImport()
 
                 model->sendCmdPublic(QString("memory remove %1").arg(idx),
                     [model, dialogGuard, state, runNext, rowLabel, idx, advanceProgress](int removeCode, const QString& removeBody) {
-                    if (!dialogGuard)
+                    if (!dialogGuard) {
                         return;
+                    }
 
                     if (removeCode == 0) {
                         QMap<QString, QString> kvs;
@@ -1322,7 +1347,10 @@ void MemoryDialog::onRemove()
             : QString("Memory %1").arg(idx));
     }
 
-    QMessageBox confirm(this);
+    const QPointer<MemoryDialog> dialogGuard(this);
+    const QPointer<RadioModel> modelGuard(m_model);
+    ScopedChildWidget<QMessageBox> confirmOwner(this);
+    QMessageBox& confirm = *confirmOwner.get();
     confirm.setIcon(QMessageBox::Warning);
     confirm.setWindowTitle(indices.size() == 1 ? "Delete Memory" : "Delete Memories");
     confirm.setText(indices.size() == 1
@@ -1333,13 +1361,16 @@ void MemoryDialog::onRemove()
         confirm.setDetailedText(memoryDescriptions.join('\n'));
     confirm.setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
     confirm.setDefaultButton(QMessageBox::Cancel);
-    if (confirm.exec() != QMessageBox::Yes) {
-        focusTableOnCurrentRow();
+    const int result = confirm.exec();
+    if (!dialogGuard || !modelGuard || dialogGuard->m_model != modelGuard.data() || !confirmOwner) {
+        return;
+    }
+    if (result != QMessageBox::Yes) {
+        dialogGuard->focusTableOnCurrentRow();
         return;
     }
 
-    RadioModel* const model = m_model;
-    const QPointer<MemoryDialog> dialogGuard(this);
+    RadioModel* const model = modelGuard.data();
     struct RemovalState {
         QList<int> indices;
         QStringList descriptions;
@@ -1378,8 +1409,9 @@ void MemoryDialog::onRemove()
 
     const auto runNext = QSharedPointer<std::function<void()>>::create();
     *runNext = [model, dialogGuard, state, runNext, progressGuard, advanceProgress]() {
-        if (!dialogGuard)
+        if (!dialogGuard) {
             return;
+        }
 
         if (state->nextIndex >= state->indices.size()) {
             if (progressGuard) {
@@ -1388,7 +1420,8 @@ void MemoryDialog::onRemove()
             }
             dialogGuard->populateTable();
             if (state->failed > 0) {
-                QMessageBox failure(dialogGuard);
+                ScopedChildWidget<QMessageBox> failureOwner(dialogGuard.data());
+                QMessageBox& failure = *failureOwner.get();
                 failure.setIcon(QMessageBox::Warning);
                 failure.setWindowTitle(state->failed == 1 ? "Delete Memory" : "Delete Memories");
                 failure.setText(state->failed == 1
@@ -1397,6 +1430,9 @@ void MemoryDialog::onRemove()
                 if (state->failedDescriptions.size() > 1)
                     failure.setDetailedText(state->failedDescriptions.join('\n'));
                 failure.exec();
+                if (!dialogGuard || !failureOwner) {
+                    return;
+                }
             }
             dialogGuard->focusTableOnCurrentRow();
             return;

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -468,9 +468,6 @@ void MidiMappingDialog::importProfileFromFile()
         box.setStandardButtons(QMessageBox::Ok);
         box.setDetailedText(result.errors.join(QLatin1Char('\n')));
         box.exec();
-        if (!self || !boxOwner || !manager) {
-            return;
-        }
         return;
     }
 
@@ -509,9 +506,6 @@ void MidiMappingDialog::importProfileFromFile()
         if (!detailLines.isEmpty())
             box.setDetailedText(detailLines.join(QLatin1Char('\n')));
         box.exec();
-        if (!self || !boxOwner || !manager) {
-            return;
-        }
         return;
     }
 
@@ -534,9 +528,6 @@ void MidiMappingDialog::importProfileFromFile()
     if (!detailLines.isEmpty())
         box.setDetailedText(detailLines.join(QLatin1Char('\n')));
     box.exec();
-    if (!self || !boxOwner || !manager) {
-        return;
-    }
 }
 
 void MidiMappingDialog::exportProfileToFile()

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -4,6 +4,7 @@
 #include "MidiMappingDialog.h"
 #include "core/AppSettings.h"
 #include "FramelessMessageBox.h"
+#include "ScopedChildWidget.h"
 #include "core/MidiControlManager.h"
 #include "core/MidiSettings.h"
 
@@ -27,6 +28,7 @@
 #include <QDir>
 #include <QFileDialog>
 #include <QFileInfo>
+#include <QPointer>
 #include <QStandardPaths>
 
 namespace AetherSDR {
@@ -435,29 +437,40 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
 
 void MidiMappingDialog::importProfileFromFile()
 {
-    QFileDialog dialog(this, QStringLiteral("Import MIDI Profile"),
-                       midiTransferDirectory(),
-                       QStringLiteral("MIDI profiles (*.xml *.map);;All files (*)"));
+    const QPointer<MidiMappingDialog> self(this);
+    const QPointer<MidiControlManager> manager(m_manager);
+    ScopedChildWidget<QFileDialog> dialogOwner(this);
+    QFileDialog& dialog = *dialogOwner.get();
+    dialog.setWindowTitle(QStringLiteral("Import MIDI Profile"));
+    dialog.setDirectory(midiTransferDirectory());
+    dialog.setNameFilter(QStringLiteral("MIDI profiles (*.xml *.map);;All files (*)"));
     dialog.setAcceptMode(QFileDialog::AcceptOpen);
     dialog.setFileMode(QFileDialog::ExistingFile);
-    if (dialog.exec() != QDialog::Accepted || dialog.selectedFiles().isEmpty())
+    const int dialogResult = dialog.exec();
+    if (!self || !dialogOwner || !manager || dialogResult != QDialog::Accepted
+        || dialog.selectedFiles().isEmpty()) {
         return;
+    }
     const QString path = dialog.selectedFiles().first();
     rememberMidiTransferDirectory(path);
 
     const MidiImportResult result = MidiSettings::instance().importProfile(
         path,
-        [this](const QString& id) { return m_manager->findParam(id) != nullptr; });
+        [manager](const QString& id) { return manager && manager->findParam(id) != nullptr; });
 
     const QString fileName = QFileInfo(path).fileName();
     if (!result.ok()) {
-        FramelessMessageBox box(this);
+        ScopedChildWidget<FramelessMessageBox> boxOwner(this);
+        FramelessMessageBox& box = *boxOwner.get();
         box.setIcon(QMessageBox::Warning);
         box.setWindowTitle(QStringLiteral("Import MIDI Profile"));
         box.setText(QStringLiteral("No bindings were imported from %1.").arg(fileName));
         box.setStandardButtons(QMessageBox::Ok);
         box.setDetailedText(result.errors.join(QLatin1Char('\n')));
         box.exec();
+        if (!self || !boxOwner || !manager) {
+            return;
+        }
         return;
     }
 
@@ -485,7 +498,8 @@ void MidiMappingDialog::importProfileFromFile()
                QStringLiteral("%1 duplicate row(s) were dropped."));
 
     if (result.importedCount == 0) {
-        FramelessMessageBox box(this);
+        ScopedChildWidget<FramelessMessageBox> boxOwner(this);
+        FramelessMessageBox& box = *boxOwner.get();
         box.setIcon(QMessageBox::Warning);
         box.setWindowTitle(QStringLiteral("Import MIDI Profile"));
         box.setText(QStringLiteral("No usable bindings in %1.").arg(fileName));
@@ -495,13 +509,17 @@ void MidiMappingDialog::importProfileFromFile()
         if (!detailLines.isEmpty())
             box.setDetailedText(detailLines.join(QLatin1Char('\n')));
         box.exec();
+        if (!self || !boxOwner || !manager) {
+            return;
+        }
         return;
     }
 
     refreshProfileList();
     m_profileCombo->setCurrentText(result.profileName);
 
-    FramelessMessageBox box(this);
+    ScopedChildWidget<FramelessMessageBox> boxOwner(this);
+    FramelessMessageBox& box = *boxOwner.get();
     box.setIcon(informativeLines.isEmpty() ? QMessageBox::Information
                                            : QMessageBox::Warning);
     box.setWindowTitle(QStringLiteral("Import MIDI Profile"));
@@ -516,11 +534,19 @@ void MidiMappingDialog::importProfileFromFile()
     if (!detailLines.isEmpty())
         box.setDetailedText(detailLines.join(QLatin1Char('\n')));
     box.exec();
+    if (!self || !boxOwner || !manager) {
+        return;
+    }
 }
 
 void MidiMappingDialog::exportProfileToFile()
 {
-    const auto& bindings = m_manager->bindings();
+    const QPointer<MidiMappingDialog> self(this);
+    const QPointer<MidiControlManager> manager(m_manager);
+    if (!manager) {
+        return;
+    }
+    const auto bindings = manager->bindings();
     if (bindings.isEmpty()) {
         FramelessMessageBox::information(this, QStringLiteral("Export MIDI Profile"),
                                          QStringLiteral("There are no bindings to export."));
@@ -533,13 +559,20 @@ void MidiMappingDialog::exportProfileToFile()
                                  .arg(QDateTime::currentDateTime().toString(
                                           QStringLiteral("yyyyMMdd_HHmmss")),
                                       QCoreApplication::applicationVersion());
-    QFileDialog dialog(this, QStringLiteral("Export MIDI Profile"),
-                       QDir(midiTransferDirectory()).filePath(fileName),
-                       QStringLiteral("MIDI profile XML (*.xml)"));
+    ScopedChildWidget<QFileDialog> dialogOwner(this);
+    QFileDialog& dialog = *dialogOwner.get();
+    dialog.setWindowTitle(QStringLiteral("Export MIDI Profile"));
+    const QString initialPath = QDir(midiTransferDirectory()).filePath(fileName);
+    dialog.setDirectory(QFileInfo(initialPath).absolutePath());
+    dialog.selectFile(QFileInfo(initialPath).fileName());
+    dialog.setNameFilter(QStringLiteral("MIDI profile XML (*.xml)"));
     dialog.setAcceptMode(QFileDialog::AcceptSave);
     dialog.setDefaultSuffix(QStringLiteral("xml"));
-    if (dialog.exec() != QDialog::Accepted || dialog.selectedFiles().isEmpty())
+    const int dialogResult = dialog.exec();
+    if (!self || !dialogOwner || !manager || dialogResult != QDialog::Accepted
+        || dialog.selectedFiles().isEmpty()) {
         return;
+    }
     const QString path = dialog.selectedFiles().first();
     rememberMidiTransferDirectory(path);
 
@@ -663,19 +696,27 @@ void MidiMappingDialog::refreshProfileList()
 
 void MidiMappingDialog::openManualEditor(const QString& paramId, const MidiBinding* existing)
 {
+    const QString stableParamId(paramId);
+    const QPointer<MidiMappingDialog> self(this);
+    const QPointer<MidiControlManager> manager(m_manager);
+    if (!manager) {
+        return;
+    }
     // A stray controller touch must not complete a half-armed Learn while the
     // operator is typing in this form.
-    if (m_manager->isLearning())
-        m_manager->cancelLearn();
+    if (manager->isLearning()) {
+        manager->cancelLearn();
+    }
 
-    const MidiParam* param = m_manager->findParam(paramId);
+    const MidiParam* param = manager->findParam(stableParamId);
     const QString paramLabel = param
-        ? QString("[%1] %2").arg(param->category, param->displayName) : paramId;
+        ? QString("[%1] %2").arg(param->category, param->displayName) : stableParamId;
     // Learn forces relative=true on VFO CC captures (onMidiMessage); the form
     // mirrors that as a default so a typed VFO knob behaves like a learned one.
-    const bool isVfoKnob = MidiControlManager::isVfoTuneKnob(paramId);
+    const bool isVfoKnob = MidiControlManager::isVfoTuneKnob(stableParamId);
 
-    QDialog dlg(this);
+    ScopedChildWidget<QDialog> dialogOwner(this);
+    QDialog& dlg = *dialogOwner.get();
     dlg.setWindowTitle(existing ? "Edit MIDI Binding" : "Add MIDI Binding");
     dlg.setModal(true);
     dlg.setObjectName("midiManualBindingDialog");
@@ -777,15 +818,17 @@ void MidiMappingDialog::openManualEditor(const QString& paramId, const MidiBindi
     connect(typeCombo, &QComboBox::currentIndexChanged, &dlg, refreshFieldStates);
     refreshFieldStates();
 
-    if (dlg.exec() != QDialog::Accepted)
+    const int dialogResult = dlg.exec();
+    if (!self || !dialogOwner || !manager || dialogResult != QDialog::Accepted) {
         return;
+    }
 
     MidiBinding b;
     b.channel  = channelCombo->currentData().toInt();
     b.msgType  = MidiBinding::MsgType(typeCombo->currentData().toInt());
     // Learn stores -1 for Pitch Bend (the message carries no number); mirror it.
     b.number   = (b.msgType == MidiBinding::PitchBend) ? -1 : numberSpin->value();
-    b.paramId  = paramId;
+    b.paramId  = stableParamId;
     b.inverted = invertCheck->isChecked();
     b.relative = relativeCheck->isChecked() && b.msgType == MidiBinding::CC;
 
@@ -796,7 +839,7 @@ void MidiMappingDialog::openManualEditor(const QString& paramId, const MidiBindi
     // silently — name the loser and ask.
     QStringList shadowedNames;
     QStringList shadowedIds;
-    for (const auto& cur : m_manager->bindings()) {
+    for (const auto& cur : manager->bindings()) {
         // Overlap, not key() equality: key() folds the wildcard channel to
         // 0xFF while dispatch probes the exact-channel key first and falls
         // back to the wildcard — so an "Any" binding and a channel-specific
@@ -808,7 +851,7 @@ void MidiMappingDialog::openManualEditor(const QString& paramId, const MidiBindi
             && (b.msgType == MidiBinding::PitchBend || cur.number == b.number)
             && (cur.channel < 0 || b.channel < 0 || cur.channel == b.channel);
         if (cur.paramId != b.paramId && sameSource) {
-            const MidiParam* cp = m_manager->findParam(cur.paramId);
+            const MidiParam* cp = manager->findParam(cur.paramId);
             shadowedNames << (cp ? QString("[%1] %2").arg(cp->category, cp->displayName)
                                  : cur.paramId);
             shadowedIds << cur.paramId;
@@ -824,15 +867,18 @@ void MidiMappingDialog::openManualEditor(const QString& paramId, const MidiBindi
                     "Replace the existing binding%3?")
                 .arg(b.sourceDisplayName(), shadowedNames.join("\n  "),
                      shadowedIds.size() > 1 ? QStringLiteral("s") : QString()));
+        if (!self || !manager) {
+            return;
+        }
         if (answer != FramelessMessageBox::Yes)
             return;
         for (const auto& id : shadowedIds)
-            m_manager->removeBinding(id);
+            manager->removeBinding(id);
     }
 
-    m_manager->addBinding(b);
+    manager->addBinding(b);
     refreshBindingTable();
-    MidiSettings::instance().saveBindings(m_manager->bindings());
+    MidiSettings::instance().saveBindings(manager->bindings());
 }
 
 } // namespace AetherSDR

--- a/src/gui/NetSchedulerDialog.cpp
+++ b/src/gui/NetSchedulerDialog.cpp
@@ -1,4 +1,5 @@
 #include "NetSchedulerDialog.h"
+#include "ScopedChildWidget.h"
 
 #include "core/NetRecurrence.h"
 #include "core/NetScheduleStore.h"
@@ -21,11 +22,13 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QMessageBox>
+#include <QPointer>
 #include <QPushButton>
 #include <QSaveFile>
 #include <QSpinBox>
 #include <QStringList>
 #include <QTableWidget>
+#include <QTimer>
 #include <QTimeEdit>
 #include <QTimeZone>
 #include <QVBoxLayout>
@@ -170,7 +173,10 @@ int leadIndexFromMinutes(int minutes)
 bool editNetEntry(QWidget* parent, NetEntry& entry,
                   const NetSchedulerDialog::CaptureFn& capture, bool isNew)
 {
-    QDialog dlg(parent);
+    const NetSchedulerDialog::CaptureFn captureFn = capture;
+    const QPointer<QWidget> parentGuard(parent);
+    ScopedChildWidget<QDialog> dialogOwner(parent);
+    QDialog& dlg = *dialogOwner.get();
     dlg.setWindowTitle(isNew ? QStringLiteral("Add Net") : QStringLiteral("Edit Net"));
     dlg.setModal(true);
     dlg.setMinimumWidth(440);
@@ -382,14 +388,24 @@ bool editNetEntry(QWidget* parent, NetEntry& entry,
     for (int i = 0; i < 7; ++i)
         QObject::connect(c.weekdayChips[i], &QPushButton::toggled, &dlg, [refresh](bool) { refresh(); });
 
-    QObject::connect(captureBtn, &QPushButton::clicked, &dlg, [&c, &capture, &dlg, refresh]() {
+    const QPointer<QDialog> dialogGuard(&dlg);
+    QObject::connect(captureBtn, &QPushButton::clicked, &dlg,
+                     [&c, capture = captureFn, dialogGuard, refresh]() {
         if (!capture) {
             return;
         }
         const MemoryEntry m = capture();
+        if (!dialogGuard) {
+            return;
+        }
         if (m.freq <= 0.0) {
-            QMessageBox::information(&dlg, QStringLiteral("Capture current VFO"),
-                                     QStringLiteral("Open a slice on a connected radio first."));
+            ScopedChildWidget<QMessageBox> infoOwner(dialogGuard.data());
+            QMessageBox& info = *infoOwner.get();
+            info.setWindowTitle(QStringLiteral("Capture current VFO"));
+            info.setText(QStringLiteral("Open a slice on a connected radio first."));
+            info.setIcon(QMessageBox::Information);
+            info.setStandardButtons(QMessageBox::Ok);
+            info.exec();
             return;
         }
         c.freq->setValue(m.freq);
@@ -440,8 +456,8 @@ bool editNetEntry(QWidget* parent, NetEntry& entry,
     c.filterHigh->setValue(entry.preset.rxFilterHigh);
 
     // On a brand-new net, prefill the preset from the current VFO if available.
-    if (isNew && capture) {
-        const MemoryEntry m = capture();
+    if (isNew && captureFn) {
+        const MemoryEntry m = captureFn();
         if (m.freq > 0.0) {
             c.freq->setValue(m.freq);
             if (!m.mode.isEmpty())
@@ -453,8 +469,10 @@ bool editNetEntry(QWidget* parent, NetEntry& entry,
 
     refresh();
 
-    if (dlg.exec() != QDialog::Accepted)
+    const int resultCode = dlg.exec();
+    if (!parentGuard || !dialogOwner || resultCode != QDialog::Accepted) {
         return false;
+    }
 
     NetEntry result = snapshotEntry();
     // Anchor a recurring rule's INTERVAL phasing to today if unset; a one-time
@@ -528,7 +546,10 @@ NetSchedulerDialog::NetSchedulerDialog(QList<NetEntry> entries, CaptureFn captur
     connect(importBtn, &QPushButton::clicked, this, &NetSchedulerDialog::onImport);
     connect(exportBtn, &QPushButton::clicked, this, &NetSchedulerDialog::onExport);
     connect(m_table, &QTableWidget::itemSelectionChanged, this, &NetSchedulerDialog::updateButtons);
-    connect(m_table, &QTableWidget::cellDoubleClicked, this, [this](int, int) { onEdit(); });
+    connect(m_table, &QTableWidget::cellDoubleClicked, this, [this](int, int) {
+        // Finish Qt's table event before an editor loop can delete the table.
+        QTimer::singleShot(0, this, &NetSchedulerDialog::onEdit);
+    });
 
     populateTable();
     updateButtons();
@@ -591,12 +612,19 @@ void NetSchedulerDialog::commit()
 void NetSchedulerDialog::onAdd()
 {
     NetEntry e;
-    if (!editNetEntry(this, e, m_capture, /*isNew=*/true))
+    const QPointer<NetSchedulerDialog> self(this);
+    const CaptureFn capture = m_capture;
+    const bool accepted = editNetEntry(this, e, capture, /*isNew=*/true);
+    if (!self || !accepted) {
         return;
+    }
     e.id = NetScheduleStore::newId();
-    m_entries.append(e);
-    commit();
-    m_table->setCurrentCell(m_entries.size() - 1, 1);
+    self->m_entries.append(e);
+    self->commit();
+    if (!self || !self->m_table) {
+        return;
+    }
+    self->m_table->setCurrentCell(self->m_entries.size() - 1, 1);
 }
 
 void NetSchedulerDialog::onEdit()
@@ -605,11 +633,29 @@ void NetSchedulerDialog::onEdit()
     if (row < 0 || row >= m_entries.size())
         return;
     NetEntry e = m_entries.at(row);
-    if (!editNetEntry(this, e, m_capture, /*isNew=*/false))
+    const QString entryId = e.id;
+    const QPointer<NetSchedulerDialog> self(this);
+    const CaptureFn capture = m_capture;
+    const bool accepted = editNetEntry(this, e, capture, /*isNew=*/false);
+    if (!self || !accepted) {
         return;
-    m_entries[row] = e;
-    commit();
-    m_table->setCurrentCell(row, 1);
+    }
+    int updatedRow = -1;
+    for (int i = 0; i < self->m_entries.size(); ++i) {
+        if (self->m_entries.at(i).id == entryId) {
+            self->m_entries[i] = e;
+            updatedRow = i;
+            break;
+        }
+    }
+    if (updatedRow < 0) {
+        return;
+    }
+    self->commit();
+    if (!self || !self->m_table) {
+        return;
+    }
+    self->m_table->setCurrentCell(updatedRow, 1);
 }
 
 void NetSchedulerDialog::onRemove()
@@ -617,13 +663,27 @@ void NetSchedulerDialog::onRemove()
     const int row = selectedRow();
     if (row < 0 || row >= m_entries.size())
         return;
-    const auto answer = QMessageBox::question(
-        this, QStringLiteral("Remove Net"),
-        QStringLiteral("Remove \"%1\" from your schedule?").arg(m_entries.at(row).name));
-    if (answer != QMessageBox::Yes)
+    const QString entryId = m_entries.at(row).id;
+    const QString entryName = m_entries.at(row).name;
+    const QPointer<NetSchedulerDialog> self(this);
+    ScopedChildWidget<QMessageBox> boxOwner(this);
+    QMessageBox& box = *boxOwner.get();
+    box.setWindowTitle(QStringLiteral("Remove Net"));
+    box.setText(QStringLiteral("Remove \"%1\" from your schedule?").arg(entryName));
+    box.setIcon(QMessageBox::Question);
+    box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+    box.exec();
+    if (!self || !boxOwner
+        || box.standardButton(box.clickedButton()) != QMessageBox::Yes) {
         return;
-    m_entries.removeAt(row);
-    commit();
+    }
+    for (int i = 0; i < self->m_entries.size(); ++i) {
+        if (self->m_entries.at(i).id == entryId) {
+            self->m_entries.removeAt(i);
+            self->commit();
+            return;
+        }
+    }
 }
 
 void NetSchedulerDialog::onToggleEnabled()
@@ -646,33 +706,51 @@ void NetSchedulerDialog::onTuneNow()
 
 void NetSchedulerDialog::onImport()
 {
+    const QPointer<NetSchedulerDialog> self(this);
     const QString path = QFileDialog::getOpenFileName(
         this, QStringLiteral("Import Net Schedule"), QString(),
         QStringLiteral("Net schedule (*.json);;All files (*)"));
-    if (path.isEmpty())
+    if (!self || path.isEmpty()) {
         return;
+    }
 
     QFile file(path);
     if (!file.open(QIODevice::ReadOnly)) {
-        QMessageBox::warning(this, QStringLiteral("Import"),
-                             QStringLiteral("Could not open the file."));
+        ScopedChildWidget<QMessageBox> warningOwner(self.data());
+        QMessageBox& warning = *warningOwner.get();
+        warning.setWindowTitle(QStringLiteral("Import"));
+        warning.setText(QStringLiteral("Could not open the file."));
+        warning.setIcon(QMessageBox::Warning);
+        warning.setStandardButtons(QMessageBox::Ok);
+        warning.exec();
         return;
     }
     const auto result = NetScheduleStore::parse(file.readAll());
     if (!result.ok()) {
-        QMessageBox::warning(this, QStringLiteral("Import"),
-                             QStringLiteral("Could not read this file:\n%1")
-                                 .arg(result.errors.join('\n')));
+        ScopedChildWidget<QMessageBox> warningOwner(self.data());
+        QMessageBox& warning = *warningOwner.get();
+        warning.setWindowTitle(QStringLiteral("Import"));
+        warning.setText(QStringLiteral("Could not read this file:\n%1")
+                            .arg(result.errors.join('\n')));
+        warning.setIcon(QMessageBox::Warning);
+        warning.setStandardButtons(QMessageBox::Ok);
+        warning.exec();
         return;
     }
     if (result.nets.isEmpty()) {
-        QMessageBox::information(this, QStringLiteral("Import"),
-                                 QStringLiteral("No nets were found in this file."));
+        ScopedChildWidget<QMessageBox> infoOwner(self.data());
+        QMessageBox& info = *infoOwner.get();
+        info.setWindowTitle(QStringLiteral("Import"));
+        info.setText(QStringLiteral("No nets were found in this file."));
+        info.setIcon(QMessageBox::Information);
+        info.setStandardButtons(QMessageBox::Ok);
+        info.exec();
         return;
     }
 
     NetScheduleStore::MergePolicy policy = NetScheduleStore::MergePolicy::Duplicate;
-    QMessageBox box(this);
+    ScopedChildWidget<QMessageBox> boxOwner(self.data());
+    QMessageBox& box = *boxOwner.get();
     box.setWindowTitle(QStringLiteral("Import Net Schedule"));
     box.setText(QStringLiteral("Importing %1 net(s). How should entries that already "
                                "exist be handled?")
@@ -682,6 +760,9 @@ void NetSchedulerDialog::onImport()
     auto* dupBtn = box.addButton(QStringLiteral("Import as new"), QMessageBox::AcceptRole);
     box.addButton(QMessageBox::Cancel);
     box.exec();
+    if (!self || !boxOwner) {
+        return;
+    }
     if (box.clickedButton() == skipBtn)
         policy = NetScheduleStore::MergePolicy::Skip;
     else if (box.clickedButton() == overwriteBtn)
@@ -691,24 +772,31 @@ void NetSchedulerDialog::onImport()
     else
         return;
 
-    m_entries = NetScheduleStore::merge(m_entries, result.nets, policy);
-    commit();
+    self->m_entries = NetScheduleStore::merge(self->m_entries, result.nets, policy);
+    self->commit();
 }
 
 void NetSchedulerDialog::onExport()
 {
+    const QPointer<NetSchedulerDialog> self(this);
     const QString path = QFileDialog::getSaveFileName(
         this, QStringLiteral("Export Net Schedule"), QStringLiteral("net-schedule.json"),
         QStringLiteral("Net schedule (*.json)"));
-    if (path.isEmpty())
+    if (!self || path.isEmpty()) {
         return;
+    }
 
     const QByteArray json = NetScheduleStore::serialize(
-        m_entries, QDateTime::currentDateTimeUtc().toString(Qt::ISODate));
+        self->m_entries, QDateTime::currentDateTimeUtc().toString(Qt::ISODate));
     QSaveFile file(path);
     if (!file.open(QIODevice::WriteOnly) || file.write(json) != json.size() || !file.commit()) {
-        QMessageBox::warning(this, QStringLiteral("Export"),
-                             QStringLiteral("Could not write the file."));
+        ScopedChildWidget<QMessageBox> warningOwner(self.data());
+        QMessageBox& warning = *warningOwner.get();
+        warning.setWindowTitle(QStringLiteral("Export"));
+        warning.setText(QStringLiteral("Could not write the file."));
+        warning.setIcon(QMessageBox::Warning);
+        warning.setStandardButtons(QMessageBox::Ok);
+        warning.exec();
         return;
     }
 }

--- a/src/gui/NetworkDiagnosticsDialog.cpp
+++ b/src/gui/NetworkDiagnosticsDialog.cpp
@@ -1,4 +1,5 @@
 #include "NetworkDiagnosticsDialog.h"
+#include "ScopedChildWidget.h"
 #include "LogSyntaxHighlighter.h"
 #include "TimeSeriesGraphWidget.h"
 #include "core/AudioEngine.h"
@@ -25,6 +26,7 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <QPlainTextEdit>
+#include <QPersistentModelIndex>
 #include <QLineEdit>
 #include <QPushButton>
 #include <QRegularExpression>
@@ -1376,7 +1378,12 @@ void NetworkDiagnosticsDialog::onTciLogContextMenu(const QPoint& pos)
     if (!m_tciLogTable)
         return;
     const QModelIndex idx = m_tciLogTable->indexAt(pos);
-    const auto sel = m_tciLogTable->selectionModel()->selectedRows();
+    const auto selected = m_tciLogTable->selectionModel()->selectedRows();
+    QList<QPersistentModelIndex> selectedRows;
+    selectedRows.reserve(selected.size());
+    for (const QModelIndex& row : selected) {
+        selectedRows.append(QPersistentModelIndex(row));
+    }
 
     QString cmdHere;
     if (idx.isValid()) {
@@ -1384,12 +1391,16 @@ void NetworkDiagnosticsDialog::onTciLogContextMenu(const QPoint& pos)
             cmdHere = tciCmdOf(it->text());
     }
 
-    QMenu menu(this);
+    const QPointer<NetworkDiagnosticsDialog> self(this);
+    const QPointer<QTableWidget> table(m_tciLogTable);
+    ScopedChildWidget<QMenu> menuOwner(this);
+    QMenu& menu = *menuOwner.get();
     QAction* removeAct = nullptr;
-    if (!sel.isEmpty())
-        removeAct = menu.addAction(sel.size() == 1
+    if (!selectedRows.isEmpty()) {
+        removeAct = menu.addAction(selectedRows.size() == 1
             ? QStringLiteral("Remove this row")
-            : QStringLiteral("Remove %1 selected rows").arg(sel.size()));
+            : QStringLiteral("Remove %1 selected rows").arg(selectedRows.size()));
+    }
     QAction* suppressAct = nullptr;
     if (!cmdHere.isEmpty())
         suppressAct = menu.addAction(
@@ -1399,17 +1410,27 @@ void NetworkDiagnosticsDialog::onTciLogContextMenu(const QPoint& pos)
     QAction* clearAct = menu.addAction(QStringLiteral("Clear log"));
 
     QAction* chosen = menu.exec(m_tciLogTable->viewport()->mapToGlobal(pos));
-    if (!chosen)
+    if (!self || !menuOwner || !table
+        || self->m_tciLogTable != table.data() || !chosen) {
         return;
+    }
     if (chosen == clearAct) {
-        m_tciLogTable->setRowCount(0);
+        table->setRowCount(0);
     } else if (removeAct && chosen == removeAct) {
         QList<int> rows;
-        for (const QModelIndex& i : sel) rows << i.row();
+        for (const QPersistentModelIndex& row : selectedRows) {
+            if (row.isValid() && row.model() == table->model()) {
+                rows << row.row();
+            }
+        }
         std::sort(rows.begin(), rows.end(), std::greater<int>());
-        for (int r : rows) m_tciLogTable->removeRow(r);
+        for (int r : rows) {
+            if (r >= 0 && r < table->rowCount()) {
+                table->removeRow(r);
+            }
+        }
     } else if (suppressAct && chosen == suppressAct) {
-        tciSuppress(cmdHere);
+        self->tciSuppress(cmdHere);
     }
 }
 
@@ -1454,6 +1475,8 @@ void NetworkDiagnosticsDialog::onTciSaveLog()
 {
     if (!m_tciLogTable)
         return;
+    const QPointer<NetworkDiagnosticsDialog> self(this);
+    const QPointer<QTableWidget> table(m_tciLogTable);
     const QString stamp =
         QDateTime::currentDateTime().toString(QStringLiteral("yyyyMMdd-HHmmss"));
     const QString dir =
@@ -1463,18 +1486,19 @@ void NetworkDiagnosticsDialog::onTciSaveLog()
     const QString path = QFileDialog::getSaveFileName(
         this, QStringLiteral("Save TCI log"), suggested,
         QStringLiteral("Log files (*.log);;All files (*)"));
-    if (path.isEmpty())
+    if (!self || !table || self->m_tciLogTable != table.data() || path.isEmpty()) {
         return;
+    }
     QFile f(path);
     if (!f.open(QIODevice::WriteOnly | QIODevice::Text)) {
         qWarning() << "TCI monitor: cannot write" << path;
         return;
     }
     QTextStream ts(&f);
-    for (int r = 0; r < m_tciLogTable->rowCount(); ++r) {
-        const auto* t = m_tciLogTable->item(r, 0);
-        const auto* c = m_tciLogTable->item(r, 1);
-        const auto* m = m_tciLogTable->item(r, 2);
+    for (int r = 0; r < table->rowCount(); ++r) {
+        const auto* t = table->item(r, 0);
+        const auto* c = table->item(r, 1);
+        const auto* m = table->item(r, 2);
         ts << (t ? t->text() : QString()) << '\t'
            << (c ? c->text() : QString()) << '\t'
            << (m ? m->text() : QString()) << '\n';

--- a/src/gui/ProfileImportExportDialog.cpp
+++ b/src/gui/ProfileImportExportDialog.cpp
@@ -4,6 +4,7 @@
 #include "core/ThemeManager.h"
 #include "models/RadioModel.h"
 #include "models/TransmitModel.h"
+#include "ScopedChildWidget.h"
 
 #include <QCloseEvent>
 #include <QCheckBox>
@@ -19,6 +20,7 @@
 #include <QMessageBox>
 #include <QProgressBar>
 #include <QPushButton>
+#include <QPointer>
 #include <QRegularExpression>
 #include <QSignalBlocker>
 #include <QStandardPaths>
@@ -145,7 +147,13 @@ ProfileImportExportDialog::ProfileImportExportDialog(RadioModel* model, QWidget*
             : QStringLiteral("Import sent. The radio accepted the package and profile lists are being refreshed.");
         setStatus(message);
         rememberProfileTransferDirectory(path);
-        QMessageBox::information(this, windowTitle(), message);
+        ScopedChildWidget<QMessageBox> boxOwner(this);
+        QMessageBox& box = *boxOwner.get();
+        box.setIcon(QMessageBox::Information);
+        box.setWindowTitle(windowTitle());
+        box.setText(message);
+        box.setStandardButtons(QMessageBox::Ok);
+        box.exec();
     });
     connect(m_transfer, &ProfileTransfer::failed, this,
             [this](ProfileTransfer::Operation, const QString& error) {
@@ -153,7 +161,13 @@ ProfileImportExportDialog::ProfileImportExportDialog(RadioModel* model, QWidget*
         m_progress->setRange(0, 100);
         m_progress->setValue(0);
         setStatus(error);
-        QMessageBox::warning(this, windowTitle(), error);
+        ScopedChildWidget<QMessageBox> boxOwner(this);
+        QMessageBox& box = *boxOwner.get();
+        box.setIcon(QMessageBox::Warning);
+        box.setWindowTitle(windowTitle());
+        box.setText(error);
+        box.setStandardButtons(QMessageBox::Ok);
+        box.exec();
     });
 
     if (m_model) {
@@ -174,14 +188,24 @@ ProfileImportExportDialog::ProfileImportExportDialog(RadioModel* model, QWidget*
 void ProfileImportExportDialog::closeEvent(QCloseEvent* event)
 {
     if (m_transfer && m_transfer->isBusy()) {
-        const auto choice = QMessageBox::question(
-            this, windowTitle(),
-            QStringLiteral("A profile transfer is still running. Cancel it and close this window?"));
+        const QPointer<ProfileImportExportDialog> self(this);
+        const QPointer<ProfileTransfer> transferGuard(m_transfer);
+        ScopedChildWidget<QMessageBox> boxOwner(this);
+        QMessageBox& box = *boxOwner.get();
+        box.setIcon(QMessageBox::Question);
+        box.setWindowTitle(windowTitle());
+        box.setText(QStringLiteral("A profile transfer is still running. Cancel it and close this window?"));
+        box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+        const int choice = box.exec();
+        if (!self || !transferGuard || self->m_transfer != transferGuard.data() || !boxOwner) {
+            event->ignore();
+            return;
+        }
         if (choice != QMessageBox::Yes) {
             event->ignore();
             return;
         }
-        m_transfer->cancel();
+        transferGuard->cancel();
     }
     PersistentDialog::closeEvent(event);
 }
@@ -369,7 +393,10 @@ bool ProfileImportExportDialog::confirmImport()
             .arg(exportVersion.toString(), radioVersion);
     }
 
-    QMessageBox box(this);
+    const QPointer<ProfileImportExportDialog> self(this);
+    const QPointer<RadioModel> modelGuard(m_model);
+    ScopedChildWidget<QMessageBox> boxOwner(this);
+    QMessageBox& box = *boxOwner.get();
     box.setIcon(QMessageBox::Warning);
     box.setWindowTitle(QStringLiteral("Confirm Profile Import"));
     box.setText(QStringLiteral("Import this .ssdr_cfg backup to the radio?"));
@@ -387,6 +414,10 @@ bool ProfileImportExportDialog::confirmImport()
     box.addButton(QMessageBox::Cancel);
     box.exec();
 
+    if (!self || !modelGuard || self->m_model != modelGuard.data() || !boxOwner) {
+        return false;
+    }
+
     if (box.clickedButton() == backupButton) {
         m_tabs->setCurrentIndex(0);
         startExport();
@@ -397,27 +428,33 @@ bool ProfileImportExportDialog::confirmImport()
 
 void ProfileImportExportDialog::chooseExportPath()
 {
+    const QPointer<ProfileImportExportDialog> self(this);
+    const QPointer<QLineEdit> exportPath(m_exportPath);
     QString initial = m_exportPath ? m_exportPath->text() : defaultExportPath();
     if (initial.trimmed().isEmpty())
         initial = defaultExportPath();
     const QString path = QFileDialog::getSaveFileName(
         this, QStringLiteral("Export Profile Backup"),
         initial, QStringLiteral("Profile Backup (*.ssdr_cfg)"));
-    if (path.isEmpty())
+    if (!self || !exportPath || self->m_exportPath != exportPath.data() || path.isEmpty()) {
         return;
-    m_exportPath->setText(path.endsWith(QStringLiteral(".ssdr_cfg"), Qt::CaseInsensitive)
+    }
+    exportPath->setText(path.endsWith(QStringLiteral(".ssdr_cfg"), Qt::CaseInsensitive)
                               ? path
                               : path + QStringLiteral(".ssdr_cfg"));
 }
 
 void ProfileImportExportDialog::chooseImportPath()
 {
+    const QPointer<ProfileImportExportDialog> self(this);
+    const QPointer<QLineEdit> importPath(m_importPath);
     const QString path = QFileDialog::getOpenFileName(
         this, QStringLiteral("Import Profile Backup"),
         profileTransferDirectory(), QStringLiteral("Profile Backup (*.ssdr_cfg)"));
-    if (path.isEmpty())
+    if (!self || !importPath || self->m_importPath != importPath.data() || path.isEmpty()) {
         return;
-    m_importPath->setText(path);
+    }
+    importPath->setText(path);
 }
 
 void ProfileImportExportDialog::startExport()
@@ -430,10 +467,12 @@ void ProfileImportExportDialog::startExport()
 
 void ProfileImportExportDialog::startImport()
 {
+    const QPointer<ProfileImportExportDialog> self(this);
     if (!m_importPath || m_importPath->text().trimmed().isEmpty()) {
         chooseImportPath();
-        if (!m_importPath || m_importPath->text().trimmed().isEmpty())
+        if (!self || !self->m_importPath || self->m_importPath->text().trimmed().isEmpty()) {
             return;
+        }
     }
     rememberProfileTransferDirectory(m_importPath->text());
     if (!confirmImport())

--- a/src/gui/ProfileManagerDialog.cpp
+++ b/src/gui/ProfileManagerDialog.cpp
@@ -15,6 +15,7 @@
 #include <QPointer>
 #include <QSignalBlocker>
 #include <QTimer>
+#include "ScopedChildWidget.h"
 
 namespace AetherSDR {
 
@@ -282,7 +283,9 @@ QWidget* ProfileManagerDialog::buildProfileTab(const QString& type,
             m_model->sendCmdPublic(
                 QString("profile global save \"%1\"").arg(name),
                 [self, type, name, token](int code, const QString& body) {
-                    if (!self) return;
+                    if (!self) {
+                        return;
+                    }
                     // Superseded by a newer save on this tab, or already
                     // resolved by the timeout — either way, stay quiet.
                     if (self->m_pendingSaveToken.value(type) != token) return;
@@ -321,7 +324,9 @@ QWidget* ProfileManagerDialog::buildProfileTab(const QString& type,
             // the save is in flight for the life of the window.
             QTimer::singleShot(kSaveResponseTimeoutMs, this,
                                [self, type, name, token] {
-                if (!self) return;
+                if (!self) {
+                    return;
+                }
                 if (self->m_pendingSaveToken.value(type) != token) return;
                 self->m_pendingSaveToken[type] = 0;
                 self->setTabStatus(
@@ -341,7 +346,10 @@ QWidget* ProfileManagerDialog::buildProfileTab(const QString& type,
                 if (!m_model->autoSave()) {
                     // Offer Auto-Save inline so the user can act on the
                     // remedy without hunting for the Auto-Save tab.
-                    QMessageBox box(this);
+                    const QPointer<ProfileManagerDialog> self(this);
+                    const QPointer<RadioModel> modelGuard(m_model);
+                    ScopedChildWidget<QMessageBox> boxOwner(this);
+                    QMessageBox& box = *boxOwner.get();
                     box.setWindowTitle("Profile already exists");
                     box.setIcon(QMessageBox::Question);
                     box.setText(
@@ -356,22 +364,30 @@ QWidget* ProfileManagerDialog::buildProfileTab(const QString& type,
                     box.addButton("Close", QMessageBox::RejectRole);
                     box.setDefaultButton(enableBtn);
                     box.exec();
+                    if (!self || !modelGuard || self->m_model != modelGuard.data() || !boxOwner) {
+                        return;
+                    }
                     if (box.clickedButton() == enableBtn) {
                         // The sibling Auto-Save tab checkbox is wired to
                         // RadioModel::autoSaveChanged below, so the radio's
                         // confirmation of auto_save=1 will sync it.
-                        m_model->sendCommand("profile autosave on");
+                        modelGuard->sendCommand("profile autosave on");
                     }
                     return;
                 }
-                QMessageBox::information(this, "Profile already exists",
-                    QString("A %1 profile named \"%2\" already exists.\n\n"
+                ScopedChildWidget<QMessageBox> infoOwner(this);
+                QMessageBox& info = *infoOwner.get();
+                info.setIcon(QMessageBox::Information);
+                info.setWindowTitle("Profile already exists");
+                info.setText(QString("A %1 profile named \"%2\" already exists.\n\n"
                             "The radio cannot overwrite %1 profiles directly. "
                             "Updates are captured by Auto-Save (currently ON) "
                             "while the profile is active.\n\n"
                             "To replace this profile, delete it first and then "
                             "Create it again.")
                         .arg(kind, name));
+                info.setStandardButtons(QMessageBox::Ok);
+                info.exec();
                 return;
             }
             if (type == "transmit")
@@ -392,9 +408,18 @@ QWidget* ProfileManagerDialog::buildProfileTab(const QString& type,
         if (!item) return;
         const QString name = item->text();
 
-        auto reply = QMessageBox::question(this, "Delete Profile",
-            QString("Delete profile \"%1\"?").arg(name),
-            QMessageBox::Yes | QMessageBox::No);
+        const QPointer<ProfileManagerDialog> self(this);
+        const QPointer<RadioModel> modelGuard(m_model);
+        ScopedChildWidget<QMessageBox> boxOwner(this);
+        QMessageBox& box = *boxOwner.get();
+        box.setIcon(QMessageBox::Question);
+        box.setWindowTitle("Delete Profile");
+        box.setText(QString("Delete profile \"%1\"?").arg(name));
+        box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+        const int reply = box.exec();
+        if (!self || !modelGuard || self->m_model != modelGuard.data() || !boxOwner) {
+            return;
+        }
         if (reply != QMessageBox::Yes) return;
 
         // Drop the last Save result: leaving it up would keep reporting
@@ -402,11 +427,11 @@ QWidget* ProfileManagerDialog::buildProfileTab(const QString& type,
         setTabStatus(type, QString(), false);
 
         if (type == "global")
-            m_model->sendCommand(QString("profile global delete \"%1\"").arg(name));
+            modelGuard->sendCommand(QString("profile global delete \"%1\"").arg(name));
         else if (type == "transmit")
-            m_model->sendCommand(QString("profile transmit delete \"%1\"").arg(name));
+            modelGuard->sendCommand(QString("profile transmit delete \"%1\"").arg(name));
         else if (type == "mic")
-            m_model->sendCommand(QString("profile mic delete \"%1\"").arg(name));
+            modelGuard->sendCommand(QString("profile mic delete \"%1\"").arg(name));
     });
 
     return page;

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -1282,16 +1282,19 @@ QWidget* RadioSetupDialog::buildRadioTab()
                 : QStringLiteral("Reboot the connected radio now?\n\n"
                                  "AetherSDR will disconnect and automatically reconnect "
                                  "once the radio finishes booting.");
-            const auto ret = QMessageBox::warning(
-                this,
-                QStringLiteral("Reboot Radio"),
-                body,
-                QMessageBox::Ok | QMessageBox::Cancel,
-                QMessageBox::Cancel);
-            if (ret == QMessageBox::Ok) {
-                m_model->rebootRadio();
-                close();
+            const QPointer<RadioSetupDialog> self(this);
+            const QPointer<RadioModel> model(m_model);
+            ScopedChildWidget<QMessageBox> boxOwner(
+                QMessageBox::Warning, QStringLiteral("Reboot Radio"), body,
+                QMessageBox::Ok | QMessageBox::Cancel, this);
+            boxOwner.get()->setDefaultButton(QMessageBox::Cancel);
+            const int ret = boxOwner.get()->exec();
+            if (!self || !boxOwner || !model || self->m_model != model.data()
+                || ret != QMessageBox::Ok) {
+                return;
             }
+            model->rebootRadio();
+            self->close();
         });
         m_rebootInfoField = makeInfoField(QStringLiteral("Reboot:"), rebootBtn,
                                           kInfoLeftLabelWidth);
@@ -1630,6 +1633,8 @@ QWidget* RadioSetupDialog::buildRadioTab()
         // from FlexRadio (.msi for v4.2+, .exe for older releases) or a
         // pre-extracted .ssdr file. The stager auto-detects which.
         connect(browseBtn, &QPushButton::clicked, this, [this] {
+            const QPointer<RadioSetupDialog> self(this);
+            const QPointer<RadioModel> model(m_model);
             const QString path = QFileDialog::getOpenFileName(
                 this, "Select SmartSDR Installer or Firmware File", QString(),
                 "SmartSDR installer or firmware (*.msi *.exe *.ssdr);;"
@@ -1637,7 +1642,9 @@ QWidget* RadioSetupDialog::buildRadioTab()
                 "EXE installer (*.exe);;"
                 "Extracted firmware (*.ssdr);;"
                 "All files (*)");
-            if (path.isEmpty()) return;
+            if (!self || !model || self->m_model != model.data() || path.isEmpty()) {
+                return;
+            }
 
             m_fwFilePath.clear();
             m_fwUploadBtn->setEnabled(false);
@@ -1656,13 +1663,21 @@ QWidget* RadioSetupDialog::buildRadioTab()
         connect(m_fwUploadBtn, &QPushButton::clicked, this, [this] {
             if (m_fwFilePath.isEmpty()) return;
 
-            const auto reply = QMessageBox::warning(this, "Firmware Update",
+            const QPointer<RadioSetupDialog> self(this);
+            const QPointer<RadioModel> model(m_model);
+            ScopedChildWidget<QMessageBox> boxOwner(
+                QMessageBox::Warning, QStringLiteral("Firmware Update"),
                 QString("Upload %1 to %2?\n\n"
                         "The radio will reboot after the update.\n"
                         "Do not disconnect during the upload.")
                     .arg(QFileInfo(m_fwFilePath).fileName(), m_model->model()),
-                QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Cancel);
-            if (reply != QMessageBox::Ok) return;
+                QMessageBox::Ok | QMessageBox::Cancel, this);
+            boxOwner.get()->setDefaultButton(QMessageBox::Cancel);
+            const int reply = boxOwner.get()->exec();
+            if (!self || !boxOwner || !model || self->m_model != model.data()
+                || reply != QMessageBox::Ok) {
+                return;
+            }
 
             if (!m_uploader)
                 m_uploader = new FirmwareUploader(m_model, this);
@@ -2016,7 +2031,7 @@ QWidget* RadioSetupDialog::buildNetworkTab()
                     AutomationBridgeSettings::setTxAck(true);
                 }
                 AutomationBridgeSettings::setTxAllowed(on);
-                emit self->automationBridgeTxAllowedChanged(on);
+                emit automationBridgeTxAllowedChanged(on);
             });
             grid->addWidget(txCheck, 3, 1);
         }
@@ -4140,10 +4155,12 @@ QWidget* RadioSetupDialog::buildAudioTab()
         browseBtn->setFixedWidth(30);
         browseBtn->setStyleSheet(modeBtnStyle);
         connect(browseBtn, &QPushButton::clicked, this, [this, dirEdit]() {
+            const QPointer<RadioSetupDialog> self(this);
+            const QPointer<QLineEdit> dirEditGuard(dirEdit);
             QString dir = QFileDialog::getExistingDirectory(this, "Select Recording Directory",
                                                             dirEdit->text());
-            if (!dir.isEmpty()) {
-                dirEdit->setText(dir);
+            if (self && dirEditGuard && !dir.isEmpty()) {
+                dirEditGuard->setText(dir);
                 auto& s = AppSettings::instance();
                 s.setValue("QsoRecordingDir", dir);
                 s.save();
@@ -9195,12 +9212,16 @@ QWidget* RadioSetupDialog::buildUiEnhancementsTab()
     for (int i = 0; i < AetherSDR::kSliceColorCount; ++i) {
         connect(colorBtns[i], &QPushButton::clicked, page,
                 [i, pMgr, applyBtnColor, page]() mutable {
+            const QPointer<QWidget> pageGuard(page);
+            const QPointer<SliceColorManager> mgr(pMgr);
             QColor initial = pMgr->customColor(i);
             QColor chosen = QColorDialog::getColor(initial, page,
                                                    QStringLiteral("Slice %1 Color")
                                                        .arg(QChar('A' + i)));
-            if (!chosen.isValid()) return;
-            pMgr->setCustomColor(i, chosen);
+            if (!pageGuard || !mgr || !chosen.isValid()) {
+                return;
+            }
+            mgr->setCustomColor(i, chosen);
             applyBtnColor(i);
         });
     }
@@ -9415,15 +9436,19 @@ QWidget* RadioSetupDialog::buildSmartLinkTab()
     });
 
     connect(forgetAll, &QPushButton::clicked, this, [this]() {
-        if (QMessageBox::question(this, tr("Forget all SmartLink certificates"),
-                tr("Clear every pinned SmartLink cert fingerprint?\n\n"
-                   "Next connect to each radio will silently re-pin "
-                   "whatever certificate it presents (no mismatch warning)."))
-            != QMessageBox::Yes) {
+        const QPointer<RadioSetupDialog> self(this);
+        ScopedChildWidget<QMessageBox> boxOwner(
+            QMessageBox::Question, tr("Forget all SmartLink certificates"),
+            tr("Clear every pinned SmartLink cert fingerprint?\n\n"
+               "Next connect to each radio will silently re-pin "
+               "whatever certificate it presents (no mismatch warning)."),
+            QMessageBox::Yes | QMessageBox::No, this);
+        const int reply = boxOwner.get()->exec();
+        if (!self || !boxOwner || reply != QMessageBox::Yes) {
             return;
         }
         WanCertCache::forgetAllPinnedCerts();
-        refreshPinnedCertsTable();
+        self->refreshPinnedCertsTable();
     });
 
     root->addWidget(grp);

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -2,6 +2,7 @@
 #include "RadioSetupDialog.h"
 #include "CwDecodeSettings.h"
 #include "RttyDecodeSettings.h"
+#include "ScopedChildWidget.h"
 #include "GuardedSlider.h"
 #include "ComboStyle.h"
 #include "SliceColorManager.h"
@@ -1976,9 +1977,12 @@ QWidget* RadioSetupDialog::buildNetworkTab()
                     + "\n\nForced on by the AETHER_AUTOMATION_ALLOW_TX launch variable.");
             }
             connect(txCheck, &QCheckBox::toggled, this, [this, txCheck](bool on) {
+                const QPointer<RadioSetupDialog> self(this);
+                const QPointer<QCheckBox> txCheckGuard(txCheck);
                 if (on && !AutomationBridgeSettings::txAck()) {
                     // First-time enable → confirm. Operator must acknowledge.
-                    QMessageBox box(this);
+                    ScopedChildWidget<QMessageBox> boxOwner(this);
+                    QMessageBox& box = *boxOwner.get();
                     box.setIcon(QMessageBox::Warning);
                     box.setWindowTitle("Allow TX via MCP?");
                     box.setText("Allow an AI assistant / MCP client to key the transmitter?");
@@ -1998,10 +2002,13 @@ QWidget* RadioSetupDialog::buildNetworkTab()
                     box.addButton("Cancel", QMessageBox::RejectRole);
                     box.setDefaultButton(qobject_cast<QPushButton*>(box.buttons().value(1)));
                     box.exec();
+                    if (!self || !txCheckGuard || !boxOwner) {
+                        return;
+                    }
                     if (box.clickedButton() != confirm) {
                         // Cancelled — revert without persisting or emitting.
-                        QSignalBlocker blocker(txCheck);
-                        txCheck->setChecked(false);
+                        QSignalBlocker blocker(txCheckGuard.data());
+                        txCheckGuard->setChecked(false);
                         return;
                     }
                     // Confirmed — remember the acknowledgement so we never
@@ -2009,7 +2016,7 @@ QWidget* RadioSetupDialog::buildNetworkTab()
                     AutomationBridgeSettings::setTxAck(true);
                 }
                 AutomationBridgeSettings::setTxAllowed(on);
-                emit automationBridgeTxAllowedChanged(on);
+                emit self->automationBridgeTxAllowedChanged(on);
             });
             grid->addWidget(txCheck, 3, 1);
         }
@@ -5320,12 +5327,25 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
             rowLayout->addWidget(browseButton, 3, 1);
             connect(browseButton, &QPushButton::clicked, this,
                     [this, nameEdit, endpointEdit] {
-                KiwiPublicReceiverPicker picker(this);
-                if (picker.exec() == QDialog::Accepted
-                    && !picker.selectedEndpoint().isEmpty()) {
-                    endpointEdit->setText(picker.selectedEndpoint());
-                    if (nameEdit->text().trimmed().isEmpty()) {
-                        nameEdit->setText(picker.selectedName());
+                const QPointer<RadioSetupDialog> self(this);
+                const QPointer<QLineEdit> nameEditGuard(nameEdit);
+                const QPointer<QLineEdit> endpointEditGuard(endpointEdit);
+                ScopedChildWidget<KiwiPublicReceiverPicker> pickerOwner(this);
+                KiwiPublicReceiverPicker& picker = *pickerOwner.get();
+                const int result = picker.exec();
+                if (!self || !nameEditGuard || !endpointEditGuard || !pickerOwner
+                    || result != QDialog::Accepted) {
+                    return;
+                }
+                const QString endpoint = picker.selectedEndpoint();
+                const QString name = picker.selectedName();
+                if (!endpoint.isEmpty()) {
+                    endpointEditGuard->setText(endpoint);
+                    if (!self || !nameEditGuard) {
+                        return;
+                    }
+                    if (nameEditGuard->text().trimmed().isEmpty()) {
+                        nameEditGuard->setText(name);
                     }
                 }
             });
@@ -5402,39 +5422,49 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
         styleKiwiButton(kiwiImportBtn);
         connect(kiwiImportBtn, &QPushButton::clicked, this,
                 [this, kiwiTransferDirectory, rememberKiwiTransferDirectory] {
-            QFileDialog dialog(this, QStringLiteral("Import KiwiSDR Receivers"),
-                               kiwiTransferDirectory(),
-                               QStringLiteral("CSV Files (*.csv)"));
+            const QPointer<RadioSetupDialog> self(this);
+            const QPointer<KiwiSdrManager> manager(m_kiwiSdrManager);
+            ScopedChildWidget<QFileDialog> dialogOwner(
+                this, QStringLiteral("Import KiwiSDR Receivers"),
+                kiwiTransferDirectory(), QStringLiteral("CSV Files (*.csv)"));
+            QFileDialog& dialog = *dialogOwner.get();
             dialog.setAcceptMode(QFileDialog::AcceptOpen);
             dialog.setFileMode(QFileDialog::ExistingFile);
             dialog.setDefaultSuffix(QStringLiteral("csv"));
-            if (dialog.exec() != QDialog::Accepted || dialog.selectedFiles().isEmpty()) {
+            const int dialogResult = dialog.exec();
+            if (!self || !manager || !dialogOwner || dialogResult != QDialog::Accepted
+                || dialog.selectedFiles().isEmpty()) {
                 return;
             }
             const QString path = dialog.selectedFiles().first();
             rememberKiwiTransferDirectory(path);
 
             const KiwiSdrCsvImportResult result =
-                m_kiwiSdrManager->importFromFile(path);
+                manager->importFromFile(path);
+            if (!self || !manager) {
+                return;
+            }
             if (!result.ok() && result.addedCount == 0 && result.mergedCount == 0) {
-                QMessageBox box(QMessageBox::Warning,
-                                QStringLiteral("Import KiwiSDR Receivers"),
-                                QStringLiteral("No receivers were imported from %1.")
-                                    .arg(QFileInfo(path).fileName()),
-                                QMessageBox::Ok, this);
+                ScopedChildWidget<QMessageBox> boxOwner(
+                    QMessageBox::Warning, QStringLiteral("Import KiwiSDR Receivers"),
+                    QStringLiteral("No receivers were imported from %1.")
+                        .arg(QFileInfo(path).fileName()),
+                    QMessageBox::Ok, self.data());
+                QMessageBox& box = *boxOwner.get();
                 box.setDetailedText(result.errors.join(QLatin1Char('\n')));
                 box.exec();
                 return;
             }
 
-            QMessageBox box(result.errors.isEmpty()
-                                ? QMessageBox::Information : QMessageBox::Warning,
-                            QStringLiteral("Import KiwiSDR Receivers"),
-                            QStringLiteral("Added %1 and updated %2 receiver(s) from %3.")
-                                .arg(result.addedCount)
-                                .arg(result.mergedCount)
-                                .arg(QFileInfo(path).fileName()),
-                            QMessageBox::Ok, this);
+            ScopedChildWidget<QMessageBox> boxOwner(
+                result.errors.isEmpty() ? QMessageBox::Information : QMessageBox::Warning,
+                QStringLiteral("Import KiwiSDR Receivers"),
+                QStringLiteral("Added %1 and updated %2 receiver(s) from %3.")
+                    .arg(result.addedCount)
+                    .arg(result.mergedCount)
+                    .arg(QFileInfo(path).fileName()),
+                QMessageBox::Ok, self.data());
+            QMessageBox& box = *boxOwner.get();
             if (!result.errors.isEmpty()) {
                 box.setInformativeText(
                     QStringLiteral("%1 row(s) could not be imported.")
@@ -5454,32 +5484,47 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
         styleKiwiButton(kiwiExportBtn);
         connect(kiwiExportBtn, &QPushButton::clicked, this,
                 [this, kiwiTransferDirectory, rememberKiwiTransferDirectory] {
+            const QPointer<RadioSetupDialog> self(this);
+            const QPointer<KiwiSdrManager> manager(m_kiwiSdrManager);
             const QString fileName = QStringLiteral("AetherSDR_KiwiSDR_Receivers_%1.csv")
                                          .arg(QDateTime::currentDateTime().toString(
                                              QStringLiteral("yyyyMMdd_HHmmss")));
-            QFileDialog dialog(this, QStringLiteral("Export KiwiSDR Receivers"),
-                               QDir(kiwiTransferDirectory()).filePath(fileName),
-                               QStringLiteral("CSV Files (*.csv)"));
+            ScopedChildWidget<QFileDialog> dialogOwner(
+                this, QStringLiteral("Export KiwiSDR Receivers"),
+                QDir(kiwiTransferDirectory()).filePath(fileName),
+                QStringLiteral("CSV Files (*.csv)"));
+            QFileDialog& dialog = *dialogOwner.get();
             dialog.setAcceptMode(QFileDialog::AcceptSave);
             dialog.setDefaultSuffix(QStringLiteral("csv"));
-            if (dialog.exec() != QDialog::Accepted || dialog.selectedFiles().isEmpty()) {
+            const int dialogResult = dialog.exec();
+            if (!self || !manager || !dialogOwner || dialogResult != QDialog::Accepted
+                || dialog.selectedFiles().isEmpty()) {
                 return;
             }
             const QString path = dialog.selectedFiles().first();
             rememberKiwiTransferDirectory(path);
 
-            const KiwiSdrCsvExportResult result = m_kiwiSdrManager->exportToFile(path);
-            if (!result.ok()) {
-                QMessageBox::warning(this, QStringLiteral("Export KiwiSDR Receivers"),
-                                     result.error);
+            const KiwiSdrCsvExportResult result = manager->exportToFile(path);
+            if (!self || !manager) {
                 return;
             }
-            QMessageBox::information(
-                this, QStringLiteral("Export KiwiSDR Receivers"),
+            if (!result.ok()) {
+                ScopedChildWidget<QMessageBox> boxOwner(
+                    QMessageBox::Warning, QStringLiteral("Export KiwiSDR Receivers"),
+                    result.error, QMessageBox::Ok, self.data());
+                QMessageBox& box = *boxOwner.get();
+                box.exec();
+                return;
+            }
+            ScopedChildWidget<QMessageBox> boxOwner(
+                QMessageBox::Information, QStringLiteral("Export KiwiSDR Receivers"),
                 QStringLiteral("Exported %1 receiver(s) to %2. Passwords are not "
                                "included; re-enter them after importing elsewhere.")
                     .arg(result.exportedCount)
-                    .arg(QFileInfo(path).fileName()));
+                    .arg(QFileInfo(path).fileName()),
+                QMessageBox::Ok, self.data());
+            QMessageBox& box = *boxOwner.get();
+            box.exec();
         });
         kiwiTransferRow->addWidget(kiwiExportBtn);
         kiwiLayout->addLayout(kiwiTransferRow);

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -1,5 +1,6 @@
 #include "RxApplet.h"
 #include "AgcModeAvailability.h"
+#include "ScopedChildWidget.h"
 #include "gui/CtcssToneLabel.h"
 
 #include "gui/FilterStepMath.h"
@@ -451,7 +452,11 @@ void RxApplet::buildUI()
             "font-size: 10px; font-weight: bold; padding: 0 2px; }"
             "QPushButton:hover { color: #ff6666; }");
         connect(m_txAntBtn, &QPushButton::clicked, this, [this] {
-            QMenu menu(this);
+            const QPointer<RxApplet> self(this);
+            const QPointer<SliceModel> slice(m_slice);
+            const QPointer<QPushButton> button(m_txAntBtn);
+            ScopedChildWidget<QMenu> menuOwner(this);
+            QMenu& menu = *menuOwner.get();
             const QString cur = m_slice ? m_slice->txAntenna() : "";
             const QStringList options = txAntennaOptions();
             for (const QString& ant : options) {
@@ -464,8 +469,11 @@ void RxApplet::buildUI()
             }
             const QAction* sel = menu.exec(
                 m_txAntBtn->mapToGlobal(QPoint(0, m_txAntBtn->height())));
-            if (sel && m_slice)
-                m_slice->setTxAntenna(sel->data().toString());
+            if (!self || !menuOwner || !button || !slice
+                || self->m_slice != slice.data() || !sel) {
+                return;
+            }
+            slice->setTxAntenna(sel->data().toString());
         });
         row->addWidget(m_txAntBtn);
 
@@ -3229,10 +3237,15 @@ void RxApplet::rebuildFilterButtons()
         if (customisable) {
             btn->setContextMenuPolicy(Qt::CustomContextMenu);
             connect(btn, &QPushButton::customContextMenuRequested, this, [this, i, btn](const QPoint& pos) {
-                QMenu menu;
-                menu.addAction("Set Custom Edges...", [this, i] {
+                ScopedChildWidget<QMenu> menuOwner(this);
+                QMenu& menu = *menuOwner.get();
+                menu.addAction("Set Custom Edges...", btn, [this, i,
+                                                               button = QPointer<QPushButton>(btn)] {
                     if (!m_slice) return;
-                    QDialog dlg(this);
+                    const QPointer<RxApplet> self(this);
+                    const QPointer<SliceModel> slice(m_slice);
+                    ScopedChildWidget<QDialog> dialogOwner(this);
+                    QDialog& dlg = *dialogOwner.get();
                     dlg.setWindowTitle("Set Custom Filter Edges");
                     auto* form = new QFormLayout(&dlg);
                     auto* loSpin = new QSpinBox(&dlg);
@@ -3256,7 +3269,12 @@ void RxApplet::rebuildFilterButtons()
                     QObject::connect(btns, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
                     QObject::connect(btns, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
                     form->addRow(btns);
-                    if (dlg.exec() != QDialog::Accepted) return;
+                    const int result = dlg.exec();
+                    if (!self || !dialogOwner || !button || !slice
+                        || self->m_slice != slice.data()
+                        || result != QDialog::Accepted) {
+                        return;
+                    }
                     int lo = loSpin->value();
                     int hi = hiSpin->value();
                     if (hi <= lo) return;
@@ -3265,9 +3283,9 @@ void RxApplet::rebuildFilterButtons()
                     m_filterWidths[i] = hi - lo;
                     saveFilterPresets();
                     rebuildFilterButtons();
-                    m_slice->setFilterWidth(lo, hi);
+                    slice->setFilterWidth(lo, hi);
                 });
-                menu.addAction("Reset to Default", [this, i] {
+                menu.addAction("Reset to Default", btn, [this, i] {
                     if (!m_slice) return;
                     const auto& factory = modeSettingsFor(m_slice->mode()).filterWidths;
                     if (i >= factory.size()) return;

--- a/src/gui/ScopedChildWidget.h
+++ b/src/gui/ScopedChildWidget.h
@@ -2,6 +2,7 @@
 
 #include <QPointer>
 #include <QWidget>
+#include <utility>
 
 namespace AetherSDR {
 
@@ -11,8 +12,9 @@ namespace AetherSDR {
 template <typename Widget>
 class ScopedChildWidget final {
 public:
-    explicit ScopedChildWidget(QWidget* parent)
-        : m_widget(new Widget(parent))
+    template <typename... Args>
+    explicit ScopedChildWidget(Args&&... args)
+        : m_widget(new Widget(std::forward<Args>(args)...))
     {
     }
 

--- a/src/gui/SettingsBrowserDialog.cpp
+++ b/src/gui/SettingsBrowserDialog.cpp
@@ -1,4 +1,5 @@
 #include "SettingsBrowserDialog.h"
+#include "ScopedChildWidget.h"
 #include "FramelessMessageBox.h"
 #include "core/AppSettings.h"
 #include "core/SettingsCredentialPolicy.h"
@@ -20,6 +21,7 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QPlainTextEdit>
+#include <QPointer>
 #include <QPushButton>
 #include <QShortcut>
 #include <QShowEvent>
@@ -27,6 +29,7 @@
 #include <QStyledItemDelegate>
 #include <QTableWidget>
 #include <QTreeWidget>
+#include <QTimer>
 #include <QVBoxLayout>
 
 #include <functional>
@@ -609,9 +612,18 @@ void SettingsBrowserDialog::onTableActivated(int row)
     if (featureItem == nullptr) {
         return;
     }
-    openDocumentViewer(scope.family, scope.radioId,
-                       featureItem->data(kRoleKey).toString(),
-                       featureItem->data(kRoleRawValue).toString());
+    if (m_docViewerOpen) {
+        return;
+    }
+    const QString feature = featureItem->data(kRoleKey).toString();
+    const QString rawValue = featureItem->data(kRoleRawValue).toString();
+    // Let QAbstractItemView finish dispatching the double-click before a
+    // modal loop can delete its table. Snapshot the document, not its row.
+    m_docViewerOpen = true;
+    QTimer::singleShot(0, this, [this, scope, feature, rawValue] {
+        m_docViewerOpen = false;
+        openDocumentViewer(scope.family, scope.radioId, feature, rawValue);
+    });
 }
 
 void SettingsBrowserDialog::openDocumentViewer(const QString& family,
@@ -663,7 +675,9 @@ void SettingsBrowserDialog::openDocumentViewer(const QString& family,
         displayDoc = QJsonDocument::fromJson(redacted.toUtf8()).object();
     }
 
-    QDialog viewer(this);
+    const QPointer<SettingsBrowserDialog> self(this);
+    ScopedChildWidget<QDialog> viewerOwner(this);
+    QDialog& viewer = *viewerOwner.get();
     viewer.setWindowTitle(QStringLiteral("%1 — %2 / %3").arg(
         feature, family, scopeLabelForRadioId(radioId)));
     viewer.setMinimumSize(520, 420);
@@ -781,6 +795,9 @@ void SettingsBrowserDialog::openDocumentViewer(const QString& family,
     });
 
     viewer.exec();
+    if (!self) {
+        return;
+    }
     m_docViewerOpen = false;
     populateTable();
 }
@@ -796,7 +813,9 @@ void SettingsBrowserDialog::addKey()
                                   : QStringLiteral("Station: %1").arg(
                                         AppSettings::instance().stationName());
 
-    QDialog dlg(this);
+    const QPointer<SettingsBrowserDialog> self(this);
+    ScopedChildWidget<QDialog> dialogOwner(this);
+    QDialog& dlg = *dialogOwner.get();
     dlg.setWindowTitle("Add Key");
     dlg.setStyleSheet(kDialogStyle);
     auto* form = new QFormLayout(&dlg);
@@ -812,7 +831,8 @@ void SettingsBrowserDialog::addKey()
     connect(box, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
     connect(box, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
     form->addRow(box);
-    if (dlg.exec() != QDialog::Accepted) {
+    const int result = dlg.exec();
+    if (!self || !dialogOwner || result != QDialog::Accepted) {
         return;
     }
 
@@ -841,6 +861,9 @@ void SettingsBrowserDialog::addKey()
                != FramelessMessageBox::Yes) {
         return;
     }
+    if (!self || !dialogOwner) {
+        return;
+    }
     if (scope.kind == ScopeKind::App) {
         s.setValue(key, valueEdit->text());
     } else {
@@ -864,6 +887,7 @@ void SettingsBrowserDialog::addKey()
 
 void SettingsBrowserDialog::deleteSelected()
 {
+    const QPointer<SettingsBrowserDialog> self(this);
     const Scope scope = currentScope();
     const int row = m_table->currentRow();
     if (row < 0) {
@@ -896,7 +920,7 @@ void SettingsBrowserDialog::deleteSelected()
         return;
     }
     if (FramelessMessageBox::question(this, "Delete Setting?", prompt)
-        != FramelessMessageBox::Yes) {
+        != FramelessMessageBox::Yes || !self) {
         return;
     }
 
@@ -925,11 +949,12 @@ void SettingsBrowserDialog::deleteSelected()
 
 void SettingsBrowserDialog::exportSanitized()
 {
+    const QPointer<SettingsBrowserDialog> self(this);
     const QString path = QFileDialog::getSaveFileName(
         this, "Export Sanitized Settings",
         QDir::home().filePath(QStringLiteral("AetherSDR-settings.txt")),
         "Text files (*.txt);;All files (*)");
-    if (path.isEmpty()) {
+    if (!self || path.isEmpty()) {
         return;
     }
     QFile file(path);

--- a/src/gui/SettingsBrowserDialog.cpp
+++ b/src/gui/SettingsBrowserDialog.cpp
@@ -612,6 +612,10 @@ void SettingsBrowserDialog::onTableActivated(int row)
     if (featureItem == nullptr) {
         return;
     }
+    // A double-click delivers cellActivated AND cellDoubleClicked on some
+    // platforms — one viewer per gesture (PR #4631 review). Both arrive
+    // before the deferred open below runs, so the flag is claimed here and
+    // released by openDocumentViewer() when its modal loop ends.
     if (m_docViewerOpen) {
         return;
     }
@@ -621,7 +625,6 @@ void SettingsBrowserDialog::onTableActivated(int row)
     // modal loop can delete its table. Snapshot the document, not its row.
     m_docViewerOpen = true;
     QTimer::singleShot(0, this, [this, scope, feature, rawValue] {
-        m_docViewerOpen = false;
         openDocumentViewer(scope.family, scope.radioId, feature, rawValue);
     });
 }
@@ -631,13 +634,8 @@ void SettingsBrowserDialog::openDocumentViewer(const QString& family,
                                                const QString& feature,
                                                const QString& rawValue)
 {
-    // A double-click delivers cellActivated AND cellDoubleClicked on some
-    // platforms — one viewer per gesture (PR #4631 review).
-    if (m_docViewerOpen) {
-        return;
-    }
-    m_docViewerOpen = true;
-
+    // m_docViewerOpen is claimed by onTableActivated() before this call is
+    // deferred; it is released after exec() below.
     auto& s = AppSettings::instance();
     int schemaVersion = 0;
     const QJsonObject doc =
@@ -919,8 +917,8 @@ void SettingsBrowserDialog::deleteSelected()
     case ScopeKind::None:
         return;
     }
-    if (FramelessMessageBox::question(this, "Delete Setting?", prompt)
-        != FramelessMessageBox::Yes || !self) {
+    const auto answer = FramelessMessageBox::question(this, "Delete Setting?", prompt);
+    if (!self || answer != FramelessMessageBox::Yes) {
         return;
     }
 

--- a/src/gui/ThemeEditorDialog.cpp
+++ b/src/gui/ThemeEditorDialog.cpp
@@ -1,4 +1,5 @@
 #include "ThemeEditorDialog.h"
+#include "ScopedChildWidget.h"
 #include "Theme.h"
 #include "ThemeInspector.h"
 #include "TokenEditorWidget.h"
@@ -25,11 +26,13 @@
 #include <QLineEdit>
 #include <QHeaderView>
 #include <QTreeWidget>
+#include <QTreeWidgetItemIterator>
 #include <QTreeWidgetItem>
 #include <QMessageBox>
 #include <QPainter>
 #include <QPainterPath>
 #include <QPixmap>
+#include <QPointer>
 #include <QPushButton>
 #include <QSet>
 #include <QSignalBlocker>
@@ -53,6 +56,23 @@ QString userThemesDir()
     return QDir::toNativeSeparators(
         QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation)
         + QStringLiteral("/AetherSDR/themes"));
+}
+
+QMessageBox::StandardButton showModalMessage(
+    QMessageBox::Icon icon, QWidget* parent, const QString& title,
+    const QString& text, QMessageBox::StandardButtons buttons = QMessageBox::Ok,
+    QMessageBox::StandardButton defaultButton = QMessageBox::NoButton)
+{
+    ScopedChildWidget<QMessageBox> boxOwner(parent);
+    QMessageBox& box = *boxOwner.get();
+    box.setIcon(icon);
+    box.setWindowTitle(title);
+    box.setText(text);
+    box.setStandardButtons(buttons);
+    if (defaultButton != QMessageBox::NoButton) {
+        box.setDefaultButton(defaultButton);
+    }
+    return static_cast<QMessageBox::StandardButton>(box.exec());
 }
 
 // Build a tiny coloured square QIcon for use as a swatch on a list row.
@@ -533,10 +553,11 @@ void ThemeEditorDialog::onTokenEditedByEditor(const QString& key)
 
 void ThemeEditorDialog::onRenameThemeClicked()
 {
+    const QPointer<ThemeEditorDialog> self(this);
     auto& tm = ThemeManager::instance();
     const QString current = tm.activeTheme();
     if (tm.isBuiltInTheme(current)) {
-        QMessageBox::information(this, QStringLiteral("Cannot rename"),
+        showModalMessage(QMessageBox::Information, this, QStringLiteral("Cannot rename"),
             QStringLiteral("\"%1\" is a built-in theme and can't be renamed. "
                            "Use Save As… to create an editable copy under a "
                            "different name first.").arg(current));
@@ -547,7 +568,9 @@ void ThemeEditorDialog::onRenameThemeClicked()
         QStringLiteral("Rename theme"),
         QStringLiteral("New name for \"%1\":").arg(current),
         QLineEdit::Normal, current, &ok).trimmed();
-    if (!ok || newName.isEmpty() || newName == current) return;
+    if (!self || !ok || newName.isEmpty() || newName == current) {
+        return;
+    }
 
     // Check the NAME before attempting the rename, so a refusal can say what
     // was actually wrong.  ThemeManager enforces this too — that's the safety
@@ -556,12 +579,12 @@ void ThemeEditorDialog::onRenameThemeClicked()
     // directory permissions.
     QString why;
     if (!ThemeManager::isValidThemeName(newName, &why)) {
-        QMessageBox::warning(this, QStringLiteral("Rename failed"), why);
+        showModalMessage(QMessageBox::Warning, this, QStringLiteral("Rename failed"), why);
         return;
     }
 
     if (!tm.renameTheme(current, newName)) {
-        QMessageBox::warning(this, QStringLiteral("Rename failed"),
+        showModalMessage(QMessageBox::Warning, this, QStringLiteral("Rename failed"),
             QStringLiteral("Could not rename \"%1\" to \"%2\".  A theme with "
                            "that name may already exist, or the theme file "
                            "may be unwriteable.").arg(current, newName));
@@ -570,6 +593,7 @@ void ThemeEditorDialog::onRenameThemeClicked()
 
 void ThemeEditorDialog::onExportThemeClicked()
 {
+    const QPointer<ThemeEditorDialog> self(this);
     auto& tm = ThemeManager::instance();
     const QString current = tm.activeTheme();
     if (current.isEmpty()) return;
@@ -583,11 +607,13 @@ void ThemeEditorDialog::onExportThemeClicked()
     const QString path = QFileDialog::getSaveFileName(this,
         QStringLiteral("Export theme"), suggested,
         QStringLiteral("AetherSDR themes (*.aethertheme *.json)"));
-    if (path.isEmpty()) return;
+    if (!self || path.isEmpty()) {
+        return;
+    }
 
     QString err;
     if (!tm.exportThemeToFile(current, path, &err)) {
-        QMessageBox::warning(this, QStringLiteral("Export failed"),
+        showModalMessage(QMessageBox::Warning, this, QStringLiteral("Export failed"),
             QStringLiteral("Could not write \"%1\":\n\n%2").arg(path, err));
         return;
     }
@@ -595,24 +621,31 @@ void ThemeEditorDialog::onExportThemeClicked()
 
 void ThemeEditorDialog::onImportThemeClicked()
 {
+    const QPointer<ThemeEditorDialog> self(this);
     const QString path = QFileDialog::getOpenFileName(this,
         QStringLiteral("Import theme"), QDir::homePath(),
         QStringLiteral("AetherSDR themes (*.aethertheme *.json)"));
-    if (path.isEmpty()) return;
+    if (!self || path.isEmpty()) {
+        return;
+    }
     importThemeFromPath(path);
 }
 
 void ThemeEditorDialog::importThemeFromPath(const QString& filePath)
 {
+    const QPointer<ThemeEditorDialog> self(this);
     auto& tm = ThemeManager::instance();
     QString err;
     const QString name = tm.importThemeFromFile(filePath, &err);
+    if (!self) {
+        return;
+    }
     if (name.isEmpty()) {
-        QMessageBox::warning(this, QStringLiteral("Import failed"),
+        showModalMessage(QMessageBox::Warning, this, QStringLiteral("Import failed"),
             QStringLiteral("Could not import \"%1\":\n\n%2").arg(filePath, err));
         return;
     }
-    QMessageBox::information(this, QStringLiteral("Theme imported"),
+    showModalMessage(QMessageBox::Information, this, QStringLiteral("Theme imported"),
         QStringLiteral("Installed \"%1\" and made it the active theme.").arg(name));
 }
 
@@ -655,14 +688,15 @@ void ThemeEditorDialog::dropEvent(QDropEvent* event)
 
 void ThemeEditorDialog::onDeleteThemeClicked()
 {
+    const QPointer<ThemeEditorDialog> self(this);
     auto& tm = ThemeManager::instance();
     const QString current = tm.activeTheme();
     if (tm.isBuiltInTheme(current)) {
-        QMessageBox::information(this, QStringLiteral("Cannot delete"),
+        showModalMessage(QMessageBox::Information, this, QStringLiteral("Cannot delete"),
             QStringLiteral("\"%1\" is a built-in theme and can't be deleted.").arg(current));
         return;
     }
-    const auto reply = QMessageBox::question(this,
+    const auto reply = showModalMessage(QMessageBox::Question, this,
         QStringLiteral("Delete theme"),
         QStringLiteral("Permanently delete \"%1\"?\n\n"
                        "The theme file at %2 will be removed. "
@@ -671,10 +705,12 @@ void ThemeEditorDialog::onDeleteThemeClicked()
                  userThemesDir() + QDir::separator()
                      + current + QStringLiteral(".json")),
         QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
-    if (reply != QMessageBox::Yes) return;
+    if (!self || reply != QMessageBox::Yes) {
+        return;
+    }
 
     if (!tm.deleteTheme(current)) {
-        QMessageBox::warning(this, QStringLiteral("Delete failed"),
+        showModalMessage(QMessageBox::Warning, this, QStringLiteral("Delete failed"),
             QStringLiteral("Could not delete \"%1\". The theme file may be "
                            "locked by another process.").arg(current));
         return;
@@ -694,22 +730,25 @@ void ThemeEditorDialog::onDeleteThemeClicked()
 
 void ThemeEditorDialog::onSaveAsClicked()
 {
-    bool ok = false;
+    const QPointer<ThemeEditorDialog> self(this);
     auto& tm = ThemeManager::instance();
     QString suggestion = tm.activeTheme();
     if (!suggestion.startsWith(QStringLiteral("My ")))
         suggestion = QStringLiteral("My %1").arg(suggestion);
 
+    bool ok = false;
     const QString name = QInputDialog::getText(this,
         QStringLiteral("Save Theme As"),
         QStringLiteral("Theme name:"),
         QLineEdit::Normal, suggestion, &ok).trimmed();
-    if (!ok || name.isEmpty()) return;
+    if (!self || !ok || name.isEmpty()) {
+        return;
+    }
 
     // Name first, so a rejected name is reported as a rejected name.
     QString why;
     if (!ThemeManager::isValidThemeName(name, &why)) {
-        QMessageBox::warning(this, QStringLiteral("Save failed"), why);
+        showModalMessage(QMessageBox::Warning, this, QStringLiteral("Save failed"), why);
         return;
     }
 
@@ -718,15 +757,17 @@ void ThemeEditorDialog::onSaveAsClicked()
     // User-dir themes can be overwritten freely.
     const QStringList existing = tm.availableThemes();
     if (existing.contains(name)) {
-        const auto reply = QMessageBox::question(this,
+        const auto reply = showModalMessage(QMessageBox::Question, this,
             QStringLiteral("Theme exists"),
             QStringLiteral("A theme named \"%1\" already exists. Overwrite it?").arg(name),
             QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
-        if (reply != QMessageBox::Yes) return;
+        if (!self || reply != QMessageBox::Yes) {
+            return;
+        }
     }
 
     if (!tm.saveCurrentThemeAs(name)) {
-        QMessageBox::warning(this, QStringLiteral("Save failed"),
+        showModalMessage(QMessageBox::Warning, this, QStringLiteral("Save failed"),
             QStringLiteral("Could not write the theme file. Check that "
                            "%1 is writable.").arg(userThemesDir()));
         return;
@@ -737,6 +778,7 @@ void ThemeEditorDialog::onSaveAsClicked()
 
 void ThemeEditorDialog::onSaveAsBeforeCommit()
 {
+    const QPointer<ThemeEditorDialog> self(this);
     auto& tm = ThemeManager::instance();
     const QString current = tm.activeTheme();
     if (!tm.isBuiltInTheme(current)) {
@@ -746,15 +788,17 @@ void ThemeEditorDialog::onSaveAsBeforeCommit()
         return;
     }
 
-    bool ok = false;
     QString suggestion = QStringLiteral("My %1").arg(current);
+    bool ok = false;
     const QString name = QInputDialog::getText(this,
         QStringLiteral("Save Theme As"),
         QStringLiteral("\"%1\" is a built-in theme and can't be modified "
                        "directly.\nSave your changes as a new theme:")
             .arg(current),
         QLineEdit::Normal, suggestion, &ok).trimmed();
-    if (!ok || name.isEmpty()) return;  // user cancelled — buffer stays uncommitted
+    if (!self || !ok || name.isEmpty()) {
+        return;
+    }
 
     // Name first.  This path matters more than the plain Save As: the operator
     // has a pending token edit stashed in DeferredEdit, and every early return
@@ -762,31 +806,36 @@ void ThemeEditorDialog::onSaveAsBeforeCommit()
     // name and keep the edit instead of concluding the editor is broken.
     QString why;
     if (!ThemeManager::isValidThemeName(name, &why)) {
-        QMessageBox::warning(this, QStringLiteral("Save failed"), why);
+        showModalMessage(QMessageBox::Warning, this, QStringLiteral("Save failed"), why);
         return;
     }
 
     // Disallow accidentally writing to another built-in or overwriting
     // an existing user theme without confirmation.
     if (tm.isBuiltInTheme(name)) {
-        QMessageBox::warning(this, QStringLiteral("Reserved name"),
+        showModalMessage(QMessageBox::Warning, this, QStringLiteral("Reserved name"),
             QStringLiteral("\"%1\" is a built-in theme name and can't be used.")
                 .arg(name));
         return;
     }
     const QStringList existing = tm.availableThemes();
     if (existing.contains(name)) {
-        const auto reply = QMessageBox::question(this,
+        const auto reply = showModalMessage(QMessageBox::Question, this,
             QStringLiteral("Theme exists"),
             QStringLiteral("A theme named \"%1\" already exists. Overwrite it?").arg(name),
             QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
-        if (reply != QMessageBox::Yes) return;
+        if (!self || reply != QMessageBox::Yes) {
+            return;
+        }
     }
 
     if (!tm.saveCurrentThemeAs(name)) {
-        QMessageBox::warning(this, QStringLiteral("Save failed"),
+        showModalMessage(QMessageBox::Warning, this, QStringLiteral("Save failed"),
             QStringLiteral("Could not write the theme file. Check that "
                            "%1 is writable.").arg(userThemesDir()));
+        return;
+    }
+    if (!self) {
         return;
     }
     // saveCurrentThemeAs() has switched the active theme and refreshed
@@ -1032,14 +1081,32 @@ void ThemeEditorDialog::onTokenContextMenu(const QPoint& pos)
     const QString scopeLabel = scopePath.isEmpty()
                                    ? QStringLiteral("(root)")
                                    : scopePath;
-    QMenu menu(this);
+    const QString activeTheme = tm.activeTheme();
+    const QPointer<ThemeEditorDialog> self(this);
+    const QPointer<QTreeWidget> tokenList(m_tokenList);
+    ScopedChildWidget<QMenu> menuOwner(this);
+    QMenu& menu = *menuOwner.get();
     QAction* clearAct = menu.addAction(
         QStringLiteral("Clear override at %1").arg(scopeLabel));
     QAction* picked = menu.exec(m_tokenList->viewport()->mapToGlobal(pos));
-    if (picked == clearAct) {
-        tm.removeOverride(scopePath, token);
-        // Refresh the row so the column flips back to italic "inherited".
-        populateRow(item);
+    if (!self || !menuOwner || !tokenList
+        || self->m_tokenList != tokenList.data() || picked != clearAct
+        || tm.activeTheme() != activeTheme) {
+        return;
+    }
+    tm.removeOverride(scopePath, token);
+    if (!self || !tokenList || self->m_tokenList != tokenList.data()) {
+        return;
+    }
+    // Find the current row after the nested loop; the original item may
+    // have been replaced. Keep selection and scroll position intact.
+    QTreeWidgetItemIterator rows(tokenList.data());
+    while (*rows) {
+        if ((*rows)->data(0, Qt::UserRole).toString() == token) {
+            self->populateRow(*rows);
+            break;
+        }
+        ++rows;
     }
 }
 

--- a/src/gui/TokenEditorWidget.cpp
+++ b/src/gui/TokenEditorWidget.cpp
@@ -14,6 +14,7 @@
 #include <QListWidget>
 #include <QListWidgetItem>
 #include <QMessageBox>
+#include "ScopedChildWidget.h"
 #include <QPainter>
 #include <QPainterPath>
 #include <QPushButton>
@@ -1022,8 +1023,10 @@ void TokenEditorWidget::onGradientRequestDeleteStop(int index)
     if (m_settingControlsFromToken) return;
     if (index < 0 || index >= m_gradientBuf.stops.size()) return;
     if (m_gradientBuf.stops.size() <= 2) {
-        QMessageBox::information(this, QStringLiteral("Cannot delete stop"),
-            QStringLiteral("A gradient needs at least two stops."));
+        ScopedChildWidget<QMessageBox> boxOwner(
+            QMessageBox::Information, QStringLiteral("Cannot delete stop"),
+            QStringLiteral("A gradient needs at least two stops."), QMessageBox::Ok, this);
+        boxOwner.get()->exec();
         return;
     }
     m_gradientBuf.stops.removeAt(index);

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -1,5 +1,6 @@
 #include "TxApplet.h"
 #include "AtuPreTuneDialog.h"
+#include "ScopedChildWidget.h"
 #include "GuardedSlider.h"
 #include "ComboStyle.h"
 #include "HGauge.h"
@@ -874,7 +875,10 @@ void TxApplet::openPreTuneDialog()
 void TxApplet::confirmAndClearAtuMemories()
 {
     if (!m_model) return;
-    QMessageBox box(this->window());
+    const QPointer<TxApplet> self(this);
+    const QPointer<TransmitModel> model(m_model);
+    ScopedChildWidget<QMessageBox> boxOwner(this->window());
+    QMessageBox& box = *boxOwner.get();
     box.setWindowTitle("Clear ATU memories");
     box.setIcon(QMessageBox::Warning);
     box.setText("Clear the radio's entire ATU memory database?");
@@ -886,8 +890,10 @@ void TxApplet::confirmAndClearAtuMemories()
     auto* clearBtn = box.addButton("Clear all bands", QMessageBox::DestructiveRole);
     box.addButton("Cancel", QMessageBox::RejectRole);
     box.exec();
-    if (box.clickedButton() == clearBtn)
-        m_model->atuClearMemories();
+    if (self && boxOwner && model && self->m_model == model.data()
+        && box.clickedButton() == clearBtn) {
+        model->atuClearMemories();
+    }
 }
 
 void TxApplet::setPowerScale(int maxWatts, bool hasAmplifier)

--- a/src/gui/UlanziDialMapperDialog.cpp
+++ b/src/gui/UlanziDialMapperDialog.cpp
@@ -25,6 +25,7 @@
 #ifdef Q_OS_LINUX
 #include "core/LogManager.h"
 #include <QMessageBox>
+#include "ScopedChildWidget.h"
 #include <QMetaObject>
 #include <QProcess>
 #include <QStandardPaths>
@@ -680,9 +681,11 @@ void UlanziDialMapperDialog::onGrantAccessClicked()
 {
     const QString pkexec = QStandardPaths::findExecutable(QStringLiteral("pkexec"));
     if (pkexec.isEmpty()) {
-        QMessageBox::warning(this, tr("Grant access"),
+        ScopedChildWidget<QMessageBox> boxOwner(
+            QMessageBox::Warning, tr("Grant access"),
             tr("pkexec was not found. Install polkit, or add this user to the "
-               "'input' group manually."));
+               "'input' group manually."), QMessageBox::Ok, this);
+        boxOwner.get()->exec();
         return;
     }
 

--- a/src/gui/WaveformsDialog.cpp
+++ b/src/gui/WaveformsDialog.cpp
@@ -7,6 +7,7 @@
 #include "models/FlexWaveformModel.h"
 #include "models/RadioModel.h"
 #include "gui/WaveformInstallGate.h"   // #4210 pure Docker-install gate policy
+#include "ScopedChildWidget.h"
 
 #include <QAction>
 #include <QCheckBox>
@@ -27,6 +28,7 @@
 #include <QPainterPath>
 #include <QPixmap>
 #include <QProgressBar>
+#include <QPointer>
 #include <QPushButton>
 #include <QRegularExpression>
 #include <QRegularExpressionValidator>
@@ -774,7 +776,9 @@ QWidget* makeEmptyWaveformsState(QWidget* parent = nullptr)
 
 void showDockerWfpNotReadyDialog(QWidget* parent, const QString& statusText)
 {
-    PersistentDialog dialog(QObject::tr("Docker Waveform Unavailable"), QString(), parent);
+    ScopedChildWidget<PersistentDialog> dialogOwner(
+        QObject::tr("Docker Waveform Unavailable"), QString(), parent);
+    PersistentDialog& dialog = *dialogOwner.get();
     theme::setContainer(&dialog, QStringLiteral("dialog/waveforms/wfpNotReady"));
     dialog.setWindowModality(Qt::WindowModal);
     dialog.setModal(true);
@@ -818,7 +822,9 @@ bool confirmRadioWaveformRemoval(QWidget* parent, const QString& name, bool isCo
         ? QObject::tr("Remove")
         : QObject::tr("Uninstall");
 
-    PersistentDialog dialog(title, QString(), parent);
+    const QPointer<QWidget> parentGuard(parent);
+    ScopedChildWidget<PersistentDialog> dialogOwner(title, QString(), parent);
+    PersistentDialog& dialog = *dialogOwner.get();
     theme::setContainer(&dialog, QStringLiteral("dialog/waveforms/removeConfirm"));
     dialog.setWindowModality(Qt::WindowModal);
     dialog.setModal(true);
@@ -849,14 +855,16 @@ bool confirmRadioWaveformRemoval(QWidget* parent, const QString& name, bool isCo
 
     root->addLayout(buttons);
 
-    return dialog.exec() == QDialog::Accepted;
+    const int result = dialog.exec();
+    return parentGuard && dialogOwner && result == QDialog::Accepted;
 }
 
 void showWaveformInstallResultDialog(QWidget* parent,
                                      const QString& title,
                                      const QString& messageText)
 {
-    PersistentDialog dialog(title, QString(), parent);
+    ScopedChildWidget<PersistentDialog> dialogOwner(title, QString(), parent);
+    PersistentDialog& dialog = *dialogOwner.get();
     theme::setContainer(&dialog, QStringLiteral("dialog/waveforms/installResult"));
     dialog.setWindowModality(Qt::WindowModal);
     dialog.setModal(true);
@@ -1489,19 +1497,21 @@ void WaveformsDialog::installWaveformFile(const QString& title,
         return;
     }
 
+    const QPointer<WaveformsDialog> self(this);
+    const QPointer<RadioModel> modelGuard(m_radioModel);
     const QString path = QFileDialog::getOpenFileName(
         this,
         title,
         initialPath,
         filter);
 
-    if (path.isEmpty()) {
+    if (!self || !modelGuard || self->m_radioModel != modelGuard.data() || path.isEmpty()) {
         return;
     }
 
     if (docker) {
-        const FlexWaveformModel& wfModel = m_radioModel->flexWaveformModel();
-        const QString blocker = dockerInstallBlockerText(m_radioModel, wfModel);
+        const FlexWaveformModel& wfModel = modelGuard->flexWaveformModel();
+        const QString blocker = dockerInstallBlockerText(modelGuard, wfModel);
         if (!blocker.isEmpty()) {
             showDockerWfpNotReadyDialog(this, blocker);
             return;
@@ -1509,7 +1519,7 @@ void WaveformsDialog::installWaveformFile(const QString& title,
     }
 
     if (!m_installer) {
-        m_installer = new WaveformInstaller(m_radioModel, this);
+        m_installer = new WaveformInstaller(modelGuard, this);
     }
 
     if (m_installer->isInstalling()) {
@@ -1613,19 +1623,21 @@ void WaveformsDialog::onDStarStartStopClicked()
 
 void WaveformsDialog::onDStarBrowseClicked()
 {
+    const QPointer<WaveformsDialog> self(this);
+    const QPointer<QLineEdit> executableEdit(m_dstarExecutableEdit);
     const QString initialPath =
         dstarExecutableBrowseStartPath(m_dstarExecutableEdit->text().trimmed());
     const QString path = QFileDialog::getOpenFileName(
         this,
         tr("Select Digital Voice Service Executable"),
         initialPath);
-    if (path.isEmpty()) {
+    if (!self || !executableEdit || self->m_dstarExecutableEdit != executableEdit.data() || path.isEmpty()) {
         return;
     }
-    m_dstarExecutableEdit->setText(path);
-    m_dstarExecutableEdit->setCursorPosition(path.size());
-    m_dstarExecutableEdit->setFocus();
-    saveDStarSettings();
+    executableEdit->setText(path);
+    executableEdit->setCursorPosition(path.size());
+    executableEdit->setFocus();
+    self->saveDStarSettings();
 }
 
 void WaveformsDialog::refreshStatus()

--- a/src/gui/WaveformsDialog.cpp
+++ b/src/gui/WaveformsDialog.cpp
@@ -1518,12 +1518,20 @@ void WaveformsDialog::installWaveformFile(const QString& title,
         }
     }
 
-    if (!m_installer) {
-        m_installer = new WaveformInstaller(modelGuard, this);
+    if (m_installer && m_installer->isInstalling()) {
+        return;
     }
 
-    if (m_installer->isInstalling()) {
-        return;
+    // Rebuild the installer if the radio changed under us — it caches the
+    // model it was constructed with, and the picker above is a nested loop
+    // during which the model can be swapped (#5568 review).
+    if (m_installer && m_installerModel != modelGuard) {
+        m_installer->deleteLater();
+        m_installer = nullptr;
+    }
+    if (!m_installer) {
+        m_installer = new WaveformInstaller(modelGuard, this);
+        m_installerModel = modelGuard;
     }
 
     m_installBtn->setEnabled(false);

--- a/src/gui/WaveformsDialog.h
+++ b/src/gui/WaveformsDialog.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "PersistentDialog.h"
+#include <QPointer>
 
 class QLabel;
 class QAction;
@@ -66,6 +67,11 @@ private:
     QWidget*           m_listContainer{nullptr};
     QVBoxLayout*       m_listLayout{nullptr};
     WaveformInstaller* m_installer{nullptr};
+    // The model m_installer was built for. The guards in installWaveformFile()
+    // establish that a model swap across a file picker is reachable, so a
+    // cached installer must not keep uploading to the previous radio (#5568
+    // review).
+    QPointer<RadioModel> m_installerModel;
 
     QLabel*      m_dstarStatusLabel{nullptr};
     QLabel*      m_dstarDetailLabel{nullptr};

--- a/tests/gui_nested_lifetime_test.cpp
+++ b/tests/gui_nested_lifetime_test.cpp
@@ -1,0 +1,294 @@
+#include "TestSettingsProfile.h"
+#include "core/AppSettings.h"
+#include "gui/NetSchedulerDialog.h"
+#include "gui/RxApplet.h"
+#include "gui/ScopedChildWidget.h"
+#include "models/SliceModel.h"
+
+#include <QAction>
+#include <QApplication>
+#include <QDialog>
+#include <QMenu>
+#include <QMetaObject>
+#include <QPointer>
+#include <QPushButton>
+#include <QSignalSpy>
+#include <QSpinBox>
+#include <QTableWidget>
+#include <QTimer>
+#include <QtTest>
+
+#include <memory>
+
+using namespace AetherSDR;
+
+namespace {
+
+QPushButton* buttonByAccessibleName(QWidget& parent, const QString& name)
+{
+    for (QPushButton* button : parent.findChildren<QPushButton*>()) {
+        if (button->accessibleName() == name) {
+            return button;
+        }
+    }
+    return nullptr;
+}
+
+QPushButton* buttonByText(QWidget& parent, const QString& text)
+{
+    for (QPushButton* button : parent.findChildren<QPushButton*>()) {
+        if (button->text() == text) {
+            return button;
+        }
+    }
+    return nullptr;
+}
+
+QPushButton* customFilterButton(QWidget& parent)
+{
+    for (QPushButton* button : parent.findChildren<QPushButton*>()) {
+        if (button->contextMenuPolicy() == Qt::CustomContextMenu) {
+            return button;
+        }
+    }
+    return nullptr;
+}
+
+QMenu* activeMenu()
+{
+    return qobject_cast<QMenu*>(QApplication::activePopupWidget());
+}
+
+void openContextMenu(QPushButton* button)
+{
+    QMetaObject::invokeMethod(button, "customContextMenuRequested",
+                              Qt::DirectConnection,
+                              Q_ARG(QPoint, button->rect().center()));
+}
+
+} // namespace
+
+// These are component-lifetime contracts: destruction is injected while the
+// production widget owns a nested modal loop. They do not claim to reproduce
+// a particular persistent-dialog shutdown path.
+class GuiNestedLifetimeTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void txAntennaMenuReturnsAfterAppletDeletion()
+    {
+        SliceModel slice(0);
+        slice.setTxAntenna(QStringLiteral("ANT1"));
+        auto rx = std::make_unique<RxApplet>();
+        rx->setSlice(&slice);
+        QPushButton* button = buttonByAccessibleName(*rx, QStringLiteral("TX antenna"));
+        QVERIFY(button);
+
+        QPointer<RxApplet> observer(rx.get());
+        QTimer::singleShot(0, qApp, [&rx] { rx.reset(); });
+        QMetaObject::invokeMethod(button, "click", Qt::DirectConnection);
+
+        QVERIFY(observer.isNull());
+        QCOMPARE(slice.txAntenna(), QStringLiteral("ANT1"));
+    }
+
+    void customFilterDialogAppliesOnlyToOriginalSlice_data()
+    {
+        QTest::addColumn<bool>("rebind");
+        QTest::newRow("live-owner-accepts") << false;
+        QTest::newRow("rebound-owner-rejects") << true;
+    }
+
+    void customFilterDialogAppliesOnlyToOriginalSlice()
+    {
+        QFETCH(bool, rebind);
+        SliceModel original(0);
+        SliceModel replacement(1);
+        auto rx = std::make_unique<RxApplet>();
+        rx->setSlice(&original);
+        QPushButton* button = customFilterButton(*rx);
+        QVERIFY(button);
+
+        QSignalSpy originalWrites(&original, &SliceModel::filterCommandIssued);
+        QSignalSpy replacementWrites(&replacement, &SliceModel::filterCommandIssued);
+        bool openedDialog = false;
+        QTimer::singleShot(0, qApp, [&] {
+            QMenu* menu = activeMenu();
+            QVERIFY(menu);
+            if (!menu) {
+                return;
+            }
+            QAction* action = nullptr;
+            for (QAction* candidate : menu->actions()) {
+                if (candidate->text() == QStringLiteral("Set Custom Edges...")) {
+                    action = candidate;
+                    break;
+                }
+            }
+            QVERIFY(action);
+            if (!action) {
+                return;
+            }
+            menu->close();
+            openedDialog = true;
+            QMetaObject::invokeMethod(qApp, [&] {
+                auto* dialog = qobject_cast<QDialog*>(QApplication::activeModalWidget());
+                QVERIFY(dialog);
+                if (!dialog) {
+                    return;
+                }
+                const auto spinBoxes = dialog->findChildren<QSpinBox*>();
+                QCOMPARE(spinBoxes.size(), 2);
+                if (spinBoxes.size() != 2) {
+                    return;
+                }
+                spinBoxes.at(0)->setValue(100);
+                spinBoxes.at(1)->setValue(2400);
+                if (rebind) {
+                    rx->setSlice(&replacement);
+                }
+                dialog->accept();
+            }, Qt::QueuedConnection);
+            action->trigger();
+        });
+        openContextMenu(button);
+
+        QVERIFY(openedDialog);
+        if (rebind) {
+            QVERIFY(originalWrites.isEmpty());
+            QVERIFY(replacementWrites.isEmpty());
+            return;
+        }
+        QCOMPARE(originalWrites.size(), 1);
+        QCOMPARE(replacementWrites.size(), 0);
+        QCOMPARE(originalWrites.at(0).at(0).toInt(), 100);
+        QCOMPARE(originalWrites.at(0).at(1).toInt(), 2400);
+        QCOMPARE(original.filterLow(), 100);
+        QCOMPARE(original.filterHigh(), 2400);
+    }
+
+    void customFilterDialogReturnsAfterAppletDeletion()
+    {
+        SliceModel slice(0);
+        auto rx = std::make_unique<RxApplet>();
+        rx->setSlice(&slice);
+        QPushButton* button = customFilterButton(*rx);
+        QVERIFY(button);
+
+        QPointer<RxApplet> observer(rx.get());
+        QTimer::singleShot(0, qApp, [&] {
+            QMenu* menu = activeMenu();
+            QVERIFY(menu);
+            if (!menu) {
+                return;
+            }
+            QAction* action = nullptr;
+            for (QAction* candidate : menu->actions()) {
+                if (candidate->text() == QStringLiteral("Set Custom Edges...")) {
+                    action = candidate;
+                    break;
+                }
+            }
+            QVERIFY(action);
+            if (!action) {
+                return;
+            }
+            menu->close();
+            QMetaObject::invokeMethod(qApp, [&rx] { rx.reset(); }, Qt::QueuedConnection);
+            action->trigger();
+        });
+        openContextMenu(button);
+
+        QVERIFY(observer.isNull());
+    }
+
+    void netSchedulerEditorReturnsAfterOwnerDeletion_data()
+    {
+        QTest::addColumn<bool>("edit");
+        QTest::newRow("add-net") << false;
+        QTest::newRow("doubleclick-edit-net") << true;
+    }
+
+    void netSchedulerEditorReturnsAfterOwnerDeletion()
+    {
+        QFETCH(bool, edit);
+
+        QList<NetEntry> entries;
+        if (edit) {
+            NetEntry entry;
+            entry.id = QStringLiteral("test-net");
+            entry.name = QStringLiteral("Test net");
+            entries.append(entry);
+        }
+
+        ScopedChildWidget<NetSchedulerDialog> ownerHolder(entries, [] {
+            return MemoryEntry{};
+        });
+        NetSchedulerDialog* owner = ownerHolder.get();
+        QVERIFY(owner);
+        owner->setAttribute(Qt::WA_DeleteOnClose);
+        owner->show();
+        QTest::qWait(20);
+
+        QPointer<NetSchedulerDialog> ownerObserver(owner);
+        QPointer<QDialog> editorObserver;
+        bool openedEditor = false;
+        QTimer closer;
+        closer.setInterval(10);
+        QObject::connect(&closer, &QTimer::timeout, qApp, [&] {
+            auto* editor = qobject_cast<QDialog*>(QApplication::activeModalWidget());
+            if (!editor || editor->windowTitle() != (edit ? QStringLiteral("Edit Net")
+                                                           : QStringLiteral("Add Net"))) {
+                return;
+            }
+            openedEditor = true;
+            editorObserver = editor;
+            if (ownerObserver) {
+                ownerObserver->close();
+            }
+            closer.stop();
+        });
+        closer.start();
+
+        if (edit) {
+            QTableWidget* table = owner->findChild<QTableWidget*>();
+            QVERIFY(table);
+            const QPoint cellCenter = table->visualRect(table->model()->index(0, 1)).center();
+            QTest::mouseClick(table->viewport(), Qt::LeftButton, Qt::NoModifier, cellCenter);
+            QTest::mouseDClick(table->viewport(), Qt::LeftButton, Qt::NoModifier, cellCenter);
+            QTRY_VERIFY(openedEditor);
+        } else {
+            QPushButton* add = buttonByText(*owner, QStringLiteral("Add…"));
+            QVERIFY(add);
+            QMetaObject::invokeMethod(add, "click", Qt::DirectConnection);
+        }
+        closer.stop();
+
+        QVERIFY(openedEditor);
+        QTRY_VERIFY(ownerObserver.isNull());
+        QVERIFY(editorObserver.isNull());
+    }
+
+
+};
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile profile(QStringLiteral("gui-nested-lifetime"));
+    if (!profile.isValid()) {
+        return 1;
+    }
+    QApplication app(argc, argv);
+    app.setQuitOnLastWindowClosed(false);
+    AppSettings::instance().load();
+    QTimer watchdog;
+    QObject::connect(&watchdog, &QTimer::timeout, &app, [] {
+        qFatal("Nested lifetime test failed to leave its modal loop");
+    });
+    watchdog.start(15000);
+    GuiNestedLifetimeTest test;
+    return QTest::qExec(&test, argc, argv);
+}
+
+#include "gui_nested_lifetime_test.moc"

--- a/tests/scoped_child_widget_test.cpp
+++ b/tests/scoped_child_widget_test.cpp
@@ -4,6 +4,7 @@
 #include <QApplication>
 #include <QDialog>
 #include <QMenu>
+#include <QMessageBox>
 #include <QKeyEvent>
 #include <QPointer>
 #include <QTimer>
@@ -104,6 +105,27 @@ void nestedDialogLifetime()
           returnedFromDialog && menuObserver.isNull() && dialogObserver.isNull());
 }
 
+void forwardedConstructorLifetime()
+{
+    auto parent = std::make_unique<QWidget>();
+    AetherSDR::ScopedChildWidget<QMessageBox> child(
+        QMessageBox::Information, QStringLiteral("Original title"),
+        QStringLiteral("Original text"), QMessageBox::Ok, parent.get());
+    // Compare with Qt's direct constructor: macOS may normalize message-box
+    // window titles even though the caller supplied an explicit title.
+    QMessageBox direct(QMessageBox::Information, QStringLiteral("Original title"),
+                       QStringLiteral("Original text"), QMessageBox::Ok);
+    check("forwarded constructor preserves dialog configuration",
+          child.get()->windowTitle() == direct.windowTitle()
+              && child.get()->text() == direct.text()
+              && child.get()->icon() == direct.icon()
+              && child.get()->standardButtons() == direct.standardButtons()
+              && child.get()->parentWidget() == parent.get());
+    QTimer::singleShot(0, child.get(), [&] { parent.reset(); });
+    child.get()->exec();
+    check("forwarded constructor retains guarded parent ownership", !child);
+}
+
 void selectedActionLifetime()
 {
     QWidget parent;
@@ -151,6 +173,7 @@ int main(int argc, char** argv)
     dialogLifetime(false, true);
     dialogLifetime(true, false);
     nestedDialogLifetime();
+    forwardedConstructorLifetime();
     selectedActionLifetime();
     actionLifetime();
     return failures ? 1 : 0;

--- a/tests/scoped_child_widget_test.cpp
+++ b/tests/scoped_child_widget_test.cpp
@@ -111,15 +111,22 @@ void forwardedConstructorLifetime()
     AetherSDR::ScopedChildWidget<QMessageBox> child(
         QMessageBox::Information, QStringLiteral("Original title"),
         QStringLiteral("Original text"), QMessageBox::Ok, parent.get());
-    // Compare with Qt's direct constructor: macOS may normalize message-box
-    // window titles even though the caller supplied an explicit title.
-    QMessageBox direct(QMessageBox::Information, QStringLiteral("Original title"),
-                       QStringLiteral("Original text"), QMessageBox::Ok);
+    // Compare with Qt's direct constructor under the SAME parent, so the check
+    // isolates argument forwarding rather than parentage: macOS may normalize
+    // message-box window titles even though the caller supplied an explicit
+    // one, and an unparented control would diverge for that reason instead.
+    // Heap-allocated deliberately — a stack QMessageBox parented here is the
+    // invalid free this header exists to prevent, and the parent is destroyed
+    // below.
+    auto* direct = new QMessageBox(QMessageBox::Information,
+                                   QStringLiteral("Original title"),
+                                   QStringLiteral("Original text"),
+                                   QMessageBox::Ok, parent.get());
     check("forwarded constructor preserves dialog configuration",
-          child.get()->windowTitle() == direct.windowTitle()
-              && child.get()->text() == direct.text()
-              && child.get()->icon() == direct.icon()
-              && child.get()->standardButtons() == direct.standardButtons()
+          child.get()->windowTitle() == direct->windowTitle()
+              && child.get()->text() == direct->text()
+              && child.get()->icon() == direct->icon()
+              && child.get()->standardButtons() == direct->standardButtons()
               && child.get()->parentWidget() == parent.get());
     QTimer::singleShot(0, child.get(), [&] { parent.reset(); });
     child.get()->exec();

--- a/tests/settings_browser_dialog_test.cpp
+++ b/tests/settings_browser_dialog_test.cpp
@@ -12,6 +12,7 @@
 #include "core/AppSettings.h"
 #include "core/SettingsDatabase.h"
 #include "core/SettingsPaths.h"
+#include "gui/FramelessMessageBox.h"
 #include "gui/SettingsBrowserDialog.h"
 
 #include <QApplication>
@@ -21,6 +22,7 @@
 #include <QMouseEvent>
 #include <QStyle>
 #include <QPlainTextEdit>
+#include <QPointer>
 #include <QPushButton>
 #include <QTableWidget>
 #include <QTest>
@@ -438,6 +440,179 @@ void testEditableRowShowsStoredBytes()
            "control: that row is the editable one (masked rows may diverge)");
 }
 
+void testAddKeyNestedDialogSurvivesPersistentParentClose()
+{
+    // Match MainWindow::showOrRaisePersistent(): the browser is a top-level
+    // persistent dialog that deletes itself on close, then opens Add Key.
+    QPointer<SettingsBrowserDialog> parent(new SettingsBrowserDialog);
+    parent->setAttribute(Qt::WA_DeleteOnClose);
+    parent->setFramelessMode(
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
+    parent->show();
+
+    QPushButton* add = nullptr;
+    for (QPushButton* button : parent->findChildren<QPushButton*>()) {
+        if (button->accessibleName() == QStringLiteral("Add settings key")) {
+            add = button;
+            break;
+        }
+    }
+    expect(add != nullptr, "the persistent browser exposes Add Key");
+    if (add == nullptr) {
+        parent->close();
+        settle();
+        return;
+    }
+
+    QPointer<QWidget> child;
+    bool closeIssued = false;
+    bool timedOut = false;
+    QTimer closeParent;
+    closeParent.setSingleShot(true);
+    QObject::connect(&closeParent, &QTimer::timeout, &closeParent, [&] {
+        QWidget* modal = QApplication::activeModalWidget();
+        if (modal == nullptr || !parent) {
+            return;
+        }
+        child = modal;
+        closeIssued = true;
+        parent->close();
+    });
+    QTimer watchdog;
+    watchdog.setSingleShot(true);
+    QObject::connect(&watchdog, &QTimer::timeout, &watchdog, [&] {
+        timedOut = true;
+        if (QWidget* modal = QApplication::activeModalWidget()) {
+            modal->close();
+        }
+        if (parent) {
+            parent->close();
+        }
+    });
+    closeParent.start(0);
+    watchdog.start(1500);
+    QTest::mouseClick(add, Qt::LeftButton);
+    watchdog.stop();
+    settle();
+
+    expect(!timedOut, "Add Key parent-close scenario returns before its watchdog");
+    expect(closeIssued, "Add Key was open when its persistent parent closed");
+    expect(parent.isNull() && child.isNull(),
+           "closing the WA_DeleteOnClose browser deletes both browser and Add Key child");
+}
+
+void testViewerNestedDialogSurvivesPersistentParentClose()
+{
+    QPointer<SettingsBrowserDialog> parent(new SettingsBrowserDialog);
+    parent->setAttribute(Qt::WA_DeleteOnClose);
+    parent->setFramelessMode(
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
+    parent->resize(900, 600);
+    parent->show();
+
+    QTreeWidget* tree = treeOf(*parent);
+    QTableWidget* table = tableOf(*parent);
+    if (tree == nullptr || table == nullptr
+        || !selectScope(tree, QStringLiteral("AA:BB:CC:DD:EE:01"))) {
+        expect(false, "persistent browser exposes the seeded viewer row");
+        parent->close();
+        settle();
+        return;
+    }
+    QApplication::processEvents();
+    const int row = rowForKey(table, QStringLiteral("CleanDoc"));
+    if (row < 0) {
+        expect(false, "persistent browser lists CleanDoc for viewer teardown");
+        parent->close();
+        settle();
+        return;
+    }
+
+    QPointer<QWidget> child;
+    bool closeIssued = false;
+    bool timedOut = false;
+    QTimer closeParent;
+    QObject::connect(&closeParent, &QTimer::timeout, &closeParent, [&] {
+        QWidget* modal = QApplication::activeModalWidget();
+        if (modal == nullptr || !parent) {
+            return;
+        }
+        child = modal;
+        closeIssued = true;
+        closeParent.stop();
+        parent->close();
+    });
+    QTimer watchdog;
+    watchdog.setSingleShot(true);
+    QObject::connect(&watchdog, &QTimer::timeout, &watchdog, [&] {
+        timedOut = true;
+        if (QWidget* modal = QApplication::activeModalWidget()) {
+            modal->close();
+        }
+        if (parent) {
+            parent->close();
+        }
+    });
+    closeParent.start(10);
+    watchdog.start(1500);
+    sendDoubleClick(table, row, 2);
+    for (int i = 0; i < 160 && !closeIssued && !timedOut; ++i) {
+        QTest::qWait(10);
+    }
+    closeParent.stop();
+    watchdog.stop();
+    settle();
+
+    expect(!timedOut, "viewer parent-close scenario returns before its watchdog");
+    expect(closeIssued, "document viewer was open when its persistent parent closed");
+    expect(parent.isNull() && child.isNull(),
+           "closing the WA_DeleteOnClose browser deletes both browser and viewer child");
+}
+
+void testStaticWarningSurvivesParentDeletion()
+{
+    QPointer<QWidget> parent(new QWidget);
+    parent->setAttribute(Qt::WA_DeleteOnClose);
+    parent->show();
+
+    QPointer<QWidget> warning;
+    bool closeIssued = false;
+    bool timedOut = false;
+    QTimer closeParent;
+    closeParent.setSingleShot(true);
+    QObject::connect(&closeParent, &QTimer::timeout, &closeParent, [&] {
+        QWidget* modal = QApplication::activeModalWidget();
+        if (modal == nullptr || !parent) {
+            return;
+        }
+        warning = modal;
+        closeIssued = true;
+        parent->close();
+    });
+    QTimer watchdog;
+    watchdog.setSingleShot(true);
+    QObject::connect(&watchdog, &QTimer::timeout, &watchdog, [&] {
+        timedOut = true;
+        if (QWidget* modal = QApplication::activeModalWidget()) {
+            modal->close();
+        }
+        if (parent) {
+            parent->close();
+        }
+    });
+    closeParent.start(0);
+    watchdog.start(1500);
+    FramelessMessageBox::warning(parent, QStringLiteral("Lifetime test"),
+                                 QStringLiteral("Parent will close during this modal warning."));
+    watchdog.stop();
+    settle();
+
+    expect(!timedOut, "static warning parent-close scenario returns before its watchdog");
+    expect(closeIssued, "static warning was open when its parent closed");
+    expect(parent.isNull() && warning.isNull(),
+           "closing the warning parent deletes both parent and static warning child");
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -480,6 +655,9 @@ int main(int argc, char** argv)
     testDoubleClickOpensOneViewer();
     testCorruptDocumentIsNotEditable();
     testArrayDocumentIsTreatedAsCorrupt();
+    testAddKeyNestedDialogSurvivesPersistentParentClose();
+    testViewerNestedDialogSurvivesPersistentParentClose();
+    testStaticWarningSurvivesParentDeletion();
 
     std::printf("\n%s\n", g_failures == 0 ? "PASS" : "FAIL");
     return g_failures == 0 ? 0 : 1;

--- a/tests/settings_browser_dialog_test.cpp
+++ b/tests/settings_browser_dialog_test.cpp
@@ -602,8 +602,14 @@ void testStaticWarningSurvivesParentDeletion()
     });
     closeParent.start(0);
     watchdog.start(1500);
-    FramelessMessageBox::warning(parent, QStringLiteral("Lifetime test"),
-                                 QStringLiteral("Parent will close during this modal warning."));
+    // Ask for a non-default button set with an explicit default, so a stale
+    // "the operator pressed Yes" cannot masquerade as the cancellation the
+    // callers rely on: SettingsBrowserDialog::addKey()/deleteSelected() only
+    // write to the store when this returns Yes.
+    const QMessageBox::StandardButton result = FramelessMessageBox::warning(
+        parent, QStringLiteral("Lifetime test"),
+        QStringLiteral("Parent will close during this modal warning."),
+        QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
     watchdog.stop();
     settle();
 
@@ -611,6 +617,8 @@ void testStaticWarningSurvivesParentDeletion()
     expect(closeIssued, "static warning was open when its parent closed");
     expect(parent.isNull() && warning.isNull(),
            "closing the warning parent deletes both parent and static warning child");
+    expect(result == QMessageBox::NoButton,
+           "a warning whose parent dies mid-loop reports cancellation, never a button");
 }
 
 } // namespace

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -4680,6 +4680,35 @@ add_test(NAME rx_applet_squelch_reconciliation_test
 set_tests_properties(rx_applet_squelch_reconciliation_test PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
+# Socket-free production-widget lifetime regression coverage (#5568).
+add_executable(gui_nested_lifetime_test
+    tests/gui_nested_lifetime_test.cpp
+    src/gui/RxApplet.cpp
+    src/gui/VfoWidget.cpp
+    src/gui/FrequencyEntryParser.cpp
+    src/gui/DragValuePopup.cpp
+    src/gui/FilterPassbandWidget.cpp
+    src/gui/SliceColorManager.cpp
+    src/gui/SliceLabel.cpp
+    src/gui/PhaseKnob.cpp
+    src/gui/SmartMtrWidget.cpp
+    src/gui/SmartMtrConfig.cpp
+    src/gui/MeterViewController.cpp
+    src/gui/AdaptiveFilterControls.cpp
+    src/gui/GuardedSlider.h
+    src/gui/NetSchedulerDialog.cpp
+    src/gui/PersistentDialog.cpp
+    src/gui/FramelessResizer.cpp
+    src/gui/FramelessWindowTitleBar.cpp
+)
+target_include_directories(gui_nested_lifetime_test PRIVATE src tests)
+target_link_libraries(gui_nested_lifetime_test PRIVATE
+    aethercore Qt6::Widgets Qt6::Test
+)
+add_test(NAME gui_nested_lifetime_test COMMAND gui_nested_lifetime_test)
+set_tests_properties(gui_nested_lifetime_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
 add_executable(tx_applet_power_reconciliation_test
     tests/tx_applet_power_reconciliation_test.cpp
     src/gui/TxApplet.cpp
@@ -4854,6 +4883,7 @@ set(AETHER_SETTINGS_CONSUMERS
     atu_seam_gate_test
     backend_slice_lifecycle_test
     client_display_settings_test
+    gui_nested_lifetime_test
     rx_applet_squelch_reconciliation_test
     rtl_slice_settings_test
     weather_radar_loading_test


### PR DESCRIPTION
Closing a delete-on-close utility window while one of its modal children is running can make QObject delete a stack-owned widget. After the nested loop returns, several callers also retain dead widgets, replaced table items, or a slice that has since been rebound.

This sweep reuses `ScopedChildWidget` where the audit found a reachable parent-deletion route, checks owner/model/child survival before continuing, and resolves mutable rows by identity. Settings Browser and Net Scheduler defer double-click modal opening until Qt's table event handler returns. The audit records the retained safe cases: ordinary applet containers are evicted intact before workspace removal, and MainWindow's outer-loop destructor is not a nested-loop deletion route. Confirmation defaults, modal behavior and settings ownership are preserved.

Fixes #5568. Follow-up to #5566 / #5567; this does not replace the earlier spectrum/VFO fix.

## Scope

- Delete-on-close utility dialogs, their derived dialogs and static message-box helpers; shared FramelessMessageBox and forwarded constructor support in ScopedChildWidget.
- RX antenna/custom-filter original-slice guards; CWX text snapshot; discovery-row relookup; diagnostics persistent indexes; theme-row relookup.
- Workspace-parented ATU clear confirmation and spectrum image picker.
- [Audited sites, ownership routes and intentional safe cases](https://github.com/rfoust/AetherSDR/blob/6f12a01cb635786cd12ed4db3d531f3f03857346/docs/gui-nested-loop-lifetime-audit.md).

The #5554 backend review was checked. This changes GUI lifetime handling, with no new backend family-specific behavior, wire commands, capabilities, or TX gate bypass.

## Validation

- Full macOS RelWithDebInfo build passed using the dedicated ARM64 toolchain, RADE enabled. Host/system processors and executable are ARM64; no RNNoise x86 sources appear in the build graph.
- **9/9 focused CTests passed:** settings_browser_dialog, scoped_child_widget_test, gui_nested_lifetime_test, rx_applet_squelch_reconciliation_test, tx_applet_power_reconciliation_test, theme_manager_test, theme_seed_test, midi_settings_test, atu_pretune_centers_test.
- **ASan:** production Settings Browser Add Key/viewer/shared warning parent-close cases pass. The original source with the same new tests fails with `AddressSanitizer: attempting free on address which was not malloc()-ed` in `QObjectPrivate::deleteChildren`.
- **ASan GUI suite: 8 passed.** Real RX controls exercise owner loss and live/rebound custom-filter acceptance. Net Scheduler tests close its parent during Add and actual table double-click Edit.
- **Mutation:** removing the custom-filter slice/button guard in a scratch source copy fails the rebound case (`replacementWrites.isEmpty()` is false — the unguarded `m_slice->setFilterWidth()` writes to the *rebound* slice, corrected from an earlier `originalWrites` reading during review); the paired live acceptance still passes.
- Touchpoint manifest, strict test registration, frozen CI gate, and diff-whitespace checks pass. New coverage is socket-free and registered in the regular suite; the per-PR CI allow-list is unchanged.

ASan instruments the tests and affected Settings Browser/FramelessMessageBox/RX/Net Scheduler sources, not all of Qt or the engine. The Linux-only missing-polkit notice is source-reviewed but not executed on this Mac.

## Agent automation bridge proof

A fresh settings profile, `AETHER_AUTOMATION_NO_TX=1`, and explicit `connect local serial DEMO-0001` were used for the final native run.

| Sequence | Observed result |
| --- | --- |
| Open Settings Browser → Add Key → close SettingsBrowserDialog | Parent and child absent from subsequent dumpTree; ping succeeds. |
| Open Net Scheduler → Add Net → close NetSchedulerDialog | Parent and child absent from subsequent dumpTree; ping succeeds. |
| Read radio, then close MainWindow | `serial=DEMO-0001`, `connected=true`, `transmitting=false`; the actual process subsequently exits **0**, and the app lock is released. |

The screenshots show the children immediately before their parents were closed. They document the exercised paths; they are not a visual redesign claim.

![Add Key before parent closure](https://raw.githubusercontent.com/rfoust/AetherSDR/fix-5568-assets/.pr-assets/5568-add-key.png)
![Add Net before parent closure](https://raw.githubusercontent.com/rfoust/AetherSDR/fix-5568-assets/.pr-assets/5568-add-net.png)

An initial agent bridge request mistakenly supplied `serial` as a separate JSON field. That unknown field was ignored, causing the default first discovered physical radio to be briefly connected. Its state was verified non-transmitting and it was disconnected; the final proof above was repeated from a new profile using the documented selector and only Demo. A bridge follow-up would reject unknown connection-selector fields instead of silently falling back to `first`. No TX was requested.

Generated with OpenAI Codex.

## Review follow-up (commit `7269e2ab`)

Addresses the review on this PR. Six further nested-loop sites in `RadioSetupDialog` are now guarded — reboot, firmware browse, firmware upload, recording directory, slice colour, forget-all SmartLink certs — and the audit doc records that dialog's full inventory. Three of them were the stack-allocated `showNewMessageBox` case this sweep exists to remove; `Cancel`/`No` defaults are preserved.

Also: the shared-warning test now asserts the `NoButton` cancellation contract (unpinned before — reverting it fails the test); the scoped-widget comparison control shares the parent and is heap-owned; `m_docViewerOpen` has a single owner; three dead `MidiMappingDialog` guards dropped; `WaveformsDialog` rebuilds its cached installer on a model swap.

Verified on Linux: nine focused CTests pass, and an offscreen `DEMO-0001` run closes the delete-on-close Settings Browser mid-Add-Key with no widget left behind, no bad free, and a clean process exit.
