### PR TITLE
Fix firmware upload byte accounting and unconfirmed outcomes

### DIFF
--- a/src/core/FirmwareUploader.cpp
+++ b/src/core/FirmwareUploader.cpp
@@ -1,189 +1,590 @@
 #include "FirmwareUploader.h"
+
 #include "LogManager.h"
 #include "../models/RadioModel.h"
-#include "../core/RadioConnection.h"
 
 #include <QFile>
 #include <QFileInfo>
-#include <QHostAddress>
+#include <QTcpSocket>
 #include <QTimer>
+
+#include <cmath>
+#include <limits>
 
 namespace AetherSDR {
 
 FirmwareUploader::FirmwareUploader(RadioModel* model, QObject* parent)
     : QObject(parent), m_model(model)
 {
-    connect(&m_socket, &QTcpSocket::connected, this, &FirmwareUploader::onConnected);
-    connect(&m_socket, &QTcpSocket::bytesWritten, this, &FirmwareUploader::onBytesWritten);
-    connect(&m_socket, &QTcpSocket::errorOccurred, this, [this] { onError(); });
+    if (m_model) {
+        connect(m_model, &RadioModel::connectionStateChanged,
+                this, &FirmwareUploader::handleConnectionStateChanged);
+    }
+    m_timeoutTimer.setSingleShot(true);
+    connect(&m_timeoutTimer, &QTimer::timeout, this, [this] {
+        onTimeout(m_timeoutGeneration, m_timeoutToken, m_timeoutMessage);
+    });
+    m_overallTimeoutTimer.setSingleShot(true);
+    connect(&m_overallTimeoutTimer, &QTimer::timeout, this, [this] {
+        onOverallTimeout(m_overallTimeoutGeneration, m_overallTimeoutToken);
+    });
 }
 
 void FirmwareUploader::upload(const QString& filePath)
 {
+    // Do not emit a terminal result for the operation which already owns this uploader.
     if (m_uploading) {
-        emit finished(false, "Upload already in progress");
+        return;
+    }
+    if (!m_model || !m_model->isConnected()) {
+        emit finished(false, tr("Connect to the radio before uploading firmware"));
         return;
     }
 
-    // Read the file
     QFile file(filePath);
     if (!file.open(QIODevice::ReadOnly)) {
-        emit finished(false, "Cannot open file: " + file.errorString());
+        emit finished(false, tr("Cannot open file: %1").arg(file.errorString()));
+        return;
+    }
+    if (file.size() > kMaxFileBytes) {
+        emit finished(false, tr("File too large (> 500MB)"));
+        return;
+    }
+    const QByteArray fileData = file.readAll();
+    if (file.error() != QFileDevice::NoError) {
+        emit finished(false, tr("Could not read firmware file: %1").arg(file.errorString()));
+        return;
+    }
+    if (fileData.isEmpty()) {
+        emit finished(false, tr("File is empty"));
+        return;
+    }
+    if (fileData.size() != file.size()) {
+        emit finished(false, tr("Firmware file changed while it was being read"));
         return;
     }
 
-    m_fileData = file.readAll();
-    file.close();
-
-    if (m_fileData.isEmpty()) {
-        emit finished(false, "File is empty");
+    if (!beginOperation(fileData, QFileInfo(filePath).fileName())) {
         return;
     }
-
-    // Sanity check size (< 500MB)
-    if (m_fileData.size() > 500 * 1024 * 1024) {
-        emit finished(false, "File too large (> 500MB)");
-        return;
+    const Generation generation = m_generation;
+    emit progressChanged(0, tr("Preparing upload..."));
+    if (isCurrent(generation)) {
+        requestUploadPort(generation);
     }
-
-    m_fileName = QFileInfo(filePath).fileName();
-    m_bytesSent = 0;
-    m_uploadPort = -1;
-    m_uploading = true;
-    m_cancelled = false;
-
-    emit progressChanged(0, "Preparing upload...");
-
-    // Step 1: Send filename to radio
-    m_model->sendCommand("file filename " + m_fileName);
-
-    // Step 2: Request upload — radio responds with port number
-    emit progressChanged(0, "Requesting upload port...");
-
-    m_model->sendCmdPublic(
-        QString("file upload %1 update").arg(m_fileData.size()),
-        [this](int code, const QString& body) {
-            onUploadPortReceived(code, body);
-        });
 }
 
 void FirmwareUploader::cancel()
 {
-    if (!m_uploading) return;
-    m_cancelled = true;
-    m_socket.abort();
-    m_uploading = false;
-    m_fileData.clear();
-    emit finished(false, "Upload cancelled");
+    if (!m_uploading) {
+        return;
+    }
+    finishOperation(m_generation, false, tr("Firmware upload cancelled"));
 }
 
-void FirmwareUploader::onUploadPortReceived(int code, const QString& body)
+bool FirmwareUploader::beginOperation(const QByteArray& fileData, const QString& fileName)
 {
-    if (m_cancelled) return;
+    // File-update status has no attempt identifier. A late failure from the
+    // previous upload must not be attributed to a retry on the same session.
+    if (m_requiresFreshConnection) {
+        emit finished(false, tr("Disconnect and reconnect to the radio before retrying firmware upload; "
+                               "the previous update outcome may still be pending"));
+        return false;
+    }
+    destroySocket();
+    disconnectStatusRelay();
+    m_timeoutTimer.stop();
+    m_overallTimeoutTimer.stop();
+    m_generation = nextGeneration();
+    m_timeoutToken = 0;
+    m_fileData = fileData;
+    m_fileName = fileName;
+    m_writer = {};
+    m_bytesQueued = 0;
+    m_bytesAcknowledged = 0;
+    m_pendingBytes = 0;
+    m_uploadPort = 0;
+    m_uploading = true;
+    m_waitingForConfirmation = false;
+    m_radioProgressSeen = false;
+    m_radioProgressPercent = 0;
+    armOverallTimeout(m_generation);
 
-    if (code != 0) {
-        m_uploading = false;
-        m_fileData.clear();
-        emit finished(false, QString("Radio rejected upload (error 0x%1)")
-                          .arg(code, 0, 16));
+    if (!m_model) {
+        return true;
+    }
+    const Generation generation = m_generation;
+    const QPointer<FirmwareUploader> self(this);
+    m_statusConnection = connect(
+        m_model, &RadioModel::statusReceived, this,
+        [self, generation](const QString& object, const QMap<QString, QString>& kvs) {
+            if (self) {
+                self->onRadioStatus(generation, object, kvs);
+            }
+        });
+    return true;
+}
+
+void FirmwareUploader::requestUploadPort(Generation generation)
+{
+    if (!isCurrent(generation)) {
+        return;
+    }
+    if (!m_model) {
+        finishOperation(generation, false, tr("Radio disconnected before upload started"));
         return;
     }
 
-    // Parse port number from response body
-    bool ok = false;
-    int port = body.trimmed().toInt(&ok);
-    if (!ok || port <= 0)
-        port = DEFAULT_PORT;
-
-    m_uploadPort = port;
-
-    qCDebug(lcFirmware) << "FirmwareUploader: connecting to upload port" << m_uploadPort;
-    emit progressChanged(0, QString("Connecting to port %1...").arg(m_uploadPort));
-
-    // Step 3: Connect TCP to the upload port
-    // Small delay to let the radio set up the server
-    QTimer::singleShot(200, this, [this] {
-        if (m_cancelled) return;
-        m_socket.connectToHost(m_model->radioAddress(), m_uploadPort);
-
-        // Timeout after 10 seconds
-        QTimer::singleShot(10000, this, [this] {
-            if (m_uploading && m_socket.state() != QAbstractSocket::ConnectedState) {
-                // Try fallback port
-                if (m_uploadPort != FALLBACK_PORT) {
-                    m_uploadPort = FALLBACK_PORT;
-                    qCDebug(lcFirmware) << "FirmwareUploader: trying fallback port" << FALLBACK_PORT;
-                    emit progressChanged(0, QString("Trying fallback port %1...").arg(FALLBACK_PORT));
-                    m_socket.abort();
-                    m_socket.connectToHost(m_model->radioAddress(), m_uploadPort);
-                } else {
-                    m_uploading = false;
-                    m_fileData.clear();
-                    emit finished(false, "Cannot connect to upload port");
-                }
+    emit progressChanged(0, tr("Requesting upload port..."));
+    if (!isCurrent(generation)) {
+        return;
+    }
+    armTimeout(generation,
+               kUploadPortTimeoutMs,
+               tr("Radio did not provide a firmware upload port"));
+    if (!isCurrent(generation)) {
+        return;
+    }
+    m_model->sendCommand(QStringLiteral("file filename ") + m_fileName);
+    if (!isCurrent(generation) || !m_model) {
+        return;
+    }
+    const QPointer<FirmwareUploader> self(this);
+    markUploadDispatched();
+    m_model->sendCmdPublic(
+        QStringLiteral("file upload %1 update").arg(m_fileData.size()),
+        [self, generation](int code, const QString& body) {
+            if (self) {
+                self->onUploadPortReceived(generation, code, body);
             }
         });
+}
+
+void FirmwareUploader::onUploadPortReceived(Generation generation,
+                                             int code,
+                                             const QString& body)
+{
+    if (!isCurrent(generation)) {
+        return;
+    }
+    if (code != 0) {
+        finishOperation(generation,
+                        false,
+                        tr("Radio rejected firmware upload (error 0x%1)").arg(code, 0, 16));
+        return;
+    }
+
+    bool parsed = false;
+    const uint port = body.trimmed().toUInt(&parsed);
+    const quint16 uploadPort = parsed && port > 0U && port <= 65535U
+        ? static_cast<quint16>(port)
+        : kDefaultPort;
+    emit progressChanged(0, tr("Connecting to port %1...").arg(uploadPort));
+    if (!isCurrent(generation)) {
+        return;
+    }
+
+    const QPointer<FirmwareUploader> self(this);
+    QTimer::singleShot(kConnectDelayMs, this, [self, generation, uploadPort] {
+        if (self && self->isCurrent(generation)) {
+            self->connectUploadSocket(generation, uploadPort);
+        }
     });
 }
 
-void FirmwareUploader::onConnected()
+void FirmwareUploader::connectUploadSocket(Generation generation, quint16 port)
 {
-    if (m_cancelled) return;
+    if (!isCurrent(generation)) {
+        return;
+    }
+    if (!m_model) {
+        finishOperation(generation, false, tr("Radio disconnected before upload started"));
+        return;
+    }
 
+    destroySocket();
+    m_uploadPort = port;
+    auto* socket = new QTcpSocket(this);
+    m_socket = socket;
+    const QPointer<FirmwareUploader> self(this);
+    connect(socket, &QTcpSocket::connected, this, [self, generation, socket] {
+        if (self) {
+            self->onConnected(generation, socket);
+        }
+    });
+    connect(socket, &QTcpSocket::bytesWritten, this,
+            [self, generation, socket](qint64 bytes) {
+                if (self) {
+                    self->onBytesWritten(generation, socket, bytes);
+                }
+            });
+    connect(socket, &QTcpSocket::disconnected, this, [self, generation, socket] {
+        if (self) {
+            self->onDisconnected(generation, socket);
+        }
+    });
+    connect(socket, &QTcpSocket::errorOccurred, this,
+            [self, generation, socket](QAbstractSocket::SocketError) {
+                if (self) {
+                    self->onError(generation, socket);
+                }
+            });
+
+    qCDebug(lcFirmware) << "FirmwareUploader: connecting to upload port" << port;
+    socket->connectToHost(m_model->radioAddress(), port);
+    armTimeout(generation, kConnectTimeoutMs, tr("Cannot connect to firmware upload port"));
+}
+
+void FirmwareUploader::tryFallbackPort(Generation generation)
+{
+    if (!isCurrent(generation)) {
+        return;
+    }
+    if (m_uploadPort == kFallbackPort) {
+        finishOperation(generation, false, tr("Cannot connect to firmware upload port"));
+        return;
+    }
+    emit progressChanged(0, tr("Trying fallback port %1...").arg(kFallbackPort));
+    if (!isCurrent(generation)) {
+        return;
+    }
+    connectUploadSocket(generation, kFallbackPort);
+}
+
+void FirmwareUploader::onConnected(Generation generation, QTcpSocket* socket)
+{
+    if (!isCurrent(generation) || socket != m_socket) {
+        return;
+    }
     qCDebug(lcFirmware) << "FirmwareUploader: connected, sending" << m_fileData.size() << "bytes";
-    emit progressChanged(0, "Uploading firmware...");
-
-    // Step 4: Send the file data in chunks
-    const qint64 toSend = qMin(static_cast<qint64>(CHUNK_SIZE),
-                                m_fileData.size() - m_bytesSent);
-    m_socket.write(m_fileData.constData() + m_bytesSent, toSend);
+    emit progressChanged(0, tr("Uploading firmware..."));
+    if (!isCurrent(generation)) {
+        return;
+    }
+    startSending(generation, [socket](const char* data, qint64 size) {
+        return socket->write(data, size);
+    });
 }
 
-void FirmwareUploader::onBytesWritten(qint64 bytes)
+void FirmwareUploader::startSending(Generation generation, WriteFunction writer)
 {
-    if (m_cancelled) return;
+    if (!isCurrent(generation) || !writer || m_waitingForConfirmation) {
+        return;
+    }
+    m_writer = std::move(writer);
+    armTimeout(generation, kUploadInactivityTimeoutMs, tr("Firmware upload timed out"));
+    queueNextChunk(generation);
+}
 
-    m_bytesSent += bytes;
-    const int percent = static_cast<int>(m_bytesSent * 100 / m_fileData.size());
-    emit progressChanged(percent, QString("Uploading... %1 / %2 KB")
-                             .arg(m_bytesSent / 1024)
-                             .arg(m_fileData.size() / 1024));
+void FirmwareUploader::queueNextChunk(Generation generation)
+{
+    if (!isCurrent(generation) || m_waitingForConfirmation || m_pendingBytes != 0) {
+        return;
+    }
+    const qint64 remaining = m_fileData.size() - m_bytesQueued;
+    if (remaining <= 0) {
+        return;
+    }
+    const qint64 requested = qMin(kChunkSize, remaining);
+    const WriteFunction writer = m_writer;
+    const qint64 accepted = writer(m_fileData.constData() + m_bytesQueued, requested);
+    if (!isCurrent(generation)) {
+        return;
+    }
+    if (accepted <= 0 || accepted > requested || accepted > remaining) {
+        finishOperation(generation, false, tr("Upload failed: socket accepted no data"));
+        return;
+    }
+    // Advance only by bytes accepted by write(), never by a partial drain from
+    // an earlier chunk. The next write therefore cannot duplicate source bytes.
+    m_bytesQueued += accepted;
+    m_pendingBytes = accepted;
+}
 
-    if (m_bytesSent >= m_fileData.size()) {
-        // Upload complete
-        qCDebug(lcFirmware) << "FirmwareUploader: upload complete";
-        m_socket.flush();
-        m_socket.disconnectFromHost();
-        m_uploading = false;
-        m_fileData.clear();
-        emit progressChanged(100, "Upload complete — radio is rebooting...");
-        emit finished(true, "Firmware uploaded successfully. The radio will reboot.");
+void FirmwareUploader::onBytesWritten(Generation generation,
+                                      QTcpSocket* socket,
+                                      qint64 bytes)
+{
+    if (!isCurrent(generation) || socket != m_socket) {
+        return;
+    }
+    acknowledgeBytes(generation, bytes);
+}
+
+void FirmwareUploader::acknowledgeBytes(Generation generation, qint64 bytes)
+{
+    if (!isCurrent(generation) || m_waitingForConfirmation) {
+        return;
+    }
+    if (bytes <= 0 || bytes > m_pendingBytes) {
+        finishOperation(generation, false, tr("Upload failed: invalid socket byte accounting"));
+        return;
+    }
+    m_pendingBytes -= bytes;
+    m_bytesAcknowledged += bytes;
+    if (!m_radioProgressSeen) {
+        const int percent = static_cast<int>((m_bytesAcknowledged * 100LL) / m_fileData.size());
+        emit progressChanged(percent,
+                             tr("Uploading... %1 / %2 KB")
+                                 .arg(m_bytesAcknowledged / 1024)
+                                 .arg(m_fileData.size() / 1024));
+        if (!isCurrent(generation)) {
+            return;
+        }
+    }
+    armTimeout(generation, kUploadInactivityTimeoutMs, tr("Firmware upload timed out"));
+
+    if (m_bytesAcknowledged == m_fileData.size()) {
+        if (m_bytesQueued != m_fileData.size() || m_pendingBytes != 0) {
+            finishOperation(generation, false, tr("Upload failed: invalid socket byte accounting"));
+            return;
+        }
+        qCDebug(lcFirmware) << "FirmwareUploader: firmware bytes drained";
+        m_waitingForConfirmation = true;
+        m_writer = {};
+        emit progressChanged(m_radioProgressSeen ? m_radioProgressPercent : 100,
+                             tr("Firmware bytes sent; waiting for radio confirmation..."));
+        if (!isCurrent(generation)) {
+            return;
+        }
+        // FlexLib closes the upload stream before its post-upload delay; do
+        // likewise instead of holding a completed upload socket open.
+        destroySocket(false);
+        armTimeout(generation,
+                   kConfirmationTimeoutMs,
+                   tr("Firmware bytes were sent, but the radio did not confirm installation"));
         return;
     }
 
-    // Send next chunk
-    const qint64 toSend = qMin(static_cast<qint64>(CHUNK_SIZE),
-                                m_fileData.size() - m_bytesSent);
-    m_socket.write(m_fileData.constData() + m_bytesSent, toSend);
+    if (m_pendingBytes == 0) {
+        queueNextChunk(generation);
+    }
 }
 
-void FirmwareUploader::onError()
+void FirmwareUploader::onDisconnected(Generation generation, QTcpSocket* socket)
 {
-    if (m_cancelled) return;
+    if (!isCurrent(generation) || socket != m_socket) {
+        return;
+    }
+    handleDisconnected(generation);
+}
 
-    // If we haven't sent anything and this is the first port attempt, try fallback
-    if (m_bytesSent == 0 && m_uploadPort != FALLBACK_PORT) {
-        m_uploadPort = FALLBACK_PORT;
-        qCDebug(lcFirmware) << "FirmwareUploader: error on primary port, trying" << FALLBACK_PORT;
-        emit progressChanged(0, QString("Retrying on port %1...").arg(FALLBACK_PORT));
-        m_socket.abort();
-        m_socket.connectToHost(m_model->radioAddress(), m_uploadPort);
+void FirmwareUploader::handleDisconnected(Generation generation)
+{
+    if (!isCurrent(generation) || m_waitingForConfirmation) {
+        return;
+    }
+    finishOperation(generation,
+                    false,
+                    tr("Radio closed the firmware upload connection before the transfer completed"));
+}
+
+void FirmwareUploader::onError(Generation generation, QTcpSocket* socket)
+{
+    if (!isCurrent(generation) || socket != m_socket || m_waitingForConfirmation) {
+        return;
+    }
+    if (m_bytesQueued == 0 && m_uploadPort != kFallbackPort) {
+        tryFallbackPort(generation);
+        return;
+    }
+    finishOperation(generation, false, tr("Upload failed: %1").arg(socket->errorString()));
+}
+
+void FirmwareUploader::onRadioStatus(Generation generation,
+                                      const QString& object,
+                                      const QMap<QString, QString>& kvs)
+{
+    if (!isCurrent(generation) || object != QStringLiteral("file update")) {
         return;
     }
 
-    m_uploading = false;
+    if (kvs.contains(QStringLiteral("failed"))) {
+        bool parsed = false;
+        const int failed = kvs.value(QStringLiteral("failed")).toInt(&parsed);
+        if (parsed && (failed == 0 || failed == 1) && failed == 1) {
+            const QString reason = kvs.value(QStringLiteral("reason")).trimmed();
+            finishOperation(generation,
+                            false,
+                            reason.isEmpty()
+                                ? tr("Radio reported that firmware installation failed")
+                                : tr("Radio reported that firmware installation failed: %1").arg(reason));
+            return;
+        }
+    }
+
+    bool parsed = false;
+    const double transfer = kvs.value(QStringLiteral("transfer")).toDouble(&parsed);
+    if (!parsed || !std::isfinite(transfer) || transfer < 0.0 || transfer > 1.0) {
+        return;
+    }
+    const int percent = static_cast<int>(transfer * 100.0);
+    m_radioProgressSeen = true;
+    m_radioProgressPercent = percent;
+    emit progressChanged(percent,
+                         m_waitingForConfirmation
+                             ? tr("Radio reported firmware transfer %1%; installation remains unconfirmed")
+                                   .arg(percent)
+                             : tr("Radio reports firmware transfer... %1%").arg(percent));
+    if (!isCurrent(generation)) {
+        return;
+    }
+    if (m_waitingForConfirmation) {
+        return;
+    }
+    armTimeout(generation,
+               kUploadInactivityTimeoutMs,
+               tr("Firmware upload timed out"));
+}
+
+void FirmwareUploader::markUploadDispatched()
+{
+    m_requiresFreshConnection = true;
+    m_disconnectObserved = false;
+}
+
+void FirmwareUploader::handleConnectionStateChanged(bool connected)
+{
+    if (!connected) {
+        m_disconnectObserved = true;
+        handleModelDisconnected(m_generation);
+    } else if (m_disconnectObserved) {
+        m_requiresFreshConnection = false;
+        m_disconnectObserved = false;
+    }
+}
+
+void FirmwareUploader::handleModelDisconnected(Generation generation)
+{
+    if (!isCurrent(generation)) {
+        return;
+    }
+    finishOperation(generation,
+                    false,
+                    m_waitingForConfirmation
+                        ? tr("Radio disconnected after the firmware bytes were sent; installation is unconfirmed")
+                        : tr("Radio disconnected before the firmware transfer completed"));
+}
+
+void FirmwareUploader::armTimeout(Generation generation, int timeoutMs, const QString& message)
+{
+    if (!isCurrent(generation)) {
+        return;
+    }
+    if (m_timeoutToken == std::numeric_limits<quint64>::max()) {
+        m_timeoutToken = 1;
+    } else {
+        ++m_timeoutToken;
+    }
+    m_timeoutGeneration = generation;
+    m_timeoutMessage = message;
+    m_timeoutTimer.start(timeoutMs);
+}
+
+void FirmwareUploader::onTimeout(Generation generation,
+                                  quint64 timeoutToken,
+                                  const QString& message)
+{
+    if (!isCurrent(generation) || timeoutToken != m_timeoutToken) {
+        return;
+    }
+    if (m_socket
+        && m_socket->state() != QAbstractSocket::ConnectedState
+        && m_bytesQueued == 0
+        && m_uploadPort != kFallbackPort) {
+        tryFallbackPort(generation);
+        return;
+    }
+    finishOperation(generation, false, message);
+}
+
+void FirmwareUploader::armOverallTimeout(Generation generation)
+{
+    if (!isCurrent(generation)) {
+        return;
+    }
+    if (m_overallTimeoutToken == std::numeric_limits<quint64>::max()) {
+        m_overallTimeoutToken = 1;
+    } else {
+        ++m_overallTimeoutToken;
+    }
+    m_overallTimeoutGeneration = generation;
+    m_overallTimeoutTimer.start(kOverallUploadTimeoutMs);
+}
+
+void FirmwareUploader::onOverallTimeout(Generation generation, quint64 timeoutToken)
+{
+    if (!isCurrent(generation) || timeoutToken != m_overallTimeoutToken) {
+        return;
+    }
+    finishOperation(generation,
+                    false,
+                    tr("Firmware upload exceeded the 10-minute operation limit"));
+}
+
+void FirmwareUploader::finishOperation(Generation generation,
+                                       bool success,
+                                       const QString& message)
+{
+    if (!isCurrent(generation)) {
+        return;
+    }
+    m_timeoutTimer.stop();
+    m_overallTimeoutTimer.stop();
+    destroySocket(!m_waitingForConfirmation);
+    disconnectStatusRelay();
+    m_writer = {};
     m_fileData.clear();
-    emit finished(false, "Upload failed: " + m_socket.errorString());
+    m_fileName.clear();
+    m_bytesQueued = 0;
+    m_bytesAcknowledged = 0;
+    m_pendingBytes = 0;
+    m_uploadPort = 0;
+    m_waitingForConfirmation = false;
+    m_radioProgressSeen = false;
+    m_radioProgressPercent = 0;
+    m_uploading = false;
+    m_generation = nextGeneration();
+    ++m_timeoutToken;
+    ++m_overallTimeoutToken;
+    emit finished(success, message);
+}
+
+void FirmwareUploader::destroySocket(bool abortConnection)
+{
+    if (!m_socket) {
+        return;
+    }
+    QTcpSocket* socket = m_socket;
+    m_socket = nullptr;
+    QObject::disconnect(socket, nullptr, this, nullptr);
+    if (abortConnection) {
+        socket->abort();
+    } else {
+        socket->disconnectFromHost();
+    }
+    socket->deleteLater();
+}
+
+void FirmwareUploader::disconnectStatusRelay()
+{
+    if (m_statusConnection) {
+        QObject::disconnect(m_statusConnection);
+        m_statusConnection = {};
+    }
+}
+
+bool FirmwareUploader::isCurrent(Generation generation) const
+{
+    return m_uploading && generation == m_generation;
+}
+
+FirmwareUploader::Generation FirmwareUploader::nextGeneration()
+{
+    if (m_generation == std::numeric_limits<Generation>::max()) {
+        return 1;
+    }
+    return m_generation + 1;
 }
 
 } // namespace AetherSDR

--- a/src/core/FirmwareUploader.cpp
+++ b/src/core/FirmwareUploader.cpp
@@ -37,30 +37,30 @@ void FirmwareUploader::upload(const QString& filePath)
         return;
     }
     if (!m_model || !m_model->isConnected()) {
-        emit finished(false, tr("Connect to the radio before uploading firmware"));
+        emit finished(Outcome::Failed, tr("Connect to the radio before uploading firmware"));
         return;
     }
 
     QFile file(filePath);
     if (!file.open(QIODevice::ReadOnly)) {
-        emit finished(false, tr("Cannot open file: %1").arg(file.errorString()));
+        emit finished(Outcome::Failed, tr("Cannot open file: %1").arg(file.errorString()));
         return;
     }
     if (file.size() > kMaxFileBytes) {
-        emit finished(false, tr("File too large (> 500MB)"));
+        emit finished(Outcome::Failed, tr("File too large (> 500MB)"));
         return;
     }
     const QByteArray fileData = file.readAll();
     if (file.error() != QFileDevice::NoError) {
-        emit finished(false, tr("Could not read firmware file: %1").arg(file.errorString()));
+        emit finished(Outcome::Failed, tr("Could not read firmware file: %1").arg(file.errorString()));
         return;
     }
     if (fileData.isEmpty()) {
-        emit finished(false, tr("File is empty"));
+        emit finished(Outcome::Failed, tr("File is empty"));
         return;
     }
     if (fileData.size() != file.size()) {
-        emit finished(false, tr("Firmware file changed while it was being read"));
+        emit finished(Outcome::Failed, tr("Firmware file changed while it was being read"));
         return;
     }
 
@@ -79,15 +79,15 @@ void FirmwareUploader::cancel()
     if (!m_uploading) {
         return;
     }
-    finishOperation(m_generation, false, tr("Firmware upload cancelled"));
+    finishOperation(m_generation, Outcome::Failed, tr("Firmware upload cancelled"));
 }
 
 bool FirmwareUploader::beginOperation(const QByteArray& fileData, const QString& fileName)
 {
     // File-update status has no attempt identifier. A late failure from the
     // previous upload must not be attributed to a retry on the same session.
-    if (m_requiresFreshConnection) {
-        emit finished(false, tr("Disconnect and reconnect to the radio before retrying firmware upload; "
+    if (retryBarrierActive()) {
+        emit finished(Outcome::Failed, tr("Disconnect and reconnect to the radio before retrying firmware upload; "
                                "the previous update outcome may still be pending"));
         return false;
     }
@@ -108,6 +108,8 @@ bool FirmwareUploader::beginOperation(const QByteArray& fileData, const QString&
     m_waitingForConfirmation = false;
     m_radioProgressSeen = false;
     m_radioProgressPercent = 0;
+    m_radioProgressAge.invalidate();
+    m_outcomeSettledByRadio = false;
     armOverallTimeout(m_generation);
 
     if (!m_model) {
@@ -131,7 +133,7 @@ void FirmwareUploader::requestUploadPort(Generation generation)
         return;
     }
     if (!m_model) {
-        finishOperation(generation, false, tr("Radio disconnected before upload started"));
+        finishOperation(generation, Outcome::Failed, tr("Radio disconnected before upload started"));
         return;
     }
 
@@ -149,8 +151,11 @@ void FirmwareUploader::requestUploadPort(Generation generation)
     if (!isCurrent(generation) || !m_model) {
         return;
     }
+    // The barrier is armed in onUploadPortReceived, once the radio has actually
+    // accepted the command and opened its file server. Arming it here would
+    // lock out a retry after a rejection that dispatched no firmware byte and
+    // can leave no `file update` status pending (#5572 review).
     const QPointer<FirmwareUploader> self(this);
-    markUploadDispatched();
     m_model->sendCmdPublic(
         QStringLiteral("file upload %1 update").arg(m_fileData.size()),
         [self, generation](int code, const QString& body) {
@@ -169,10 +174,15 @@ void FirmwareUploader::onUploadPortReceived(Generation generation,
     }
     if (code != 0) {
         finishOperation(generation,
-                        false,
+                        Outcome::Failed,
                         tr("Radio rejected firmware upload (error 0x%1)").arg(code, 0, 16));
         return;
     }
+
+    // The radio accepted the upload and is standing up its file server: from
+    // here a `file update` outcome may arrive for this attempt, so the retry
+    // barrier becomes real.
+    markUploadDispatched();
 
     bool parsed = false;
     const uint port = body.trimmed().toUInt(&parsed);
@@ -198,7 +208,7 @@ void FirmwareUploader::connectUploadSocket(Generation generation, quint16 port)
         return;
     }
     if (!m_model) {
-        finishOperation(generation, false, tr("Radio disconnected before upload started"));
+        finishOperation(generation, Outcome::Failed, tr("Radio disconnected before upload started"));
         return;
     }
 
@@ -241,7 +251,7 @@ void FirmwareUploader::tryFallbackPort(Generation generation)
         return;
     }
     if (m_uploadPort == kFallbackPort) {
-        finishOperation(generation, false, tr("Cannot connect to firmware upload port"));
+        finishOperation(generation, Outcome::Failed, tr("Cannot connect to firmware upload port"));
         return;
     }
     emit progressChanged(0, tr("Trying fallback port %1...").arg(kFallbackPort));
@@ -292,7 +302,7 @@ void FirmwareUploader::queueNextChunk(Generation generation)
         return;
     }
     if (accepted <= 0 || accepted > requested || accepted > remaining) {
-        finishOperation(generation, false, tr("Upload failed: socket accepted no data"));
+        finishOperation(generation, Outcome::Failed, tr("Upload failed: socket accepted no data"));
         return;
     }
     // Advance only by bytes accepted by write(), never by a partial drain from
@@ -317,12 +327,20 @@ void FirmwareUploader::acknowledgeBytes(Generation generation, qint64 bytes)
         return;
     }
     if (bytes <= 0 || bytes > m_pendingBytes) {
-        finishOperation(generation, false, tr("Upload failed: invalid socket byte accounting"));
+        finishOperation(generation, Outcome::Failed, tr("Upload failed: invalid socket byte accounting"));
         return;
     }
     m_pendingBytes -= bytes;
     m_bytesAcknowledged += bytes;
-    if (!m_radioProgressSeen) {
+    // Radio-reported transfer supersedes the local counter, but only while it
+    // is still arriving. Latching m_radioProgressSeen forever would freeze the
+    // bar at the last reported percentage if the status stream stalled while
+    // TCP kept draining — the inactivity timer is re-armed just below, so
+    // nothing else would notice (#5572 review).
+    const bool radioProgressFresh =
+        m_radioProgressSeen && m_radioProgressAge.isValid()
+        && m_radioProgressAge.elapsed() < m_radioProgressStaleMs;
+    if (!radioProgressFresh) {
         const int percent = static_cast<int>((m_bytesAcknowledged * 100LL) / m_fileData.size());
         emit progressChanged(percent,
                              tr("Uploading... %1 / %2 KB")
@@ -336,7 +354,7 @@ void FirmwareUploader::acknowledgeBytes(Generation generation, qint64 bytes)
 
     if (m_bytesAcknowledged == m_fileData.size()) {
         if (m_bytesQueued != m_fileData.size() || m_pendingBytes != 0) {
-            finishOperation(generation, false, tr("Upload failed: invalid socket byte accounting"));
+            finishOperation(generation, Outcome::Failed, tr("Upload failed: invalid socket byte accounting"));
             return;
         }
         qCDebug(lcFirmware) << "FirmwareUploader: firmware bytes drained";
@@ -352,7 +370,8 @@ void FirmwareUploader::acknowledgeBytes(Generation generation, qint64 bytes)
         destroySocket(false);
         armTimeout(generation,
                    kConfirmationTimeoutMs,
-                   tr("Firmware bytes were sent, but the radio did not confirm installation"));
+                   tr("Firmware bytes were sent, but the radio did not confirm installation. "
+                      "Reconnect to check the radio's firmware version."));
         return;
     }
 
@@ -375,7 +394,7 @@ void FirmwareUploader::handleDisconnected(Generation generation)
         return;
     }
     finishOperation(generation,
-                    false,
+                    Outcome::Failed,
                     tr("Radio closed the firmware upload connection before the transfer completed"));
 }
 
@@ -388,7 +407,7 @@ void FirmwareUploader::onError(Generation generation, QTcpSocket* socket)
         tryFallbackPort(generation);
         return;
     }
-    finishOperation(generation, false, tr("Upload failed: %1").arg(socket->errorString()));
+    finishOperation(generation, Outcome::Failed, tr("Upload failed: %1").arg(socket->errorString()));
 }
 
 void FirmwareUploader::onRadioStatus(Generation generation,
@@ -402,13 +421,26 @@ void FirmwareUploader::onRadioStatus(Generation generation,
     if (kvs.contains(QStringLiteral("failed"))) {
         bool parsed = false;
         const int failed = kvs.value(QStringLiteral("failed")).toInt(&parsed);
-        if (parsed && (failed == 0 || failed == 1) && failed == 1) {
+        if (parsed && failed == 1) {
+            m_outcomeSettledByRadio = true;
             const QString reason = kvs.value(QStringLiteral("reason")).trimmed();
             finishOperation(generation,
-                            false,
+                            Outcome::Failed,
                             reason.isEmpty()
                                 ? tr("Radio reported that firmware installation failed")
                                 : tr("Radio reported that firmware installation failed: %1").arg(reason));
+            return;
+        }
+        if (parsed && failed == 0) {
+            // The radio's own word that it accepted the image. FlexLib treats
+            // any parseable `failed` as terminal and drops the command channel
+            // on it ("close main command channel too since the radio will
+            // reboot", Radio.cs:12626-12630), so this — not a drained socket,
+            // not transfer=1.00 — is the one signal that confirms an install.
+            m_outcomeSettledByRadio = true;
+            finishOperation(generation,
+                            Outcome::Succeeded,
+                            tr("Radio accepted the firmware image and is rebooting"));
             return;
         }
     }
@@ -421,6 +453,7 @@ void FirmwareUploader::onRadioStatus(Generation generation,
     const int percent = static_cast<int>(transfer * 100.0);
     m_radioProgressSeen = true;
     m_radioProgressPercent = percent;
+    m_radioProgressAge.restart();
     emit progressChanged(percent,
                          m_waitingForConfirmation
                              ? tr("Radio reported firmware transfer %1%; installation remains unconfirmed")
@@ -441,6 +474,24 @@ void FirmwareUploader::markUploadDispatched()
 {
     m_requiresFreshConnection = true;
     m_disconnectObserved = false;
+    // This object is parented to RadioSetupDialog, which carries
+    // WA_DeleteOnClose: closing the window destroys the uploader and would take
+    // the barrier with it, so reopening would offer the ambiguous same-session
+    // retry the barrier exists to forbid. Record it on the model, which outlives
+    // the dialog and clears it only on a genuine reconnect (#5572 review).
+    if (m_model) {
+        m_model->blockFirmwareRetryUntilReconnect();
+    }
+}
+
+bool FirmwareUploader::retryBarrierActive() const
+{
+    // The model is authoritative whenever there is one; the local copy is the
+    // fallback for a model-less uploader (tests).
+    if (m_model) {
+        return m_model->firmwareRetryBlocked();
+    }
+    return m_requiresFreshConnection;
 }
 
 void FirmwareUploader::handleConnectionStateChanged(bool connected)
@@ -459,10 +510,15 @@ void FirmwareUploader::handleModelDisconnected(Generation generation)
     if (!isCurrent(generation)) {
         return;
     }
+    // A command-channel drop after the bytes landed is the signature of the
+    // radio rebooting to apply the image — but it is equally the signature of
+    // it falling over, so it confirms nothing either way. Report it as its own
+    // outcome instead of collapsing it into success or failure (#5572 review).
     finishOperation(generation,
-                    false,
+                    m_waitingForConfirmation ? Outcome::Unconfirmed : Outcome::Failed,
                     m_waitingForConfirmation
-                        ? tr("Radio disconnected after the firmware bytes were sent; installation is unconfirmed")
+                        ? tr("Radio disconnected after the firmware bytes were sent — it is most likely "
+                             "rebooting to apply the image. Reconnect to confirm the firmware version.")
                         : tr("Radio disconnected before the firmware transfer completed"));
 }
 
@@ -495,7 +551,11 @@ void FirmwareUploader::onTimeout(Generation generation,
         tryFallbackPort(generation);
         return;
     }
-    finishOperation(generation, false, message);
+    // Only the post-drain wait is ambiguous; every earlier timeout means the
+    // transfer demonstrably did not complete.
+    finishOperation(generation,
+                    m_waitingForConfirmation ? Outcome::Unconfirmed : Outcome::Failed,
+                    message);
 }
 
 void FirmwareUploader::armOverallTimeout(Generation generation)
@@ -509,7 +569,19 @@ void FirmwareUploader::armOverallTimeout(Generation generation)
         ++m_overallTimeoutToken;
     }
     m_overallTimeoutGeneration = generation;
-    m_overallTimeoutTimer.start(kOverallUploadTimeoutMs);
+    m_overallTimeoutTimer.start(overallTimeoutMsFor(m_fileData.size()));
+}
+
+int FirmwareUploader::overallTimeoutMsFor(qint64 fileBytes) const
+{
+    // Ten minutes is the floor, not the value: a 386 MB image (the #5572 case)
+    // needs ~644 KB/s to fit in ten minutes, which no SmartLink/WAN uplink owes
+    // us. Allow the image's size at a pessimistic floor rate, then cap it so a
+    // wedged transfer still cannot run forever.
+    const qint64 sizeAllowanceMs =
+        (fileBytes * 1000LL) / kMinExpectedBytesPerSec + kConfirmationTimeoutMs;
+    const qint64 budget = qMax<qint64>(kOverallUploadBaseMs, sizeAllowanceMs);
+    return static_cast<int>(qMin<qint64>(budget, kOverallUploadCeilingMs));
 }
 
 void FirmwareUploader::onOverallTimeout(Generation generation, quint64 timeoutToken)
@@ -518,12 +590,13 @@ void FirmwareUploader::onOverallTimeout(Generation generation, quint64 timeoutTo
         return;
     }
     finishOperation(generation,
-                    false,
-                    tr("Firmware upload exceeded the 10-minute operation limit"));
+                    m_waitingForConfirmation ? Outcome::Unconfirmed : Outcome::Failed,
+                    tr("Firmware upload exceeded its %1-minute operation limit")
+                        .arg(overallTimeoutMsFor(m_fileData.size()) / 60000));
 }
 
 void FirmwareUploader::finishOperation(Generation generation,
-                                       bool success,
+                                       Outcome outcome,
                                        const QString& message)
 {
     if (!isCurrent(generation)) {
@@ -543,11 +616,24 @@ void FirmwareUploader::finishOperation(Generation generation,
     m_waitingForConfirmation = false;
     m_radioProgressSeen = false;
     m_radioProgressPercent = 0;
+    m_radioProgressAge.invalidate();
     m_uploading = false;
     m_generation = nextGeneration();
     ++m_timeoutToken;
     ++m_overallTimeoutToken;
-    emit finished(success, message);
+    // Release the barrier only for an outcome the RADIO settled (`file update
+    // failed=`, either value): that leaves nothing pending to misattribute to a
+    // later attempt. Every other terminal — socket error, byte-accounting
+    // failure, cancel, any timeout — can still have dispatched bytes whose fate
+    // the radio never reported, which is precisely what the barrier is for.
+    if (m_outcomeSettledByRadio) {
+        m_requiresFreshConnection = false;
+        if (m_model) {
+            m_model->clearFirmwareRetryBlock();
+        }
+    }
+    m_outcomeSettledByRadio = false;
+    emit finished(outcome, message);
 }
 
 void FirmwareUploader::destroySocket(bool abortConnection)

--- a/src/core/FirmwareUploader.h
+++ b/src/core/FirmwareUploader.h
@@ -6,6 +6,7 @@
 #include <QObject>
 #include <QPointer>
 #include <QString>
+#include <QElapsedTimer>
 #include <QTimer>
 
 #include <functional>
@@ -33,9 +34,24 @@ public:
 
     bool isUploading() const { return m_uploading; }
 
+    // What a finished operation actually established. A drained local socket,
+    // `transfer=1.00`, and a command-channel disconnect are all consistent with
+    // a successful install and with a silent failure, so none of them may be
+    // reported as either (#5572). Only the radio's own `file update failed=`
+    // settles it: FlexLib's ParseUpdateStatus treats any parseable `failed`
+    // value as the terminal word on the update and tears down the command
+    // channel on it (reference/FlexLib_API_v4.1.5.39794/FlexLib/Radio.cs
+    // :12612-12631), so failed=0 is the radio saying "accepted, rebooting".
+    enum class Outcome {
+        Succeeded,    // the radio confirmed the image (failed=0)
+        Unconfirmed,  // bytes left the host; the radio never said either way
+        Failed,       // the radio rejected it, or the transfer did not complete
+    };
+    Q_ENUM(Outcome)
+
 signals:
     void progressChanged(int percent, const QString& status);
-    void finished(bool success, const QString& message);
+    void finished(Outcome outcome, const QString& message);
 
 private:
     friend class FirmwareUploaderTestAccess;
@@ -65,8 +81,10 @@ private:
     void armTimeout(Generation generation, int timeoutMs, const QString& message);
     void onTimeout(Generation generation, quint64 timeoutToken, const QString& message);
     void armOverallTimeout(Generation generation);
+    int overallTimeoutMsFor(qint64 fileBytes) const;
     void onOverallTimeout(Generation generation, quint64 timeoutToken);
-    void finishOperation(Generation generation, bool success, const QString& message);
+    void finishOperation(Generation generation, Outcome outcome, const QString& message);
+    bool retryBarrierActive() const;
     void destroySocket(bool abortConnection = true);
     void disconnectStatusRelay();
     bool isCurrent(Generation generation) const;
@@ -94,8 +112,13 @@ private:
     bool m_requiresFreshConnection{false};
     bool m_disconnectObserved{false};
     bool m_waitingForConfirmation{false};
+    bool m_outcomeSettledByRadio{false};
     bool m_radioProgressSeen{false};
     int m_radioProgressPercent{0};
+    QElapsedTimer m_radioProgressAge;
+    // Constant in production; the test lowers it so the stale branch is
+    // reachable without a five-second wall-clock wait.
+    qint64 m_radioProgressStaleMs{kRadioProgressStaleMs};
 
     static constexpr qint64 kChunkSize = 64LL * 1024LL;
     static constexpr qint64 kMaxFileBytes = 500LL * 1024LL * 1024LL;
@@ -106,7 +129,21 @@ private:
     static constexpr int kConnectTimeoutMs = 10000;
     static constexpr int kUploadInactivityTimeoutMs = 30000;
     static constexpr int kConfirmationTimeoutMs = 120000;
-    static constexpr int kOverallUploadTimeoutMs = 10 * 60 * 1000;
+    // Hard ceiling on one upload. Fixed at ten minutes this was not
+    // reachable-bandwidth-aware: #5572's own image is 386,282,416 bytes, which
+    // needs a sustained ~644 KB/s to finish inside it — fine on the reporter's
+    // LAN (~57 s), but a SmartLink/WAN update on a modest uplink would be
+    // killed mid-image and then refused a retry by the barrier above. The real
+    // stall guard is kUploadInactivityTimeoutMs; this only bounds a transfer
+    // that is progressing pathologically slowly, so size it off the image at a
+    // deliberately pessimistic floor rate and keep ten minutes as the minimum.
+    static constexpr int kOverallUploadBaseMs = 10 * 60 * 1000;
+    static constexpr qint64 kMinExpectedBytesPerSec = 64LL * 1024LL;
+    static constexpr int kOverallUploadCeilingMs = 2 * 60 * 60 * 1000;
+    // Radio `transfer=` supersedes the local byte counter, but only while it is
+    // actually arriving: if the status stream stalls while TCP keeps draining,
+    // fall back to local progress rather than freezing the bar (#5572 review).
+    static constexpr qint64 kRadioProgressStaleMs = 5000;
 };
 
 } // namespace AetherSDR

--- a/src/core/FirmwareUploader.h
+++ b/src/core/FirmwareUploader.h
@@ -1,30 +1,34 @@
 #pragma once
 
-#include <QObject>
-#include <QTcpSocket>
 #include <QByteArray>
+#include <QMap>
+#include <QMetaObject>
+#include <QObject>
+#include <QPointer>
+#include <QString>
+#include <QTimer>
+
+#include <functional>
+#include <utility>
+
+QT_BEGIN_NAMESPACE
+class QTcpSocket;
+QT_END_NAMESPACE
 
 namespace AetherSDR {
 
 class RadioModel;
+class FirmwareUploaderTestAccess;
 
-// Handles firmware file upload to the radio via TCP.
-//
-// Protocol:
-//   1. Send "file filename <name>" on command channel
-//   2. Send "file upload <size> update" — radio responds with TCP port
-//   3. Open TCP to radio IP:port, stream the file
-//   4. Radio validates, applies, reboots
-
+// Handles firmware file upload to a Flex radio via its file-upload TCP socket.
+// A fully drained local socket only proves the bytes left the local write
+// buffer. Radio receipt, firmware installation, and restart remain unconfirmed.
 class FirmwareUploader : public QObject {
     Q_OBJECT
 public:
     explicit FirmwareUploader(RadioModel* model, QObject* parent = nullptr);
 
-    // Start the upload process for the given .ssdr file
     void upload(const QString& filePath);
-
-    // Cancel an in-progress upload
     void cancel();
 
     bool isUploading() const { return m_uploading; }
@@ -34,23 +38,75 @@ signals:
     void finished(bool success, const QString& message);
 
 private:
-    void onUploadPortReceived(int code, const QString& body);
-    void onConnected();
-    void onBytesWritten(qint64 bytes);
-    void onError();
+    friend class FirmwareUploaderTestAccess;
 
-    RadioModel*  m_model{nullptr};
-    QTcpSocket   m_socket;
-    QByteArray   m_fileData;
-    QString      m_fileName;
-    qint64       m_bytesSent{0};
-    int          m_uploadPort{-1};
-    bool         m_uploading{false};
-    bool         m_cancelled{false};
+    using Generation = quint64;
+    using WriteFunction = std::function<qint64(const char*, qint64)>;
 
-    static constexpr int CHUNK_SIZE = 65536;  // 64KB chunks
-    static constexpr int DEFAULT_PORT = 4995;
-    static constexpr int FALLBACK_PORT = 42607;
+    bool beginOperation(const QByteArray& fileData, const QString& fileName);
+    void requestUploadPort(Generation generation);
+    void onUploadPortReceived(Generation generation, int code, const QString& body);
+    void connectUploadSocket(Generation generation, quint16 port);
+    void tryFallbackPort(Generation generation);
+    void onConnected(Generation generation, QTcpSocket* socket);
+    void startSending(Generation generation, WriteFunction writer);
+    void queueNextChunk(Generation generation);
+    void onBytesWritten(Generation generation, QTcpSocket* socket, qint64 bytes);
+    void acknowledgeBytes(Generation generation, qint64 bytes);
+    void onDisconnected(Generation generation, QTcpSocket* socket);
+    void handleDisconnected(Generation generation);
+    void onError(Generation generation, QTcpSocket* socket);
+    void onRadioStatus(Generation generation,
+                       const QString& object,
+                       const QMap<QString, QString>& kvs);
+    void handleModelDisconnected(Generation generation);
+    void handleConnectionStateChanged(bool connected);
+    void markUploadDispatched();
+    void armTimeout(Generation generation, int timeoutMs, const QString& message);
+    void onTimeout(Generation generation, quint64 timeoutToken, const QString& message);
+    void armOverallTimeout(Generation generation);
+    void onOverallTimeout(Generation generation, quint64 timeoutToken);
+    void finishOperation(Generation generation, bool success, const QString& message);
+    void destroySocket(bool abortConnection = true);
+    void disconnectStatusRelay();
+    bool isCurrent(Generation generation) const;
+    Generation nextGeneration();
+
+    QPointer<RadioModel> m_model;
+    QPointer<QTcpSocket> m_socket;
+    QByteArray m_fileData;
+    QString m_fileName;
+    WriteFunction m_writer;
+    QMetaObject::Connection m_statusConnection;
+    QTimer m_timeoutTimer;
+    QTimer m_overallTimeoutTimer;
+    QString m_timeoutMessage;
+    qint64 m_bytesQueued{0};
+    qint64 m_bytesAcknowledged{0};
+    qint64 m_pendingBytes{0};
+    quint16 m_uploadPort{0};
+    Generation m_generation{0};
+    Generation m_timeoutGeneration{0};
+    Generation m_overallTimeoutGeneration{0};
+    quint64 m_timeoutToken{0};
+    quint64 m_overallTimeoutToken{0};
+    bool m_uploading{false};
+    bool m_requiresFreshConnection{false};
+    bool m_disconnectObserved{false};
+    bool m_waitingForConfirmation{false};
+    bool m_radioProgressSeen{false};
+    int m_radioProgressPercent{0};
+
+    static constexpr qint64 kChunkSize = 64LL * 1024LL;
+    static constexpr qint64 kMaxFileBytes = 500LL * 1024LL * 1024LL;
+    static constexpr quint16 kDefaultPort = 4995;
+    static constexpr quint16 kFallbackPort = 42607;
+    static constexpr int kConnectDelayMs = 200;
+    static constexpr int kUploadPortTimeoutMs = 10000;
+    static constexpr int kConnectTimeoutMs = 10000;
+    static constexpr int kUploadInactivityTimeoutMs = 30000;
+    static constexpr int kConfirmationTimeoutMs = 120000;
+    static constexpr int kOverallUploadTimeoutMs = 10 * 60 * 1000;
 };
 
 } // namespace AetherSDR

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -1684,11 +1684,13 @@ QWidget* RadioSetupDialog::buildRadioTab()
                         // colour — colour alone never states it (docs/a11y.md).
                         m_fwStatusLabel->setText(msg);
                         m_fwStatusLabel->setAccessibleDescription(msg);
+                        // One setStyleSheet site for all three outcomes: the
+                        // colour ratchet counts call sites, not just literals.
+                        QString colour;
                         switch (outcome) {
                         case FirmwareUploader::Outcome::Succeeded:
                             m_fwProgress->setValue(100);
-                            m_fwStatusLabel->setStyleSheet(
-                                "QLabel { color: #80e080; font-size: 10px; }");
+                            colour = QStringLiteral("#80e080");
                             m_fwUploadBtn->setEnabled(false);
                             break;
                         case FirmwareUploader::Outcome::Unconfirmed:
@@ -1697,24 +1699,29 @@ QWidget* RadioSetupDialog::buildRadioTab()
                             // reads as "nothing happened" — and do not offer a
                             // retry: the uploader refuses one until reconnect.
                             m_fwProgress->setValue(100);
-                            m_fwStatusLabel->setStyleSheet(
-                                "QLabel { color: #e0c080; font-size: 10px; }");
+                            colour = QStringLiteral("{{color.accent.warning}}");
                             m_fwUploadBtn->setEnabled(false);
                             break;
                         case FirmwareUploader::Outcome::Failed:
                             m_fwProgress->hide();
-                            m_fwStatusLabel->setStyleSheet(
-                                "QLabel { color: #e08080; font-size: 10px; }");
+                            colour = QStringLiteral("#e08080");
                             m_fwUploadBtn->setEnabled(true);
                             break;
                         }
+                        // applyStyleSheet, not setStyleSheet: the latter does
+                        // not expand {{tokens}} (ThemeManager.h:174), and it
+                        // keeps the label repainting on themeChanged.
+                        AetherSDR::ThemeManager::instance().applyStyleSheet(
+                            m_fwStatusLabel,
+                            QStringLiteral("QLabel { color: %1; font-size: 10px; }").arg(colour));
                     });
             }
 
             m_fwProgress->show();
             m_fwProgress->setValue(0);
             m_fwUploadBtn->setEnabled(false);
-            m_fwStatusLabel->setStyleSheet("QLabel { color: #6888a0; font-size: 10px; }");
+            AetherSDR::ThemeManager::instance().applyStyleSheet(
+                m_fwStatusLabel, QStringLiteral("QLabel { color: #6888a0; font-size: 10px; }"));
 
             m_uploader->upload(m_fwFilePath);
         });

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -1663,31 +1663,58 @@ QWidget* RadioSetupDialog::buildRadioTab()
                 QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Cancel);
             if (reply != QMessageBox::Ok) return;
 
-            if (!m_uploader)
+            // Wire the uploader once, at creation. These used to be connected
+            // inside this clicked handler, so every click added another copy.
+            if (!m_uploader) {
                 m_uploader = new FirmwareUploader(m_model, this);
+
+                connect(m_uploader, &FirmwareUploader::progressChanged, this,
+                    [this](int pct, const QString& status) {
+                        m_fwProgress->setValue(pct);
+                        m_fwStatusLabel->setText(status);
+                        m_fwStatusLabel->setAccessibleDescription(status);
+                    });
+                connect(m_uploader, &FirmwareUploader::finished, this,
+                    [this](FirmwareUploader::Outcome outcome, const QString& msg) {
+                        // Three outcomes, not two. A drained socket or a
+                        // post-upload disconnect confirms nothing either way, so
+                        // it must not be painted as either (#5572): only the
+                        // radio's own `file update failed=` settles it. The
+                        // message carries the distinction in words as well as in
+                        // colour — colour alone never states it (docs/a11y.md).
+                        m_fwStatusLabel->setText(msg);
+                        m_fwStatusLabel->setAccessibleDescription(msg);
+                        switch (outcome) {
+                        case FirmwareUploader::Outcome::Succeeded:
+                            m_fwProgress->setValue(100);
+                            m_fwStatusLabel->setStyleSheet(
+                                "QLabel { color: #80e080; font-size: 10px; }");
+                            m_fwUploadBtn->setEnabled(false);
+                            break;
+                        case FirmwareUploader::Outcome::Unconfirmed:
+                            // Bytes left the host and the radio is probably
+                            // applying them. Keep the progress bar — hiding it
+                            // reads as "nothing happened" — and do not offer a
+                            // retry: the uploader refuses one until reconnect.
+                            m_fwProgress->setValue(100);
+                            m_fwStatusLabel->setStyleSheet(
+                                "QLabel { color: #e0c080; font-size: 10px; }");
+                            m_fwUploadBtn->setEnabled(false);
+                            break;
+                        case FirmwareUploader::Outcome::Failed:
+                            m_fwProgress->hide();
+                            m_fwStatusLabel->setStyleSheet(
+                                "QLabel { color: #e08080; font-size: 10px; }");
+                            m_fwUploadBtn->setEnabled(true);
+                            break;
+                        }
+                    });
+            }
 
             m_fwProgress->show();
             m_fwProgress->setValue(0);
             m_fwUploadBtn->setEnabled(false);
             m_fwStatusLabel->setStyleSheet("QLabel { color: #6888a0; font-size: 10px; }");
-
-            connect(m_uploader, &FirmwareUploader::progressChanged, this,
-                [this](int pct, const QString& status) {
-                    m_fwProgress->setValue(pct);
-                    m_fwStatusLabel->setText(status);
-                });
-            connect(m_uploader, &FirmwareUploader::finished, this,
-                [this](bool ok, const QString& msg) {
-                    m_fwStatusLabel->setText(msg);
-                    m_fwUploadBtn->setEnabled(!ok);
-                    if (ok) {
-                        m_fwProgress->setValue(100);
-                        m_fwStatusLabel->setStyleSheet("QLabel { color: #80e080; font-size: 10px; }");
-                    } else {
-                        m_fwProgress->hide();
-                        m_fwStatusLabel->setStyleSheet("QLabel { color: #e08080; font-size: 10px; }");
-                    }
-                });
 
             m_uploader->upload(m_fwFilePath);
         });

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -6416,6 +6416,11 @@ void RadioModel::onConnected()
     if (AppSettings::instance().value("InhibitSleepWhileConnected", "False").toString() == "True")
         m_sleepInhibitor.acquire("AetherSDR connected to radio");
 
+    // A fresh command session is the one thing that makes a firmware retry
+    // unambiguous again: any `file update` status arriving now belongs to this
+    // connection, not to an attempt dispatched before the radio rebooted (#5572).
+    m_firmwareRetryBlocked = false;
+
     emit connectionStateChanged(true);
     // A Flex dumps its memory slots as status during the handshake below. A
     // radio without any has nothing to dump, so the bank is what populates the

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -166,6 +166,21 @@ public:
     // stays the unadorned token that rigctl and the bridge serve.
     QString versionLabel() const { return m_versionLabel; }
     bool isConnected() const;
+
+    // Firmware-upload retry barrier (#5572). A dispatched firmware upload has
+    // no attempt identifier in the `file update` status, so a late failure from
+    // a previous attempt cannot be told apart from a fresh one on the same
+    // command session. The barrier therefore has to outlive the uploader, and
+    // the uploader is parented to RadioSetupDialog — which carries
+    // WA_DeleteOnClose, so closing the window would otherwise drop the barrier
+    // and hand the operator exactly the ambiguous retry it exists to forbid.
+    // It lives here because the connection is what it is really keyed to: only
+    // a genuine disconnect→reconnect clears it (see setConnected()).
+    bool firmwareRetryBlocked() const { return m_firmwareRetryBlocked; }
+    void blockFirmwareRetryUntilReconnect() { m_firmwareRetryBlocked = true; }
+    // Only for an outcome the radio itself settled (`file update failed=`),
+    // which leaves nothing pending to misattribute to the next attempt.
+    void clearFirmwareRetryBlock() { m_firmwareRetryBlocked = false; }
     // "idle" / "connecting" / "connected" — the bridge's third value, so a
     // caller can tell a connect that is working from one that is not happening
     // at all. `isConnected()` is unchanged (#5413 item 3). Derived from
@@ -1912,6 +1927,10 @@ private:
     QHash<QString, int> m_panTransmitInhibitedTxSlices;
     int  m_tuneInhibitBandId{-1};  // band ID whose TX outputs were inhibited during tune
     bool m_tuneInhibitActive{false};
+    // #5572 firmware-upload retry barrier. Set when an upload is dispatched to
+    // the radio; cleared only when a NEW connection is established, so it
+    // survives the Radio Setup dialog (and its uploader) being closed.
+    bool m_firmwareRetryBlocked{false};
 
     int bandIdForFrequency(double freqMhz) const;  // map TX freq → band ID
     void applyTuneInhibit();    // suppress selected TX outputs before tune

--- a/tests/firmware_uploader_test.cpp
+++ b/tests/firmware_uploader_test.cpp
@@ -1,0 +1,433 @@
+#include "core/FirmwareUploader.h"
+
+#include <QCoreApplication>
+#include <QVector>
+
+#include <algorithm>
+#include <cstdio>
+
+namespace AetherSDR {
+
+// The seam injects only write acceptance and callback delivery. It creates no
+// socket, server, RadioModel, or radio connection; production queue and status
+// handlers are exercised unchanged.
+class FirmwareUploaderTestAccess {
+public:
+    static bool beginAllowed(FirmwareUploader& uploader, const QByteArray& data)
+    {
+        return uploader.beginOperation(data, QStringLiteral("test.ssdr"));
+    }
+    static void dispatched(FirmwareUploader& uploader) { uploader.markUploadDispatched(); }
+    static void connectionChanged(FirmwareUploader& uploader, bool connected)
+    {
+        uploader.handleConnectionStateChanged(connected);
+    }
+    static FirmwareUploader::Generation begin(FirmwareUploader& uploader,
+                                              const QByteArray& data)
+    {
+        uploader.beginOperation(data, QStringLiteral("test.ssdr"));
+        return uploader.m_generation;
+    }
+
+    static FirmwareUploader::Generation start(FirmwareUploader& uploader,
+                                              const QByteArray& data,
+                                              FirmwareUploader::WriteFunction writer)
+    {
+        const FirmwareUploader::Generation generation = begin(uploader, data);
+        uploader.startSending(generation, std::move(writer));
+        return generation;
+    }
+
+    static void acknowledge(FirmwareUploader& uploader,
+                            FirmwareUploader::Generation generation,
+                            qint64 bytes)
+    {
+        uploader.acknowledgeBytes(generation, bytes);
+    }
+
+    static void disconnected(FirmwareUploader& uploader,
+                             FirmwareUploader::Generation generation)
+    {
+        uploader.handleDisconnected(generation);
+    }
+
+    static void modelDisconnected(FirmwareUploader& uploader,
+                                  FirmwareUploader::Generation generation)
+    {
+        uploader.handleModelDisconnected(generation);
+    }
+
+    static void status(FirmwareUploader& uploader,
+                       FirmwareUploader::Generation generation,
+                       const QString& object,
+                       const QMap<QString, QString>& kvs)
+    {
+        uploader.onRadioStatus(generation, object, kvs);
+    }
+
+    static void reject(FirmwareUploader& uploader,
+                       FirmwareUploader::Generation generation,
+                       int code)
+    {
+        uploader.onUploadPortReceived(generation, code, {});
+    }
+
+    static void expire(FirmwareUploader& uploader,
+                       FirmwareUploader::Generation generation,
+                       quint64 timeoutToken,
+                       const QString& message)
+    {
+        uploader.onTimeout(generation, timeoutToken, message);
+    }
+
+    static void expireOverall(FirmwareUploader& uploader,
+                              FirmwareUploader::Generation generation,
+                              quint64 timeoutToken)
+    {
+        uploader.onOverallTimeout(generation, timeoutToken);
+    }
+
+    static qint64 pending(const FirmwareUploader& uploader) { return uploader.m_pendingBytes; }
+    static bool waiting(const FirmwareUploader& uploader) { return uploader.m_waitingForConfirmation; }
+    static quint64 timeoutToken(const FirmwareUploader& uploader) { return uploader.m_timeoutToken; }
+    static quint64 overallTimeoutToken(const FirmwareUploader& uploader)
+    {
+        return uploader.m_overallTimeoutToken;
+    }
+};
+
+} // namespace AetherSDR
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* message)
+{
+    if (!condition) {
+        std::fprintf(stderr, "FAIL: %s\n", message);
+        ++g_failures;
+    }
+}
+
+QByteArray nonPeriodicBytes(qsizetype size)
+{
+    QByteArray data;
+    data.resize(size);
+    quint32 state = 0xC0FFEE11U;
+    for (qsizetype i = 0; i < size; ++i) {
+        state = state * 1664525U + 1013904223U;
+        data[i] = static_cast<char>((state >> 24U) & 0xffU);
+    }
+    return data;
+}
+
+struct FinishedEvent {
+    bool success;
+    QString message;
+};
+
+void checkRetryRequiresFreshConnection()
+{
+    AetherSDR::FirmwareUploader uploader(nullptr);
+    QVector<FinishedEvent> finished;
+    QObject::connect(&uploader, &AetherSDR::FirmwareUploader::finished,
+                     [&finished](bool success, const QString& message) {
+                         finished.append({success, message});
+                     });
+    const QByteArray data = nonPeriodicBytes(8);
+    const auto first = AetherSDR::FirmwareUploaderTestAccess::begin(uploader, data);
+    AetherSDR::FirmwareUploaderTestAccess::dispatched(uploader);
+    uploader.cancel();
+    check(!AetherSDR::FirmwareUploaderTestAccess::beginAllowed(uploader, data)
+              && !uploader.isUploading()
+              && finished.back().message.contains(QStringLiteral("reconnect")),
+          "a dispatched upload cannot be retried on the same command session");
+    AetherSDR::FirmwareUploaderTestAccess::status(
+        uploader, first, QStringLiteral("file update"), {{QStringLiteral("failed"), QStringLiteral("1")}});
+    AetherSDR::FirmwareUploaderTestAccess::connectionChanged(uploader, true);
+    check(!AetherSDR::FirmwareUploaderTestAccess::beginAllowed(uploader, data),
+          "a same-session connected notification cannot bypass the retry barrier");
+    AetherSDR::FirmwareUploaderTestAccess::connectionChanged(uploader, false);
+    check(!AetherSDR::FirmwareUploaderTestAccess::beginAllowed(uploader, data),
+          "disconnect alone cannot permit retry before reconnection");
+    AetherSDR::FirmwareUploaderTestAccess::connectionChanged(uploader, true);
+    check(AetherSDR::FirmwareUploaderTestAccess::beginAllowed(uploader, data),
+          "a fresh connection permits an explicitly requested new upload");
+    AetherSDR::FirmwareUploaderTestAccess::dispatched(uploader);
+    const qsizetype count = finished.size();
+    AetherSDR::FirmwareUploaderTestAccess::connectionChanged(uploader, false);
+    AetherSDR::FirmwareUploaderTestAccess::connectionChanged(uploader, false);
+    check(!uploader.isUploading() && finished.size() == count + 1,
+          "command disconnection terminates an active attempt once");
+    check(!AetherSDR::FirmwareUploaderTestAccess::beginAllowed(uploader, data),
+          "terminal cleanup does not erase the fresh-connection requirement");
+}
+
+void checkByteIdentityAndPostDrainState()
+{
+    AetherSDR::FirmwareUploader uploader(nullptr);
+    QVector<FinishedEvent> finished;
+    int lastProgress = -1;
+    QObject::connect(&uploader, &AetherSDR::FirmwareUploader::finished,
+                     [&finished](bool success, const QString& message) {
+                         finished.append({success, message});
+                     });
+    QObject::connect(&uploader, &AetherSDR::FirmwareUploader::progressChanged,
+                     [&lastProgress](int percent, const QString&) { lastProgress = percent; });
+
+    const QByteArray source = nonPeriodicBytes(2 * 65536 + 913);
+    QByteArray written;
+    QVector<qint64> acceptedSizes{32769, 7, 4099, 31, 65535, 2, 8191};
+    qsizetype writeIndex = 0;
+    const auto writer = [&written, &acceptedSizes, &writeIndex](const char* data, qint64 requested) {
+        const qint64 accepted = qMin(requested, acceptedSizes.at(writeIndex % acceptedSizes.size()));
+        ++writeIndex;
+        written.append(data, accepted);
+        return accepted;
+    };
+    const auto generation = AetherSDR::FirmwareUploaderTestAccess::start(
+        uploader, source, writer);
+    AetherSDR::FirmwareUploaderTestAccess::status(
+        uploader, generation, QStringLiteral("file update"), {{QStringLiteral("transfer"), QStringLiteral("0.50")}});
+
+    const qint64 firstPending = AetherSDR::FirmwareUploaderTestAccess::pending(uploader);
+    const qsizetype writesBeforePartialDrain = writeIndex;
+    AetherSDR::FirmwareUploaderTestAccess::acknowledge(uploader, generation, 1024);
+    check(writeIndex == writesBeforePartialDrain,
+          "a partial bytesWritten drain does not queue a duplicate chunk");
+    check(AetherSDR::FirmwareUploaderTestAccess::pending(uploader) == firstPending - 1024,
+          "partial drain retains the accepted remainder as the only in-flight chunk");
+
+    while (uploader.isUploading() && !AetherSDR::FirmwareUploaderTestAccess::waiting(uploader)) {
+        const qint64 pending = AetherSDR::FirmwareUploaderTestAccess::pending(uploader);
+        check(pending > 0, "each active transfer phase has one accepted chunk to drain");
+        if (pending <= 0) {
+            break;
+        }
+        AetherSDR::FirmwareUploaderTestAccess::acknowledge(uploader, generation, pending);
+    }
+
+    check(written == source,
+          "partial drains and short write acceptance preserve exact nonperiodic firmware bytes once");
+    check(uploader.isUploading() && AetherSDR::FirmwareUploaderTestAccess::waiting(uploader),
+          "draining every local byte enters radio-confirmation wait");
+    check(lastProgress == 50,
+          "local byte drain preserves the last radio-reported transfer percentage");
+    check(finished.isEmpty(),
+          "a drained upload socket never claims firmware installation success");
+}
+
+void checkUploadTimeoutAndModelDisconnect()
+{
+    AetherSDR::FirmwareUploader uploader(nullptr);
+    QVector<FinishedEvent> finished;
+    QObject::connect(&uploader, &AetherSDR::FirmwareUploader::finished,
+                     [&finished](bool success, const QString& message) {
+                         finished.append({success, message});
+                     });
+
+    const auto timedOutGeneration = AetherSDR::FirmwareUploaderTestAccess::start(
+        uploader, nonPeriodicBytes(8), [](const char*, qint64 requested) { return requested; });
+    const quint64 uploadTimeout = AetherSDR::FirmwareUploaderTestAccess::timeoutToken(uploader);
+    AetherSDR::FirmwareUploaderTestAccess::expire(
+        uploader, timedOutGeneration, uploadTimeout, QStringLiteral("upload timeout"));
+    AetherSDR::FirmwareUploaderTestAccess::expire(
+        uploader, timedOutGeneration, uploadTimeout, QStringLiteral("late timeout"));
+    check(finished.size() == 1 && !finished.front().success,
+          "an inactive upload is bounded and its stale timeout cannot emit twice");
+
+    const auto disconnectedGeneration = AetherSDR::FirmwareUploaderTestAccess::start(
+        uploader, nonPeriodicBytes(1), [](const char*, qint64 requested) { return requested; });
+    AetherSDR::FirmwareUploaderTestAccess::acknowledge(uploader, disconnectedGeneration, 1);
+    AetherSDR::FirmwareUploaderTestAccess::modelDisconnected(uploader, disconnectedGeneration);
+    check(finished.size() == 2 && !finished.back().success
+              && finished.back().message.contains(QStringLiteral("unconfirmed")),
+          "radio command-channel disconnect after drain reports an unconfirmed outcome once");
+}
+
+void checkReportedCompletePercentageIsNotOverwritten()
+{
+    AetherSDR::FirmwareUploader uploader(nullptr);
+    int lastProgress = -1;
+    QObject::connect(&uploader, &AetherSDR::FirmwareUploader::progressChanged,
+                     [&lastProgress](int percent, const QString&) { lastProgress = percent; });
+    const auto generation = AetherSDR::FirmwareUploaderTestAccess::start(
+        uploader, nonPeriodicBytes(1), [](const char*, qint64 requested) { return requested; });
+    AetherSDR::FirmwareUploaderTestAccess::status(
+        uploader, generation, QStringLiteral("file update"), {{QStringLiteral("transfer"), QStringLiteral("1.00")}});
+    AetherSDR::FirmwareUploaderTestAccess::acknowledge(uploader, generation, 1);
+    check(lastProgress == 100 && uploader.isUploading()
+              && AetherSDR::FirmwareUploaderTestAccess::waiting(uploader),
+          "reported transfer=1.00 remains visible while installation is still unconfirmed");
+}
+
+void checkOverallDeadlineCannotBeExtendedByProgress()
+{
+    AetherSDR::FirmwareUploader uploader(nullptr);
+    QVector<FinishedEvent> finished;
+    QObject::connect(&uploader, &AetherSDR::FirmwareUploader::finished,
+                     [&finished](bool success, const QString& message) {
+                         finished.append({success, message});
+                     });
+    const auto generation = AetherSDR::FirmwareUploaderTestAccess::start(
+        uploader, nonPeriodicBytes(8), [](const char*, qint64 requested) { return requested; });
+    const quint64 overallTimeout = AetherSDR::FirmwareUploaderTestAccess::overallTimeoutToken(uploader);
+    AetherSDR::FirmwareUploaderTestAccess::status(
+        uploader, generation, QStringLiteral("file update"), {{QStringLiteral("transfer"), QStringLiteral("0.25")}});
+    AetherSDR::FirmwareUploaderTestAccess::status(
+        uploader, generation, QStringLiteral("file update"), {{QStringLiteral("transfer"), QStringLiteral("0.26")}});
+    AetherSDR::FirmwareUploaderTestAccess::expireOverall(uploader, generation, overallTimeout);
+    AetherSDR::FirmwareUploaderTestAccess::expireOverall(uploader, generation, overallTimeout);
+    check(finished.size() == 1 && !finished.front().success
+              && finished.front().message.contains(QStringLiteral("10-minute")),
+          "radio progress cannot extend the hard client operation deadline");
+}
+
+void checkRadioStatusValidationAndFailure()
+{
+    AetherSDR::FirmwareUploader uploader(nullptr);
+    QVector<FinishedEvent> finished;
+    QVector<QString> progress;
+    QObject::connect(&uploader, &AetherSDR::FirmwareUploader::finished,
+                     [&finished](bool success, const QString& message) {
+                         finished.append({success, message});
+                     });
+    QObject::connect(&uploader, &AetherSDR::FirmwareUploader::progressChanged,
+                     [&progress](int, const QString& message) { progress.append(message); });
+
+    const auto generation = AetherSDR::FirmwareUploaderTestAccess::start(
+        uploader, nonPeriodicBytes(3), [](const char*, qint64 requested) { return requested; });
+    AetherSDR::FirmwareUploaderTestAccess::acknowledge(uploader, generation, 3);
+    const qsizetype progressBeforeMalformed = progress.size();
+    for (const QString& transfer : {QStringLiteral("nan"), QStringLiteral("-0.01"),
+                                    QStringLiteral("1.01"), QStringLiteral("not-a-number")}) {
+        AetherSDR::FirmwareUploaderTestAccess::status(
+            uploader, generation, QStringLiteral("file update"), {{QStringLiteral("transfer"), transfer}});
+    }
+    AetherSDR::FirmwareUploaderTestAccess::status(
+        uploader, generation, QStringLiteral("file update"), {{QStringLiteral("failed"), QStringLiteral("2")}});
+    AetherSDR::FirmwareUploaderTestAccess::status(
+        uploader, generation, QStringLiteral("file update"),
+        {{QStringLiteral("failed"), QStringLiteral("0")}, {QStringLiteral("reason"), QStringLiteral("none")}});
+    check(progress.size() == progressBeforeMalformed && finished.isEmpty(),
+          "malformed transfer and failed values are ignored without inventing a result");
+
+    AetherSDR::FirmwareUploaderTestAccess::status(
+        uploader, generation, QStringLiteral("file update"),
+        {{QStringLiteral("failed"), QStringLiteral("1")},
+         {QStringLiteral("reason"), QStringLiteral("signature validation failed")}});
+    check(finished.size() == 1 && !finished.front().success
+              && finished.front().message.contains(QStringLiteral("signature validation failed")),
+          "radio failed=1 terminates once and preserves the reported reason");
+}
+
+void checkDisconnectTimeoutAndStaleCallbacks()
+{
+    AetherSDR::FirmwareUploader uploader(nullptr);
+    QVector<FinishedEvent> finished;
+    QObject::connect(&uploader, &AetherSDR::FirmwareUploader::finished,
+                     [&finished](bool success, const QString& message) {
+                         finished.append({success, message});
+                     });
+
+    const auto disconnectedGeneration = AetherSDR::FirmwareUploaderTestAccess::start(
+        uploader, nonPeriodicBytes(8), [](const char*, qint64 requested) { return requested; });
+    const quint64 disconnectedTimeout = AetherSDR::FirmwareUploaderTestAccess::timeoutToken(uploader);
+    AetherSDR::FirmwareUploaderTestAccess::disconnected(uploader, disconnectedGeneration);
+    AetherSDR::FirmwareUploaderTestAccess::expire(
+        uploader, disconnectedGeneration, disconnectedTimeout, QStringLiteral("late timeout"));
+    check(finished.size() == 1 && !finished.front().success,
+          "disconnect before drain is an unconfirmed failure and emits one terminal result");
+
+    const auto cancelledGeneration = AetherSDR::FirmwareUploaderTestAccess::start(
+        uploader, nonPeriodicBytes(8), [](const char*, qint64 requested) { return requested; });
+    const quint64 cancelledTimeout = AetherSDR::FirmwareUploaderTestAccess::timeoutToken(uploader);
+    uploader.cancel();
+    AetherSDR::FirmwareUploaderTestAccess::acknowledge(uploader, cancelledGeneration, 8);
+    AetherSDR::FirmwareUploaderTestAccess::status(
+        uploader, cancelledGeneration, QStringLiteral("file update"),
+        {{QStringLiteral("failed"), QStringLiteral("1")}, {QStringLiteral("reason"), QStringLiteral("late")}});
+    AetherSDR::FirmwareUploaderTestAccess::expire(
+        uploader, cancelledGeneration, cancelledTimeout, QStringLiteral("late timeout"));
+    check(finished.size() == 2 && !finished.back().success,
+          "cancel invalidates late byte, status, and timeout callbacks exactly once");
+
+    const auto waitingGeneration = AetherSDR::FirmwareUploaderTestAccess::start(
+        uploader, nonPeriodicBytes(1), [](const char*, qint64 requested) { return requested; });
+    AetherSDR::FirmwareUploaderTestAccess::acknowledge(uploader, waitingGeneration, 1);
+    const quint64 confirmationTimeout = AetherSDR::FirmwareUploaderTestAccess::timeoutToken(uploader);
+    AetherSDR::FirmwareUploaderTestAccess::disconnected(uploader, waitingGeneration);
+    check(finished.size() == 2 && uploader.isUploading(),
+          "disconnect after drain remains unconfirmed rather than reporting install success");
+    AetherSDR::FirmwareUploaderTestAccess::expire(
+        uploader, waitingGeneration, confirmationTimeout, QStringLiteral("confirmation timed out"));
+    check(finished.size() == 3 && !finished.back().success,
+          "post-drain confirmation wait is bounded and never succeeds speculatively");
+}
+
+void checkRejectedUploadResponse()
+{
+    AetherSDR::FirmwareUploader uploader(nullptr);
+    QVector<FinishedEvent> finished;
+    QObject::connect(&uploader, &AetherSDR::FirmwareUploader::finished,
+                     [&finished](bool success, const QString& message) {
+                         finished.append({success, message});
+                     });
+    const auto generation = AetherSDR::FirmwareUploaderTestAccess::begin(uploader, nonPeriodicBytes(4));
+    AetherSDR::FirmwareUploaderTestAccess::reject(uploader, generation, 0x15);
+    check(finished.size() == 1 && !finished.front().success,
+          "a rejected upload-port response terminates without starting a transfer");
+}
+
+void checkProgressReentrancyCannotMutateReplacementAttempt()
+{
+    AetherSDR::FirmwareUploader uploader(nullptr);
+    QVector<FinishedEvent> finished;
+    bool restarted = false;
+    quint64 replacementGeneration = 0;
+    QObject::connect(&uploader, &AetherSDR::FirmwareUploader::finished,
+                     [&finished](bool success, const QString& message) {
+                         finished.append({success, message});
+                     });
+    QObject::connect(&uploader, &AetherSDR::FirmwareUploader::progressChanged,
+                     [&uploader, &restarted, &replacementGeneration](int, const QString& message) {
+                         if (restarted || !message.startsWith(QStringLiteral("Uploading..."))) {
+                             return;
+                         }
+                         restarted = true;
+                         uploader.cancel();
+                         replacementGeneration = AetherSDR::FirmwareUploaderTestAccess::start(
+                             uploader, nonPeriodicBytes(5),
+                             [](const char*, qint64 requested) { return requested; });
+                     });
+
+    const auto oldGeneration = AetherSDR::FirmwareUploaderTestAccess::start(
+        uploader, nonPeriodicBytes(8), [](const char*, qint64 requested) { return requested; });
+    AetherSDR::FirmwareUploaderTestAccess::acknowledge(uploader, oldGeneration, 8);
+    check(restarted && uploader.isUploading()
+              && !AetherSDR::FirmwareUploaderTestAccess::waiting(uploader)
+              && AetherSDR::FirmwareUploaderTestAccess::pending(uploader) == 5,
+          "progress callback cancellation cannot let an old acknowledgement mutate its replacement");
+    AetherSDR::FirmwareUploaderTestAccess::acknowledge(uploader, replacementGeneration, 5);
+    check(AetherSDR::FirmwareUploaderTestAccess::waiting(uploader)
+              && finished.size() == 1 && !finished.front().success,
+          "replacement attempt remains independent after reentrant cancellation");
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    checkRetryRequiresFreshConnection();
+    checkByteIdentityAndPostDrainState();
+    checkRadioStatusValidationAndFailure();
+    checkUploadTimeoutAndModelDisconnect();
+    checkReportedCompletePercentageIsNotOverwritten();
+    checkOverallDeadlineCannotBeExtendedByProgress();
+    checkDisconnectTimeoutAndStaleCallbacks();
+    checkRejectedUploadResponse();
+    checkProgressReentrancyCannotMutateReplacementAttempt();
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/firmware_uploader_test.cpp
+++ b/tests/firmware_uploader_test.cpp
@@ -87,6 +87,18 @@ public:
         uploader.onOverallTimeout(generation, timeoutToken);
     }
 
+    static int overallTimeoutMs(const FirmwareUploader& uploader, qint64 bytes)
+    {
+        return uploader.overallTimeoutMsFor(bytes);
+    }
+    static bool barrierActive(const FirmwareUploader& uploader)
+    {
+        return uploader.retryBarrierActive();
+    }
+    static void expireRadioProgressFreshness(FirmwareUploader& uploader)
+    {
+        uploader.m_radioProgressStaleMs = 0;
+    }
     static qint64 pending(const FirmwareUploader& uploader) { return uploader.m_pendingBytes; }
     static bool waiting(const FirmwareUploader& uploader) { return uploader.m_waitingForConfirmation; }
     static quint64 timeoutToken(const FirmwareUploader& uploader) { return uploader.m_timeoutToken; }
@@ -122,8 +134,10 @@ QByteArray nonPeriodicBytes(qsizetype size)
     return data;
 }
 
+using Outcome = AetherSDR::FirmwareUploader::Outcome;
+
 struct FinishedEvent {
-    bool success;
+    Outcome outcome;
     QString message;
 };
 
@@ -132,8 +146,8 @@ void checkRetryRequiresFreshConnection()
     AetherSDR::FirmwareUploader uploader(nullptr);
     QVector<FinishedEvent> finished;
     QObject::connect(&uploader, &AetherSDR::FirmwareUploader::finished,
-                     [&finished](bool success, const QString& message) {
-                         finished.append({success, message});
+                     [&finished](Outcome outcome, const QString& message) {
+                         finished.append({outcome, message});
                      });
     const QByteArray data = nonPeriodicBytes(8);
     const auto first = AetherSDR::FirmwareUploaderTestAccess::begin(uploader, data);
@@ -170,8 +184,8 @@ void checkByteIdentityAndPostDrainState()
     QVector<FinishedEvent> finished;
     int lastProgress = -1;
     QObject::connect(&uploader, &AetherSDR::FirmwareUploader::finished,
-                     [&finished](bool success, const QString& message) {
-                         finished.append({success, message});
+                     [&finished](Outcome outcome, const QString& message) {
+                         finished.append({outcome, message});
                      });
     QObject::connect(&uploader, &AetherSDR::FirmwareUploader::progressChanged,
                      [&lastProgress](int percent, const QString&) { lastProgress = percent; });
@@ -223,8 +237,8 @@ void checkUploadTimeoutAndModelDisconnect()
     AetherSDR::FirmwareUploader uploader(nullptr);
     QVector<FinishedEvent> finished;
     QObject::connect(&uploader, &AetherSDR::FirmwareUploader::finished,
-                     [&finished](bool success, const QString& message) {
-                         finished.append({success, message});
+                     [&finished](Outcome outcome, const QString& message) {
+                         finished.append({outcome, message});
                      });
 
     const auto timedOutGeneration = AetherSDR::FirmwareUploaderTestAccess::start(
@@ -234,15 +248,15 @@ void checkUploadTimeoutAndModelDisconnect()
         uploader, timedOutGeneration, uploadTimeout, QStringLiteral("upload timeout"));
     AetherSDR::FirmwareUploaderTestAccess::expire(
         uploader, timedOutGeneration, uploadTimeout, QStringLiteral("late timeout"));
-    check(finished.size() == 1 && !finished.front().success,
+    check(finished.size() == 1 && finished.front().outcome == Outcome::Failed,
           "an inactive upload is bounded and its stale timeout cannot emit twice");
 
     const auto disconnectedGeneration = AetherSDR::FirmwareUploaderTestAccess::start(
         uploader, nonPeriodicBytes(1), [](const char*, qint64 requested) { return requested; });
     AetherSDR::FirmwareUploaderTestAccess::acknowledge(uploader, disconnectedGeneration, 1);
     AetherSDR::FirmwareUploaderTestAccess::modelDisconnected(uploader, disconnectedGeneration);
-    check(finished.size() == 2 && !finished.back().success
-              && finished.back().message.contains(QStringLiteral("unconfirmed")),
+    check(finished.size() == 2 && finished.back().outcome == Outcome::Unconfirmed
+              && finished.back().message.contains(QStringLiteral("rebooting")),
           "radio command-channel disconnect after drain reports an unconfirmed outcome once");
 }
 
@@ -267,8 +281,8 @@ void checkOverallDeadlineCannotBeExtendedByProgress()
     AetherSDR::FirmwareUploader uploader(nullptr);
     QVector<FinishedEvent> finished;
     QObject::connect(&uploader, &AetherSDR::FirmwareUploader::finished,
-                     [&finished](bool success, const QString& message) {
-                         finished.append({success, message});
+                     [&finished](Outcome outcome, const QString& message) {
+                         finished.append({outcome, message});
                      });
     const auto generation = AetherSDR::FirmwareUploaderTestAccess::start(
         uploader, nonPeriodicBytes(8), [](const char*, qint64 requested) { return requested; });
@@ -279,8 +293,8 @@ void checkOverallDeadlineCannotBeExtendedByProgress()
         uploader, generation, QStringLiteral("file update"), {{QStringLiteral("transfer"), QStringLiteral("0.26")}});
     AetherSDR::FirmwareUploaderTestAccess::expireOverall(uploader, generation, overallTimeout);
     AetherSDR::FirmwareUploaderTestAccess::expireOverall(uploader, generation, overallTimeout);
-    check(finished.size() == 1 && !finished.front().success
-              && finished.front().message.contains(QStringLiteral("10-minute")),
+    check(finished.size() == 1 && finished.front().outcome == Outcome::Failed
+              && finished.front().message.contains(QStringLiteral("operation limit")),
           "radio progress cannot extend the hard client operation deadline");
 }
 
@@ -290,8 +304,8 @@ void checkRadioStatusValidationAndFailure()
     QVector<FinishedEvent> finished;
     QVector<QString> progress;
     QObject::connect(&uploader, &AetherSDR::FirmwareUploader::finished,
-                     [&finished](bool success, const QString& message) {
-                         finished.append({success, message});
+                     [&finished](Outcome outcome, const QString& message) {
+                         finished.append({outcome, message});
                      });
     QObject::connect(&uploader, &AetherSDR::FirmwareUploader::progressChanged,
                      [&progress](int, const QString& message) { progress.append(message); });
@@ -307,9 +321,6 @@ void checkRadioStatusValidationAndFailure()
     }
     AetherSDR::FirmwareUploaderTestAccess::status(
         uploader, generation, QStringLiteral("file update"), {{QStringLiteral("failed"), QStringLiteral("2")}});
-    AetherSDR::FirmwareUploaderTestAccess::status(
-        uploader, generation, QStringLiteral("file update"),
-        {{QStringLiteral("failed"), QStringLiteral("0")}, {QStringLiteral("reason"), QStringLiteral("none")}});
     check(progress.size() == progressBeforeMalformed && finished.isEmpty(),
           "malformed transfer and failed values are ignored without inventing a result");
 
@@ -317,7 +328,7 @@ void checkRadioStatusValidationAndFailure()
         uploader, generation, QStringLiteral("file update"),
         {{QStringLiteral("failed"), QStringLiteral("1")},
          {QStringLiteral("reason"), QStringLiteral("signature validation failed")}});
-    check(finished.size() == 1 && !finished.front().success
+    check(finished.size() == 1 && finished.front().outcome == Outcome::Failed
               && finished.front().message.contains(QStringLiteral("signature validation failed")),
           "radio failed=1 terminates once and preserves the reported reason");
 }
@@ -327,8 +338,8 @@ void checkDisconnectTimeoutAndStaleCallbacks()
     AetherSDR::FirmwareUploader uploader(nullptr);
     QVector<FinishedEvent> finished;
     QObject::connect(&uploader, &AetherSDR::FirmwareUploader::finished,
-                     [&finished](bool success, const QString& message) {
-                         finished.append({success, message});
+                     [&finished](Outcome outcome, const QString& message) {
+                         finished.append({outcome, message});
                      });
 
     const auto disconnectedGeneration = AetherSDR::FirmwareUploaderTestAccess::start(
@@ -337,8 +348,8 @@ void checkDisconnectTimeoutAndStaleCallbacks()
     AetherSDR::FirmwareUploaderTestAccess::disconnected(uploader, disconnectedGeneration);
     AetherSDR::FirmwareUploaderTestAccess::expire(
         uploader, disconnectedGeneration, disconnectedTimeout, QStringLiteral("late timeout"));
-    check(finished.size() == 1 && !finished.front().success,
-          "disconnect before drain is an unconfirmed failure and emits one terminal result");
+    check(finished.size() == 1 && finished.front().outcome == Outcome::Failed,
+          "disconnect before drain is a failure and emits one terminal result");
 
     const auto cancelledGeneration = AetherSDR::FirmwareUploaderTestAccess::start(
         uploader, nonPeriodicBytes(8), [](const char*, qint64 requested) { return requested; });
@@ -350,7 +361,7 @@ void checkDisconnectTimeoutAndStaleCallbacks()
         {{QStringLiteral("failed"), QStringLiteral("1")}, {QStringLiteral("reason"), QStringLiteral("late")}});
     AetherSDR::FirmwareUploaderTestAccess::expire(
         uploader, cancelledGeneration, cancelledTimeout, QStringLiteral("late timeout"));
-    check(finished.size() == 2 && !finished.back().success,
+    check(finished.size() == 2 && finished.back().outcome == Outcome::Failed,
           "cancel invalidates late byte, status, and timeout callbacks exactly once");
 
     const auto waitingGeneration = AetherSDR::FirmwareUploaderTestAccess::start(
@@ -362,8 +373,8 @@ void checkDisconnectTimeoutAndStaleCallbacks()
           "disconnect after drain remains unconfirmed rather than reporting install success");
     AetherSDR::FirmwareUploaderTestAccess::expire(
         uploader, waitingGeneration, confirmationTimeout, QStringLiteral("confirmation timed out"));
-    check(finished.size() == 3 && !finished.back().success,
-          "post-drain confirmation wait is bounded and never succeeds speculatively");
+    check(finished.size() == 3 && finished.back().outcome == Outcome::Unconfirmed,
+          "post-drain confirmation wait is bounded and resolves unconfirmed, never successful");
 }
 
 void checkRejectedUploadResponse()
@@ -371,12 +382,12 @@ void checkRejectedUploadResponse()
     AetherSDR::FirmwareUploader uploader(nullptr);
     QVector<FinishedEvent> finished;
     QObject::connect(&uploader, &AetherSDR::FirmwareUploader::finished,
-                     [&finished](bool success, const QString& message) {
-                         finished.append({success, message});
+                     [&finished](Outcome outcome, const QString& message) {
+                         finished.append({outcome, message});
                      });
     const auto generation = AetherSDR::FirmwareUploaderTestAccess::begin(uploader, nonPeriodicBytes(4));
     AetherSDR::FirmwareUploaderTestAccess::reject(uploader, generation, 0x15);
-    check(finished.size() == 1 && !finished.front().success,
+    check(finished.size() == 1 && finished.front().outcome == Outcome::Failed,
           "a rejected upload-port response terminates without starting a transfer");
 }
 
@@ -387,8 +398,8 @@ void checkProgressReentrancyCannotMutateReplacementAttempt()
     bool restarted = false;
     quint64 replacementGeneration = 0;
     QObject::connect(&uploader, &AetherSDR::FirmwareUploader::finished,
-                     [&finished](bool success, const QString& message) {
-                         finished.append({success, message});
+                     [&finished](Outcome outcome, const QString& message) {
+                         finished.append({outcome, message});
                      });
     QObject::connect(&uploader, &AetherSDR::FirmwareUploader::progressChanged,
                      [&uploader, &restarted, &replacementGeneration](int, const QString& message) {
@@ -411,8 +422,117 @@ void checkProgressReentrancyCannotMutateReplacementAttempt()
           "progress callback cancellation cannot let an old acknowledgement mutate its replacement");
     AetherSDR::FirmwareUploaderTestAccess::acknowledge(uploader, replacementGeneration, 5);
     check(AetherSDR::FirmwareUploaderTestAccess::waiting(uploader)
-              && finished.size() == 1 && !finished.front().success,
+              && finished.size() == 1 && finished.front().outcome == Outcome::Failed,
           "replacement attempt remains independent after reentrant cancellation");
+}
+
+
+// #5572 review: failed=0 is the radio's own confirmation, not noise. FlexLib
+// treats any parseable `failed` as the terminal word on an update and drops the
+// command channel on it (Radio.cs:12612-12631), so dropping failed=0 would
+// discard the one signal that can distinguish a real install from a silent one.
+// #5572 review: m_radioProgressSeen used to latch forever, so if the radio's
+// status stream stalled while TCP kept draining, the bar froze at the last
+// reported percentage for the rest of the transfer — and acknowledgeBytes
+// re-arms the inactivity timer, so nothing else would have noticed.
+void checkStaleRadioProgressFallsBackToLocalBytes()
+{
+    AetherSDR::FirmwareUploader uploader(nullptr);
+    int lastProgress = -1;
+    QObject::connect(&uploader, &AetherSDR::FirmwareUploader::progressChanged,
+                     [&lastProgress](int percent, const QString&) { lastProgress = percent; });
+    const auto generation = AetherSDR::FirmwareUploaderTestAccess::start(
+        uploader, nonPeriodicBytes(100), [](const char*, qint64 requested) { return requested; });
+    AetherSDR::FirmwareUploaderTestAccess::status(
+        uploader, generation, QStringLiteral("file update"),
+        {{QStringLiteral("transfer"), QStringLiteral("0.10")}});
+    AetherSDR::FirmwareUploaderTestAccess::acknowledge(uploader, generation, 40);
+    check(lastProgress == 10,
+          "fresh radio progress supersedes the local byte counter");
+
+    AetherSDR::FirmwareUploaderTestAccess::expireRadioProgressFreshness(uploader);
+    AetherSDR::FirmwareUploaderTestAccess::acknowledge(uploader, generation, 40);
+    check(lastProgress == 80,
+          "a stalled radio status stream falls back to local byte progress");
+}
+
+void checkRadioConfirmationSucceedsAndReleasesBarrier()
+{
+    AetherSDR::FirmwareUploader uploader(nullptr);
+    QVector<FinishedEvent> finished;
+    QObject::connect(&uploader, &AetherSDR::FirmwareUploader::finished,
+                     [&finished](Outcome outcome, const QString& message) {
+                         finished.append({outcome, message});
+                     });
+    const auto generation = AetherSDR::FirmwareUploaderTestAccess::start(
+        uploader, nonPeriodicBytes(4), [](const char*, qint64 requested) { return requested; });
+    AetherSDR::FirmwareUploaderTestAccess::dispatched(uploader);
+    AetherSDR::FirmwareUploaderTestAccess::acknowledge(uploader, generation, 4);
+    check(AetherSDR::FirmwareUploaderTestAccess::waiting(uploader) && finished.isEmpty(),
+          "a drained socket still waits for the radio rather than claiming success");
+
+    AetherSDR::FirmwareUploaderTestAccess::status(
+        uploader, generation, QStringLiteral("file update"),
+        {{QStringLiteral("failed"), QStringLiteral("0")}});
+    check(finished.size() == 1 && finished.front().outcome == Outcome::Succeeded,
+          "radio failed=0 confirms the install and is the only path to Succeeded");
+    check(!AetherSDR::FirmwareUploaderTestAccess::barrierActive(uploader),
+          "a radio-settled outcome leaves nothing pending, so the retry barrier clears");
+}
+
+// The barrier exists for attempts whose outcome the radio never reported. An
+// outcome the radio DID report must not keep it armed, and an ambiguous one must.
+void checkBarrierReleasedOnlyByRadioSettledOutcomes()
+{
+    AetherSDR::FirmwareUploader rejected(nullptr);
+    QVector<FinishedEvent> rejectedFinished;
+    QObject::connect(&rejected, &AetherSDR::FirmwareUploader::finished,
+                     [&rejectedFinished](Outcome outcome, const QString& message) {
+                         rejectedFinished.append({outcome, message});
+                     });
+    const auto generation = AetherSDR::FirmwareUploaderTestAccess::start(
+        rejected, nonPeriodicBytes(8), [](const char*, qint64 requested) { return requested; });
+    AetherSDR::FirmwareUploaderTestAccess::dispatched(rejected);
+    AetherSDR::FirmwareUploaderTestAccess::status(
+        rejected, generation, QStringLiteral("file update"),
+        {{QStringLiteral("failed"), QStringLiteral("1")},
+         {QStringLiteral("reason"), QStringLiteral("bad-signature")}});
+    check(rejectedFinished.size() == 1 && rejectedFinished.front().outcome == Outcome::Failed
+              && !AetherSDR::FirmwareUploaderTestAccess::barrierActive(rejected),
+          "a radio-reported rejection is unambiguous and releases the barrier");
+
+    AetherSDR::FirmwareUploader stalled(nullptr);
+    const auto stalledGeneration = AetherSDR::FirmwareUploaderTestAccess::start(
+        stalled, nonPeriodicBytes(8), [](const char*, qint64 requested) { return requested; });
+    AetherSDR::FirmwareUploaderTestAccess::dispatched(stalled);
+    AetherSDR::FirmwareUploaderTestAccess::expire(
+        stalled, stalledGeneration,
+        AetherSDR::FirmwareUploaderTestAccess::timeoutToken(stalled),
+        QStringLiteral("upload timeout"));
+    check(AetherSDR::FirmwareUploaderTestAccess::barrierActive(stalled),
+          "a timeout after dispatch leaves the outcome unobservable, so the barrier holds");
+}
+
+// #5572 review: a fixed ten-minute ceiling needed ~644 KB/s to pass the
+// reporter's own 386 MB image, which a SmartLink uplink does not owe us.
+void checkOverallDeadlineScalesWithImageSize()
+{
+    AetherSDR::FirmwareUploader uploader(nullptr);
+    const int small = AetherSDR::FirmwareUploaderTestAccess::overallTimeoutMs(uploader, 1024);
+    check(small == 10 * 60 * 1000,
+          "a small image keeps the ten-minute floor");
+
+    const qint64 reportedImage = 386282416;
+    const int large =
+        AetherSDR::FirmwareUploaderTestAccess::overallTimeoutMs(uploader, reportedImage);
+    check(large > small, "a large image is given more than the floor");
+    // It must survive a genuinely slow uplink: the budget has to exceed the time
+    // the image takes at a rate the floor would have failed.
+    check(static_cast<qint64>(large) > (reportedImage * 1000LL) / (128LL * 1024LL),
+          "#5572's 386MB image survives a 128 KB/s uplink within the deadline");
+    check(AetherSDR::FirmwareUploaderTestAccess::overallTimeoutMs(
+              uploader, 500LL * 1024LL * 1024LL) <= 2 * 60 * 60 * 1000,
+          "the deadline is still capped so a wedged transfer cannot run forever");
 }
 
 } // namespace
@@ -429,5 +549,9 @@ int main(int argc, char** argv)
     checkDisconnectTimeoutAndStaleCallbacks();
     checkRejectedUploadResponse();
     checkProgressReentrancyCannotMutateReplacementAttempt();
+    checkStaleRadioProgressFallsBackToLocalBytes();
+    checkRadioConfirmationSucceedsAndReleasesBarrier();
+    checkBarrierReleasedOnlyByRadioSettledOutcomes();
+    checkOverallDeadlineScalesWithImageSize();
     return g_failures == 0 ? 0 : 1;
 }

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1894,6 +1894,15 @@ target_include_directories(waveform_upload_state_test PRIVATE src)
 target_link_libraries(waveform_upload_state_test PRIVATE Qt6::Core)
 add_test(NAME waveform_upload_state_test COMMAND waveform_upload_state_test)
 
+# #5572 — socket-free firmware upload lifecycle. The injected writer exercises
+# production queue accounting and terminal handlers without a radio peer.
+add_executable(firmware_uploader_test
+    tests/firmware_uploader_test.cpp
+)
+target_include_directories(firmware_uploader_test PRIVATE src)
+target_link_libraries(firmware_uploader_test PRIVATE aethercore Qt6::Core Qt6::Network)
+add_test(NAME firmware_uploader_test COMMAND firmware_uploader_test)
+
 add_executable(zip_archive_test
     tests/zip_archive_test.cpp
     src/core/ZipArchive.cpp


### PR DESCRIPTION
When a firmware upload produces a partial `bytesWritten` notification, the old uploader queues the next chunk from the drained offset even though part of the previous chunk remains queued. This can duplicate image bytes. It also reports successful upload/reboot on local drain without observing the radio's installation outcome.

This patch separates accepted and drained bytes, respects short writes, and waits for each accepted chunk to drain before queueing the next. The existing Flex-specific uploader consumes the existing model status relay for validated radio transfer progress and rejection reasons. Local drain, `transfer=1.00`, and command-channel disconnect never claim successful installation.

Addresses #5572's confirmed client-side defects. The reporter's physical-radio activation failure remains unverified; this draft needs reporter/maintainer validation before the issue is considered resolved.

### Lifecycle handling

- Guard asynchronous replies, socket callbacks, and progress-signal reentrancy against cancellation and replacement attempts.
- Bound port, connection, upload inactivity, and post-upload waits with owned timers and a separate ten-minute operation limit.
- Require an observed disconnect/reconnect before retrying a dispatched upload: the existing firmware status relay has no upload-attempt identifier, so late status cannot safely be attributed to a retry on the same connection. No automatic reconnect or firmware retry is added.
- Preserve graceful upload EOF. FlexLib v4.2.18 `SendUpdateFile()` disposes its upload stream/client before its five-second delay; the reference does not support the triage proposal to hold that socket open. No speculative commit/reboot command is added.

### Evidence and validation

The actual attachment ends at radio `transfer=0.99`, followed by the client's local completion log. It contains no `transfer=1.00`, rejection reason, or post-upload disconnect. The overlapping-write defect is demonstrated independently; the attachment does not establish that this callback sequence caused this particular radio's stall.

- Full macOS ARM64 build passed with RADE enabled; host/system processors and executable verified ARM64, with no RNNoise x86 sources in the build graph.
- Socket-free CTest: `firmware_uploader_test` and `waveform_upload_state_test`, **2/2 passed**.
- The new test drives production queue/lifecycle handlers with an in-memory writer: nonperiodic byte identity through partial drains and short writes, progress/rejection validation, cancellation, stale callbacks, reentrancy, disconnects, bounded waits, and retry gating.
- Three mutations detected: overlapping writes, premature local-drain success, and removal of the fresh-connection barrier. Restored-source tests passed; all four source hashes matched the reviewed snapshot.
- Engine-boundary, test-registration, frozen CI-gate, generated touchpoint, and whitespace checks passed. Independent source review found no remaining material blocker after corrections.

### Verification boundary

**No firmware was uploaded, no radio was rebooted, and no live-radio test was performed.** The operator explicitly prohibited a firmware update and subsequently requested publication of this draft with that limitation. The agent automation bridge currently has no safe firmware-transfer writer injection/status replay path, so there is **no bridge-backed installation/reboot proof**. Socket-free tests establish client behavior, not radio firmware acceptance or Linux/live-radio compatibility. Existing reconnect behavior is unchanged.

Related: original firmware feature #76 and the waveform byte-accounting precedent in #4186.

Generated with OpenAI Codex.
