### PR TITLE
Add typed producer PCM contract and compatibility adapters (A1)

### DIFF
--- a/docs/producer-pcm-contract.md
+++ b/docs/producer-pcm-contract.md
@@ -1,0 +1,90 @@
+# Producer PCM contract (RFC #5468 A1)
+
+`PcmFrame` in `src/core/PcmFrame.h` is the in-process RX producer envelope.
+It is not an aetherd wire resource or a sound-device format. A1 keeps the current
+24 kHz stereo audio paths active. The new RTL WDSP 48 kHz producer remains disabled;
+A2–A5 must qualify playback, recording, TCI and fixed-rate decoders before M1/S2
+activate it. No radio capability or default changes in this step.
+
+## Format, identity and ownership
+
+A frame carries owning, native-endian interleaved float32 samples, an immutable
+24/48 kHz mono/stereo format, and separate source, connection session,
+format-generation, receiver-instance and stable slice-slot identities.
+Speaker mixes and auxiliary sources have no slice slot. A slice stream accepts
+F4 `Handle::session`, `Handle::instance` and `Handle::slot` as separate values;
+legacy adapters use process-local identities until the native producer lands.
+These identifiers are not persistence keys. DAX channels and Kiwi source IDs
+travel alongside their frame and retain their existing meanings.
+
+`firstSample` counts sample frames (LR pairs for stereo), not floats or bytes.
+It advances only on accepted input. A start or accepted format change resets its
+origin and marks the first frame discontinuous. Explicit forward gaps require a
+discontinuity flag; backward positions, overflow and repeated or older explicit
+sessions are refused. Legacy adapters count accepted output samples; this does
+not reconstruct missing capture timestamps or establish multi-receiver alignment.
+
+Only `PcmProducer` constructs valid frames. It rejects empty, oversized (more than
+65,536 sample frames), incomplete-channel and nonfinite input. Finite values,
+including signed zero and peaks outside ±1, are preserved without clipping.
+Qt queued delivery copies the samples and metadata together with shared ownership;
+borrowed buffers are detached at publication. Consumers have no mutable access.
+
+An epoch token contains immutable metadata and an atomic live bit, with no radio,
+worker, DSP or QObject ownership. Stop, reconnect, format change and slice retirement
+revoke old tokens. A queued frame stays invalid even after the same slot or rate is
+reused. `PcmFrameGate` independently rejects stale, replayed and out-of-order frames
+for each consumer, with at most 32 live stream cursors. Inactive entries are reused.
+
+Each producer and consumer gate has one execution context. Only token revocation
+may overlap production/delivery; start, format change and destruction remain
+serialized with the producer, and its caller joins it before destruction. A
+revocation rejects a later admission; it cannot retract samples already admitted
+into an existing AudioEngine processing/device queue. Queue flushing and rate-domain
+transitions are A2 work. A1 does not claim bounded end-to-end latency or lock-free
+real-time performance: it adds ownership copies and finite-sample validation.
+
+## Compatibility boundaries
+
+`legacyStereo24()` refuses revoked frames and every format except 24 kHz stereo.
+It copies sample bits unchanged; it never converts or relabels 48 kHz or mono input.
+Fixed-rate consumers unwrap at the receiving callback, after queued delivery.
+
+| Producer / route | A1 adapter and retained behavior |
+|---|---|
+| Flex LAN float/reduced-bandwidth/Opus | `PanadapterStream` publishes typed speaker PCM after the existing decode/concealment. Float alignment/finiteness is checked before concealment history. DAX registration owns revocable per-stream tokens. |
+| Hermes-Lite | The current DSP instance is checked before accepting queued worker output. Per-slice validation precedes the existing mixer. Its unity fast path, gain/balance, alignment and sum/clamp behavior stay unchanged. |
+| ANAN | `AnanRxDsp` tags its actual configured output rate before worker-to-owner delivery and revokes old tokens on channel installation. The production backend still requests 24 kHz, with the existing single-receiver speaker and slice outputs. |
+| Icom | The current session instance is checked; malformed/nonfinite mono input is refused before the existing 48 kHz mono to 24 kHz stereo converter. |
+| RTL | The current legacy worker is checked before publication. Existing DDC/demodulation, 24 kHz output, WFM behavior and slice-0 runtime remain in use. F4 preparation/registry is not activated as the audio producer. |
+| Simulator | Worker output has a connection epoch before queueing; the backend checks that epoch against its session before publishing. Existing pacing and speaker/slice samples remain unchanged. |
+| Kiwi | Existing resampling, silence, squelch and loss padding precede typed publication. Socket cleanup revokes queued audio; AudioEngine has an independent auxiliary ingress gate. |
+
+`IRadioBackend` publishes typed speaker and per-slice signals. Its compatibility
+publishers initialize on `connected`, revoke on `disconnected`/slice removal, and
+refuse further publication from retired streams. `RadioModel` retires them before
+backend teardown and uses the same guarded PCM bindings for production and test
+injection. No new backend-family decision is introduced.
+
+The existing single-producer choices remain: Flex stream playback, backend-owned
+speaker playback, and the simulator's existing direct speaker route. The normalized
+`rxDemodAudioReady` bus remains a separate subscriber for recording/CW/RTTY. Per-slice
+TCI/AetherClock, Flex DAX/RADE and concurrent Kiwi routes retain their attribution.
+Raw compatibility signals on the Flex, Kiwi and ANAN producer objects remain for
+existing low-level users; the migrated production GUI routes use typed signals.
+
+AudioEngine's original byte APIs remain for legacy internal/playback callers. Its
+new typed entry points reject incompatible formats and duplicate/stale frames,
+then call the existing processing functions. The main RX L/R resamplers, TX CW
+sidetone adapter, decoded RADE speech adapter and device-rate state are unchanged.
+
+## Validation scope
+
+`pcm_frame_test` covers format, ownership, bounds, identity, continuity, queued
+revocation and replay/capacity rules without sockets or devices.
+`pcm_compatibility_test` injects the production backend/model/AudioEngine route,
+Flex decoders/DAX registration, and the Hermes mixer without a firmware peer or
+hardware connection. Existing simulator and ANAN DSP tests cover paired output
+and actual producer rates. Tests are registered in `tests/tests.cmake`; no frozen
+PR CI allow-list is expanded. Build, sanitizer and mutation results belong in the
+A1 execution report, with their host/configuration and hardware limits.

--- a/docs/producer-pcm-contract.md
+++ b/docs/producer-pcm-contract.md
@@ -19,8 +19,8 @@ travel alongside their frame and retain their existing meanings.
 
 `firstSample` counts sample frames (LR pairs for stereo), not floats or bytes.
 It advances only on accepted input. A start or accepted format change resets its
-origin and marks the first frame discontinuous. Explicit forward gaps require a
-discontinuity flag; backward positions, overflow and repeated or older explicit
+origin and marks the first frame discontinuous. Backward positions, overflow and
+repeated or older explicit
 sessions are refused. Legacy adapters count accepted output samples; this does
 not reconstruct missing capture timestamps or establish multi-receiver alignment.
 
@@ -35,6 +35,15 @@ worker, DSP or QObject ownership. Stop, reconnect, format change and slice retir
 revoke old tokens. A queued frame stays invalid even after the same slot or rate is
 reused. `PcmFrameGate` independently rejects stale, replayed and out-of-order frames
 for each consumer, with at most 32 live stream cursors. Inactive entries are reused.
+
+The gate is deliberately one-sided: it refuses a frame at or behind the cursor and
+admits one ahead of it. A forward gap means the consumer missed frames, which every
+consumer that can be detached from a running producer does legitimately — playback
+mute detaches the Flex speaker feed and short-circuits the seam-backend feed while
+the producer keeps counting. Because a cursor only advances on an accepted frame,
+refusing that gap would strand the consumer behind a live epoch with no way back,
+silencing RX until the next reconnect. Replay protection comes from the backward
+check plus epoch liveness, neither of which a forward gap weakens.
 
 Each producer and consumer gate has one execution context. Only token revocation
 may overlap production/delivery; start, format change and destruction remain
@@ -70,8 +79,19 @@ The existing single-producer choices remain: Flex stream playback, backend-owned
 speaker playback, and the simulator's existing direct speaker route. The normalized
 `rxDemodAudioReady` bus remains a separate subscriber for recording/CW/RTTY. Per-slice
 TCI/AetherClock, Flex DAX/RADE and concurrent Kiwi routes retain their attribution.
-Raw compatibility signals on the Flex, Kiwi and ANAN producer objects remain for
-existing low-level users; the migrated production GUI routes use typed signals.
+Every production route uses the typed signals. `PanadapterStream`'s byte-valued
+`audioDataReady`/`daxAudioReady` are removed rather than retained: after the
+migration nothing in the tree connected to them, their arguments were still being
+deep-copied per audio block, and they bypassed the gate — so any later consumer
+wired to them would silently have skipped admission control.
+
+No A1 adapter sets `discontinuity` after the first frame of an epoch: each one
+publishes contiguous positions, so a lost Flex UDP audio packet is presented as
+continuous even though packet-loss concealment detected it. Propagating that would
+make AudioEngine retire and reset the chain on every lost packet, which is an
+audible-behaviour change rather than a wiring fix, so it belongs with the later
+milestones that own playback policy. Today the field is exercised by tests and by
+explicit-position producers only.
 
 AudioEngine's original byte APIs remain for legacy internal/playback callers. Its
 new typed entry points reject incompatible formats and duplicate/stale frames,

--- a/src/core/AetherClockEngine.h
+++ b/src/core/AetherClockEngine.h
@@ -9,7 +9,7 @@
 // classes. The wiring layer (GUI applet, tests, any future host) injects a
 // DAX-hold provider wrapping the CENTRAL
 // PanadapterStream::acquireDaxChannel/releaseDaxChannel(ch,
-// DaxConsumer::Clock) registry, and connects the stream's daxAudioReady to
+// DaxConsumer::Clock) registry, and connects the stream's daxPcmReady to
 // feedRxAudio(). That keeps the engine above the radio seam and
 // source-agnostic: any 24 kHz float32-stereo feed (Flex DAX today, other
 // backends tomorrow) drives it through the same two seams.
@@ -44,7 +44,7 @@ public:
     explicit AetherClockEngine(QObject* parent = nullptr);
     ~AetherClockEngine() override;
 
-    // DAX RX audio sample rate (Hz) — the daxAudioReady contract.
+    // DAX RX audio sample rate (Hz) — the daxPcmReady contract.
     static constexpr int kSampleRateHz = 24000;
 
     // Station presets. Listening dial = carrier − 1 kHz, USB.
@@ -116,7 +116,7 @@ public slots:
     void applyStationPreset(SliceModel* slice, ClockStation station,
                             double carrierMHz);
 
-    // PCM ingest — the daxAudioReady payload (float32 interleaved stereo,
+    // PCM ingest — the daxPcmReady payload (float32 interleaved stereo,
     // native-endian, 24 kHz). The wiring layer connects the audio source
     // here; it is also the test-harness seam and the future non-Flex source
     // seam. Samples whose channel differs from the bound slice's live

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -1764,7 +1764,7 @@ AudioEngine::AudioEngine(QObject* parent)
                 return;
             if (frames <= 0 || sampleRateHz <= 0) return;
             // CwDecoder::feedAudio expects 24 kHz stereo float32 — the
-            // same shape PanadapterStream::audioDataReady() emits on
+            // same shape PanadapterStream::pcmFrameReady() carries on
             // the RX side.  Decimate 48→24 by averaging consecutive
             // pairs; the sidetone is a single sine well below 12 kHz
             // so the cheap two-tap LPF is sufficient for ggmorse.  For

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -4361,6 +4361,30 @@ QByteArray AudioEngine::resampleStereo(const QByteArray& pcm,
     return result;
 }
 
+void AudioEngine::feedPcmFrame(const PcmFrame& frame)
+{
+    if (frame.stream().purpose != PcmPurpose::Speaker
+        || frame.stream().format != PcmFormat{} || !m_pcmIngress.accept(frame)) {
+        return;
+    }
+    const QByteArray pcm = frame.legacyStereo24();
+    if (!pcm.isEmpty()) {
+        feedAudioData(pcm);
+    }
+}
+
+void AudioEngine::feedKiwiPcmFrame(const QString& sourceId, const PcmFrame& frame)
+{
+    if (frame.stream().purpose != PcmPurpose::Auxiliary
+        || frame.stream().format != PcmFormat{} || !m_kiwiPcmIngress.accept(frame)) {
+        return;
+    }
+    const QByteArray pcm = frame.legacyStereo24();
+    if (!pcm.isEmpty()) {
+        feedKiwiSdrAudioData(sourceId, pcm);
+    }
+}
+
 void AudioEngine::feedAudioData(const QByteArray& pcm)
 {
     captureAutomationAudio(QStringLiteral("raw"), QStringLiteral("flex"),

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "core/PcmFrame.h"
+
 #include <QObject>
 #include <QAudioSink>
 #include <QAudioSource>
@@ -679,8 +681,11 @@ public:
     }
 
 public slots:
-    // Receives stripped PCM from PanadapterStream::audioDataReady().
+    // Legacy internal/playback ingress: native float32 stereo at 24 kHz.
+    // Live producers use feedPcmFrame so validation survives queued delivery.
     void feedAudioData(const QByteArray& pcm);
+    void feedPcmFrame(const AetherSDR::PcmFrame& frame);
+    void feedKiwiPcmFrame(const QString& sourceId, const AetherSDR::PcmFrame& frame);
     // Receives decoded KiwiSDR PCM after a clean protocol decoder exists.
     // Same format as feedAudioData(): 24 kHz stereo float32.
     void feedKiwiSdrAudioData(const QByteArray& pcm24kStereoFloat);
@@ -1199,6 +1204,9 @@ private:
     QElapsedTimer m_lastTxMicChannelLog;
     QElapsedTimer m_lastDaxRadioChannelLog;
     std::unique_ptr<Resampler> m_txResampler;  // RADE e.g. 48k -> 24k (lazy init)
+
+    PcmFrameGate m_pcmIngress;
+    PcmFrameGate m_kiwiPcmIngress;
 
     // DSP lifecycle mutex: held during feedAudioData() DSP section AND
     // during enable/disable to prevent use-after-free (#502)

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -72,7 +72,7 @@ class MacNRFilter;
 // AudioEngine handles audio playback (RX) and capture (TX).
 //
 // RX path:
-//   Audio PCM arrives via PanadapterStream::audioDataReady() — the radio sends
+//   Audio PCM arrives via PanadapterStream::pcmFrameReady() — the radio sends
 //   VITA-49 IF-Data packets to the single "client udpport" socket owned by
 //   PanadapterStream. PanadapterStream strips the header and emits the raw PCM;
 //   connect that signal to feedAudioData() then call startRxStream() to open
@@ -742,7 +742,7 @@ signals:
     // from the audio thread; receivers should connect via Qt::AutoConnection
     // (which becomes queued across threads) so feedAudio() lands on the
     // decoder's thread.  Format: 24 kHz stereo float32 — same as the
-    // RX panStream::audioDataReady() path so CwDecoder::feedAudio()
+    // RX panStream::pcmFrameReady() path so CwDecoder::feedAudio()
     // accepts it without a separate adapter.
     void txDecodeAudioReady(const QByteArray& pcm24kStereoFloat);
     // `channels` is carried explicitly (#4489) rather than left for a consumer
@@ -1205,8 +1205,6 @@ private:
     QElapsedTimer m_lastDaxRadioChannelLog;
     std::unique_ptr<Resampler> m_txResampler;  // RADE e.g. 48k -> 24k (lazy init)
 
-    PcmFrameGate m_pcmIngress;
-    PcmFrameGate m_kiwiPcmIngress;
 
     // DSP lifecycle mutex: held during feedAudioData() DSP section AND
     // during enable/disable to prevent use-after-free (#502)
@@ -1464,6 +1462,12 @@ private:
     static constexpr quint16 FLEX_INFO_CLASS = 0x534C;
     static constexpr quint16 PCC_IF_NARROW = 0x03E3;
     static constexpr quint16 PCC_DAX_REDUCED = 0x0123;  // reduced BW DAX (24kHz int16 mono)
+
+private:
+    // Per-consumer replay cursors for the two typed PCM ingress slots. Data,
+    // not slots — kept out of the `private slots:` block above deliberately.
+    PcmFrameGate m_pcmIngress;
+    PcmFrameGate m_kiwiPcmIngress;
 };
 
 } // namespace AetherSDR

--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -780,6 +780,7 @@ void KiwiSdrClient::handleStatusPreflightFinished(QNetworkReply* reply)
 
 void KiwiSdrClient::openWebSockets()
 {
+    m_pcmProducer.start(PcmPurpose::Auxiliary);
     const QString scheme = m_secureWebSocket
         ? QStringLiteral("wss")
         : QStringLiteral("ws");
@@ -1195,6 +1196,7 @@ bool KiwiSdrClient::diagnosticSoundCompressionRequested()
 
 void KiwiSdrClient::cleanupSockets()
 {
+    m_pcmProducer.invalidate();
     if (m_keepaliveTimer) {
         m_keepaliveTimer->stop();
     }
@@ -1949,6 +1951,14 @@ void KiwiSdrClient::handleBinaryMessage(StreamKind stream,
     }
 }
 
+void KiwiSdrClient::publishDecodedAudio(const QByteArray& pcm)
+{
+    if (const auto frame = m_pcmProducer.legacyStereo24(pcm)) {
+        emit pcmFrameReady(*frame);
+        emit decodedAudioReady(frame->legacyStereo24());
+    }
+}
+
 void KiwiSdrClient::handleSoundFrame(const QByteArray& frame)
 {
     m_soundFrameSeen = true;
@@ -2166,10 +2176,10 @@ void KiwiSdrClient::handleSoundFrame(const QByteArray& frame)
                                           kMaxSequenceGapPaddingFrames);
         if (!compressedSound && !m_lastDecodedSoundPcm.isEmpty()) {
             for (quint64 i = 0; i < padFrames; ++i) {
-                emit decodedAudioReady(m_lastDecodedSoundPcm);
+                publishDecodedAudio(m_lastDecodedSoundPcm);
             }
         }
-        emit decodedAudioReady(pcm);
+        publishDecodedAudio(pcm);
         m_lastDecodedSoundPcm = pcm;
         emit meterReadingReady(meterReading);
     }

--- a/src/core/KiwiSdrClient.h
+++ b/src/core/KiwiSdrClient.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "core/PcmFrame.h"
+
 #include "KiwiSdrProtocol.h"
 
 #include <QByteArray>
@@ -142,6 +144,7 @@ signals:
                              const QString& mode, int filterLowHz,
                              int filterHighHz, const QString& panId);
     void decodedAudioReady(const QByteArray& pcm24kStereoFloat);
+    void pcmFrameReady(const AetherSDR::PcmFrame& frame);
     void waterfallRowReady(const QString& panId, const QVector<float>& binsDbm,
                            double lowFreqMhz, double highFreqMhz,
                            quint32 timecode);
@@ -159,6 +162,8 @@ protected:
     virtual void sendWaterfallCommand(const QString& command);
 
 private:
+    PcmProducer m_pcmProducer;
+    void publishDecodedAudio(const QByteArray& pcm);
     friend class KiwiSdrWaterfallSetupTest;
     enum class StreamKind {
         Sound,

--- a/src/core/KiwiSdrManager.cpp
+++ b/src/core/KiwiSdrManager.cpp
@@ -1339,12 +1339,16 @@ KiwiSdrClient* KiwiSdrManager::ensureClient(const QString& id)
         }
         emit profileWaterfallAvailabilityChanged(id, available, detail);
     }, Qt::QueuedConnection);
-    connect(c, &KiwiSdrClient::decodedAudioReady,
-            this, [this, id, c](const QByteArray& pcm) {
+    connect(c, &KiwiSdrClient::pcmFrameReady,
+            this, [this, id, c](const PcmFrame& frame) {
         if (client(id) != c) {
             return;
         }
-        emit decodedAudioReady(id, pcm);
+        const QByteArray pcm = frame.legacyStereo24();
+        if (!pcm.isEmpty()) {
+            emit pcmFrameReady(id, frame);
+            emit decodedAudioReady(id, pcm);
+        }
     }, Qt::QueuedConnection);
     connect(c, &KiwiSdrClient::waterfallRowReady,
             this, [this, id, c](const QString& panId, const QVector<float>& binsDbm,

--- a/src/core/KiwiSdrManager.h
+++ b/src/core/KiwiSdrManager.h
@@ -180,6 +180,7 @@ signals:
     // the per-source DSP state (disabling alone only quiesces it — #3668 review).
     void audioSourceRemoved(const QString& id);
     void decodedAudioReady(const QString& id, const QByteArray& pcm24kStereoFloat);
+    void pcmFrameReady(const QString& id, const AetherSDR::PcmFrame& frame);
     void waterfallRowReady(const QString& id, const QString& panId,
                            const QVector<float>& binsDbm,
                            double lowFreqMhz, double highFreqMhz,

--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -87,6 +87,7 @@ QHostAddress chooseLanBindAddress(RadioConnection* conn,
 PanadapterStream::PanadapterStream(QObject* parent)
     : QObject(parent)
 {
+    m_pcmProducer.start();
     // Socket and timer connections are deferred to init() which runs
     // on the network thread after moveToThread(). (#561)
 }
@@ -205,6 +206,7 @@ void PanadapterStream::setReceiveBufferSizeBytes(int bytes)
 bool PanadapterStream::start(RadioConnection* conn)
 {
     if (isRunning()) stop();  // clean up previous session before rebinding (#561)
+    m_pcmProducer.start();
 
     if (conn && conn->isSyntheticDemo()) {
         // Demo radio: nothing to bind and nothing to generate.
@@ -290,6 +292,7 @@ bool PanadapterStream::start(RadioConnection* conn)
 
 bool PanadapterStream::rebindToEphemeralPort(RadioConnection* conn)
 {
+    m_pcmProducer.start();
     if (!m_socket) {
         qCWarning(lcVita49) << "PanadapterStream: cannot rebind UDP socket before init";
         return false;
@@ -358,6 +361,7 @@ bool PanadapterStream::rebindToEphemeralPort(RadioConnection* conn)
 bool PanadapterStream::startWan(const QHostAddress& radioAddr, quint16 radioUdpPort)
 {
     if (isRunning()) stop();  // clean up previous session before rebinding (#561)
+    m_pcmProducer.start();
 
     resetAudioStreamStats();
 
@@ -406,6 +410,11 @@ void PanadapterStream::startWanUdpRegister(quint32 clientHandle)
 
 void PanadapterStream::stop()
 {
+    m_pcmProducer.invalidate();
+    {
+        QMutexLocker lock(&m_streamMutex);
+        m_daxPcm.clear();
+    }
     if (m_wanRegisterTimer) {
         m_wanRegisterTimer->stop();
     }
@@ -474,6 +483,7 @@ void PanadapterStream::clearRegisteredStreams()
     m_wfFrames.clear();
     m_dbmRanges.clear();
     m_pendingDbmRanges.clear();
+    m_daxPcm.clear();
     m_daxStreamIds.clear();
     m_iqStreamIds.clear();
     m_loggedDaxPacketStreams.clear();
@@ -801,7 +811,10 @@ void PanadapterStream::processDatagram(const QByteArray& data)
             // Float32 stereo big-endian from radio → native float32 stereo
             const int payloadStart = VITA49_HEADER_BYTES;
             const int payloadBytes = data.size() - payloadStart - (hasTrailer ? 4 : 0);
-            if (payloadBytes < 4) return;
+            if (payloadBytes < 8 || payloadBytes % 8 != 0
+                || payloadBytes / 8 > PcmFrame::kMaxFrames) {
+                return;
+            }
             const int numFloats = payloadBytes / 4;
             const uchar* src = raw + payloadStart;
             pcm.resize(numFloats * static_cast<int>(sizeof(float)));
@@ -809,11 +822,17 @@ void PanadapterStream::processDatagram(const QByteArray& data)
             for (int i = 0; i < numFloats; ++i) {
                 const quint32 u = qFromBigEndian<quint32>(src + i * 4);
                 std::memcpy(&dst[i], &u, 4);
+                if (!std::isfinite(dst[i])) {
+                    return;
+                }
             }
         } else if (pcc == PCC_IF_NARROW_REDUCED) {
             const int payloadStart = VITA49_HEADER_BYTES;
             const int payloadBytes = data.size() - payloadStart - (hasTrailer ? 4 : 0);
-            if (payloadBytes < 2) return;
+            if (payloadBytes < 2 || payloadBytes % 2 != 0
+                || payloadBytes / 2 > PcmFrame::kMaxFrames) {
+                return;
+            }
             const int monoSamples = payloadBytes / 2;
             const uchar* src = raw + payloadStart;
             pcm.resize(monoSamples * 2 * static_cast<int>(sizeof(float)));
@@ -826,7 +845,7 @@ void PanadapterStream::processDatagram(const QByteArray& data)
         } else {
             return;
         }
-        emit daxAudioReady(channel, pcm);
+        publishLegacyDaxAudio(streamId, channel, pcm);
         return;
     }
 
@@ -1120,6 +1139,42 @@ void PanadapterStream::setPacketLossConcealment(bool on)
     }
 }
 
+void PanadapterStream::publishLegacyDaxAudio(quint32 streamId, int channel,
+                                            const QByteArray& pcm)
+{
+    std::optional<PcmFrame> frame;
+    {
+        QMutexLocker lock(&m_streamMutex);
+        if (m_daxStreamIds.value(streamId, -1) != channel) {
+            return;
+        }
+        auto it = m_daxPcm.find(streamId);
+        if (it == m_daxPcm.end()) {
+            if (m_daxPcm.size() >= PcmFrameGate::kMaxStreams) {
+                return;
+            }
+            auto producer = std::make_unique<PcmProducer>();
+            // DAX channel identity is supplied alongside the frame. A channel
+            // is not a stable slice slot; A4 owns that attribution/conversion.
+            producer->start(PcmPurpose::Auxiliary);
+            it = m_daxPcm.emplace(streamId, std::move(producer)).first;
+        }
+        frame = it->second->legacyStereo24(pcm);
+    }
+    if (frame) {
+        emit daxPcmReady(channel, *frame);
+        emit daxAudioReady(channel, frame->legacyStereo24());
+    }
+}
+
+void PanadapterStream::publishLegacyAudio(const QByteArray& pcm)
+{
+    if (const auto frame = m_pcmProducer.legacyStereo24(pcm)) {
+        emit pcmFrameReady(*frame);
+        emit audioDataReady(frame->legacyStereo24());
+    }
+}
+
 void PanadapterStream::decodeNarrowAudio(const uchar* raw, int totalBytes, bool hasTrailer, quint32 streamId)
 {
     // One-time: log the RX audio VITA-49 header for comparison with our TX packets
@@ -1143,7 +1198,10 @@ void PanadapterStream::decodeNarrowAudio(const uchar* raw, int totalBytes, bool 
     // Byte-swap to native float32 and emit directly — no int16 conversion.
     const int payloadStart = VITA49_HEADER_BYTES;
     const int payloadBytes = totalBytes - payloadStart - (hasTrailer ? 4 : 0);
-    if (payloadBytes < 4) return;
+    if (payloadBytes < 8 || payloadBytes % 8 != 0
+        || payloadBytes / 8 > PcmFrame::kMaxFrames) {
+        return;
+    }
 
     const int numFloats = payloadBytes / 4;
     const uchar* src = raw + payloadStart;
@@ -1154,11 +1212,14 @@ void PanadapterStream::decodeNarrowAudio(const uchar* raw, int totalBytes, bool 
     for (int i = 0; i < numFloats; ++i) {
         const quint32 u = qFromBigEndian<quint32>(src + i * 4);
         std::memcpy(&dst[i], &u, 4);
+        if (!std::isfinite(dst[i])) {
+            return;
+        }
     }
 
     auto& plc = m_audioPlc[streamId];
     pcm = applyConcealmentFade(std::move(pcm), plc, m_plcEnabled.load());
-    emit audioDataReady(pcm);
+    publishLegacyAudio(pcm);
 }
 
 void PanadapterStream::decodeReducedBwAudio(const uchar* raw, int totalBytes, bool hasTrailer, quint32 streamId)
@@ -1183,7 +1244,10 @@ void PanadapterStream::decodeReducedBwAudio(const uchar* raw, int totalBytes, bo
     // Payload: big-endian int16 mono. Convert to float32 stereo.
     const int payloadStart = VITA49_HEADER_BYTES;
     const int payloadBytes = totalBytes - payloadStart - (hasTrailer ? 4 : 0);
-    if (payloadBytes < 2) return;
+    if (payloadBytes < 2 || payloadBytes % 2 != 0
+        || payloadBytes / 2 > PcmFrame::kMaxFrames) {
+        return;
+    }
 
     const int monoSamples = payloadBytes / 2;
     const uchar* src = raw + payloadStart;
@@ -1199,7 +1263,7 @@ void PanadapterStream::decodeReducedBwAudio(const uchar* raw, int totalBytes, bo
 
     auto& plc = m_audioPlc[streamId];
     pcm = applyConcealmentFade(std::move(pcm), plc, m_plcEnabled.load());
-    emit audioDataReady(pcm);
+    publishLegacyAudio(pcm);
 }
 
 // ─── Meter data decode ───────────────────────────────────────────────────────
@@ -1269,7 +1333,7 @@ void PanadapterStream::decodeOpusAudio(const uchar* raw, int totalBytes, bool ha
         plc.tailL = dst[numSamples - 2];
         plc.tailR = dst[numSamples - 1];
     }
-    emit audioDataReady(pcm);
+    publishLegacyAudio(pcm);
 }
 
 void PanadapterStream::decodeMeterData(const uchar* raw, int totalBytes, bool hasTrailer)
@@ -1464,10 +1528,14 @@ void PanadapterStream::registerDaxStream(quint32 streamId, int channel)
         if (it.value() == channel && it.key() != streamId) {
             qCDebug(lcVita49) << "PanadapterStream: evicting stale DAX stream"
                               << Qt::hex << it.key() << "from channel" << channel;
+            m_daxPcm.erase(it.key());
             it = m_daxStreamIds.erase(it);
         } else {
             ++it;
         }
+    }
+    if (m_daxStreamIds.value(streamId, -1) != channel) {
+        m_daxPcm.erase(streamId);
     }
     m_daxStreamIds[streamId] = channel;
     m_loggedDaxPacketStreams.remove(streamId);
@@ -1500,6 +1568,7 @@ void PanadapterStream::unregisterDaxStream(quint32 streamId)
     int channel = 0;
     {
         QMutexLocker lock(&m_streamMutex);
+        m_daxPcm.erase(streamId);
         m_daxStreamIds.remove(streamId);
         m_loggedDaxPacketStreams.remove(streamId);
         // DAX audio streams use the PLC path too; drop the per-stream PLC

--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -292,11 +292,14 @@ bool PanadapterStream::start(RadioConnection* conn)
 
 bool PanadapterStream::rebindToEphemeralPort(RadioConnection* conn)
 {
-    m_pcmProducer.start();
     if (!m_socket) {
         qCWarning(lcVita49) << "PanadapterStream: cannot rebind UDP socket before init";
         return false;
     }
+    // Rotate the epoch only once the rebind is actually going ahead. Starting
+    // above the guard revoked every queued frame and reset continuity on a
+    // stream that then kept running unchanged.
+    m_pcmProducer.start();
 
     if (m_routedPrimeTimer)
         m_routedPrimeTimer->stop();
@@ -1163,7 +1166,6 @@ void PanadapterStream::publishLegacyDaxAudio(quint32 streamId, int channel,
     }
     if (frame) {
         emit daxPcmReady(channel, *frame);
-        emit daxAudioReady(channel, frame->legacyStereo24());
     }
 }
 
@@ -1171,7 +1173,6 @@ void PanadapterStream::publishLegacyAudio(const QByteArray& pcm)
 {
     if (const auto frame = m_pcmProducer.legacyStereo24(pcm)) {
         emit pcmFrameReady(*frame);
-        emit audioDataReady(frame->legacyStereo24());
     }
 }
 
@@ -1522,7 +1523,7 @@ void PanadapterStream::registerDaxStream(quint32 streamId, int channel)
     QMutexLocker lock(&m_streamMutex);
     // Enforce one active stream per channel. A stale stream from a previous
     // session or a duplicate subscription created by another code path would
-    // cause daxAudioReady to fire twice per audio period — doubling perceived
+    // cause daxPcmReady to fire twice per audio period — doubling perceived
     // speed. Remove any prior mapping for this channel before inserting.
     for (auto it = m_daxStreamIds.begin(); it != m_daxStreamIds.end(); ) {
         if (it.value() == channel && it.key() != streamId) {

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -27,8 +27,8 @@ class OpusCodec;
 
 // Receives all VITA-49 UDP datagrams from the radio on the single "client udpport"
 // and routes them by PacketClassCode (bytes 14-15 of the VITA-49 class ID):
-//   • PCC 0x03E3 → narrow audio, float32 stereo big-endian  → audioDataReady()
-//   • PCC 0x0123 → narrow audio reduced-BW, int16 mono BE   → audioDataReady()
+//   • PCC 0x03E3 → narrow audio, float32 stereo big-endian  → pcmFrameReady()
+//   • PCC 0x0123 → narrow audio reduced-BW, int16 mono BE   → pcmFrameReady()
 //   • PCC 0x8003 → panadapter FFT bins                      → spectrumReady()
 //   • PCC 0x8004 → waterfall tiles (Width×Height uint16)    → waterfallRowReady()
 //   • PCC 0x8002 → meter data (id/value pairs)             → meterDataReady()
@@ -216,7 +216,7 @@ signals:
     // TCI uses this to invalidate its channel→trx routing cache.
     void daxStreamUnregistered(int channel, quint32 streamId);
 
-    void daxAudioReady(int channel, const QByteArray& pcm);
+    // One DAX channel's RX audio as owning typed PCM.
     void daxPcmReady(int channel, const AetherSDR::PcmFrame& frame);
     void iqDataReady(int channel, const QByteArray& rawPayload, int sampleRate);
     void spectrumReady(quint32 streamId, const QVector<float>& binsDbm, qint64 emittedNs);
@@ -226,9 +226,8 @@ signals:
                            quint32 timecode, qint64 emittedNs);
     // Emitted once per waterfall tile with the radio's computed auto black level.
     void waterfallAutoBlackLevel(quint32 streamId, quint32 autoBlack);
-    // Compatibility output after IF-Data decode: owning native-endian
-    // float32 stereo at 24 kHz. Production routes use pcmFrameReady instead.
-    void audioDataReady(const QByteArray& pcm);
+    // Speaker RX audio after IF-Data decode: owning native-endian float32,
+    // at the producer's declared format. A1 publishes 24 kHz stereo.
     void pcmFrameReady(const AetherSDR::PcmFrame& frame);
     // Meter data: parallel arrays of (meter_index, raw_int16_value).
     void meterDataReady(const QVector<quint16>& ids, const QVector<qint16>& vals);

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "core/PcmFrame.h"
+#include <map>
+
 #include "PacketLossConcealment.h"
 #include "VitaBinCoverage.h"
 
@@ -214,6 +217,7 @@ signals:
     void daxStreamUnregistered(int channel, quint32 streamId);
 
     void daxAudioReady(int channel, const QByteArray& pcm);
+    void daxPcmReady(int channel, const AetherSDR::PcmFrame& frame);
     void iqDataReady(int channel, const QByteArray& rawPayload, int sampleRate);
     void spectrumReady(quint32 streamId, const QVector<float>& binsDbm, qint64 emittedNs);
     // One row of waterfall data (intensity values, Width bins).
@@ -222,9 +226,10 @@ signals:
                            quint32 timecode, qint64 emittedNs);
     // Emitted once per waterfall tile with the radio's computed auto black level.
     void waterfallAutoBlackLevel(quint32 streamId, quint32 autoBlack);
-    // Raw PCM payload (header stripped) from IF-Data (audio) VITA-49 packets.
-    // Format: 16-bit signed, stereo, 24 kHz, little-endian.
+    // Compatibility output after IF-Data decode: owning native-endian
+    // float32 stereo at 24 kHz. Production routes use pcmFrameReady instead.
     void audioDataReady(const QByteArray& pcm);
+    void pcmFrameReady(const AetherSDR::PcmFrame& frame);
     // Meter data: parallel arrays of (meter_index, raw_int16_value).
     void meterDataReady(const QVector<quint16>& ids, const QVector<qint16>& vals);
     // Emitted after the receive buffer is (re)applied on a bind or a live
@@ -235,6 +240,11 @@ private slots:
     void onDatagramReady();
 
 private:
+    friend class PcmCompatibilityTestAccess;
+    PcmProducer m_pcmProducer;
+    std::map<quint32, std::unique_ptr<PcmProducer>> m_daxPcm;
+    void publishLegacyDaxAudio(quint32 streamId, int channel, const QByteArray& pcm);
+    void publishLegacyAudio(const QByteArray& pcm);
     void processDatagram(const QByteArray& data);
     // Raise the kernel receive buffer (SO_RCVBUF) on the bound VITA-49 socket so
     // bursts / brief drain stalls don't overflow it and surface as false

--- a/src/core/PcmFrame.h
+++ b/src/core/PcmFrame.h
@@ -222,9 +222,19 @@ private:
     bool m_first = true;
 };
 
-// Receiver-side bounded replay/order guard. Separate consumers have separate
-// cursors; reading a slice tap never consumes the speaker's frame. New streams
-// are admitted only with a live producer token; traffic cannot resurrect one.
+// Receiver-side bounded replay guard. Separate consumers have separate cursors;
+// reading a slice tap never consumes the speaker's frame. New streams are
+// admitted only with a live producer token; traffic cannot resurrect one.
+//
+// The guard is deliberately ONE-SIDED: it refuses a frame at or behind the
+// cursor (replay, duplicate, reorder) and admits one ahead of it. A forward gap
+// is not an attack, it is "this consumer missed frames" — which every consumer
+// that can be detached from a running producer does legitimately. Playback mute
+// is the live example: MainWindow disconnects the Flex speaker feed, and
+// MainWindow_Session returns early for a seam backend, while the producer keeps
+// counting. Refusing the gap would leave that consumer's cursor permanently
+// behind a live epoch, and since the cursor only advances on an accepted frame
+// there is no way back — RX audio would stay silent until the next reconnect.
 class PcmFrameGate final {
 public:
     static constexpr std::size_t kMaxStreams = 32;
@@ -237,8 +247,7 @@ public:
         for (Cursor& cursor : m_cursors) {
             const std::shared_ptr<const detail::PcmEpoch> epoch = cursor.epoch.lock();
             if (epoch == frame.m_epoch) {
-                if (frame.firstSample() < cursor.nextSample
-                    || (frame.firstSample() != cursor.nextSample && !frame.discontinuity())) {
+                if (frame.firstSample() < cursor.nextSample) {
                     return false;
                 }
                 cursor.nextSample = frame.firstSample() + frame.frameCount();

--- a/src/core/PcmFrame.h
+++ b/src/core/PcmFrame.h
@@ -1,0 +1,268 @@
+#pragma once
+
+#include <QByteArray>
+#include <QMetaType>
+#include <QVector>
+
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <utility>
+
+namespace AetherSDR {
+
+// RFC #5468 A1. These are PRODUCER formats, independent of the audio device
+// and of fixed-rate decoder domains. No 48 kHz producer is enabled by A1.
+enum class PcmLayout { Mono, Stereo };
+enum class PcmPurpose { Speaker, Slice, Auxiliary };
+
+struct PcmFormat {
+    int sampleRateHz = 24000;
+    PcmLayout layout = PcmLayout::Stereo;
+    int channels() const { return layout == PcmLayout::Mono ? 1 : 2; }
+    bool valid() const
+    {
+        return (sampleRateHz == 24000 || sampleRateHz == 48000)
+            && (layout == PcmLayout::Mono || layout == PcmLayout::Stereo);
+    }
+    bool operator==(const PcmFormat&) const = default;
+};
+
+struct PcmStreamDescriptor {
+    quint64 source = 0;             // process-local producer identity
+    quint64 session = 0;            // connection, distinct from source/slot
+    quint64 formatGeneration = 0;   // changes even on a 24 -> 48 -> 24 cycle
+    quint64 receiverInstance = 0;   // F4 Handle::instance, never the slot
+    int sliceId = -1;               // F4 Handle::slot, or -1 for a mix
+    PcmPurpose purpose = PcmPurpose::Speaker;
+    PcmFormat format;
+    bool operator==(const PcmStreamDescriptor&) const = default;
+};
+
+namespace detail {
+// Revocation is the only mutable field. It lets a queued frame fail closed
+// after stop/reconnect/removal, even before a consumer's event loop runs a
+// reset. This token owns no radio, DSP, QObject or callback resources.
+struct PcmEpoch {
+    const PcmStreamDescriptor descriptor;
+    std::atomic<bool> active{true};
+    explicit PcmEpoch(PcmStreamDescriptor value) : descriptor(value) {}
+};
+} // namespace detail
+
+class PcmProducer;
+class PcmFrameGate;
+
+// Owning native-endian, interleaved IEEE float32 PCM. Metadata and samples are
+// immutable to consumers and copied together by Qt queued delivery. Neither a
+// borrowed callback buffer nor a mutable global rate can reinterpret a frame.
+class PcmFrame final {
+public:
+    static constexpr qsizetype kMaxFrames = 65536;
+    PcmFrame() = default; // invalid, suitable for QVariant/queued metatypes
+    const PcmStreamDescriptor& stream() const
+    {
+        static const PcmStreamDescriptor empty;
+        return m_epoch ? m_epoch->descriptor : empty;
+    }
+    const QVector<float>& samples() const { return m_samples; }
+    qsizetype frameCount() const { return m_samples.size() / stream().format.channels(); }
+    quint64 firstSample() const { return m_firstSample; }
+    bool discontinuity() const { return m_discontinuity; }
+    bool current() const
+    {
+        return m_epoch && m_epoch->active.load(std::memory_order_acquire);
+    }
+
+    // Compatibility boundary ONLY. Refuse formats the existing 24 kHz stereo
+    // consumers cannot interpret; never resample, downmix, clip or relabel.
+    // A2-A5 replace these boundaries as their consumers become rate-aware.
+    QByteArray legacyStereo24() const
+    {
+        if (!current() || stream().format != PcmFormat{}) {
+            return {};
+        }
+        return QByteArray(reinterpret_cast<const char*>(m_samples.constData()),
+                         m_samples.size() * static_cast<qsizetype>(sizeof(float)));
+    }
+
+private:
+    friend class PcmProducer;
+    friend class PcmFrameGate;
+    std::shared_ptr<const detail::PcmEpoch> m_epoch;
+    QVector<float> m_samples;
+    quint64 m_firstSample = 0;
+    bool m_discontinuity = false;
+};
+
+// One execution context produces a stream. start()/stop()/format changes run
+// on that same context. invalidate() may overlap produce()/queued delivery,
+// but must not overlap start(), setFormat() or destruction. The caller must
+// join the producer before destroying it. Only the tiny epoch token survives.
+class PcmProducer final {
+public:
+    PcmProducer() : m_source(s_nextSource.fetch_add(1, std::memory_order_relaxed)) {}
+    ~PcmProducer() { invalidate(); }
+    PcmProducer(const PcmProducer&) = delete;
+    PcmProducer& operator=(const PcmProducer&) = delete;
+
+    // Explicit F4 session/instance values may be supplied. Legacy adapters use
+    // local monotonic sessions and the unique producer id as receiver instance.
+    bool start(PcmPurpose purpose = PcmPurpose::Speaker, int sliceId = -1,
+               PcmFormat format = {}, quint64 session = 0,
+               quint64 receiverInstance = 0)
+    {
+        if (!format.valid() || m_source == 0 || (session != 0 && session <= m_session)
+            || (purpose != PcmPurpose::Speaker && purpose != PcmPurpose::Slice
+                && purpose != PcmPurpose::Auxiliary)
+            || (purpose == PcmPurpose::Slice ? sliceId < 0 : sliceId != -1)
+            || m_session == std::numeric_limits<quint64>::max()) {
+            return false;
+        }
+        invalidate();
+        m_session = session ? session : m_session + 1;
+        m_generation = 1;
+        const PcmStreamDescriptor descriptor{m_source, m_session, m_generation,
+            purpose == PcmPurpose::Slice ? (receiverInstance ? receiverInstance : m_source) : 0,
+            sliceId, purpose, format};
+        m_epoch = std::make_shared<detail::PcmEpoch>(descriptor);
+        m_nextSample = 0;
+        m_first = true;
+        return true;
+    }
+
+    bool setFormat(PcmFormat format)
+    {
+        if (!m_epoch || !m_epoch->active.load(std::memory_order_acquire)
+            || !format.valid() || m_generation == std::numeric_limits<quint64>::max()) {
+            return false;
+        }
+        if (format == m_epoch->descriptor.format) {
+            return true;
+        }
+        PcmStreamDescriptor descriptor = m_epoch->descriptor;
+        descriptor.format = format;
+        descriptor.formatGeneration = ++m_generation;
+        invalidate();
+        m_epoch = std::make_shared<detail::PcmEpoch>(descriptor);
+        m_nextSample = 0;
+        m_first = true;
+        return true;
+    }
+
+    void invalidate() const
+    {
+        if (m_epoch) {
+            m_epoch->active.store(false, std::memory_order_release);
+        }
+    }
+
+    std::optional<PcmFrame> produce(QVector<float> samples,
+                                    std::optional<quint64> firstSample = std::nullopt,
+                                    bool discontinuity = false)
+    {
+        if (!m_epoch || !m_epoch->active.load(std::memory_order_acquire)) {
+            return std::nullopt;
+        }
+        const int channels = m_epoch->descriptor.format.channels();
+        if (samples.isEmpty() || samples.size() % channels != 0
+            || samples.size() / channels > PcmFrame::kMaxFrames) {
+            return std::nullopt;
+        }
+        const quint64 count = static_cast<quint64>(samples.size() / channels);
+        const quint64 position = firstSample.value_or(m_nextSample);
+        if (position < m_nextSample || (position != m_nextSample && !discontinuity)
+            || position > std::numeric_limits<quint64>::max() - count) {
+            return std::nullopt;
+        }
+        // Detach explicitly: Qt containers can also wrap read-only external
+        // storage. A queued frame must own that storage independently.
+        samples.detach();
+        for (float sample : std::as_const(samples)) {
+            if (!std::isfinite(sample)) {
+                return std::nullopt;
+            }
+        }
+        PcmFrame frame;
+        frame.m_epoch = m_epoch;
+        frame.m_samples = std::move(samples);
+        frame.m_firstSample = position;
+        frame.m_discontinuity = m_first || discontinuity;
+        m_nextSample = position + count;
+        m_first = false;
+        return frame;
+    }
+
+    // Existing producers all publish 24 kHz stereo. Copy into typed, owned
+    // storage before queueing; QByteArray::fromRawData must not escape borrowed.
+    std::optional<PcmFrame> legacyStereo24(const QByteArray& pcm)
+    {
+        constexpr qsizetype kFrameBytes = 2 * sizeof(float);
+        if (!m_epoch || m_epoch->descriptor.format != PcmFormat{}
+            || pcm.isEmpty() || pcm.size() % kFrameBytes != 0
+            || pcm.size() / kFrameBytes > PcmFrame::kMaxFrames) {
+            return std::nullopt;
+        }
+        QVector<float> samples(pcm.size() / static_cast<qsizetype>(sizeof(float)));
+        std::memcpy(samples.data(), pcm.constData(), static_cast<std::size_t>(pcm.size()));
+        return produce(std::move(samples));
+    }
+
+private:
+    inline static std::atomic<quint64> s_nextSource{1};
+    const quint64 m_source;
+    quint64 m_session = 0;
+    quint64 m_generation = 0;
+    std::shared_ptr<detail::PcmEpoch> m_epoch;
+    quint64 m_nextSample = 0;
+    bool m_first = true;
+};
+
+// Receiver-side bounded replay/order guard. Separate consumers have separate
+// cursors; reading a slice tap never consumes the speaker's frame. New streams
+// are admitted only with a live producer token; traffic cannot resurrect one.
+class PcmFrameGate final {
+public:
+    static constexpr std::size_t kMaxStreams = 32;
+    bool accept(const PcmFrame& frame)
+    {
+        if (!frame.current()) {
+            return false;
+        }
+        Cursor* available = nullptr;
+        for (Cursor& cursor : m_cursors) {
+            const std::shared_ptr<const detail::PcmEpoch> epoch = cursor.epoch.lock();
+            if (epoch == frame.m_epoch) {
+                if (frame.firstSample() < cursor.nextSample
+                    || (frame.firstSample() != cursor.nextSample && !frame.discontinuity())) {
+                    return false;
+                }
+                cursor.nextSample = frame.firstSample() + frame.frameCount();
+                return true;
+            }
+            if (!epoch || !epoch->active.load(std::memory_order_acquire)) {
+                available = &cursor;
+            }
+        }
+        if (!available) {
+            return false;
+        }
+        available->epoch = frame.m_epoch;
+        available->nextSample = frame.firstSample() + frame.frameCount();
+        return true;
+    }
+private:
+    struct Cursor {
+        std::weak_ptr<const detail::PcmEpoch> epoch;
+        quint64 nextSample = 0;
+    };
+    std::array<Cursor, kMaxStreams> m_cursors;
+};
+
+} // namespace AetherSDR
+
+Q_DECLARE_METATYPE(AetherSDR::PcmFrame)

--- a/src/core/QsoRecordStartPolicy.h
+++ b/src/core/QsoRecordStartPolicy.h
@@ -3,7 +3,7 @@
 // QsoRecordStartPolicy — may a QSO recording start? (#4629)
 //
 // Client-Side recording captures RadioModel::rxDemodAudioReady, which on a Flex
-// is fed by PanadapterStream::audioDataReady — the `remote_audio_rx` VITA-49
+// is fed by PanadapterStream::pcmFrameReady — the `remote_audio_rx` VITA-49
 // stream. That stream is created ONLY when PC Audio is enabled
 // (RadioModel::scheduleRxAudioStreamEnsure, which returns early on
 // PcAudioEnabled=False and removes an already-owned stream). With PC Audio off

--- a/src/core/QsoRecorder.h
+++ b/src/core/QsoRecorder.h
@@ -27,7 +27,7 @@ class TransmitModel;
 // Records QSO audio (both RX and TX sides) to WAV files.
 //
 // Usage:
-//   - Connect feedRxAudio() (float32 RX) to PanadapterStream::audioDataReady
+//   - Connect feedRxAudio() (float32 RX) to RadioModel::rxDemodAudioReady
 //   - Connect feedTxAudio() (int16 post-limiter TX monitor) to
 //     AudioEngine::txFinalMonitorPcmReady — the source that carries SSB/phone TX
 //     (txRawPcmReady is RADE-only and would leave SSB recordings silent, #3556)

--- a/src/core/RttyDecoder.h
+++ b/src/core/RttyDecoder.h
@@ -12,11 +12,11 @@ namespace AetherSDR {
 
 // Client-side RTTY (Baudot/ITA2) decoder using mark/space bandpass filters.
 // Runs decoding on a worker thread. Feed it 24 kHz stereo float32 PCM
-// (the same format audioDataReady emits) and it emits decoded text.
+// (the same format rxDemodAudioReady carries) and it emits decoded text.
 //
 // Usage:
 //   decoder.start();
-//   connect(panStream, &PanadapterStream::audioDataReady, &decoder, &RttyDecoder::feedAudio);
+//   connect(&radioModel, &RadioModel::rxDemodAudioReady, ...); // unwrap with PcmFrame::legacyStereo24()
 //   connect(&decoder, &RttyDecoder::textDecoded, panel, &PanadapterApplet::appendRttyText);
 
 class RttyDecoder : public QObject {

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -4211,7 +4211,7 @@ void TciServer::onWaterfallRowReady(quint32 streamId, const QVector<float>& bins
 
 // ── DAX channel management for TCI audio (#1331) ─────────────────────────────
 //
-// TCI audio feeds from daxAudioReady (not audioDataReady) so that audio_mute
+// TCI audio feeds from daxPcmReady (not pcmFrameReady) so that audio_mute
 // doesn't kill TCI audio. We auto-assign a DAX channel to each slice that
 // doesn't already have one, and release it when the last TCI audio client
 // disconnects.
@@ -4271,7 +4271,7 @@ void TciServer::ensureDaxForTci()
     // Acquire the needed channels from the centralized manager (#3305). It
     // creates the radio-side stream only when the channel gains its FIRST
     // holder — never a duplicate subscription (duplicate streams made
-    // daxAudioReady fire twice per period, doubling apparent audio speed) —
+    // daxPcmReady fire twice per period, doubling apparent audio speed) —
     // and reuses anything the DAX bridge or a previous arm already created.
     // Acquire is idempotent, so re-arm paths can call this freely.
     //

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "core/RadioSettingsIdentity.h"
+#include "core/PcmFrame.h"
+
+#include <map>
 
 #include <QByteArray>
 #include <QMap>
@@ -174,8 +177,30 @@ class IRadioBackend : public QObject {
     Q_OBJECT
 
 public:
-    explicit IRadioBackend(QObject* parent = nullptr) : QObject(parent) {}
+    explicit IRadioBackend(QObject* parent = nullptr) : QObject(parent)
+    {
+        connect(this, &IRadioBackend::connected, this, [this] {
+            m_slicePcm.clear();
+            ++m_pcmSession;
+            m_pcmLive = m_speakerPcm.start(PcmPurpose::Speaker, -1, {}, m_pcmSession);
+        });
+        connect(this, &IRadioBackend::disconnected, this, [this] {
+            retirePcmStreams();
+        });
+        connect(this, &IRadioBackend::sliceRemoved, this, [this](int id) {
+            m_slicePcm.erase(id);
+        });
+    }
     ~IRadioBackend() override = default;
+
+    // Owner-thread retirement before disconnect/teardown can pump events.
+    // Revokes already queued compatibility frames without touching the radio.
+    void retirePcmStreams()
+    {
+        m_pcmLive = false;
+        m_speakerPcm.invalidate();
+        m_slicePcm.clear();
+    }
 
     // ---- identity & capability (feeds the protocol `welcome`, §4.1) ----
     virtual RadioCapabilities capabilities() const = 0;
@@ -1116,7 +1141,7 @@ signals:
     // Flex does NOT emit this: its per-slice audio already arrives as DAX
     // channels, which are per-slice by construction. Only a backend that
     // demodulates in this process has to say which slice a buffer belongs to.
-    void sliceAudioFrameReady(int sliceId, const QByteArray& pcm);
+    void sliceAudioFrameReady(int sliceId, const AetherSDR::PcmFrame& pcm);
 
 
     // The pan's front end is WIDE: the hardware band filter cannot serve every
@@ -1230,7 +1255,55 @@ signals:
     // then a backend may relay the existing in-tree frame types.
     void spectrumFrameReady(int panId, const QByteArray& frame);
     void waterfallRowReady(int panId, const QByteArray& row);
-    void audioFrameReady(const QByteArray& pcm);
+    void audioFrameReady(const AetherSDR::PcmFrame& pcm);
+
+protected:
+    quint64 pcmSession() const { return m_pcmSession; }
+
+    // Compatibility publishers for current 24 kHz backends. Call on the owner
+    // thread, after rejecting obsolete worker deliveries. Native-rate producers
+    // will publish their own PcmFrame without using these fixed-format adapters.
+    void publishLegacyAudio(const QByteArray& pcm)
+    {
+        if (!m_pcmLive || !isConnected()) {
+            return;
+        }
+        if (const auto frame = m_speakerPcm.legacyStereo24(pcm)) {
+            emit audioFrameReady(*frame);
+        }
+    }
+    bool publishLegacySliceAudio(int sliceId, const QByteArray& pcm)
+    {
+        if (!m_pcmLive || !isConnected() || sliceId < 0) {
+            return false;
+        }
+        auto it = m_slicePcm.find(sliceId);
+        if (it == m_slicePcm.end()) {
+            if (m_slicePcm.size() >= PcmFrameGate::kMaxStreams) {
+                return false;
+            }
+            auto producer = std::make_unique<PcmProducer>();
+            producer->start(PcmPurpose::Slice, sliceId, {}, m_pcmSession);
+            const auto frame = producer->legacyStereo24(pcm);
+            if (!frame) {
+                return false;
+            }
+            m_slicePcm.emplace(sliceId, std::move(producer));
+            emit sliceAudioFrameReady(sliceId, *frame);
+            return true;
+        }
+        if (const auto frame = it->second->legacyStereo24(pcm)) {
+            emit sliceAudioFrameReady(sliceId, *frame);
+            return true;
+        }
+        return false;
+    }
+
+private:
+    bool m_pcmLive = false;
+    quint64 m_pcmSession = 0;
+    PcmProducer m_speakerPcm;
+    std::map<int, std::unique_ptr<PcmProducer>> m_slicePcm;
 };
 
 }  // namespace AetherSDR

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -6,6 +6,7 @@
 #include <map>
 
 #include <QByteArray>
+#include <QLoggingCategory>
 #include <QMap>
 #include <QObject>
 #include <QString>
@@ -183,6 +184,13 @@ public:
             m_slicePcm.clear();
             ++m_pcmSession;
             m_pcmLive = m_speakerPcm.start(PcmPurpose::Speaker, -1, {}, m_pcmSession);
+            if (!m_pcmLive) {
+                // Refusing here means total RX silence on this backend. Say so:
+                // every downstream refusal is a silent return, so without this
+                // the failure is indistinguishable from a dead radio.
+                qWarning() << "IRadioBackend: speaker PCM producer refused to start for session"
+                           << m_pcmSession << "- RX audio will be silent on this connection";
+            }
         });
         connect(this, &IRadioBackend::disconnected, this, [this] {
             retirePcmStreams();
@@ -1266,6 +1274,7 @@ protected:
     void publishLegacyAudio(const QByteArray& pcm)
     {
         if (!m_pcmLive || !isConnected()) {
+            warnAudioDropped();
             return;
         }
         if (const auto frame = m_speakerPcm.legacyStereo24(pcm)) {
@@ -1275,6 +1284,7 @@ protected:
     bool publishLegacySliceAudio(int sliceId, const QByteArray& pcm)
     {
         if (!m_pcmLive || !isConnected() || sliceId < 0) {
+            warnAudioDropped();
             return false;
         }
         auto it = m_slicePcm.find(sliceId);
@@ -1300,8 +1310,21 @@ protected:
     }
 
 private:
+    // One line per session, not per frame: this fires at audio rate.
+    void warnAudioDropped()
+    {
+        if (m_pcmDropWarned == m_pcmSession) {
+            return;
+        }
+        m_pcmDropWarned = m_pcmSession;
+        qWarning() << "IRadioBackend: dropping RX audio in session" << m_pcmSession
+                   << "- no live PCM producer (live =" << m_pcmLive
+                   << ", connected =" << isConnected() << ")";
+    }
+
     bool m_pcmLive = false;
     quint64 m_pcmSession = 0;
+    quint64 m_pcmDropWarned = 0;
     PcmProducer m_speakerPcm;
     std::map<int, std::unique_ptr<PcmProducer>> m_slicePcm;
 };

--- a/src/core/backends/anan/AnanBackend.cpp
+++ b/src/core/backends/anan/AnanBackend.cpp
@@ -276,12 +276,15 @@ AnanBackend::AnanBackend(QObject* parent)
         emit capabilitiesChanged();
     });
 
-    connect(m_dsp, &AnanRxDsp::audioReady, this, [this](const std::vector<float>& pcm) {
-        const QByteArray bytes = floatBytes(pcm);
-        emit sliceAudioFrameReady(kSliceId, bytes);
+    connect(m_dsp, &AnanRxDsp::pcmReady, this, [this](const PcmFrame& frame) {
+        const QByteArray bytes = frame.legacyStereo24();
+        if (bytes.isEmpty()) {
+            return;
+        }
+        publishLegacySliceAudio(kSliceId, bytes);
         // One DDC, so "mixing" the speaker feed is the identity -- no
         // separate mix stage needed for a single receiver.
-        emit audioFrameReady(bytes);
+        publishLegacyAudio(bytes);
     });
     connect(m_dsp, &AnanRxDsp::spectrumReady, this, [this](const std::vector<float>& binsDbfs) {
         std::vector<float> dbm(binsDbfs.size());
@@ -599,6 +602,7 @@ void AnanBackend::startP2ClientSession(quint64 generation)
 
 void AnanBackend::disconnectRadio()
 {
+    retirePcmStreams();
     m_droopCalibrator.stop(false);
     m_droopCalibrator.setLandedRate(0);
     ++m_connectGeneration;   // orphan any in-flight finishDspSetup callback

--- a/src/core/backends/anan/AnanRxDsp.cpp
+++ b/src/core/backends/anan/AnanRxDsp.cpp
@@ -141,6 +141,8 @@ void AnanRxDsp::installChannel(RebuildResult result)
                                      static_cast<double>(m_config.audioSampleRateHz));
     m_dcBlockL.r = pole;
     m_dcBlockR.r = pole;
+    m_pcmProducer.start(PcmPurpose::Speaker, -1,
+                        {m_config.audioSampleRateHz, PcmLayout::Stereo});
     m_dcBlockL.reset();
     m_dcBlockR.reset();
     // Fresh smoothing state for the new channel -- see smoothSpectrumBins()'s
@@ -368,7 +370,11 @@ void AnanRxDsp::processIqBlock(const std::vector<std::complex<float>>& iq)
             m_stereo[2 * k] = m_dcBlockL.process(m_left[k]);
             m_stereo[2 * k + 1] = m_dcBlockR.process(m_right[k]);
         }
-        emit audioReady(m_stereo);
+        QVector<float> samples(m_stereo.begin(), m_stereo.end());
+        if (const auto frame = m_pcmProducer.produce(std::move(samples))) {
+            emit pcmReady(*frame);
+            emit audioReady(m_stereo);
+        }
         emit meterUpdate(static_cast<float>(
             m_channel->meter(WdspChannel::Meter::SignalPeak)));
     }

--- a/src/core/backends/anan/AnanRxDsp.cpp
+++ b/src/core/backends/anan/AnanRxDsp.cpp
@@ -1,5 +1,6 @@
 #include "core/backends/anan/AnanRxDsp.h"
 
+#include <QDebug>
 #include <QMetaType>
 
 #include <algorithm>
@@ -141,8 +142,16 @@ void AnanRxDsp::installChannel(RebuildResult result)
                                      static_cast<double>(m_config.audioSampleRateHz));
     m_dcBlockL.r = pole;
     m_dcBlockR.r = pole;
-    m_pcmProducer.start(PcmPurpose::Speaker, -1,
-                        {m_config.audioSampleRateHz, PcmLayout::Stereo});
+    // PcmFormat accepts 24000/48000 only. AnanBackend hardcodes 24000 today, so
+    // this cannot fail in production — but if that rate ever moves, a silent
+    // refusal here stops ANAN audio dead while the spectrum keeps updating,
+    // which reads as a dead radio rather than a configuration error.
+    if (!m_pcmProducer.start(PcmPurpose::Speaker, -1,
+                             {m_config.audioSampleRateHz, PcmLayout::Stereo})) {
+        qWarning() << "AnanRxDsp: no PCM producer for audio rate"
+                   << m_config.audioSampleRateHz
+                   << "Hz - RX audio will be silent on this channel";
+    }
     m_dcBlockL.reset();
     m_dcBlockR.reset();
     // Fresh smoothing state for the new channel -- see smoothSpectrumBins()'s

--- a/src/core/backends/anan/AnanRxDsp.h
+++ b/src/core/backends/anan/AnanRxDsp.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "core/PcmFrame.h"
+
 #include <QElapsedTimer>
 #include <QObject>
 
@@ -269,6 +271,7 @@ public slots:
     void processIqBlock(const std::vector<std::complex<float>>& iq);
 
 signals:
+    void pcmReady(const AetherSDR::PcmFrame& frame);
     void audioReady(const std::vector<float>& stereoPcm);   // interleaved L,R
     void spectrumReady(const std::vector<float>& binsDbfs); // DC-centred dBFS
     // WDSP's own signal-strength meter (SignalPeak), NOT the RMS of the
@@ -277,6 +280,7 @@ signals:
     void meterUpdate(float dbfs);
 
 private:
+    PcmProducer m_pcmProducer;
     bool spectrumFrameDue();
 
     // Shared install step for a successful RebuildResult -- resizes scratch

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -778,10 +778,12 @@ bool Hl2Backend::openReceiverDsp(int ddc, std::string* error)
     });
 
     connect(dsp, &Hl2RxDsp::audioReady, this,
-            [this, ui](const std::vector<float>& pcm) {
+            [this, ui, producer = QPointer<Hl2RxDsp>(dsp)](const std::vector<float>& pcm) {
         const auto* ids = m_ids.byUi(ui);
-        if (!ids)
+        const Receiver* receiver = ids ? rx(ids->ddcIndex) : nullptr;
+        if (!producer || !receiver || receiver->dsp != producer.data()) {
             return;
+        }
         // THIS SLICE's audio, before the mixer touches it. Per-slice consumers
         // (a TCI receiver channel, a decoder) need one slice's audio and cannot
         // un-mix the speaker sum. Pre-mute and pre-gain on purpose — see the
@@ -790,7 +792,9 @@ bool Hl2Backend::openReceiverDsp(int ddc, std::string* error)
         // Emitted even while keyed. The mixer drops keyed audio for the speaker
         // (we hear our own transmitter), but a per-slice consumer decides that
         // for itself, and the TX path already mutes the demodulator.
-        emit sliceAudioFrameReady(ids->uiNumber, floatBytes(pcm));
+        if (!publishLegacySliceAudio(ids->uiNumber, floatBytes(pcm))) {
+            return; // malformed PCM must not enter the stateful speaker mixer
+        }
 
         mixReceiverAudio(ids->ddcIndex, pcm);
     });
@@ -1203,9 +1207,10 @@ void Hl2Backend::mixReceiverAudio(int ddc, const std::vector<float>& pcm)
         && r->audioPanPercent == kAudioPanCentre) {
         // The queue was empty before the insert above, so it holds exactly the
         // block we were handed: emit that directly. This is the steady state and
-        // the reason the fast path exists — no copy, no clamp.
+        // the reason the fast path exists — no remix or clamp. The PCM
+        // adapter takes an owning copy for queued consumers.
         if (q.size() == pcm.size()) {
-            emit audioFrameReady(floatBytes(pcm));
+            publishLegacyAudio(floatBytes(pcm));
             q.clear();
             return;
         }
@@ -1222,7 +1227,7 @@ void Hl2Backend::mixReceiverAudio(int ddc, const std::vector<float>& pcm)
         // cannot swap the channels of what follows it.
         m_mixAccum.assign(q.cbegin(), q.cend());
         q.clear();
-        emit audioFrameReady(floatBytes(m_mixAccum));
+        publishLegacyAudio(floatBytes(m_mixAccum));
         return;
     }
 
@@ -1297,7 +1302,7 @@ void Hl2Backend::mixReceiverAudio(int ddc, const std::vector<float>& pcm)
     for (float& s : m_mixAccum)
         s = std::clamp(s, -kMixCeiling, kMixCeiling);
 
-    emit audioFrameReady(floatBytes(m_mixAccum));
+    publishLegacyAudio(floatBytes(m_mixAccum));
 }
 
 void Hl2Backend::releaseReceiverDsps()
@@ -2388,6 +2393,7 @@ void Hl2Backend::invalidateTxDspConfiguration()
 
 void Hl2Backend::disconnectRadio()
 {
+    retirePcmStreams();
     invalidateTxDspConfiguration();
     // Invalidate any DSP build still in flight. Without this, a disconnect
     // during the opens would be followed by finishDspSetup() starting a wire

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -165,6 +165,7 @@ signals:
 
 private:
     friend struct Hl2DspReadbackTestAccess;
+    friend struct Hl2PcmTestAccess;
     void invalidateTxDspConfiguration();
     // Publish linkStats() on the fixed cadence the seam promises. Driven by a
     // timer here rather than by MetisClient's receive path so the tick survives

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -1,5 +1,7 @@
 #include "core/backends/icom/IcomCivBackend.h"
 
+#include <QPointer>
+
 #include <QDateTime>
 #include <QHash>
 #include <QJsonDocument>
@@ -919,7 +921,12 @@ void IcomCivBackend::connectRadio(const RadioConnectRequest& request)
             [this, sessionGeneration](const CivFrame& frame) {
                 onCivFrame(frame, sessionGeneration);
             });
-    connect(m_session.get(), &IcomSession::audioReady, this, &IcomCivBackend::onAudio);
+    connect(m_session.get(), &IcomSession::audioReady, this,
+            [this, producer = QPointer<IcomSession>(m_session.get())](const std::vector<float>& pcm) {
+        if (producer && producer.data() == m_session.get()) {
+            onAudio(pcm);
+        }
+    });
 
     if (!m_session->start(p))
         emit connectionError(QStringLiteral("could not open the Icom session"));
@@ -927,6 +934,7 @@ void IcomCivBackend::connectRadio(const RadioConnectRequest& request)
 
 void IcomCivBackend::disconnectRadio()
 {
+    retirePcmStreams();
     finishAx25PostResampleCapture();
     finishMemoryRefresh(false);
     m_tuneTimer->stop();
@@ -3200,8 +3208,15 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame,
 
 void IcomCivBackend::onAudio(const std::vector<float>& mono)
 {
-    if (mono.empty() || !m_rxResampler)
+    if (mono.empty() || mono.size() > static_cast<std::size_t>(PcmFrame::kMaxFrames)
+        || !m_rxResampler) {
         return;
+    }
+    for (float sample : mono) {
+        if (!std::isfinite(sample)) {
+            return; // do not poison the persistent input converter
+        }
+    }
 
     // 48 kHz MONO from the radio -> 24 kHz interleaved STEREO for the engine.
     //
@@ -3217,7 +3232,7 @@ void IcomCivBackend::onAudio(const std::vector<float>& mono)
         return;
 
     // The speaker feed.
-    emit audioFrameReady(stereo24k);
+    publishLegacyAudio(stereo24k);
 
     // And the PER-SLICE feed, which is a different consumer and not optional:
     // the TCI receiver channels are routed by slice, because a mixed feed
@@ -3226,7 +3241,7 @@ void IcomCivBackend::onAudio(const std::vector<float>& mono)
     //
     // Emitted PRE-mute and PRE-gain by contract — muting a slice must silence
     // the monitor without stopping a decoder that is running on it.
-    emit sliceAudioFrameReady(sliceId(), stereo24k);
+    publishLegacySliceAudio(sliceId(), stereo24k);
 }
 
 void IcomCivBackend::submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz,

--- a/src/core/backends/rtl/RtlSdrBackend.cpp
+++ b/src/core/backends/rtl/RtlSdrBackend.cpp
@@ -1,4 +1,6 @@
 #include "core/backends/rtl/RtlSdrBackend.h"
+
+#include <QPointer>
 #include "core/backends/rtl/RtlSdrWorker.h"
 #include "core/backends/rtl/RtlSdrDdc.h"
 #include "core/backends/RadioDelta.h"
@@ -394,9 +396,12 @@ void RtlSdrBackend::connectRadio(const RadioConnectRequest& request)
     connect(m_worker.get(), &RtlSdrWorker::waterfallRowReady,
             this, &IRadioBackend::waterfallRowReady);
     connect(m_worker.get(), &RtlSdrWorker::audioFrameReady,
-            this, [this](const QByteArray& pcm) {
-                emit audioFrameReady(pcm);
-                emit sliceAudioFrameReady(0, pcm);
+            this, [this, producer = QPointer<RtlSdrWorker>(m_worker.get())](const QByteArray& pcm) {
+                if (!producer || producer.data() != m_worker.get()) {
+                    return;
+                }
+                publishLegacyAudio(pcm);
+                publishLegacySliceAudio(0, pcm);
             });
     connect(m_worker.get(), &RtlSdrWorker::readError,
             this, [this](const QString& err) {
@@ -418,6 +423,7 @@ void RtlSdrBackend::connectRadio(const RadioConnectRequest& request)
 
 void RtlSdrBackend::disconnectRadio()
 {
+    retirePcmStreams();
     if (!m_connected) {
         return;
     }

--- a/src/core/backends/sim/SimBackend.cpp
+++ b/src/core/backends/sim/SimBackend.cpp
@@ -31,12 +31,16 @@ SimBackend::SimBackend(QObject* parent) : IRadioBackend(parent)
     // disconnected backend emits nothing (sim_backend_test pins it; the
     // unguarded forward was a latent flake that fired on the slower build).
     connect(m_signalSource, &SimSignalSource::audioFrameReady,
-            this, [this](const QByteArray& pcm) {
-                if (m_connected) emit audioFrameReady(pcm);
+            this, [this](const PcmFrame& frame) {
+                if (m_connected && frame.stream().session == pcmSession()) {
+                    publishLegacyAudio(frame.legacyStereo24());
+                }
             });
     connect(m_signalSource, &SimSignalSource::sliceAudioFrameReady,
-            this, [this](int sliceId, const QByteArray& pcm) {
-                if (m_connected) emit sliceAudioFrameReady(sliceId, pcm);
+            this, [this](int sliceId, const PcmFrame& frame) {
+                if (m_connected && frame.stream().session == pcmSession()) {
+                    publishLegacySliceAudio(sliceId, frame.legacyStereo24());
+                }
             });
     connect(m_signalSource, &SimSignalSource::spectrumFrameReady,
             this, [this](int panId, const QByteArray& bins) {
@@ -114,7 +118,9 @@ SimBackend::SimBackend(QObject* parent) : IRadioBackend(parent)
         m_wirePanIds = QStringList{wirePanIdFor(0)};
         m_pansAwaitingGeometry.clear();
         pushPanIndicesToSource();
-        QMetaObject::invokeMethod(m_signalSource, &SimSignalSource::start,
+        QMetaObject::invokeMethod(m_signalSource, [source = m_signalSource, session = pcmSession()] {
+            source->startSession(session);
+        },
                                   Qt::QueuedConnection);
         QTimer::singleShot(150, this, [this]() {
             if (m_connected) emitInitialState();
@@ -383,12 +389,15 @@ void SimBackend::connectRadio(const RadioConnectRequest& /*request*/)
     emit connected();
     emit capabilitiesChanged();
     emitInitialState();
-    QMetaObject::invokeMethod(m_signalSource, &SimSignalSource::start,
+    QMetaObject::invokeMethod(m_signalSource, [source = m_signalSource, session = pcmSession()] {
+            source->startSession(session);
+        },
                               Qt::QueuedConnection);   // synthetic RX begins
 }
 
 void SimBackend::disconnectRadio()
 {
+    retirePcmStreams();
     if (!m_connected) {
         return;
     }

--- a/src/core/backends/sim/SimSignalSource.cpp
+++ b/src/core/backends/sim/SimSignalSource.cpp
@@ -1,5 +1,7 @@
 #include "core/backends/sim/SimSignalSource.h"
 
+#include <QDebug>
+
 namespace AetherSDR {
 
 SimSignalSource::SimSignalSource(QObject* parent) : QObject(parent)
@@ -43,8 +45,16 @@ void SimSignalSource::start()
 
 void SimSignalSource::startSession(quint64 session)
 {
-    m_speakerPcm.start(PcmPurpose::Speaker, -1, {}, session);
-    m_slicePcm.start(PcmPurpose::Slice, kSliceId, {}, session);
+    // Both callers pass the backend's monotonic pcmSession(), so a repeated
+    // value is a wiring bug, not a benign retry: PcmProducer refuses a session
+    // at or below the current one and the OLD epoch stays live, which used to
+    // look like working audio purely by ordering luck.
+    const bool speakerOk = m_speakerPcm.start(PcmPurpose::Speaker, -1, {}, session);
+    const bool sliceOk = m_slicePcm.start(PcmPurpose::Slice, kSliceId, {}, session);
+    if (!speakerOk || !sliceOk) {
+        qWarning() << "SimSignalSource: producer refused session" << session
+                   << "(speaker =" << speakerOk << ", slice =" << sliceOk << ")";
+    }
     m_clock.invalidate();   // fresh pacing baseline; first frames next tick
     m_debtNs = 0;
     m_timer.start();

--- a/src/core/backends/sim/SimSignalSource.cpp
+++ b/src/core/backends/sim/SimSignalSource.cpp
@@ -38,6 +38,13 @@ SimSignalSource::SimSignalSource(QObject* parent) : QObject(parent)
 
 void SimSignalSource::start()
 {
+    startSession(0);
+}
+
+void SimSignalSource::startSession(quint64 session)
+{
+    m_speakerPcm.start(PcmPurpose::Speaker, -1, {}, session);
+    m_slicePcm.start(PcmPurpose::Slice, kSliceId, {}, session);
     m_clock.invalidate();   // fresh pacing baseline; first frames next tick
     m_debtNs = 0;
     m_timer.start();
@@ -45,6 +52,8 @@ void SimSignalSource::start()
 
 void SimSignalSource::stop()
 {
+    m_speakerPcm.invalidate();
+    m_slicePcm.invalidate();
     m_timer.stop();
     m_clock.invalidate();
     m_debtNs = 0;
@@ -109,10 +118,14 @@ void SimSignalSource::onTick()
             ? QVector<float>(NoiseMixer::kFrameLen, 0.0f)
             : m_audio.mixFrame();
         const QByteArray stereo = toStereoBytes(frame);
-        emit audioFrameReady(stereo);
+        if (const auto frame = m_speakerPcm.legacyStereo24(stereo)) {
+            emit audioFrameReady(*frame);
+        }
         // Per-slice audio too — the TCI receiver channels are fed from
         // sliceAudioFrameReady (see the SimBackend original for the history).
-        emit sliceAudioFrameReady(kSliceId, stereo);
+        if (const auto frame = m_slicePcm.legacyStereo24(stereo)) {
+            emit sliceAudioFrameReady(kSliceId, *frame);
+        }
 
         // A panadapter row a few times a second (~21 fps at the 5.33 ms
         // frame). The stallscope fault freezes the spectrum while audio keeps

--- a/src/core/backends/sim/SimSignalSource.h
+++ b/src/core/backends/sim/SimSignalSource.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "core/PcmFrame.h"
+
 #include <QByteArray>
 #include <QElapsedTimer>
 #include <QList>
@@ -49,6 +51,7 @@ public:
 
 public slots:
     void start();
+    void startSession(quint64 session);
     void stop();
 
     void setKeyed(bool keyed);            // mute while keyed (Principle VI)
@@ -78,11 +81,13 @@ public slots:
 
 signals:
     // 24 kHz stereo float32, the format AudioEngine::feedAudioData() eats.
-    void audioFrameReady(const QByteArray& stereo);
-    void sliceAudioFrameReady(int sliceId, const QByteArray& stereo);
+    void audioFrameReady(const AetherSDR::PcmFrame& stereo);
+    void sliceAudioFrameReady(int sliceId, const AetherSDR::PcmFrame& stereo);
     void spectrumFrameReady(int panId, const QByteArray& bins);
 
 private:
+    PcmProducer m_speakerPcm;
+    PcmProducer m_slicePcm;
     void onTick();
     void updateBirdieFromVfo();
     static QByteArray toStereoBytes(const QVector<float>& mono);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1292,8 +1292,8 @@ MainWindow::MainWindow(QWidget* parent)
         // and so has no stream connection to drop. (PR #4537 review.)
         m_rxMutedForPlayback = mute;
         if (mute) {
-            disconnect(m_radioModel.panStream(), &PanadapterStream::audioDataReady,
-                       m_audio, &AudioEngine::feedAudioData);
+            disconnect(m_radioModel.panStream(), &PanadapterStream::pcmFrameReady,
+                       m_audio, &AudioEngine::feedPcmFrame);
         } else {
             // Only restore the stream→sink feed for backends that actually use it.
             // A backend that emits its own seam audio (the demo, RFC #4288 Route A)
@@ -1301,8 +1301,8 @@ MainWindow::MainWindow(QWidget* parent)
             // double-feed that wirePanStreamRxAudioSinks() deliberately skips, and
             // Qt permits duplicates, so every unmute would stack another copy.
             if (!backendFeedsEngineDirectly()) {
-                connect(m_radioModel.panStream(), &PanadapterStream::audioDataReady,
-                        m_audio, &AudioEngine::feedAudioData,
+                connect(m_radioModel.panStream(), &PanadapterStream::pcmFrameReady,
+                        m_audio, &AudioEngine::feedPcmFrame,
                         Qt::UniqueConnection);
             }
         }
@@ -1482,15 +1482,15 @@ MainWindow::MainWindow(QWidget* parent)
         m_rxMutedForPlayback = mute;   // seam backends — see the recorder handler
         if (mute) {
             disconnect(m_radioModel.panStream(),
-                       &PanadapterStream::audioDataReady,
-                       m_audio, &AudioEngine::feedAudioData);
+                       &PanadapterStream::pcmFrameReady,
+                       m_audio, &AudioEngine::feedPcmFrame);
         } else {
             // Same rule as the QSO-recorder unmute above: never resurrect the
             // stream→sink feed for a backend that supplies its own seam audio.
             if (!backendFeedsEngineDirectly()) {
                 connect(m_radioModel.panStream(),
-                        &PanadapterStream::audioDataReady,
-                        m_audio, &AudioEngine::feedAudioData,
+                        &PanadapterStream::pcmFrameReady,
+                        m_audio, &AudioEngine::feedPcmFrame,
                         Qt::UniqueConnection);
             }
         }
@@ -6961,7 +6961,7 @@ void MainWindow::wireBackendSeam(IRadioBackend* backend)
     // happen not to emit the signal today.
     if (dynamic_cast<SimBackend*>(backend) != nullptr) {
         connect(backend, &IRadioBackend::audioFrameReady,
-                m_audio, &AudioEngine::feedAudioData);
+                m_audio, &AudioEngine::feedPcmFrame);
     }
 
     // HL2 only, and deliberately: the client-side WDSP chains are this family's

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1656,10 +1656,10 @@ MainWindow::MainWindow(QWidget* parent)
 
     // ── Panadapter stream → audio engine ──────────────────────────────────
     // All VITA-49 traffic arrives on the single client udpport socket owned by
-    // PanadapterStream, which strips IF-Data headers and emits audioDataReady().
+    // PanadapterStream, which strips IF-Data headers and emits pcmFrameReady().
     // The QAudioSink feed is wired in one helper so a Flex-backend swap can
     // rebind it (the stream is destroyed/rebuilt on a family change;
-    // audioDataReady carries Flex RX audio itself, so a missed rebind is
+    // pcmFrameReady carries Flex RX audio itself, so a missed rebind is
     // silence rather than a degraded feature).
     wirePanStreamRxAudioSinks();
     // The taps that listen alongside the speaker — QSO recorder RX, CW and RTTY
@@ -2830,7 +2830,7 @@ MainWindow::~MainWindow()
     // ~QWidget::deleteChildren(), which runs *after* MainWindow's value members
     // (including m_radioModel) have already been destroyed — crash on quit
     // (#2385). Tear it down explicitly here: audio is stopped (no more
-    // daxAudioReady cross-thread signals), m_radioModel is still alive (DAX
+    // daxPcmReady cross-thread signals), m_radioModel is still alive (DAX
     // stream-remove commands reach the radio), and we null out TciApplet's raw
     // back-reference first so no dangling pointer remains in the widget tree.
     if (m_appletPanel && m_appletPanel->tciApplet())

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -540,12 +540,12 @@ private:
     // True when the connected backend supplies RX audio over the IRadioBackend
     // seam rather than through PanadapterStream — i.e. the demo (RFC #4288
     // Route A), which is the one backend that owns BOTH. Every site that wires
-    // PanadapterStream::audioDataReady → AudioEngine::feedAudioData must consult
+    // PanadapterStream::pcmFrameReady → AudioEngine::feedPcmFrame must consult
     // this, or the two sources sum at the sink (wobble + distortion).
     bool backendFeedsEngineDirectly();        // MainWindow_Session.cpp
     // Live RX is muted while the QSO recorder or the PUDU monitor plays audio
     // back through the same sink. The Flex path achieves that by disconnecting
-    // PanadapterStream::audioDataReady; a seam backend has no such connection
+    // PanadapterStream::pcmFrameReady; a seam backend has no such connection
     // to drop, so its relay consults this instead. See the muteRxRequested
     // handlers in MainWindow.cpp. (PR #4537 review.)
     bool m_rxMutedForPlayback{false};
@@ -1796,7 +1796,7 @@ private:
 // AetherClock (MainWindow_AetherClock.cpp)
     AetherClockEngine* m_clockEngine{nullptr};
     AetherClockModel* m_clockModel{nullptr};
-    QMetaObject::Connection m_clockDaxConn;  // daxAudioReady feed — live only while the engine runs
+    QMetaObject::Connection m_clockDaxConn;  // daxPcmReady feed — live only while the engine runs
     QMetaObject::Connection m_clockSliceAudioConn;  // seam per-slice audio feed — same lifetime
     void setupAetherClock();
 

--- a/src/gui/MainWindow_AetherClock.cpp
+++ b/src/gui/MainWindow_AetherClock.cpp
@@ -67,9 +67,14 @@ void MainWindow::setupAetherClock()
                     auto* ps = m_radioModel.panStream();
                     if (ps && !m_clockDaxConn)
                         m_clockDaxConn = connect(
-                            ps, &PanadapterStream::daxAudioReady,
-                            m_clockEngine, &AetherClockEngine::feedRxAudio,
-                            Qt::QueuedConnection);
+                            ps, &PanadapterStream::daxPcmReady,
+                            m_clockEngine,
+                            [engine = m_clockEngine](int channel, const PcmFrame& frame) {
+                                const QByteArray pcm = frame.legacyStereo24();
+                                if (!pcm.isEmpty()) {
+                                    engine->feedRxAudio(channel, pcm);
+                                }
+                            }, Qt::QueuedConnection);
                     // Seam-native per-slice audio (MainWindow_Session.cpp:1811
                     // feeds TciServer from the same signal for the same
                     // reason). A backend that demodulates in-process has no
@@ -82,8 +87,12 @@ void MainWindow::setupAetherClock()
                             &m_radioModel,
                             &RadioModel::backendSliceAudioFrameReady,
                             m_clockEngine,
-                            &AetherClockEngine::feedRxSliceAudio,
-                            Qt::QueuedConnection);
+                            [engine = m_clockEngine](int sliceId, const PcmFrame& frame) {
+                                const QByteArray pcm = frame.legacyStereo24();
+                                if (!pcm.isEmpty()) {
+                                    engine->feedRxSliceAudio(sliceId, pcm);
+                                }
+                            }, Qt::QueuedConnection);
                 } else {
                     if (m_clockDaxConn) {
                         disconnect(m_clockDaxConn);

--- a/src/gui/MainWindow_AetherClock.cpp
+++ b/src/gui/MainWindow_AetherClock.cpp
@@ -15,7 +15,7 @@
 // is up, so nothing here touches it at construction time: the DAX-hold
 // provider resolves panStream() at call time (the engine only drives it
 // while started, which requires a live slice and therefore a live backend),
-// and the daxAudioReady feed is connected on runningChanged(true) and torn
+// and the daxPcmReady feed is connected on runningChanged(true) and torn
 // down on runningChanged(false). The engine itself ignores PCM whose
 // channel differs from the bound slice's live daxChannel(), and PCM whose
 // slice id differs from the bound slice on the seam-native feed.

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -301,7 +301,7 @@ void MainWindow::activateRADE(int sliceId)
     auto* s = m_radioModel.slice(sliceId);
     if (!s) return;
 
-    // RADE's receive path is DAX channel audio (PanadapterStream::daxAudioReady),
+    // RADE's receive path is DAX channel audio (PanadapterStream::daxPcmReady),
     // and only a Flex backend owns a PanadapterStream — RadioModel leaves
     // panStream() null for every other family. The connect() further down
     // dereferenced it bare, so selecting RADE on a Hermes-Lite 2 was a SEGFAULT,

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -576,8 +576,12 @@ void MainWindow::activateRADE(int sliceId)
     // Filter by the RADE slice's DAX channel so other slices' DAX audio is ignored.
     // Look up the channel live so it tracks if the user changes DAX assignment.
     int sid = sliceId;
-    connect(m_radioModel.panStream(), &PanadapterStream::daxAudioReady,
-            m_radeEngine, [this, sid](int channel, const QByteArray& pcm) {
+    connect(m_radioModel.panStream(), &PanadapterStream::daxPcmReady,
+            m_radeEngine, [this, sid](int channel, const PcmFrame& frame) {
+        const QByteArray pcm = frame.legacyStereo24();
+        if (pcm.isEmpty()) {
+            return;
+        }
         auto* s = m_radioModel.slice(sid);
         if (s && channel == s->daxChannel())
             m_radeEngine->feedRxAudio(channel, pcm);
@@ -761,7 +765,7 @@ void MainWindow::deactivateRADE()
                    m_radeEngine, nullptr);
         disconnect(m_radeEngine, &RADEEngine::txModemReady,
                    m_audio, nullptr);
-        disconnect(m_radioModel.panStream(), &PanadapterStream::daxAudioReady,
+        disconnect(m_radioModel.panStream(), &PanadapterStream::daxPcmReady,
                    m_radeEngine, nullptr);
         disconnect(m_radeEngine, &RADEEngine::rxSpeechReady,
                    m_audio, nullptr);
@@ -1206,8 +1210,13 @@ bool MainWindow::startDax()
     }));
 
     // Wire DAX RX: PanadapterStream routes registered DAX streams here
-    connect(m_radioModel.panStream(), &PanadapterStream::daxAudioReady,
-            m_daxBridge, &DaxBridge::feedDaxAudio);
+    connect(m_radioModel.panStream(), &PanadapterStream::daxPcmReady,
+            m_daxBridge, [bridge = m_daxBridge](int channel, const PcmFrame& frame) {
+        const QByteArray pcm = frame.legacyStereo24();
+        if (!pcm.isEmpty()) {
+            bridge->feedDaxAudio(channel, pcm);
+        }
+    });
 
     // DAX-IQ stream-status routing, the VITA-49 IQ feed, level meter, and the
     // enable/disable/rate connections are wired ONCE at construction (see the
@@ -1275,7 +1284,7 @@ void MainWindow::stopDax()
     m_daxSliceConns.clear();
     m_daxSliceLastCh.clear();
 
-    disconnect(m_radioModel.panStream(), &PanadapterStream::daxAudioReady,
+    disconnect(m_radioModel.panStream(), &PanadapterStream::daxPcmReady,
                m_daxBridge, nullptr);
     disconnect(m_daxBridge, &DaxBridge::txAudioReady,
                this, nullptr);

--- a/src/gui/MainWindow_KiwiSdr.cpp
+++ b/src/gui/MainWindow_KiwiSdr.cpp
@@ -2005,10 +2005,10 @@ void MainWindow::wireKiwiSdr()
                 m_radioModel.transmitModel().cwPitch());
         });
         if (m_audio) {
-            connect(m_kiwiSdrManager, &KiwiSdrManager::decodedAudioReady,
+            connect(m_kiwiSdrManager, &KiwiSdrManager::pcmFrameReady,
                     m_audio, [audio = m_audio](const QString& id,
-                                                const QByteArray& pcm) {
-                audio->feedKiwiSdrAudioData(id, pcm);
+                                                const PcmFrame& pcm) {
+                audio->feedKiwiPcmFrame(id, pcm);
             }, Qt::QueuedConnection);
             connect(m_kiwiSdrManager, &KiwiSdrManager::audioSourceEnabledChanged,
                     m_audio, [audio = m_audio](const QString& id, bool enabled) {

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -220,7 +220,7 @@ void MainWindow::wireDiscovery()
             m_audio, [this](const PcmFrame& pcm) {
         if (backendFeedsEngineDirectly()) return;   // demo feeds the engine directly
         // Playback mute. The Flex path mutes by disconnecting the stream's
-        // audioDataReady from feedAudioData; against a null PanadapterStream
+        // pcmFrameReady from feedPcmFrame; against a null PanadapterStream
         // that disconnect is a silent no-op, so a seam backend would keep
         // feeding live receive UNDER the playback. Reachable in practice only
         // now that the recorder captures RX on such a radio at all. (#4537.)
@@ -2238,7 +2238,7 @@ void MainWindow::wireCatPorts()
     tciServer()->wireSpotModel();
 
     // Wire RX audio from PanadapterStream → TCI server for audio streaming.
-    // TCI audio feeds exclusively from DAX (not audioDataReady) so that
+    // TCI audio feeds exclusively from DAX (not pcmFrameReady) so that
     // audio_mute doesn't kill TCI audio (#1331). Stream-bound, so it goes through
     // the shared helper the post-swap rebind also calls (#4448).
     wirePanStreamTciSinks();
@@ -2286,11 +2286,11 @@ void MainWindow::wireCatPorts()
 
 }
 
-// The RX-audio sinks fed by PanadapterStream::audioDataReady, in one place so
+// The RX-audio sinks fed by PanadapterStream::pcmFrameReady, in one place so
 // buildUI() and rewirePanStreamAfterBackendSwap() bind an identical set. The
 // stream is owned by the Flex backend and is destroyed/rebuilt on a family
 // swap (RadioModel::teardownBackend/setupBackend), which drops these — and Flex
-// RX audio itself rides audioDataReady, so a missed one is silence, not a
+// RX audio itself rides pcmFrameReady, so a missed one is silence, not a
 // degraded feature. Keeping the list here (not open-coded in two places) is why
 // a new sink added to buildUI cannot silently go un-rebound after a swap.
 // Deliberately NOT IRadioBackend::ownsRxAudio(), despite the near-identical

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -217,7 +217,7 @@ void MainWindow::wireDiscovery()
     // Qt::UniqueConnection cannot catch it: these are two DIFFERENT signals
     // arriving at the same slot, so nothing looks duplicate to Qt.
     connect(&m_radioModel, &RadioModel::backendAudioFrameReady,
-            m_audio, [this](const QByteArray& pcm) {
+            m_audio, [this](const PcmFrame& pcm) {
         if (backendFeedsEngineDirectly()) return;   // demo feeds the engine directly
         // Playback mute. The Flex path mutes by disconnecting the stream's
         // audioDataReady from feedAudioData; against a null PanadapterStream
@@ -225,7 +225,7 @@ void MainWindow::wireDiscovery()
         // feeding live receive UNDER the playback. Reachable in practice only
         // now that the recorder captures RX on such a radio at all. (#4537.)
         if (m_rxMutedForPlayback) return;
-        m_audio->feedAudioData(pcm);
+        m_audio->feedPcmFrame(pcm);
     });
 
     connect(&m_hl2Discovery, &hl2::Hl2Discovery::radioDiscovered,
@@ -2269,8 +2269,9 @@ void MainWindow::wireCatPorts()
     // through wirePanStreamTciSinks() above — so there is no double-feed and no
     // change to the Flex path.
     connect(&m_radioModel, &RadioModel::backendSliceAudioFrameReady,
-            this, [this](int sliceId, const QByteArray& pcm) {
-        if (tciServer())
+            this, [this](int sliceId, const PcmFrame& frame) {
+        const QByteArray pcm = frame.legacyStereo24();
+        if (tciServer() && !pcm.isEmpty())
             tciServer()->onDaxAudioReady(sliceId + 1, pcm);
     });
 
@@ -2338,8 +2339,8 @@ void MainWindow::wirePanStreamRxAudioSinks()
     // The backend's own audio wins; the stream's other RX taps below stay wired.
     // Primary RX audio → QAudioSink (skipped when the backend owns its audio).
     if (!backendFeedsEngineDirectly()) {
-        connect(ps, &PanadapterStream::audioDataReady,
-                m_audio, &AudioEngine::feedAudioData,
+        connect(ps, &PanadapterStream::pcmFrameReady,
+                m_audio, &AudioEngine::feedPcmFrame,
                 Qt::UniqueConnection);
     }
 
@@ -2370,20 +2371,27 @@ void MainWindow::wireRxDemodAudioSinks()
 {
     if (m_qsoRecorder) {
         connect(&m_radioModel, &RadioModel::rxDemodAudioReady,
-                m_qsoRecorder, &QsoRecorder::feedRxAudio);
+                m_qsoRecorder, [recorder = m_qsoRecorder](const PcmFrame& frame) {
+            const QByteArray pcm = frame.legacyStereo24();
+            if (!pcm.isEmpty()) {
+                recorder->feedRxAudio(pcm);
+            }
+        });
     }
 
     // CW decoder RX feed — gated live on the toggle (#2417).
     connect(&m_radioModel, &RadioModel::rxDemodAudioReady,
-            &m_cwDecoder, [this](const QByteArray& pcm) {
-                if (CwDecodeSettings::rxEnabled())
+            &m_cwDecoder, [this](const PcmFrame& frame) {
+                const QByteArray pcm = frame.legacyStereo24();
+                if (!pcm.isEmpty() && CwDecodeSettings::rxEnabled())
                     m_cwDecoder.feedAudio(pcm);
             });
 
     // RTTY decoder RX feed — gated on the decoder being running.
     connect(&m_radioModel, &RadioModel::rxDemodAudioReady,
-            &m_rttyDecoder, [this](const QByteArray& pcm) {
-                if (m_rttyDecoder.isRunning())
+            &m_rttyDecoder, [this](const PcmFrame& frame) {
+                const QByteArray pcm = frame.legacyStereo24();
+                if (!pcm.isEmpty() && m_rttyDecoder.isRunning())
                     m_rttyDecoder.feedAudio(pcm);
             });
 }
@@ -2407,8 +2415,13 @@ void MainWindow::wirePanStreamTciSinks()
     auto* ps = m_radioModel.panStream();
     if (!ps || !tciServer())
         return;
-    connect(ps, &PanadapterStream::daxAudioReady,
-            tciServer(), &TciServer::onDaxAudioReady);
+    connect(ps, &PanadapterStream::daxPcmReady,
+            tciServer(), [server = tciServer()](int channel, const PcmFrame& frame) {
+        const QByteArray pcm = frame.legacyStereo24();
+        if (!pcm.isEmpty()) {
+            server->onDaxAudioReady(channel, pcm);
+        }
+    });
     connect(ps, &PanadapterStream::iqDataReady,
             tciServer(), &TciServer::onIqDataReady);
     connect(ps, &PanadapterStream::waterfallRowReady,

--- a/src/gui/TciApplet.cpp
+++ b/src/gui/TciApplet.cpp
@@ -320,7 +320,7 @@ void TciApplet::setRadioModel(RadioModel* model)
     }
 
     // Slice → DAX channel mapping drives both DAX and TCI RX indicators.
-    // TCI RX1-8 carry the same DAX channels (PanadapterStream::daxAudioReady
+    // TCI RX1-8 carry the same DAX channels (PanadapterStream::daxPcmReady
     // fans out to both DaxBridge and TciServer), so reuse the DAX channel
     // assignments for the slice letters here. The TCI receiver (trx) index is
     // NOT capped at 4: trx is a positional slice index bounded by

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -895,20 +895,7 @@ void RadioModel::setupBackend(const QString& family)
             [this](int, const QByteArray&) {
         m_lastSpectrumMs = QDateTime::currentMSecsSinceEpoch();
     });
-    connect(m_backend.get(), &IRadioBackend::audioFrameReady, this,
-            [this](const QByteArray&) {
-        m_lastAudioMs = QDateTime::currentMSecsSinceEpoch();
-    });
-
-    // Demodulated RX audio from backends that produce it in-process (HL2).
-    // Signal-to-signal: the payload is already the engine's native format.
-    connect(m_backend.get(), &IRadioBackend::audioFrameReady,
-            this, &RadioModel::backendAudioFrameReady);
-
-    // Per-slice demodulated audio. Signal-to-signal like the mixed feed above:
-    // the payload is already the engine's native format.
-    connect(m_backend.get(), &IRadioBackend::sliceAudioFrameReady,
-            this, &RadioModel::backendSliceAudioFrameReady);
+    wireBackendPcm();
 
     // Pick the one producer for the normalized RX-audio bus. Done here, once
     // per backend, so every consumer of rxDemodAudioReady is family-blind and
@@ -1837,6 +1824,9 @@ void RadioModel::teardownBackend()
 {
     resetTxOperations();
     ++m_backendReceiverGeneration;
+    if (m_backend) {
+        m_backend->retirePcmStreams();
+    }
     // Answer, then drop, every command still waiting on the backend that is
     // about to die. The generation guard on commandResponse means a reply
     // arriving after this point is discarded, so without this the callback —
@@ -2049,6 +2039,7 @@ RadioModel::RadioModel(QObject* parent)
     });
     connect(this, &RadioModel::sliceRemoved, this, &RadioModel::updateTuneAvailability);
     connect(this, &RadioModel::capabilitiesChanged, this, &RadioModel::updateTuneAvailability);
+    qRegisterMetaType<PcmFrame>();
     qRegisterMetaType<SliceDelta>();
     qRegisterMetaType<TransmitDelta>();
     qRegisterMetaType<MeterDef>();
@@ -3086,6 +3077,30 @@ int RadioModel::activeTxSliceNum() const
     return -1;
 }
 
+void RadioModel::wireBackendPcm()
+{
+    const quint64 generation = m_backendReceiverGeneration;
+    connect(m_backend.get(), &IRadioBackend::audioFrameReady, this,
+            [this, generation](const PcmFrame& frame) {
+        if (generation != m_backendReceiverGeneration
+            || frame.stream().purpose != PcmPurpose::Speaker
+            || !m_backendPcmGate.accept(frame)) {
+            return;
+        }
+        m_lastAudioMs = QDateTime::currentMSecsSinceEpoch();
+        emit backendAudioFrameReady(frame);
+    });
+    connect(m_backend.get(), &IRadioBackend::sliceAudioFrameReady, this,
+            [this, generation](int sliceId, const PcmFrame& frame) {
+        if (generation != m_backendReceiverGeneration
+            || frame.stream().purpose != PcmPurpose::Slice
+            || frame.stream().sliceId != sliceId || !m_slicePcmGate.accept(frame)) {
+            return;
+        }
+        emit backendSliceAudioFrameReady(sliceId, frame);
+    });
+}
+
 void RadioModel::wireRxDemodAudioBus()
 {
     // Exactly one producer, ever. Drop the previous binding first: on a family
@@ -3100,15 +3115,25 @@ void RadioModel::wireRxDemodAudioBus()
         // Chained off backendAudioFrameReady rather than the backend's own
         // signal so both relays cross the thread boundary identically.
         m_rxDemodBusConn = connect(this, &RadioModel::backendAudioFrameReady,
-                                   this, &RadioModel::rxDemodAudioReady);
+                                   this, [this](const PcmFrame& frame) {
+            if (!m_demodPcmGate.accept(frame)) {
+                return;
+            }
+            emit rxDemodAudioReady(frame);
+        });
         return;
     }
     if (m_panStream) {
         // Flex: the VITA-49 slice audio, unchanged and still feeding the engine
         // by its own existing connection. This is an ADDITIONAL subscriber to
         // the same signal, so the audible path is untouched.
-        m_rxDemodBusConn = connect(m_panStream, &PanadapterStream::audioDataReady,
-                                   this, &RadioModel::rxDemodAudioReady);
+        m_rxDemodBusConn = connect(m_panStream, &PanadapterStream::pcmFrameReady,
+                                   this, [this](const PcmFrame& frame) {
+            if (!m_demodPcmGate.accept(frame)) {
+                return;
+            }
+            emit rxDemodAudioReady(frame);
+        });
     }
 }
 
@@ -9569,6 +9594,8 @@ void RadioModel::setBackendForTest(std::unique_ptr<IRadioBackend> backend,
     teardownBackend();
     m_backend = std::move(backend);
     m_family = family;
+    wireBackendPcm();
+    wireRxDemodAudioBus();
     wireBackendReceiverState();
     // Injected backends bypass onConnected(), but replacement must still drain
     // the old session before test callers can exercise the new one.

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1601,9 +1601,6 @@ private:
     // m_backend and m_panStream are both settled for the new family.
     void wireRxDemodAudioBus();
     void wireBackendPcm();
-    PcmFrameGate m_backendPcmGate;
-    PcmFrameGate m_slicePcmGate;
-    PcmFrameGate m_demodPcmGate;
 
     // aetherd RFC step 2 (§5.5): the radio-facing seam. Held via std::unique_ptr
     // (owned via unique_ptr below). As of 2.2b it OWNS the RadioConnection +
@@ -2391,6 +2388,13 @@ public:
     PanadapterStream::CategoryStats categoryStats(PanadapterStream::StreamCategory cat) const;
     QVector<PanadapterStream::AudioStreamDiagnostics> audioStreamDiagnostics() const;
     void resetAudioStreamDiagnostics();
+
+private:
+    // Per-consumer replay cursors for the three typed PCM relays wired in
+    // wireBackendPcm()/wireRxDemodAudioBus(). Data, not slots.
+    PcmFrameGate m_backendPcmGate;
+    PcmFrameGate m_slicePcmGate;
+    PcmFrameGate m_demodPcmGate;
 };
 
 } // namespace AetherSDR

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1110,22 +1110,22 @@ signals:
                                   quint32 timecode, qint64 emittedNs);
     void panFeedWaterfallAutoBlackLevel(quint32 streamId, quint32 autoBlack);
     // Demodulated RX audio from a backend that produces it in-process (HL2).
-    // 24 kHz stereo float32 — the format AudioEngine::feedAudioData expects.
+    // Owning typed PCM. A1 compatibility producers retain 24 kHz stereo.
     // Flex never emits this; its audio arrives on the PanadapterStream path.
-    void backendAudioFrameReady(const QByteArray& pcm);
+    void backendAudioFrameReady(const AetherSDR::PcmFrame& pcm);
     // ONE slice's demodulated audio, relayed from IRadioBackend. The per-slice
     // counterpart of backendAudioFrameReady, which is the mixed speaker feed.
     // Only a backend that demodulates in this process emits it; Flex per-slice
     // audio arrives as DAX channels instead.
-    void backendSliceAudioFrameReady(int sliceId, const QByteArray& pcm);
+    void backendSliceAudioFrameReady(int sliceId, const AetherSDR::PcmFrame& pcm);
 
     // ── The normalized demodulated-RX-audio bus ────────────────────────────
     //
-    // The audio the OPERATOR HEARS, whoever produced it: 24 kHz interleaved
-    // stereo float32, byte-identical to what both producers already emit.
+    // The audio the OPERATOR HEARS, whoever produced it, with immutable
+    // producer format and lifetime. A1 preserves existing 24 kHz stereo PCM.
     //
     // Exactly one producer is connected at a time — PanadapterStream::
-    // audioDataReady for a Flex, IRadioBackend::audioFrameReady for a backend
+    // pcmFrameReady for a Flex, IRadioBackend::audioFrameReady for a backend
     // that answers ownsRxAudio() — and that choice is made in ONE place
     // (wireRxDemodAudioBus). Consumers subscribe once and never rebind, because
     // this signal belongs to RadioModel, which OUTLIVES the backend swap that
@@ -1137,14 +1137,14 @@ signals:
     // radio without one they bound to nothing: no error, no log line, the
     // toggle worked and nothing ever decoded. See docs/HERMES.md §18.
     //
-    // Deliberately NOT the speaker path. AudioEngine::feedAudioData keeps its
-    // existing per-family wiring untouched, so nothing audible changes on any
-    // radio; this carries the taps that listen alongside it.
+    // This carries taps alongside playback. AudioEngine::feedPcmFrame keeps
+    // the existing speaker routing and delegates accepted 24 kHz stereo to
+    // feedAudioData; fixed-rate tap adapters unwrap after queued delivery.
     //
     // Named for the tap it carries. A future filter-flat, pre-AGC feed for
     // modems is a SEPARATE signal (rxWidebandAudioReady), not a mode flag on
     // this one — see docs/HERMES.md §18.5.
-    void rxDemodAudioReady(const QByteArray& pcm24kStereoFloat);
+    void rxDemodAudioReady(const AetherSDR::PcmFrame& pcm);
     // The backend was replaced because the operator picked a radio of another
     // family. Consumers holding backend-owned objects (PanadapterStream) must
     // re-establish anything that binds to them directly.
@@ -1600,6 +1600,10 @@ private:
     // Bind the one producer for rxDemodAudioReady. Idempotent; call after
     // m_backend and m_panStream are both settled for the new family.
     void wireRxDemodAudioBus();
+    void wireBackendPcm();
+    PcmFrameGate m_backendPcmGate;
+    PcmFrameGate m_slicePcmGate;
+    PcmFrameGate m_demodPcmGate;
 
     // aetherd RFC step 2 (§5.5): the radio-facing seam. Held via std::unique_ptr
     // (owned via unique_ptr below). As of 2.2b it OWNS the RadioConnection +

--- a/tests/aetherclock_engine_test.cpp
+++ b/tests/aetherclock_engine_test.cpp
@@ -10,7 +10,7 @@
 // The WWV signal synthesizer helpers below are COPIED (not included) from
 // tests/wwv_decoder_test.cpp — the gate-passed WS-1 vector generator. Only the
 // clean-signal path is reused (no AWGN / WAV writer / decoder driver): the
-// engine ingests float32 INTERLEAVED STEREO (the daxAudioReady payload), so
+// engine ingests float32 INTERLEAVED STEREO (the daxPcmReady payload), so
 // each mono sample is duplicated L=R into the QByteArray and fed in ~200 ms
 // blocks. A fake host clock is injected and advanced per block so the decoded
 // second edge can be compared against a known skew.
@@ -239,7 +239,7 @@ void feedStereoVia(const std::function<void(const QByteArray&)>& sink,
     }
 }
 
-// Channel-keyed feed (Flex / daxAudioReady).
+// Channel-keyed feed (Flex / daxPcmReady).
 void feedStereo(AetherClockEngine& eng, int channel, const std::vector<float>& mono,
                 qint64 epochMs, qint64 skewMs,
                 qint64& samplesFed, qint64& fakeNow, bool advanceClock) {

--- a/tests/anan_rxdsp_handedness_test.cpp
+++ b/tests/anan_rxdsp_handedness_test.cpp
@@ -44,6 +44,7 @@
 #include <functional>
 #include <complex>
 #include <cstdio>
+#include <cstring>
 #include <numbers>
 #include <vector>
 
@@ -127,8 +128,18 @@ double runTone(AnanRxDsp& dsp, double wireOffsetHz, double shiftHz)
     dsp.setShift(shiftHz);
 
     std::vector<float> audio;
+    AetherSDR::PcmFrame typed;
+    int typedCount = 0;
+    int legacyCount = 0;
+    bool exact = true;
+    const auto typedConn = QObject::connect(&dsp, &AnanRxDsp::pcmReady, &dsp,
+        [&](const AetherSDR::PcmFrame& frame) { typed = frame; ++typedCount; });
     const auto conn = QObject::connect(&dsp, &AnanRxDsp::audioReady,
-                     [&audio](const std::vector<float>& stereo) {
+                     [&](const std::vector<float>& stereo) {
+        ++legacyCount;
+        exact = exact && typed.current() && typed.stream().format.sampleRateHz == kAudioRate
+            && typed.samples().size() == static_cast<qsizetype>(stereo.size())
+            && std::memcmp(typed.samples().constData(), stereo.data(), stereo.size() * sizeof(float)) == 0;
         for (std::size_t k = 0; k + 1 < stereo.size(); k += 2)
             audio.push_back(stereo[k]);            // left channel
     });
@@ -151,6 +162,9 @@ double runTone(AnanRxDsp& dsp, double wireOffsetHz, double shiftHz)
         dsp.processIqBlock(iq);
     }
     QObject::disconnect(conn);
+    QObject::disconnect(typedConn);
+    check(exact && typedCount > 0 && typedCount == legacyCount,
+          "ANAN typed output matches every legacy sample and actual producer rate");
     return dominantHz(audio, kAudioRate);
 }
 

--- a/tests/hl2_family_transition_test.cpp
+++ b/tests/hl2_family_transition_test.cpp
@@ -108,10 +108,12 @@ int main(int argc, char** argv)
     {
         int busBlocks = 0;
         QObject::connect(&model, &RadioModel::rxDemodAudioReady,
-                         &model, [&busBlocks](const QByteArray&) { ++busBlocks; });
+                         &model, [&busBlocks](const PcmFrame&) { ++busBlocks; });
 
         const QByteArray frame(256, '\0');
-        emit model.backendAudioFrameReady(frame);
+        AetherSDR::PcmProducer pcmProducer;
+        pcmProducer.start();
+        emit model.backendAudioFrameReady(*pcmProducer.legacyStereo24(frame));
         check(busBlocks == 1,
               "RX bus: a seam backend's audio reaches rxDemodAudioReady exactly once");
 
@@ -121,7 +123,8 @@ int main(int argc, char** argv)
         // catching a doubled count later would. (PR #4537 review.)
         model.connectToRadio(flexInfo());
         busBlocks = 0;
-        emit model.backendAudioFrameReady(frame);
+        pcmProducer.start();
+        emit model.backendAudioFrameReady(*pcmProducer.legacyStereo24(frame));
         check(busBlocks == 0,
               "RX bus: the seam relay is dropped when a Flex takes over");
 
@@ -129,7 +132,8 @@ int main(int argc, char** argv)
         // on the seam relay, which is the case Qt cannot clean up for us.
         model.connectToRadio(hl2Info());
         busBlocks = 0;
-        emit model.backendAudioFrameReady(frame);
+        pcmProducer.start();
+        emit model.backendAudioFrameReady(*pcmProducer.legacyStereo24(frame));
         check(busBlocks == 1,
               "RX bus: still exactly one producer after a family round-trip");
     }

--- a/tests/icom_backend_test.cpp
+++ b/tests/icom_backend_test.cpp
@@ -487,12 +487,12 @@ int main(int argc, char** argv)
     qint64 sliceAudioBytes = 0;
     int speakerBuffers = 0;
     QObject::connect(&backend, &IRadioBackend::sliceAudioFrameReady, &app,
-                     [&](int, const QByteArray& pcm) {
+                     [&](int, const PcmFrame& pcm) {
                          ++sliceAudioBuffers;
-                         sliceAudioBytes += pcm.size();
+                         sliceAudioBytes += pcm.legacyStereo24().size();
                      });
     QObject::connect(&backend, &IRadioBackend::audioFrameReady, &app,
-                     [&](const QByteArray&) { ++speakerBuffers; });
+                     [&](const PcmFrame&) { ++speakerBuffers; });
 
     // ACCUMULATED, not last-wins. Each delta carries only the fields that
     // moved, so a plain "keep the newest" would show one setting and forget the

--- a/tests/pcm_compatibility_test.cpp
+++ b/tests/pcm_compatibility_test.cpp
@@ -255,11 +255,8 @@ void flexCompatibility()
     PanadapterStream stream; // no init(), sockets, bind or peer
     PcmFrame last;
     int speaker = 0;
-    int legacySpeaker = 0;
     QObject::connect(&stream, &PanadapterStream::pcmFrameReady, &stream,
                      [&](const PcmFrame& frame) { last = frame; ++speaker; });
-    QObject::connect(&stream, &PanadapterStream::audioDataReady, &stream,
-                     [&](const QByteArray&) { ++legacySpeaker; });
     const QVector<float> samples{0.25f, -0.5f, 1.125f, -0.0f};
     QByteArray packet(PanadapterStream::VITA49_HEADER_BYTES, '\0');
     for (float value : samples) {
@@ -269,7 +266,7 @@ void flexCompatibility()
         packet.append(reinterpret_cast<const char*>(&wire), sizeof(wire));
     }
     PcmCompatibilityTestAccess::narrow(stream, packet);
-    check(speaker == 1 && legacySpeaker == 1, "Flex publishes one typed and one compatibility frame");
+    check(speaker == 1, "Flex publishes one typed frame per decoded packet");
     check(last.legacyStereo24() == bytes(samples), "Flex LR float decode remains byte exact");
     PcmCompatibilityTestAccess::narrow(stream, packet.left(packet.size() - 4));
     check(speaker == 1, "malformed Flex stereo alignment rejected");

--- a/tests/pcm_compatibility_test.cpp
+++ b/tests/pcm_compatibility_test.cpp
@@ -1,0 +1,328 @@
+// Socket-free production routing: backend publisher -> RadioModel -> audio
+// ingress, plus Flex parser/DAX lifetime. No peers, devices or radio connect.
+#include "TestSettingsProfile.h"
+#include "core/AudioEngine.h"
+#include "core/PanadapterStream.h"
+#include "core/backends/IRadioBackend.h"
+#include "core/backends/hl2/Hl2Backend.h"
+#include "core/backends/hl2/Hl2RxDsp.h"
+#include "models/RadioModel.h"
+
+#include <QCoreApplication>
+#include <QEvent>
+#include <QJsonArray>
+#include <QtEndian>
+#include <cstdio>
+
+namespace AetherSDR {
+class PcmCompatibilityTestAccess {
+public:
+    static void narrow(PanadapterStream& stream, const QByteArray& packet)
+    {
+        stream.decodeNarrowAudio(reinterpret_cast<const uchar*>(packet.constData()),
+                                 static_cast<int>(packet.size()), false, 0x123);
+    }
+    static void reduced(PanadapterStream& stream, const QByteArray& packet)
+    {
+        stream.decodeReducedBwAudio(reinterpret_cast<const uchar*>(packet.constData()),
+                                     static_cast<int>(packet.size()), false, 0x123);
+    }
+    static void dax(PanadapterStream& stream, quint32 id, int channel, const QByteArray& pcm)
+    {
+        stream.publishLegacyDaxAudio(id, channel, pcm);
+    }
+};
+} // namespace AetherSDR
+
+namespace AetherSDR::hl2 {
+struct Hl2PcmTestAccess {
+    static void start(Hl2Backend& backend, Hl2RxDsp& first, Hl2RxDsp& second)
+    {
+        backend.m_rx.resize(2);
+        backend.m_rx[0].dsp = &first;
+        backend.m_rx[1].dsp = &second;
+        backend.m_rx[1].audioMuted = true;
+        backend.m_connected = true;
+        emit backend.connected();
+    }
+    static void mix(Hl2Backend& backend, int index, const std::vector<float>& pcm)
+    {
+        backend.mixReceiverAudio(index, pcm);
+    }
+    static void unmuteSecond(Hl2Backend& backend)
+    {
+        backend.m_rx[1].audioMuted = false;
+    }
+    static void finish(Hl2Backend& backend)
+    {
+        // Stack-owned, unconfigured DSP objects: never connect a transport or
+        // transfer their ownership to the backend's teardown path.
+        backend.m_rx.clear();
+        backend.m_connected = false;
+        backend.retirePcmStreams();
+    }
+};
+} // namespace AetherSDR::hl2
+
+using namespace AetherSDR;
+
+namespace {
+int failures = 0;
+int checks = 0;
+void check(bool pass, const char* name)
+{
+    ++checks;
+    if (!pass) {
+        ++failures;
+        std::fprintf(stderr, "FAIL: %s\n", name);
+    }
+}
+QByteArray bytes(const QVector<float>& samples)
+{
+    return {reinterpret_cast<const char*>(samples.constData()),
+            samples.size() * static_cast<qsizetype>(sizeof(float))};
+}
+
+class InjectedBackend final : public IRadioBackend {
+public:
+    RadioCapabilities capabilities() const override { return {}; }
+    bool ownsRxAudio() const override { return true; }
+    void connectRadio(const RadioConnectRequest&) override
+    {
+        m_connected = true;
+        emit connected();
+    }
+    void disconnectRadio() override
+    {
+        m_connected = false;
+        emit disconnected();
+    }
+    bool isConnected() const override { return m_connected; }
+    void setSliceFrequency(int, double) override {}
+    void setSliceMode(int, const QString&) override {}
+    void setSliceFilter(int, int, int) override {}
+    void setSliceAgc(int, const QString&, int) override {}
+    void setPanCenter(const QString&, double, PanCenterIntent) override {}
+    void setKeying(bool) override {} // deliberately no transport
+    void invokeExtension(const QString&, const QString&, quint64, const QVariant&) override {}
+    void speaker(const QByteArray& pcm) { publishLegacyAudio(pcm); }
+    void sliceAudio(int id, const QByteArray& pcm) { publishLegacySliceAudio(id, pcm); }
+private:
+    bool m_connected = false;
+};
+
+void backendAndAudioRouting()
+{
+    RadioModel model;
+    AudioEngine audio;
+    auto backend = std::make_unique<InjectedBackend>();
+    InjectedBackend* source = backend.get();
+    model.setBackendForTest(std::move(backend), QStringLiteral("rtl"));
+    source->connectRadio({});
+    int taps = 0;
+    int slices = 0;
+    PcmFrame oldSpeaker;
+    PcmFrame oldSlice;
+    const QByteArray expected = bytes({0.25f, -0.25f, 0.5f, -0.5f});
+    QObject::connect(&model, &RadioModel::backendAudioFrameReady, &audio,
+                     &AudioEngine::feedPcmFrame, Qt::QueuedConnection);
+    QObject::connect(&model, &RadioModel::rxDemodAudioReady, &model,
+                     [&](const PcmFrame& frame) {
+        ++taps;
+        oldSpeaker = frame;
+        check(frame.legacyStereo24() == expected, "model demod tap is byte exact");
+    });
+    QObject::connect(&model, &RadioModel::backendSliceAudioFrameReady, &model,
+                     [&](int id, const PcmFrame& frame) {
+        ++slices;
+        oldSlice = frame;
+        check(id == 3 && frame.stream().sliceId == 3, "sparse slice ID preserved");
+        check(frame.legacyStereo24() == expected, "pre-monitor slice samples preserved");
+    });
+    check(audio.startAutomationAudioCapture(5000, {QStringLiteral("raw")}).value("ok").toBool(),
+          "automation capture started for production ingress checks");
+    source->speaker(expected);
+    source->sliceAudio(3, expected);
+    QCoreApplication::sendPostedEvents(&audio, QEvent::MetaCall);
+    QJsonArray chunks = audio.automationAudioCaptureSnapshot(true).value("chunks").toArray();
+    check(taps == 1 && slices == 1 && chunks.size() == 1, "one speaker delivery, separate slice tap");
+    if (!chunks.isEmpty()) {
+        const QJsonObject chunk = chunks[0].toObject();
+        check(chunk.value("sampleRate").toInt() == 24000 && chunk.value("frames").toInt() == 2,
+              "AudioEngine retains producer rate and frame count");
+        check(QByteArray::fromBase64(chunk.value("pcmBase64").toString().toLatin1()) == expected,
+              "typed AudioEngine ingress preserves raw PCM exactly");
+    }
+    audio.feedPcmFrame(oldSpeaker);
+    check(audio.automationAudioCaptureSnapshot(false).value("chunks").toArray().size() == 1,
+          "AudioEngine refuses repeated frame");
+    source->speaker(QByteArray(7, '\0'));
+    source->sliceAudio(3, bytes({std::numeric_limits<float>::infinity(), 0.0f}));
+    check(taps == 1 && slices == 1, "malformed backend PCM never enters model buses");
+
+    const quint64 oldInstance = oldSlice.stream().receiverInstance;
+    emit source->sliceRemoved(3);
+    check(!oldSlice.current(), "slice removal revokes queued per-slice PCM");
+    source->sliceAudio(3, expected);
+    check(oldSlice.stream().receiverInstance != oldInstance, "reused slice gets distinct receiver instance");
+    source->speaker(expected); // queued to AudioEngine, then invalidate before delivery
+    source->disconnectRadio();
+    source->connectRadio({});
+    QCoreApplication::sendPostedEvents(&audio, QEvent::MetaCall);
+    check(audio.automationAudioCaptureSnapshot(false).value("chunks").toArray().size() == 1,
+          "queued previous-session speaker frame rejected after reconnect");
+    source->speaker(expected);
+    QCoreApplication::sendPostedEvents(&audio, QEvent::MetaCall);
+    check(audio.automationAudioCaptureSnapshot(false).value("chunks").toArray().size() == 2,
+          "new session speaker still delivered once");
+
+    PcmProducer future;
+    future.start(PcmPurpose::Speaker, -1, {48000, PcmLayout::Stereo});
+    audio.feedPcmFrame(*future.produce({0.2f, -0.2f}));
+    check(audio.automationAudioCaptureSnapshot(false).value("chunks").toArray().size() == 2,
+          "A1 AudioEngine refuses native 48 kHz until A2");
+    source->retirePcmStreams();
+    const int retiredTaps = taps;
+    const int retiredSlices = slices;
+    check(!oldSpeaker.current() && !oldSlice.current(), "retirement revokes both streams before disconnect notification");
+    source->speaker(expected);
+    source->sliceAudio(3, expected);
+    check(taps == retiredTaps && slices == retiredSlices, "queued worker cannot mint PCM during retirement");
+    source->connectRadio({});
+    source->speaker(expected);
+    const PcmFrame priorFamily = oldSpeaker;
+    auto replacement = std::make_unique<InjectedBackend>();
+    source = replacement.get();
+    model.setBackendForTest(std::move(replacement), QStringLiteral("hl2"));
+    check(!priorFamily.current(), "family switch revokes old backend PCM");
+    source->connectRadio({});
+    const int before = taps;
+    source->speaker(expected);
+    check(taps == before + 1, "shared production test binding has one relay after family swap");
+    QCoreApplication::sendPostedEvents(&audio, QEvent::MetaCall);
+    const int beforeKiwi = audio.automationAudioCaptureSnapshot(false).value("chunkCount").toInt();
+    PcmProducer kiwi;
+    kiwi.start(PcmPurpose::Auxiliary);
+    const PcmFrame kiwiFrame = *kiwi.legacyStereo24(expected);
+    const QString kiwiId = QStringLiteral("pcm-test-kiwi");
+    audio.setKiwiSdrAudioSourceEnabled(kiwiId, true);
+    audio.feedKiwiPcmFrame(kiwiId, kiwiFrame);
+    const QJsonArray combined = audio.automationAudioCaptureSnapshot(true).value("chunks").toArray();
+    check(combined.size() == beforeKiwi + 1, "concurrent Kiwi24 has an independent ingress cursor");
+    if (combined.size() == beforeKiwi + 1) {
+        const QJsonObject chunk = combined.last().toObject();
+        check(chunk.value("source").toString() == "kiwi"
+              && chunk.value("sourceId").toString() == kiwiId
+              && chunk.value("sampleRate").toInt() == 24000
+              && QByteArray::fromBase64(chunk.value("pcmBase64").toString().toLatin1()) == expected,
+              "Kiwi24 retains source attribution, sample rate and stereo bytes");
+    }
+    audio.feedKiwiPcmFrame(kiwiId, kiwiFrame);
+    kiwi.invalidate();
+    audio.feedKiwiPcmFrame(kiwiId, kiwiFrame);
+    check(audio.automationAudioCaptureSnapshot(false).value("chunkCount").toInt() == beforeKiwi + 1,
+          "Kiwi ingress rejects duplicate and retired frames");
+    audio.setKiwiSdrAudioSourceEnabled(kiwiId, false);
+    audio.stopAutomationAudioCapture();
+}
+
+void hermesCompatibility()
+{
+    hl2::Hl2Backend backend;
+    hl2::Hl2RxDsp first;
+    hl2::Hl2RxDsp second;
+    hl2::Hl2PcmTestAccess::start(backend, first, second);
+    PcmFrame last;
+    int deliveries = 0;
+    QObject::connect(&backend, &IRadioBackend::audioFrameReady, &backend,
+                     [&](const PcmFrame& frame) { last = frame; ++deliveries; });
+    const std::vector<float> one{1.25f, -1.5f, 0.25f, -0.0f};
+    hl2::Hl2PcmTestAccess::mix(backend, 0, one);
+    check(deliveries == 1 && last.legacyStereo24() == bytes({1.25f, -1.5f, 0.25f, -0.0f}),
+          "Hermes single-receiver mixer stays byte exact without clipping");
+    hl2::Hl2PcmTestAccess::unmuteSecond(backend);
+    hl2::Hl2PcmTestAccess::mix(backend, 0, {0.25f, -0.5f, 0.125f, -0.125f});
+    check(deliveries == 1, "Hermes still waits for the second receiver's matching samples");
+    hl2::Hl2PcmTestAccess::mix(backend, 1, {0.125f, -0.25f, 0.25f, -0.25f});
+    check(deliveries == 2 && last.legacyStereo24() == bytes({0.375f, -0.75f, 0.375f, -0.375f}),
+          "Hermes stereo sum and frame alignment unchanged by typed publication");
+    hl2::Hl2PcmTestAccess::finish(backend);
+    check(!last.current(), "Hermes compatibility frames revoked at retirement");
+}
+
+void flexCompatibility()
+{
+    PanadapterStream stream; // no init(), sockets, bind or peer
+    PcmFrame last;
+    int speaker = 0;
+    int legacySpeaker = 0;
+    QObject::connect(&stream, &PanadapterStream::pcmFrameReady, &stream,
+                     [&](const PcmFrame& frame) { last = frame; ++speaker; });
+    QObject::connect(&stream, &PanadapterStream::audioDataReady, &stream,
+                     [&](const QByteArray&) { ++legacySpeaker; });
+    const QVector<float> samples{0.25f, -0.5f, 1.125f, -0.0f};
+    QByteArray packet(PanadapterStream::VITA49_HEADER_BYTES, '\0');
+    for (float value : samples) {
+        quint32 bits = 0;
+        std::memcpy(&bits, &value, sizeof(bits));
+        const quint32 wire = qToBigEndian(bits);
+        packet.append(reinterpret_cast<const char*>(&wire), sizeof(wire));
+    }
+    PcmCompatibilityTestAccess::narrow(stream, packet);
+    check(speaker == 1 && legacySpeaker == 1, "Flex publishes one typed and one compatibility frame");
+    check(last.legacyStereo24() == bytes(samples), "Flex LR float decode remains byte exact");
+    PcmCompatibilityTestAccess::narrow(stream, packet.left(packet.size() - 4));
+    check(speaker == 1, "malformed Flex stereo alignment rejected");
+    QByteArray invalid = packet;
+    const quint32 nan = qToBigEndian(quint32{0x7fc00000});
+    std::memcpy(invalid.data() + PanadapterStream::VITA49_HEADER_BYTES, &nan, 4);
+    PcmCompatibilityTestAccess::narrow(stream, invalid);
+    check(speaker == 1, "nonfinite Flex PCM rejected before concealment history");
+    PcmCompatibilityTestAccess::narrow(stream, packet);
+    check(last.legacyStereo24() == bytes(samples), "malformed packet cannot poison next Flex frame");
+    QByteArray reduced(PanadapterStream::VITA49_HEADER_BYTES, '\0');
+    for (qint16 value : {qint16{8192}, qint16{-16384}}) {
+        const qint16 wire = qToBigEndian(value);
+        reduced.append(reinterpret_cast<const char*>(&wire), sizeof(wire));
+    }
+    PcmCompatibilityTestAccess::reduced(stream, reduced);
+    check(last.legacyStereo24() == bytes({0.25f, 0.25f, -0.5f, -0.5f}),
+          "Flex reduced-bandwidth mono duplicates to stereo unchanged");
+    const int before = speaker;
+    PcmCompatibilityTestAccess::reduced(stream, reduced.left(reduced.size() - 1));
+    check(speaker == before, "partial reduced-bandwidth sample rejected");
+
+    PcmFrame dax;
+    int daxCount = 0;
+    QObject::connect(&stream, &PanadapterStream::daxPcmReady, &stream,
+                     [&](int channel, const PcmFrame& frame) {
+        check(channel == 4, "DAX channel preserved independently of slice IDs");
+        dax = frame;
+        ++daxCount;
+    });
+    stream.registerDaxStream(0x101, 4);
+    PcmCompatibilityTestAccess::dax(stream, 0x101, 4, bytes(samples));
+    check(daxCount == 1 && dax.legacyStereo24() == bytes(samples), "Flex DAX byte exact");
+    stream.unregisterDaxStream(0x101);
+    check(!dax.current(), "DAX removal revokes queued PCM");
+    PcmCompatibilityTestAccess::dax(stream, 0x101, 4, bytes(samples));
+    check(daxCount == 1, "removed DAX stream cannot emit more PCM");
+    stream.stop();
+    check(!last.current(), "Flex stop revokes queued speaker frame");
+    PcmCompatibilityTestAccess::narrow(stream, packet);
+    check(speaker == before, "stopped Flex PCM adapter refuses publication");
+}
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile settings(QStringLiteral("pcm-compatibility"));
+    qputenv("AETHER_AUTOMATION", "1");
+    QCoreApplication app(argc, argv);
+    check(settings.isValid(), "isolated settings profile");
+    backendAndAudioRouting();
+    flexCompatibility();
+    hermesCompatibility();
+    std::printf("PCM compatibility: %d checks, %d failures\n", checks, failures);
+    return failures ? 1 : 0;
+}

--- a/tests/pcm_frame_test.cpp
+++ b/tests/pcm_frame_test.cpp
@@ -102,6 +102,43 @@ void identityContinuityAndQueueing(QObject& receiver)
     check(gap && gate.accept(*gap), "marked forward discontinuity accepted");
     check(!producer.produce({0.1f, -0.1f}, std::numeric_limits<quint64>::max(), true),
           "sample position overflow refused");
+
+    // A consumer detached from a running producer resumes when it is
+    // reattached. The producer counts on production, not delivery, so the
+    // frames it emitted while this gate was starved leave a forward gap that
+    // carries no discontinuity flag — the exact shape a playback mute/unmute
+    // cycle produces on both the Flex and seam-backend speaker paths. The gate
+    // must resync rather than refuse: the cursor only moves on an accepted
+    // frame, so one refusal here would silence the consumer for the life of
+    // the epoch. Backward motion stays refused (asserted below).
+    {
+        PcmProducer live;
+        live.start(PcmPurpose::Speaker);
+        PcmFrameGate attached;
+        for (int i = 0; i < 3; ++i) {
+            const auto frame = live.produce({0.3f, -0.3f});
+            check(frame && attached.accept(*frame), "attached consumer accepts steady frames");
+        }
+        // Detached: produced, never delivered to this gate.
+        for (int i = 0; i < 5; ++i) {
+            check(live.produce({0.3f, -0.3f}).has_value(), "producer advances while consumer is detached");
+        }
+        const auto resumed = live.produce({0.3f, -0.3f});
+        check(resumed && !resumed->discontinuity(),
+              "resumed frame carries no discontinuity flag");
+        check(resumed && resumed->firstSample() > 3,
+              "resumed frame is ahead of the starved cursor");
+        check(resumed && attached.accept(*resumed),
+              "consumer reattached after a forward gap resyncs instead of locking out");
+        int accepted = 0;
+        for (int i = 0; i < 5; ++i) {
+            const auto frame = live.produce({0.3f, -0.3f});
+            if (frame && attached.accept(*frame)) {
+                ++accepted;
+            }
+        }
+        check(accepted == 5, "reattached consumer keeps accepting after resync");
+    }
     int deliveries = 0;
     QMetaObject::invokeMethod(&receiver, [frame = *gap, &deliveries] {
         if (!frame.legacyStereo24().isEmpty()) {

--- a/tests/pcm_frame_test.cpp
+++ b/tests/pcm_frame_test.cpp
@@ -1,0 +1,193 @@
+// Socket-free producer contract: owned samples, format/identity/continuity,
+// delayed delivery and fail-closed compatibility. No radio or audio device.
+#include "core/PcmFrame.h"
+
+#include <QCoreApplication>
+#include <QEvent>
+#include <cstdio>
+#include <barrier>
+#include <thread>
+
+using namespace AetherSDR;
+
+namespace {
+int failures = 0;
+int checks = 0;
+void check(bool pass, const char* name)
+{
+    ++checks;
+    if (!pass) {
+        ++failures;
+        std::fprintf(stderr, "FAIL: %s\n", name);
+    }
+}
+QByteArray bytes(const QVector<float>& samples)
+{
+    return {reinterpret_cast<const char*>(samples.constData()),
+            samples.size() * static_cast<qsizetype>(sizeof(float))};
+}
+
+void formatsAndOwnership()
+{
+    PcmProducer producer;
+    check(!producer.legacyStereo24(bytes({0.1f, -0.1f})), "unstarted producer refuses PCM");
+    check(producer.start(), "start legacy producer");
+    const QVector<float> samples{0.0f, -0.0f, 1.25f, -1.5f, 0.123f, -0.456f};
+    QByteArray input = bytes(samples);
+    const auto first = producer.legacyStereo24(input);
+    check(first.has_value(), "valid legacy stereo accepted");
+    check(first->stream().format == PcmFormat{}, "producer rate stays 24 kHz stereo");
+    check(first->frameCount() == 3 && first->firstSample() == 0 && first->discontinuity(),
+          "frame count counts LR pairs and first frame marks a discontinuity");
+    check(first->legacyStereo24() == input, "byte exact, including signed zero and unclipped peaks");
+    const QByteArray borrowed = QByteArray::fromRawData(input.constData(), input.size());
+    const auto owned = producer.legacyStereo24(borrowed);
+    input.fill(0);
+    check(owned->legacyStereo24() == bytes(samples), "queued frame owns borrowed callback samples");
+    check(owned->firstSample() == 3 && !owned->discontinuity(), "legacy sample position advances");
+    check(!producer.legacyStereo24({}), "empty bytes rejected");
+    for (int n = 1; n < 8; ++n) {
+        check(!producer.legacyStereo24(QByteArray(n, '\0')), "partial stereo frame rejected");
+    }
+    check(!producer.legacyStereo24(QByteArray((PcmFrame::kMaxFrames + 1) * 8, '\0')),
+          "oversized bytes rejected before copying");
+    check(!producer.produce({1.0f}), "odd stereo sample count rejected");
+    check(!producer.produce({std::numeric_limits<float>::quiet_NaN(), 0.0f}), "NaN rejected");
+    check(!producer.produce({0.0f, std::numeric_limits<float>::infinity()}), "infinity rejected");
+    const auto next = producer.produce({0.25f, -0.25f});
+    check(next->firstSample() == 6, "malformed input never advances the cursor");
+    check(!producer.setFormat({44100, PcmLayout::Stereo}), "unsupported producer rate refused");
+    check(!producer.setFormat({24000, static_cast<PcmLayout>(9)}), "unknown layout refused");
+    check(next->current(), "refused format change preserves valid stream");
+    check(producer.setFormat({48000, PcmLayout::Stereo}), "48 kHz contract supported");
+    check(!next->current() && next->legacyStereo24().isEmpty(), "old-format queued PCM revoked");
+    const auto wide = producer.produce({0.75f, -0.75f});
+    check(wide->stream().formatGeneration == 2 && wide->firstSample() == 0,
+          "new format has new generation and sample origin");
+    check(wide->legacyStereo24().isEmpty(), "legacy consumer refuses 48 kHz, never relabels");
+    check(!producer.legacyStereo24(bytes({0.5f, -0.5f})), "24 kHz adapter cannot label bytes as 48");
+    check(producer.setFormat({24000, PcmLayout::Stereo}), "return to 24 kHz");
+    const auto returned = producer.produce({0.5f, -0.5f});
+    check(returned->stream().formatGeneration == 3 && !wide->current(), "format ABA rejected");
+    check(producer.setFormat({48000, PcmLayout::Mono}), "mono native PCM supported");
+    const auto mono = producer.produce({0.0f, 0.25f, -0.5f});
+    check(mono->frameCount() == 3 && mono->legacyStereo24().isEmpty(), "mono count and legacy refusal");
+#if QT_VERSION >= QT_VERSION_CHECK(6, 11, 0)
+    float borrowedSamples[]{0.5f, -0.5f};
+    const auto borrowedFrame = producer.produce(QVector<float>::fromReadOnlyData(borrowedSamples));
+    borrowedSamples[0] = 0.0f;
+    check(borrowedFrame->samples()[0] == 0.5f, "native frame owns external Qt container storage");
+#endif
+    check(!producer.start(PcmPurpose::Slice, -1), "slice requires stable slot");
+    check(!producer.start(PcmPurpose::Speaker, 0), "speaker cannot masquerade as a slice");
+    check(!producer.start(static_cast<PcmPurpose>(10)), "unknown purpose rejected");
+}
+
+void identityContinuityAndQueueing(QObject& receiver)
+{
+    PcmProducer producer;
+    producer.start(PcmPurpose::Slice, 3, {}, 700, 900);
+    const auto first = producer.produce({0.1f, -0.1f});
+    check(first->stream().session == 700 && first->stream().receiverInstance == 900
+          && first->stream().sliceId == 3, "F4 session, receiver instance and stable slot remain separate");
+    check(!producer.start(PcmPurpose::Slice, 3, {}, 700, 901), "repeated explicit session refused");
+    check(!producer.start(PcmPurpose::Slice, 3, {}, 699, 902), "older explicit session refused");
+    check(first->current(), "refused stale start preserves current epoch");
+    PcmFrameGate gate;
+    check(gate.accept(*first), "first delivery accepted");
+    check(!gate.accept(*first), "duplicate delivery refused");
+    check(!producer.produce({0.1f, -0.1f}, 0, true), "discontinuity cannot authorize backwards PCM");
+    check(!producer.produce({0.1f, -0.1f}, 4), "unmarked sample gap refused");
+    const auto gap = producer.produce({0.1f, -0.1f}, 4, true);
+    check(gap && gate.accept(*gap), "marked forward discontinuity accepted");
+    check(!producer.produce({0.1f, -0.1f}, std::numeric_limits<quint64>::max(), true),
+          "sample position overflow refused");
+    int deliveries = 0;
+    QMetaObject::invokeMethod(&receiver, [frame = *gap, &deliveries] {
+        if (!frame.legacyStereo24().isEmpty()) {
+            ++deliveries;
+        }
+    }, Qt::QueuedConnection);
+    producer.start(PcmPurpose::Slice, 3, {}, 701, 901);
+    QCoreApplication::sendPostedEvents(&receiver, QEvent::MetaCall);
+    check(deliveries == 0, "queued old occupant rejected after same-slot reconnect");
+    check(!gate.accept(*gap), "stale frame cannot re-admit old session");
+    const auto replacement = producer.produce({0.2f, -0.2f});
+    check(gate.accept(*replacement), "new same-slot occupant accepted");
+    check(replacement->stream().source == first->stream().source
+          && replacement->stream().session != first->stream().session,
+          "producer identity survives session change");
+    producer.invalidate();
+    check(!gate.accept(*replacement), "removed source rejected");
+    check(!producer.produce({0.1f, -0.1f}), "stopped producer cannot publish");
+    PcmFrame retained;
+    {
+        PcmProducer scoped;
+        scoped.start();
+        retained = *scoped.produce({0.1f, -0.1f});
+    }
+    check(!retained.current(), "destruction revokes pending PCM without retaining producer");
+}
+
+void concurrentRevocation()
+{
+    PcmProducer producer;
+    producer.start();
+    const PcmFrame retained = *producer.produce({0.25f, -0.5f});
+    std::barrier rendezvous(2);
+    bool samplesIntact = true;
+    bool refusedAfterRevocation = false;
+    std::thread consumer([&] {
+        rendezvous.arrive_and_wait();
+        // Read the epoch while its owner revokes it. There is deliberately no
+        // ordering between these reads and invalidate(); TSan must see the
+        // token's atomic synchronization, not a test-only mutex around it.
+        for (int i = 0; i < 10000; ++i) {
+            const bool current = retained.current();
+            const QByteArray pcm = retained.legacyStereo24();
+            samplesIntact = samplesIntact && retained.samples()[0] == 0.25f
+                && retained.samples()[1] == -0.5f
+                && (pcm.isEmpty() || pcm == bytes({0.25f, -0.5f}));
+            (void)current;
+        }
+        rendezvous.arrive_and_wait();
+        refusedAfterRevocation = !producer.produce({0.25f, -0.5f});
+    });
+    rendezvous.arrive_and_wait();
+    producer.invalidate();
+    rendezvous.arrive_and_wait();
+    consumer.join();
+    check(samplesIntact, "concurrent revocation never changes owned sample bytes");
+    check(refusedAfterRevocation && !retained.current(), "revocation reaches another execution context");
+}
+
+void boundedIndependentStreams()
+{
+    PcmFrameGate gate;
+    std::array<std::unique_ptr<PcmProducer>, PcmFrameGate::kMaxStreams + 1> producers;
+    for (std::size_t i = 0; i < producers.size(); ++i) {
+        producers[i] = std::make_unique<PcmProducer>();
+        producers[i]->start();
+        const auto frame = producers[i]->produce({0.1f, -0.1f});
+        check(gate.accept(*frame) == (i < PcmFrameGate::kMaxStreams), "bounded source admission");
+    }
+    producers[0]->invalidate();
+    check(gate.accept(*producers.back()->produce({0.2f, -0.2f})), "retired cursor reused at capacity");
+    const auto frame = producers[1]->produce({0.2f, -0.2f});
+    PcmFrameGate independentTap;
+    check(gate.accept(*frame) && independentTap.accept(*frame), "consumers have independent cursors");
+}
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    qRegisterMetaType<PcmFrame>();
+    check(QMetaType::fromName("AetherSDR::PcmFrame").isValid(), "name-based metatype registered");
+    formatsAndOwnership();
+    identityContinuityAndQueueing(app);
+    boundedIndependentStreams();
+    concurrentRevocation();
+    std::printf("PCM contract: %d checks, %d failures\n", checks, failures);
+    return failures ? 1 : 0;
+}

--- a/tests/sim_backend_test.cpp
+++ b/tests/sim_backend_test.cpp
@@ -175,7 +175,7 @@ void testEmitsAudioWhenConnected()
     const int expectBytes =
         NoiseMixer::kFrameLen * 2 * static_cast<int>(sizeof(float));
     const auto lastArgs = audioSpy.constLast();
-    const int bytes = lastArgs.isEmpty() ? -1 : lastArgs.at(0).toByteArray().size();
+    const int bytes = lastArgs.isEmpty() ? -1 : lastArgs.at(0).value<AetherSDR::PcmFrame>().legacyStereo24().size();
     report("audio frame is 24 kHz stereo float32 sized", bytes == expectBytes);
 }
 
@@ -189,7 +189,7 @@ void testKeyingMutesAudio()
     // Frames still FLOW (stream stays alive) but are all-zero when keyed.
     bool allSilent = audioSpy.count() > 0;
     for (const auto& call : audioSpy) {
-        const QByteArray pcm = call.at(0).toByteArray();
+        const QByteArray pcm = call.at(0).value<AetherSDR::PcmFrame>().legacyStereo24();
         const auto* f = reinterpret_cast<const float*>(pcm.constData());
         const int n = pcm.size() / static_cast<int>(sizeof(float));
         for (int i = 0; i < n; ++i)

--- a/tests/sim_signal_source_test.cpp
+++ b/tests/sim_signal_source_test.cpp
@@ -77,13 +77,14 @@ public:
     explicit Collector(AetherSDR::SimSignalSource* src)
     {
         connect(src, &AetherSDR::SimSignalSource::audioFrameReady, this,
-                [this](const QByteArray& b) {
+                [this](const AetherSDR::PcmFrame& frame) {
+                    const QByteArray b = frame.legacyStereo24();
                     ++audio;
                     samples += b.size() / qint64(2 * sizeof(float));
                     lastAudio = b;
                 });
         connect(src, &AetherSDR::SimSignalSource::sliceAudioFrameReady, this,
-                [this](int id, const QByteArray&) {
+                [this](int id, const AetherSDR::PcmFrame&) {
                     ++slice;
                     lastSliceId = id;
                 });

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -66,6 +66,19 @@ unset(_aether_stray_targets)
 unset(_aether_stray_registrations)
 
 
+# Typed producer PCM, queued lifetime and compatibility: QtCore only, no sockets.
+add_executable(pcm_frame_test tests/pcm_frame_test.cpp)
+target_include_directories(pcm_frame_test PRIVATE src)
+target_link_libraries(pcm_frame_test PRIVATE Qt6::Core)
+add_test(NAME pcm_frame_test COMMAND pcm_frame_test)
+set_tests_properties(pcm_frame_test PROPERTIES TIMEOUT 30)
+
+# Actual backend/model/audio/parser wiring with injected PCM; binds no sockets.
+add_executable(pcm_compatibility_test tests/pcm_compatibility_test.cpp)
+target_link_libraries(pcm_compatibility_test PRIVATE aethercore Qt6::Core)
+add_test(NAME pcm_compatibility_test COMMAND pcm_compatibility_test)
+set_tests_properties(pcm_compatibility_test PROPERTIES TIMEOUT 60)
+
 # Pure shared-capture geometry policy: no sockets, settings, DSP or hardware.
 add_executable(shared_capture_policy_test
     tests/shared_capture_policy_test.cpp
@@ -4987,6 +5000,7 @@ target_link_libraries(CAT_Flex_test PRIVATE Qt6::Core Qt6::Network)
 # directly (rather than linking aethercore) needs the vendored SQLite engine.
 # Conditional targets are guarded with if(TARGET ...).
 set(AETHER_SETTINGS_CONSUMERS
+    pcm_compatibility_test
     firmware_close_dialog_test
     atu_seam_gate_test
     backend_capability_revision_test


### PR DESCRIPTION
This A1 change carries owned RX samples with their producer, session, receiver and format identity, rejects malformed or retired input, and adapts existing producers without changing accepted sample bits or processing behavior. It implements the first audio-foundation milestone of RFC #5468; it does not complete the RFC.

**Signed linear stack #5608:** main `3b3312eb` → A1 `65e20686` (#5598) → NR `c50f9853` (#5604) → A2 `a9d9794b` (#5605). This PR targets `main`.

The rebase changes history without adding a feature change: the 36-file A1 delta retains every published added/removed line, and its complete tree matches the independently computed combination of current main and published A1. Main's merged F4, #5591 TX coordinator and newer CW/TUNE/lifetime changes are preserved. The shared settings-consumer insertion retains both the PCM compatibility test and main's firmware-close test. There is one signed feature commit per stack layer and no merge commit above the frozen main. Original authors, dates and messages are retained; statements in those messages about former bases or validation are historical.

## Change

- Add `PcmFrame`, `PcmProducer` and bounded gates: owned float32 samples; 24/48 kHz mono/stereo formats; separate source/session/format-generation/receiver-instance/slice identities; sample positions, discontinuities and atomic revocation. Reject empty, oversized, misaligned, nonfinite, backward, duplicate and unmarked-gap input.
- Carry typed speaker/per-slice PCM through `IRadioBackend` and shared production/test bindings in `RadioModel`. Retire streams before teardown or slot reuse and check worker/session identity before adapting queued legacy output.
- Adapt Flex decoding/DAX, HL2 mixing, ANAN, Icom, current RTL, Sim and Kiwi. Fixed-rate consumers unwrap after delivery. Existing recording, CW/RTTY, TCI, AetherClock, RADE and Kiwi source selection, and byte APIs remain available. (The raw `audioDataReady`/`daxAudioReady` signals were removed in review — see below.)
- Preserve 24 kHz processing and device-rate `m_rxOutputRate`. RTL48 production and multi-receiver runtime remain disabled. A2 owns rate-aware playback; A3 recording, A4 TCI and A5 decoder/clock remain separate.

The [contract and adapter inventory](https://github.com/aethersdr/AetherSDR/blob/4b7e0b202aab8af02a2a4cb323a9c55b3de2c006/docs/producer-pcm-contract.md) records ownership, execution contexts and admission limits. This feature adds no production thread, dependency, setting, UI/default, capability or frozen CI-gate entry.

## New-head validation

Local results execute `4b7e0b202aab8af02a2a4cb323a9c55b3de2c006`; CI records its actual checkout refs. All seven current checks passed under native-stack trunk `main`. Local and GitHub signature verification passed; actual tested revisions are recorded below.

| Evidence | Result |
|---|---|
| Mac build and focused tests | PASS at `4b7e0b20`; fresh aethercore and 22 C++ targets; 23/23 CTests, zero test-level skips (23.66 s). No A1 app/daemon build at this final head. |
| Nobara focused PCM/TX and upstream regression tests | PASS at `4b7e0b20`; 35 C++ targets built incrementally (106.03 s), 35/35 focused CTests (26.01 s), zero test/internal skips. GCC 16.2.1/Qt 6.11.1, RelWithDebInfo `-O2 -g1 -gz=zlib -DNDEBUG`, RTL/RADE/DFNR/MQTT/Specbleach and ASR CPU/Vulkan ON. No standalone local A1 app/daemon or unfiltered-suite claim. |
| Nobara ASan/UBSan | PASS at `4b7e0b20`; 35/35 focused tests, zero test/internal skips or sanitizer diagnostics. GCC 16.2.1/Qt 6.11.1 Debug, address+undefined, ASR OFF; leak/stack-use-after-return detection enabled. All 35 executed-binary hashes retained. System libraries and prebuilt Rust DFNR remain uninstrumented. |
| GitHub signature and observed applicable checks, with tested refs | PASS; GitHub Verified and 7/7 current checks successful: [Code Quality: PR #5598](https://github.com/aethersdr/AetherSDR/actions/runs/34685207270), [Static Checks](https://github.com/aethersdr/AetherSDR/actions/runs/34685208810), [CI](https://github.com/aethersdr/AetherSDR/actions/runs/34685208833). Repository CI/static jobs checked out [`403c2b8a`](https://github.com/aethersdr/AetherSDR/commit/403c2b8a3e43078a752b4224884b441d3aad3965), whose tree equals this signed head; dynamic Code Quality checked out the exact head. Superseded auto-cancelled runs are excluded. |

Current-head mutation evidence at integrated A2 `011c2bf2715bca8018053be8bac5d267f29d569b`: removing only the merged DSP-geometry guards from a copied registry translation unit triggered exactly eight intended unsafe-geometry failures. The normal production binary passed 483/483 before and after. Final production compile/link flags and unchanged test objects were used; all 3,189 source blobs and 34 production file hashes/inodes/mtimes remained unchanged. This is a Mac native mutation, not a sanitizer run or standalone A1/NR execution.

## Historical evidence and limits

Earlier head `e4973732ef08a5019bc9097a843d7bf808a2c075` passed Mac application/daemon builds and 23 focused tests; Nobara's full RTL-enabled suite had 405 pass, 3 skip and no failures out of 408; 25 ASan/UBSan tests passed. Its copied-production registry mutation removed the merged DSP-geometry guards, failed the unsafe-geometry assertions, and passed with the original binary. These are earlier-head results, not rebase executions.

Original A1 `3b127b3a2efc4d21b2b270a06f2b619aed6b9e0e` also had PCM-contract concurrency TSan, four contract mutations, an AudioEngine replay mutation and an atomic-removal race mutation. That TSan evidence does not qualify the whole engine.

The two A1 tests are socket-free and exercise actual backend → model → AudioEngine bindings, Flex/DAX lifetime, HL2 mixing, disconnect/reconnect, slot/family replacement, replay, A1's 48 kHz refusal and independent Kiwi streams. No synthetic firmware peer or socket-owning test is added. Full-suite runs use the documented private-state and isolated network/device harness.

Historical skips were quarantined CRDV, the platform-specific explicit-profile-path settings scenario and opt-in radar GL; internal skips included NVIDIA AFX, Linux MNR, physical audio, opt-in GL and whisper fixtures. Mac used clang 21/Qt 6.11.1 with ASR OFF and no librtlsdr/Darwin DFNR. Nobara used GCC 16.2.1/Qt 6.11.1 with RTL/RADE/DFNR/MQTT/Specbleach and native ASR CPU+Vulkan; ASR was OFF under sanitizers. System libraries and prebuilt Rust DFNR were outside ASan/UBSan instrumentation. The new-head options and skips are recorded above.

Producer revocation prevents later admission; A1 cannot retract samples already admitted to engine/device queues. Gates permit 32 live streams, and ownership copies/scans are not a real-time performance claim. Audible/native-device behavior, sustained latency/load, live Flex/RTL/USB/RF/TX and native Linux ARM remain unqualified here. Native Flex slice-0 before/after qualification requires separate authorization.

The [#5554 §2.6 audio-track exit/sign-off](https://github.com/aethersdr/AetherSDR/issues/5554#issuecomment-5642853284) remains outstanding for exactly-one producer with paired direct-route retirement, per-slice/DAX/pre-mute semantics and bounded latest-frame-wins queues across the completed track. A1 supplies milestone evidence. Independent review and applicable CODEOWNERS approval remain required; no merge is requested.

73, Ozy **K6OZY** · GPT-6 Astra-Ultra

---

## Review fixes applied (2026-09-12)

Review feedback on this stack was addressed directly on the branches; the layers
were rebased so the stack stays linear and each layer still carries its original
feature commit with its original author, date and message. The evidence tables
below describe the **pre-review-fix** heads and are retained as history; the
current heads were rebuilt and retested on Arch/GCC 16 as recorded here.

**Blocker — `PcmFrameGate` permanently silenced RX after a playback mute/unmute.**
The gate refused a frame ahead of its cursor unless the frame was flagged
discontinuous, but no A1 adapter sets that flag after the first frame of an
epoch. A consumer that missed frames was therefore refused forever: a cursor only
advances on an accepted frame. Playback mute does exactly that on both the Flex
path (`MainWindow` disconnects the speaker feed) and the seam-backend path
(`MainWindow_Session` returns early) while the producer keeps counting, so one
QSO-recording playback left RX silent until the next reconnect, with no log line.
The guard is now one-sided — refuse at or behind the cursor, admit ahead of it —
and `pcm_frame_test` pins the resync, failing against the previous guard.

**Removed `PanadapterStream::audioDataReady` / `daxAudioReady`.** This supersedes
the "low-level compatibility signals remain available" line above: after the
typed migration nothing in the tree connected to them, their arguments were still
deep-copied per audio block (per DAX channel, on the network thread), and they
bypassed the gate, so a later consumer would silently have skipped admission
control. `AudioEngine`'s byte APIs are unaffected and do remain.

**Other review fixes.** `AnanRxDsp` now warns when its producer refuses the
configured audio rate — `PcmFormat` accepts 24000/48000 only and `AnanBackend`
hardcodes 24000, so it cannot fail today, but if that rate ever moves a silent
refusal would stop ANAN audio dead while the spectrum keeps updating. `rebindToEphemeralPort()` no longer rotates the epoch
above its own failure guard; a speaker producer that refuses to start, and audio
dropped for want of a live producer, now warn once per session instead of failing
silently; `SimSignalSource::startSession()` no longer discards
`PcmProducer::start()`'s return; the gate members moved out of the
`private slots:` blocks they were declared in.

**Not changed, deliberately.** No A1 adapter sets `discontinuity`, so a lost Flex
UDP audio packet is still presented as continuous even though packet-loss
concealment detected it. Propagating that would reset the chain on every lost
packet — an audible-behaviour decision that belongs with the later milestones
that own playback policy. `docs/producer-pcm-contract.md` now records this, and
the one-sided gate rule, explicitly.

**Current-head evidence.** Clean build, `422/422` CTests pass with the documented
three skips, both on the A1 head and on its merge with current `main`
(`3b3312eb`). Driven offscreen against the demo simulator (`DEMO-0001`, isolated
settings, TX gated off): audio Active across four connect/disconnect cycles, and
the new warnings stay silent on a healthy session.

