### PR TITLE
feat(backends): announce capability revisions — flex, hl2, rtl (#5594)

### DIFF
--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -1093,6 +1093,10 @@ void FlexBackend::clearExtensionHandles()
     // handle can't survive into a reconnect (possibly a different radio).
     m_ampHandle.clear();
     m_tunerHandle.clear();
+    // #5594 (M1): a reconnect must be able to announce its model again, even if
+    // it is the same radio — capabilities were republished from scratch at the
+    // connect edge, so the previous session's announcement describes nothing.
+    m_announcedModel.clear();
 }
 
 void FlexBackend::decodeApdStatus(const QMap<QString, QString>& kvs)
@@ -1168,6 +1172,32 @@ void FlexBackend::decodeRadioStatus(const QMap<QString, QString>& kvs)
     carry(kvs, "daxiq_capacity", d.daxiqCapacity);
     carry(kvs, "daxiq_available", d.daxiqAvailable);
     emit radioChanged(d);
+
+    // #5594 (M1): announce the capability revision this status just caused.
+    //
+    // The Flex capability table is DERIVED FROM THE MODEL NAME — capabilities()
+    // runs capabilitiesFor(caps.model) to seed maxSlices, the DSP tier and the
+    // rest — and the model name is not known at the connect edge. It arrives
+    // here, in a `radio ...` status, some time after. Until now nothing said so,
+    // so every consumer that bound to capabilitiesChanged saw the pre-model
+    // table forever; RadioModel's own comment at the meterDefined handler
+    // records the symptom this produced (a mic gauge hidden at connect and
+    // un-hidden only if an unrelated status happened to land afterwards).
+    //
+    // Deliberately AFTER emit radioChanged(d): a consumer woken by
+    // capabilitiesChanged calls capabilities(), which reads the model back
+    // through m_modelProvider, and that provider only returns the new name once
+    // RadioModel has applied this delta. Same thread, direct delivery, so the
+    // apply above has already happened by the time this line runs.
+    //
+    // Change-guarded against the LAST ANNOUNCED name, not merely against the
+    // key being present: a Flex repeats `radio ...` status on unrelated edits
+    // (callsign, nickname, the audio gains above), and re-announcing on each
+    // would make a republish storm out of typing in a text field.
+    if (d.model && *d.model != m_announcedModel) {
+        m_announcedModel = *d.model;
+        emit capabilitiesChanged();
+    }
 }
 
 void FlexBackend::decodeGpsStatus(const QString& rawBody)

--- a/src/core/backends/flex/FlexBackend.h
+++ b/src/core/backends/flex/FlexBackend.h
@@ -191,6 +191,17 @@ private:
     // and the encode intent lambdas run there — so a plain QString needs no sync.
     QString m_ampHandle;
     QString m_tunerHandle;
+
+    // The model name the last capabilitiesChanged() announcement described
+    // (#5594, M1). Flex's whole capability table is derived from the model name
+    // — capabilitiesFor(caps.model) seeds maxSlices, the DSP tier and the rest —
+    // and that name arrives in a `radio ...` status AFTER the connect edge, so
+    // without this the descriptor silently changed with nothing announcing it.
+    // Held here rather than compared through m_modelProvider so the guard does
+    // not depend on radioChanged being delivered synchronously.
+    // Cleared by clearExtensionHandles() on disconnect: a reconnect to a
+    // DIFFERENT radio must announce again.
+    QString m_announcedModel;
 };
 
 }  // namespace AetherSDR

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -443,6 +443,11 @@ Hl2Backend::Hl2Backend(QObject* parent) : IRadioBackend(parent)
     // Link lifecycle: first EP6 -> connected; stop -> disconnected.
     connect(m_metis, &MetisClient::linkUp, this, [this] {
         m_connected = true;
+        // #5594 (M1): seed the announcement baseline at the connect edge. The
+        // connect itself republishes capabilities through connectionStateChanged,
+        // so this value is already described — recording it here is what stops
+        // the first zoom that does NOT move the ceiling from announcing anyway.
+        m_ceilingAnnouncer.seed(receiverCeiling());
         // Started here rather than in connectRadio(): before the first EP6 there
         // is no link to describe, and ticking through the connect attempt would
         // publish a "reported" snapshot of zeros that reads as a dead link
@@ -499,6 +504,7 @@ Hl2Backend::Hl2Backend(QObject* parent) : IRadioBackend(parent)
     connect(m_metis, &MetisClient::linkDown, this, [this] {
         if (m_connected) {
             m_connected = false;
+            m_ceilingAnnouncer.reset();   // #5594 (M1): re-seeded on the next connect
             m_linkStatsTimer->stop();
             resetIoBoardSchedule();
             emit disconnected();
@@ -516,6 +522,7 @@ Hl2Backend::Hl2Backend(QObject* parent) : IRadioBackend(parent)
         // destructor also guards against.
         QMetaObject::invokeMethod(m_metis, "stop", Qt::QueuedConnection);
         m_connected = false;
+        m_ceilingAnnouncer.reset();   // #5594 (M1): re-seeded on the next connect
         m_linkStatsTimer->stop();
         resetIoBoardSchedule();
         emit connectionError(QStringLiteral("Hermes-Lite 2: %1").arg(reason));
@@ -836,6 +843,17 @@ int Hl2Backend::receiverCeiling() const
     p.boardMaxRx = m_boardMaxRx;
     const int board = MetisClient::effectiveNumRx(p);
     return std::min(board, maxReceiversAtRate(m_sampleRateHz, board));
+}
+
+void Hl2Backend::announceReceiverCeilingRevision()
+{
+    // Disconnected, the ceiling reported by capabilities() is not receiverCeiling()
+    // at all (it falls back to the receiver count), and the connect/disconnect
+    // edges already republish capabilities on their own. Nothing to announce.
+    if (!m_connected)
+        return;
+    if (m_ceilingAnnouncer.shouldAnnounce(receiverCeiling()))
+        emit capabilitiesChanged();
 }
 
 bool Hl2Backend::createPanadapter()
@@ -3248,6 +3266,10 @@ void Hl2Backend::applyPanBandwidth(double hz)
                     Qt::QueuedConnection,
                     Q_ARG(AetherSDR::hl2::SampleRate,
                           sampleRateEnum(previousRate)));
+            // #5594 (M1): the rate went back, so the ceiling may have gone back
+            // with it. Guarded, so a rollback to the rate we already announced
+            // says nothing.
+            announceReceiverCeilingRevision();
             emitAllPanState();
             return;
         }
@@ -3259,6 +3281,13 @@ void Hl2Backend::applyPanBandwidth(double hz)
     // Written only after the reconfigure SUCCEEDED — persisting a rate the DSP
     // just refused would make the failure permanent across restarts.
     Hl2Settings::setSpanMhz(static_cast<double>(m_sampleRateHz) / 1.0e6);
+
+    // #5594 (M1): the rate is committed, so the receiver ceiling this radio can
+    // honestly offer may have moved with it — maxSlices and maxPanadapters both
+    // report it. Announced here rather than at the top of the function because
+    // an announcement before the reconfigure could be rolled back below.
+    // Guarded: the majority of zooms stay inside one ceiling and say nothing.
+    announceReceiverCeilingRevision();
 
     // A narrower window may no longer contain the slice: the usable passband
     // shrank, and a slice left outside it would sit in the roll-off (or off the

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -8,6 +8,7 @@
 #include <QThread>
 #include <QTimer>
 
+#include "core/backends/hl2/Hl2CapabilityAnnouncer.h"
 #include "core/backends/hl2/Hl2DbReference.h"
 #include "core/backends/hl2/Hl2IoBoardPolicy.h"
 #include "core/backends/hl2/Hl2Receivers.h"
@@ -522,6 +523,14 @@ private:
     // How many receivers this radio may run right now: the board's reported
     // count, capped by the link budget at the current sample rate.
     [[nodiscard]] int receiverCeiling() const;
+    // Announce a capability revision if — and only if — receiverCeiling() has
+    // actually moved since the last announcement (#5594, M1). The ceiling is
+    // reported as both maxSlices and maxPanadapters, and it FALLS when the
+    // operator zooms out: at 384 kHz a fourth receiver cannot be delivered on
+    // 100BASE-T, so the honest limit is 3. Guarded because a zoom sweep crosses
+    // several rates in a drag and an announcement per rate would be a storm;
+    // the great majority of zooms do not move the ceiling at all.
+    void announceReceiverCeilingRevision();
     // Re-evaluate the shared band filter and publish the resulting WIDE state.
     void publishWideState();
     // Destroy the DSP chains but KEEP each receiver's operator-set state. The
@@ -615,6 +624,10 @@ private:
     // because createPanadapter() has to answer "may I add one?" on this thread,
     // and the wire object lives on the I/O thread.
     int m_boardMaxRx = 0;
+    // Guards capabilitiesChanged() against a zoom sweep (#5594, M1). The
+    // decision lives in Hl2CapabilityAnnouncer.h so it is pinned socket-free;
+    // this class only supplies receiverCeiling() and does the emitting.
+    ReceiverCeilingAnnouncer m_ceilingAnnouncer;
     // What to assume when the board never reported its receiver count — a short
     // discovery reply, or a unicast probe that went unanswered. The shipping
     // hl2b5up_main gateware is built with NR=4 (variants/hl2b5up_main/

--- a/src/core/backends/hl2/Hl2CapabilityAnnouncer.h
+++ b/src/core/backends/hl2/Hl2CapabilityAnnouncer.h
@@ -1,0 +1,59 @@
+#pragma once
+
+// When a receiver-ceiling move is a CAPABILITY REVISION worth announcing — as a
+// pure decision, so the guard is testable without a radio, a socket or a running
+// event loop (the layer #5358 asks for, same shape as Hl2DspSetupPolicy.h).
+//
+// WHY THERE IS A GUARD AT ALL. Hl2Backend reports receiverCeiling() as both
+// maxSlices and maxPanadapters, and that ceiling is min(board count, what the
+// EP6 link budget admits at the current span) — so it FALLS when the operator
+// zooms out. At 384 kHz a fourth receiver is ~89 Mbit/s on the HL2's 100BASE-T
+// and genuinely cannot be delivered, so the honest limit there is 3. That is a
+// real revision of the descriptor the aetherd control protocol serializes
+// (#3849 step 3), and until #5594 nothing announced it.
+//
+// But a zoom is a DRAG. setPanBandwidth is fed roughly every 33 ms during a
+// sweep and crosses several rates on the way, while the great majority of those
+// rate changes leave the ceiling exactly where it was. Announcing per rate
+// change rather than per CEILING change would turn one gesture into a
+// republish storm at every capability consumer. Hence: compare against the last
+// value actually announced, not against "did the rate move".
+//
+// -1 is the disconnected sentinel rather than 0 so that the first announcement
+// after a connect is driven by an explicit seed() and never by a sentinel that
+// happens to equal a real ceiling.
+
+namespace AetherSDR::hl2 {
+
+class ReceiverCeilingAnnouncer {
+public:
+    // Record what the connect edge already published, without announcing it.
+    // The connect republishes capabilities through connectionStateChanged, so
+    // announcing here as well would be a duplicate — and skipping the seed
+    // entirely is what would make the first zoom announce a ceiling that never
+    // moved.
+    void seed(int ceiling) noexcept { m_announced = ceiling; }
+
+    // Forget it. A reconnect republishes from scratch, so the previous
+    // session's announcement describes nothing.
+    void reset() noexcept { m_announced = kNone; }
+
+    // True exactly once per distinct ceiling. Stateful on purpose: the caller's
+    // job is then a single `if`, with no way to emit without also recording it.
+    [[nodiscard]] bool shouldAnnounce(int ceiling) noexcept
+    {
+        if (ceiling == m_announced)
+            return false;
+        m_announced = ceiling;
+        return true;
+    }
+
+    [[nodiscard]] int announced() const noexcept { return m_announced; }
+
+    static constexpr int kNone = -1;
+
+private:
+    int m_announced = kNone;
+};
+
+}  // namespace AetherSDR::hl2

--- a/src/core/backends/rtl/RtlSdrBackend.cpp
+++ b/src/core/backends/rtl/RtlSdrBackend.cpp
@@ -95,10 +95,10 @@ RadioCapabilities RtlSdrBackend::capabilities() const
     // capabilitiesChanged, and that is the honest answer rather than a gap.
     //
     // Every field below is either a compile-time constant for the R820T/RTL2832U
-    // pair or comes from m_modelName/m_vendor, and those two are read from the
-    // USB descriptor strings during connectRadio() — BEFORE emit connected() —
-    // and cleared only in disconnectRadio(). So the declaration is fixed for the
-    // whole life of a session: there is no mid-session revision to announce, and
+    // pair or comes from the USB descriptor strings (m_vendor, m_product /
+    // m_modelName, and m_serial), read during connectRadio() before connected()
+    // and cleared on disconnect or a configuration failure before connection.
+    // The declaration is fixed for the whole session: no mid-session revision, and
     // a synthetic emission would be noise dressed up as a contract.
     //
     // If a future tuner-dependent field is added here (a per-tuner gain table,

--- a/src/core/backends/rtl/RtlSdrBackend.cpp
+++ b/src/core/backends/rtl/RtlSdrBackend.cpp
@@ -91,6 +91,19 @@ RtlSdrBackend::~RtlSdrBackend()
 
 RadioCapabilities RtlSdrBackend::capabilities() const
 {
+    // #5594 (M1) item 4: this backend deliberately never emits
+    // capabilitiesChanged, and that is the honest answer rather than a gap.
+    //
+    // Every field below is either a compile-time constant for the R820T/RTL2832U
+    // pair or comes from m_modelName/m_vendor, and those two are read from the
+    // USB descriptor strings during connectRadio() — BEFORE emit connected() —
+    // and cleared only in disconnectRadio(). So the declaration is fixed for the
+    // whole life of a session: there is no mid-session revision to announce, and
+    // a synthetic emission would be noise dressed up as a contract.
+    //
+    // If a future tuner-dependent field is added here (a per-tuner gain table,
+    // a direct-sampling range that depends on the IC), it becomes revisable and
+    // this comment stops being true.
     RadioCapabilities c;
     c.family = QStringLiteral("rtl");
     c.model  = m_modelName;

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1119,12 +1119,24 @@ void RadioModel::setupBackend(const QString& family)
     // capability flag, which is right: a Flex forbids mic-input selection too
     // and still publishes MICPEAK, so only the meter's absence means the face
     // can never move. But applyCapabilitiesToUi() runs on capabilitiesChanged,
-    // and FlexBackend never emits it — of the four backends only Sim and Icom
-    // do (#5262 M1 makes emission a contract and retires this compensation).
-    // So on a Flex the gate ran exactly once, at connect, while
-    // m_micPeakIdx was still -1, and hid a gauge that was about to start
-    // working. Its visibility then depended on whether an unrelated oscillator
-    // or GPS status message happened to land afterwards.
+    // so on a Flex the gate ran exactly once, at connect, while m_micPeakIdx was
+    // still -1, and hid a gauge that was about to start working. Its visibility
+    // then depended on whether an unrelated oscillator or GPS status message
+    // happened to land afterwards.
+    //
+    // THIS COMPENSATION STAYS. #5262 M1 assumed backend emission would retire
+    // it; #5594 item 5 checked that assumption and it does not hold. M1 makes
+    // every backend announce revisions of its RadioCapabilities (FlexBackend
+    // now emits on the model-name status, Hl2Backend on a receiver-ceiling
+    // move), but hasMicPeakMeter() is a fact about the METER CATALOGUE, not a
+    // RadioCapabilities field — publishCapabilities() below copies capability
+    // fields only and never reads MeterModel. So a capability announcement does
+    // not cover a meter-list edge, and nothing else re-runs the gate when the
+    // MICPEAK or supply-voltage meter appears or disappears.
+    //
+    // Retiring it properly means making the meter catalogue a capability input,
+    // which is a separate change with its own wire consequences under the
+    // aetherd control protocol (#3849). Not folded in here.
     connect(m_backend.get(), &IRadioBackend::meterDefined, this,
             [this](const MeterDef& def) {
         const bool hadMicPeak = m_meterModel.hasMicPeakMeter();

--- a/tests/backend_capability_revision_test.cpp
+++ b/tests/backend_capability_revision_test.cpp
@@ -1,0 +1,217 @@
+// #5594 (#5262 M1, #5554 §2.4): backends must ANNOUNCE capability revisions.
+//
+// The capability descriptor is what the aetherd control protocol's `welcome`
+// serializes (#3849 step 3), so a backend that revises its RadioCapabilities
+// without emitting IRadioBackend::capabilitiesChanged leaves every consumer —
+// the desktop UI today, a protocol client tomorrow — holding whatever the
+// backend happened to report at the connect edge, forever.
+//
+// This test pins the two backends whose descriptor genuinely moves mid-session
+// and can be driven without hardware:
+//
+//   flex — the whole Flex capability table is derived from the model name
+//          (capabilities() runs capabilitiesFor(caps.model)), and the model name
+//          arrives in a `radio ...` status AFTER connect. decodeRadioStatus() is
+//          the decode it lands in and is public, so it is driven directly here:
+//          no socket, no fake radio, no timing.
+//
+//   rtl  — the opposite claim, and it is a claim rather than an omission: the
+//          declaration is fixed for the life of a session, so the correct
+//          behaviour is to emit NOTHING. Pinned so that a future revisable
+//          field cannot be added without either an emission or a deliberate
+//          edit here.
+//
+//   hl2  — the receiver ceiling FALLS when the operator zooms out, because the
+//          EP6 link budget cannot carry four receivers at 384 kHz. Two halves
+//          are pinned here: that the ceiling really does move across the spans
+//          the operator can select (so the revision is real and not a story
+//          about arithmetic that never changes), and that the announcement
+//          guard fires exactly once per distinct ceiling (so a zoom SWEEP,
+//          which crosses several rates in one drag, cannot become a republish
+//          storm). Both are socket-free.
+//
+//          What is NOT pinned here is that Hl2Backend calls the guard at the two
+//          points the rate is committed — the success path and the rollback in
+//          applyPanBandwidth(). Driving that needs a connected radio, and the
+//          fake-EP6 fixture that used to provide one is retired (see the
+//          commented block in tests/tests.cmake and #5254). That call-site
+//          placement is review-verified, not test-verified, and this comment
+//          says so rather than letting the file read as full coverage.
+
+#include "core/backends/IRadioBackend.h"
+#include "core/backends/flex/FlexBackend.h"
+#include "core/backends/hl2/Hl2CapabilityAnnouncer.h"
+#include "core/backends/hl2/MetisClient.h"
+#include "core/backends/hl2/MetisProtocol.h"
+#ifdef AETHER_BACKEND_RTL
+#include "core/backends/rtl/RtlSdrBackend.h"
+#endif
+
+#include <QCoreApplication>
+#include <QMap>
+#include <QSignalSpy>
+#include <QString>
+
+#include <algorithm>
+#include <cstdio>
+#include <memory>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+static void check(bool cond, const char* what)
+{
+    if (!cond) {
+        std::fprintf(stderr, "FAIL: %s\n", what);
+        ++g_failures;
+    }
+}
+
+static QMap<QString, QString> radioStatus(std::initializer_list<std::pair<const char*, const char*>> kvs)
+{
+    QMap<QString, QString> m;
+    for (const auto& kv : kvs)
+        m.insert(QString::fromLatin1(kv.first), QString::fromLatin1(kv.second));
+    return m;
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    // ---- flex: the model name is the capability input, and it lands late ----
+    {
+        FlexBackend backend;
+        QSignalSpy caps(&backend, &IRadioBackend::capabilitiesChanged);
+        QSignalSpy radio(&backend, &IRadioBackend::radioChanged);
+
+        // A status with no model key revises nothing. This is the common case on
+        // a live radio — `radio ...` repeats for callsign, nickname and the
+        // audio gains — and it must stay silent or a zoom-sweep-shaped storm
+        // comes back as a typing-shaped one.
+        backend.decodeRadioStatus(radioStatus({{"callsign", "KK7GWY"},
+                                               {"nickname", "shack"}}));
+        check(radio.count() == 1, "a radio status without a model still decodes");
+        check(caps.count() == 0,
+              "a radio status carrying no model announces no capability revision");
+
+        // The model arrives. THIS is the revision the whole issue is about: the
+        // seeded table (built before the name was known) is now wrong.
+        backend.decodeRadioStatus(radioStatus({{"model", "FLEX-8600"}}));
+        check(caps.count() == 1, "the first model announces exactly one revision");
+
+        // The radio repeats the same model on an unrelated edit. Nothing about
+        // the capability table changed, so nothing may be announced.
+        backend.decodeRadioStatus(radioStatus({{"model", "FLEX-8600"},
+                                               {"nickname", "shack-2"}}));
+        check(caps.count() == 1,
+              "a repeated model announces nothing (change-guarded, not presence-guarded)");
+
+        // A genuinely different model is a genuinely different table.
+        backend.decodeRadioStatus(radioStatus({{"model", "FLEX-6400"}}));
+        check(caps.count() == 2, "a changed model announces again");
+
+        // Disconnect drops the baseline: a reconnect republishes capabilities
+        // from scratch, so the previous session's announcement describes nothing
+        // and the same radio has to be announced again.
+        backend.clearExtensionHandles();
+        backend.decodeRadioStatus(radioStatus({{"model", "FLEX-6400"}}));
+        check(caps.count() == 3,
+              "after a disconnect the same model announces again");
+    }
+
+    // ---- rtl: a static declaration, asserted rather than assumed ----
+    //
+    // Optional backend (AETHER_BACKEND_RTL): skipped, not failed, where librtlsdr
+    // is absent — the same condition tests.cmake uses to gate rtl_backend_test.
+#ifdef AETHER_BACKEND_RTL
+    {
+        AetherSDR::rtl::RtlSdrBackend backend;
+        QSignalSpy caps(&backend, &IRadioBackend::capabilitiesChanged);
+
+        // Never connected, so identity is empty and everything else is constant.
+        const RadioCapabilities a = backend.capabilities();
+        const RadioCapabilities b = backend.capabilities();
+        check(a.family == QLatin1String("rtl"), "rtl reports its family");
+        check(a.maxSlices == b.maxSlices && a.maxPanadapters == b.maxPanadapters
+                  && a.canTransmit == b.canTransmit
+                  && a.tuningMinHz == b.tuningMinHz && a.tuningMaxHz == b.tuningMaxHz
+                  && a.sampleRatesHz == b.sampleRatesHz,
+              "rtl's declaration does not vary between reads");
+        check(!a.canTransmit, "rtl declares itself receive-only (Principle VI)");
+        check(caps.count() == 0,
+              "rtl announces no revision — its declaration is fixed per session");
+    }
+#else
+    std::fprintf(stderr, "backend_capability_revision_test: RTL backend not built, "
+                         "skipping its static-declaration case\n");
+#endif
+
+    // ---- hl2: the ceiling really moves, and the guard fires once per move ----
+    {
+        using namespace AetherSDR::hl2;
+
+        // The arithmetic Hl2Backend::receiverCeiling() performs, composed from
+        // the same two public functions it calls. A four-receiver board — what
+        // the shipping hl2b5up_main gateware reports, and what the backend
+        // assumes when discovery omits byte 0x13 — is honestly four receivers
+        // at 48 kHz and three at 384 kHz.
+        const auto ceilingAt = [](int boardMaxRx, int rateHz) {
+            MetisClient::Params p;
+            p.numRx = kMaxReceivers;
+            p.boardMaxRx = boardMaxRx;
+            const int board = MetisClient::effectiveNumRx(p);
+            return std::min(board, maxReceiversAtRate(rateHz, board));
+        };
+
+        const int wide = ceilingAt(4, 48000);
+        const int mid = ceilingAt(4, 96000);
+        const int narrow = ceilingAt(4, 384000);
+        check(wide == 4, "a 4-receiver board runs 4 receivers at 48 kHz");
+        check(mid == wide, "96 kHz admits the same count as 48 kHz");
+        check(narrow < wide,
+              "384 kHz admits fewer receivers than 48 kHz — the ceiling really "
+              "does move, so the revision this announces is a real one");
+
+        // The guard. Seeded at the connect edge with what capabilities() already
+        // published there, so the first zoom that does not move the ceiling
+        // stays silent.
+        ReceiverCeilingAnnouncer a;
+        check(a.announced() == ReceiverCeilingAnnouncer::kNone,
+              "a fresh announcer has nothing recorded");
+        a.seed(wide);
+        check(!a.shouldAnnounce(wide),
+              "the span the connect edge already published announces nothing");
+        check(!a.shouldAnnounce(mid),
+              "a zoom that does not move the ceiling announces nothing");
+        check(a.shouldAnnounce(narrow),
+              "a zoom that lowers the ceiling announces");
+        check(!a.shouldAnnounce(narrow),
+              "re-requesting the span already running announces nothing");
+        check(a.shouldAnnounce(wide),
+              "zooming back in raises the ceiling and announces again — a client "
+              "told 3 has to learn it may open a fourth receiver once more");
+
+        // A whole sweep is ONE announcement per ceiling, not one per rate. This
+        // is the storm the guard exists to prevent.
+        ReceiverCeilingAnnouncer sweep;
+        sweep.seed(wide);
+        int announcements = 0;
+        for (const int rate : {48000, 96000, 192000, 384000, 192000, 96000, 48000})
+            if (sweep.shouldAnnounce(ceilingAt(4, rate)))
+                ++announcements;
+        check(announcements == 2,
+              "a full zoom sweep out and back announces twice (down, then up), "
+              "not once per rate");
+
+        // Disconnect: the next session republishes from scratch, so the same
+        // ceiling has to be announced again rather than suppressed.
+        sweep.reset();
+        check(sweep.shouldAnnounce(wide),
+              "after a disconnect the same ceiling announces again");
+    }
+
+    if (g_failures == 0)
+        std::fprintf(stderr, "backend_capability_revision_test: all checks passed\n");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/backend_capability_revision_test.cpp
+++ b/tests/backend_capability_revision_test.cpp
@@ -35,9 +35,11 @@
 //          applyPanBandwidth(). Driving that needs a connected radio, and the
 //          fake-EP6 fixture that used to provide one is retired (see the
 //          commented block in tests/tests.cmake and #5254). That call-site
-//          placement is review-verified, not test-verified, and this comment
+//          placement and receiverCeiling() itself are review-verified; the
+//          arithmetic below is reconstructed from its public helpers. This comment
 //          says so rather than letting the file read as full coverage.
 
+#include "TestSettingsProfile.h"
 #include "core/backends/IRadioBackend.h"
 #include "core/backends/flex/FlexBackend.h"
 #include "core/backends/hl2/Hl2CapabilityAnnouncer.h"
@@ -51,6 +53,7 @@
 #include <QMap>
 #include <QSignalSpy>
 #include <QString>
+#include <QVector>
 
 #include <algorithm>
 #include <cstdio>
@@ -77,6 +80,10 @@ static QMap<QString, QString> radioStatus(std::initializer_list<std::pair<const 
 
 int main(int argc, char** argv)
 {
+    TestSettingsProfile profile(QStringLiteral("backend-capability-revision"));
+    if (!profile.isValid()) {
+        return 1;
+    }
     QCoreApplication app(argc, argv);
 
     // ---- flex: the model name is the capability input, and it lands late ----
@@ -84,6 +91,23 @@ int main(int argc, char** argv)
         FlexBackend backend;
         QSignalSpy caps(&backend, &IRadioBackend::capabilitiesChanged);
         QSignalSpy radio(&backend, &IRadioBackend::radioChanged);
+
+        // Mirror RadioModel's same-thread delta application and model provider.
+        // Capture inside the notification: reading afterwards would miss an
+        // emission moved ahead of radioChanged, which exposes the old table.
+        QString model;
+        QVector<RadioCapabilities> observed;
+        backend.setModelProvider([&model] { return model; });
+        QObject::connect(&backend, &IRadioBackend::radioChanged, &backend,
+                         [&model](const RadioDelta& delta) {
+            if (delta.model) {
+                model = *delta.model;
+            }
+        });
+        QObject::connect(&backend, &IRadioBackend::capabilitiesChanged, &backend,
+                         [&backend, &observed] {
+            observed.append(backend.capabilities());
+        });
 
         // A status with no model key revises nothing. This is the common case on
         // a live radio — `radio ...` repeats for callsign, nickname and the
@@ -99,6 +123,9 @@ int main(int argc, char** argv)
         // seeded table (built before the name was known) is now wrong.
         backend.decodeRadioStatus(radioStatus({{"model", "FLEX-8600"}}));
         check(caps.count() == 1, "the first model announces exactly one revision");
+        check(observed.size() == 1 && observed[0].model == QStringLiteral("FLEX-8600")
+                  && observed[0].maxSlices == 4 && observed[0].hasExtendedDsp,
+              "the first notification exposes the new model and derived capabilities");
 
         // The radio repeats the same model on an unrelated edit. Nothing about
         // the capability table changed, so nothing may be announced.
@@ -110,14 +137,21 @@ int main(int argc, char** argv)
         // A genuinely different model is a genuinely different table.
         backend.decodeRadioStatus(radioStatus({{"model", "FLEX-6400"}}));
         check(caps.count() == 2, "a changed model announces again");
+        check(observed.size() == 2 && observed[1].model == QStringLiteral("FLEX-6400")
+                  && observed[1].maxSlices == 2 && !observed[1].hasExtendedDsp,
+              "a changed-model notification exposes the revised capability table");
 
         // Disconnect drops the baseline: a reconnect republishes capabilities
         // from scratch, so the previous session's announcement describes nothing
         // and the same radio has to be announced again.
         backend.clearExtensionHandles();
+        model.clear();
         backend.decodeRadioStatus(radioStatus({{"model", "FLEX-6400"}}));
         check(caps.count() == 3,
               "after a disconnect the same model announces again");
+        check(observed.size() == 3 && observed[2].model == QStringLiteral("FLEX-6400")
+                  && observed[2].maxSlices == 2 && !observed[2].hasExtendedDsp,
+              "a reconnect notification exposes the new session model");
     }
 
     // ---- rtl: a static declaration, asserted rather than assumed ----

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -163,6 +163,14 @@ add_test(NAME control_connection_test COMMAND control_connection_test)
 
 # ATU start on the IRadioBackend seam passes the TX gate (#5558): injected
 # backend records setAtu(); no sockets, no radio.
+# #5594 (M1): backends announce capability revisions. Socket-free — FlexBackend's
+# radio-status decode is driven directly, and the RTL case asserts the opposite
+# claim (a declaration that is fixed per session emits nothing).
+add_executable(backend_capability_revision_test tests/backend_capability_revision_test.cpp)
+target_include_directories(backend_capability_revision_test PRIVATE src tests)
+target_link_libraries(backend_capability_revision_test PRIVATE aethercore Qt6::Core Qt6::Network Qt6::Test)
+add_test(NAME backend_capability_revision_test COMMAND backend_capability_revision_test)
+
 add_executable(atu_seam_gate_test tests/atu_seam_gate_test.cpp)
 target_include_directories(atu_seam_gate_test PRIVATE src tests)
 target_link_libraries(atu_seam_gate_test PRIVATE aethercore Qt6::Core)
@@ -4867,6 +4875,7 @@ target_link_libraries(CAT_Flex_test PRIVATE Qt6::Core Qt6::Network)
 # Conditional targets are guarded with if(TARGET ...).
 set(AETHER_SETTINGS_CONSUMERS
     atu_seam_gate_test
+    backend_capability_revision_test
     tx_operation_integration_test
     backend_slice_lifecycle_test
     client_display_settings_test

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -161,8 +161,6 @@ target_compile_definitions(control_connection_test PRIVATE AETHERSDR_VERSION="${
 target_link_libraries(control_connection_test PRIVATE Qt6::Core Qt6::Network)
 add_test(NAME control_connection_test COMMAND control_connection_test)
 
-# ATU start on the IRadioBackend seam passes the TX gate (#5558): injected
-# backend records setAtu(); no sockets, no radio.
 # #5594 (M1): backends announce capability revisions. Socket-free — FlexBackend's
 # radio-status decode is driven directly, and the RTL case asserts the opposite
 # claim (a declaration that is fixed per session emits nothing).
@@ -171,6 +169,8 @@ target_include_directories(backend_capability_revision_test PRIVATE src tests)
 target_link_libraries(backend_capability_revision_test PRIVATE aethercore Qt6::Core Qt6::Network Qt6::Test)
 add_test(NAME backend_capability_revision_test COMMAND backend_capability_revision_test)
 
+# ATU start on the IRadioBackend seam passes the TX gate (#5558): injected
+# backend records setAtu(); no sockets, no radio.
 add_executable(atu_seam_gate_test tests/atu_seam_gate_test.cpp)
 target_include_directories(atu_seam_gate_test PRIVATE src tests)
 target_link_libraries(atu_seam_gate_test PRIVATE aethercore Qt6::Core)


### PR DESCRIPTION
Addresses #5594 items 1, 2, 4 and 5; item 3 remains open. Refs #5262 (M1), #5554 (§2.4), #3849 (step 3).

## Why

The capability descriptor is what the aetherd control protocol's `welcome` serializes, so it has to be honest **before** it is frozen into a versioned wire contract — and step 3 has largely landed, which makes this late rather than early.

Three of six backends never announced a revision. Verified at `3a1bc975`: `capabilitiesChanged` was emitted by `sim`, `icom` and `anan` only. Consumers held whatever the backend happened to report at the connect edge, forever. The tree already documented this against itself at `RadioModel.cpp:1119-1125`, with the operator-visible symptom: on a FlexRadio the mic-level gauge could be absent while the radio was publishing `MICPEAK`, and whether it appeared depended on whether an unrelated status message happened to land afterwards.

## What changed

**`flex` — the model name is the capability input, and it lands late.** The whole Flex table is derived from it (`capabilities()` runs `capabilitiesFor(caps.model)` to seed `maxSlices`, the DSP tier and the rest), and the name arrives in a `radio ...` status after connect.

The emission goes **inside the existing `decodeRadioStatus()`**, per the issue's corrected item 1: no new entry point on `FlexBackend`, no call site above the seam, and it lands in code #5554 §2.6 keeps rather than in something §2.6 would delete again. It sits after `emit radioChanged(d)` so a consumer woken by it reads back the new model through `m_modelProvider`.

Guarded on the model **changing**, not on the key being present — a Flex repeats `radio ...` status on unrelated edits (callsign, nickname, the audio gains), and a presence guard would make a republish storm out of typing in a text field.

**`hl2` — the ceiling moves when the operator zooms.** `receiverCeiling()` is `min(board count, maxReceiversAtRate(rate, board))`, reported as both `maxSlices` and `maxPanadapters`, and it genuinely **falls** on zoom-out: four receivers at 384 kHz is ~89 Mbit/s on the HL2's 100BASE-T and cannot be delivered, so the honest limit there is 3.

Announced at the two points `applyPanBandwidth()` commits a rate — the success path and the rollback — seeded at the connect edge (so the first zoom that moves nothing stays silent) and reset on both down edges (so a reconnect announces again).

The guard is extracted into **`Hl2CapabilityAnnouncer.h`** as a pure decision, the same shape and for the same reason as `Hl2DspSetupPolicy.h`: a zoom is a *drag*, `setPanBandwidth` is fed roughly every 33 ms during a sweep and crosses several rates, while most of those leave the ceiling alone. Announcing per rate rather than per ceiling would turn one gesture into a storm at every consumer. Extracting it is also what makes the guard pinnable socket-free.

**`rtl` — the opposite claim, stated rather than left as a gap.** `m_modelName`/`m_vendor` are read from the USB descriptor strings inside `connectRadio()` *before* `emit connected()` and cleared on disconnect or a configuration failure before connection; everything else in `capabilities()` is a compile-time constant for the R820T/RTL2832U pair. The declaration cannot revise mid-session, so item 4's correct outcome is a comment — a synthetic emission would be noise dressed up as a contract. The comment names what would make it untrue (a future tuner-dependent field).

## Item 5: the compensation stays, and the issue was right to doubt it

M1's checklist said to delete `RadioModel`'s meter-edge compensation once emission is a contract. Checked against the code, **that does not hold**:

- `publishCapabilities()` copies `RadioCapabilities` fields only and never reads `MeterModel`.
- The mic gauge follows `MeterModel::hasMicPeakMeter()` — a fact about the **meter catalogue**, not a capability field.

So a backend announcing a capability revision does not cover a meter-list edge, and the `meterDefined`/`meterRemoved` handlers remain the only thing that re-runs the gate. Retiring it properly means making the meter catalogue a capability input, which is a separate change with its own wire consequences under #3849. The stale comment that predicted its retirement is rewritten to record this; #5262's M1 wording is corrected to retain these meter-catalogue handlers.

## Not included

**Item 3 (Flex panadapter capacity from discovery, §2.4 defect A)** — the issue's own suggested split puts it in its own PR because it touches `RadioInfo` and the discovery parser, both above the seam, and §2.7 moves desktop discovery onto the unified source. It is also the one item where the easy mistake is real: FlexLib maps `available_slices` onto `MaxSlices`, and `available_*` is what is currently *free*, not capacity. `FlexBackend.cpp:168-170` keeps its `maxPanadapters = mc.maxSlices` approximation and its comment until then.

## Verification

Linux x86-64, GCC / Qt 6.11, RelWithDebInfo, RTL + ASR enabled, built in an isolated worktree.

| Check | Result |
|---|---|
| Full build (3185 targets) | **passed** |
| Full CTest suite | **404 / 405 passed**, 3 skipped |
| `backend_capability_revision_test` (new) | passed |
| `check_engine_boundary.py --strict` | 1223 files scanned, **0 would block** (102 pre-existing EB3 warnings, unchanged) |
| `check_test_registration.py` | OK |
| `check_ci_test_gate.py` | frozen list matches |
| `check_network_timeouts.py` | 0 violations |
| `gen_touchpoint_manifest.py --check` | manifest up to date |

**The one failure is not from this change.** `aether_mcp_field_mapping` failed under the full `-j` run on two `app_instance` process-lifecycle assertions (`pid 4200`, `exitCode -9`) — a pure-Python MCP schema test that spawns and reaps a helper process. `git diff origin/main -- tools/test_aether_mcp.py` is empty, and it passes 5/5 standalone and 3/3 under the same parallelism. Parallel-run PID/socket contention, not a regression.

### Mutation checks

Each guard was reverted in turn and the test fails, then passes again unmodified:

| Mutation | Result |
|---|---|
| Flex emission removed | 4 checks fail |
| Flex guard weakened to presence (`if (d.model)`) | 3 checks fail — catches the republish storm |
| HL2 change guard removed | 4 checks fail |
| HL2 `seed()` made a no-op | 2 checks fail — catches "the first zoom announces a ceiling that never moved" |

### Coverage boundary, stated rather than implied

The new test is socket-free. It drives `FlexBackend::decodeRadioStatus()` directly (public, no peer needed), pins the RTL static-declaration claim, and pins both halves of the HL2 case: that the ceiling really moves across selectable spans, and that the announcer fires exactly once per distinct ceiling including across a full sweep.

**What is not pinned** is that `Hl2Backend` calls the announcer at the two points the rate is committed. Driving that needs a connected radio, and the fake-EP6 fixture that used to provide one is retired (the commented block in `tests/tests.cmake`, per #5254). That call-site placement is review-verified, not test-verified, and the test file's header says so rather than reading as full coverage.

No physical radio was connected and no RF was transmitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Independent review validation (macOS ARM64)

The focused engine/test build and `backend_capability_revision_test` pass on current main plus this PR. The test now isolates AppSettings before constructing Qt/backend objects and captures capabilities inside Flex's notification, checking model, slice count and DSP tier across initial identity, a model change and reconnect. Reordering the notification ahead of delta application fails these readback assertions; restoring the ordering passes. Earlier independent mutations also failed four checks each when removing the Flex emission or HL2 change guard.

RTL was not built locally (librtlsdr unavailable). HL2 receiverCeiling() is checked by source review and reconstruction from its public arithmetic helpers; its connected call sites remain review-only coverage. No radio was connected and no TX was performed.
