### PR TITLE
RFC #5468 A2 prerequisite: preserve optional NR rate domains

### DIFF
--- a/docs/noise-filter-rate-domains.md
+++ b/docs/noise-filter-rate-domains.md
@@ -1,0 +1,54 @@
+# RX noise-filter rate domains (RFC #5468 A2 prerequisite)
+
+This prerequisite prepares the optional wrappers for AudioEngine's rate-aware
+RX input. It does not change AudioEngine wiring, its 24 kHz default, radio
+production rates, or the disabled RTL multi-receiver runtime.
+
+`DeepFilterFilter`, `SpecbleachFilter` and `MacNRFilter` take an optional
+constructor `sampleRate` (24000 by default). `NvidiaAfxFilter` takes it after
+the existing optional pack directory. The only supported domains are 24000 and
+48000; other rates leave initialization invalid. `process()` consumes and
+returns stereo float32 at that immutable domain, and `sampleRate()` identifies
+it. Prepare a new instance when the input rate changes; device rate never
+selects the wrapper's processing domain.
+
+| Wrapper | 24 kHz | 48 kHz |
+|---|---|---|
+| RNNoise (already available) | Existing `Legacy24k` contract | `Native48k` with `PreserveRxStereo`, through `process48kStereo()` |
+| SpectralNR (already available) | Existing constructor rate | Pass 48000 to the existing rate-aware constructor |
+| DeepFilterNet | Existing 24-to-48-to-24 SRC and model | Native48 model input/output; no intermediate24 stage |
+| NVIDIA AFX | Existing 24-to-48-to-24 SRC and model | Native48 model input/output; no intermediate24 stage |
+| Specbleach | Existing library rate and 40 ms frame request | Native48000 library rate and the same 40 ms request |
+| macOS MNR | Existing 512-point FFT / 256-sample hop | 1024-point FFT / 512-sample hop; same frequency resolution and elapsed estimator history |
+
+DeepFilterNet and NVIDIA retain their existing mono algorithm and stereo
+level-balance behavior. They do not become independent stereo denoisers in this
+change. The default playback path and native stereo RNNoise/MNR do not inherit
+that limitation. `MonoDspStereoAdapter` takes its rate as the second constructor
+argument; its five-second queue cap and power-envelope timing follow that rate.
+Legacy24 coefficients remain unchanged. DeepFilterNet's three-hop model delay
+is expressed in the selected producer domain before pairing delayed stereo.
+
+Each concurrently processed source must own its wrappers. Alternating main48
+and Kiwi24 through one instance is invalid even when the rates happen to match:
+algorithm history and queued samples belong to one source. Revoke admission,
+discard queued processing/output samples, and replace the source's prepared
+state at a rate, session, source, or discontinuity boundary. Construction may
+load models and allocate; it belongs outside an active processing callback.
+
+`MacNRFilter::reset()` clears its complete state. DeepFilterNet's reset recreates
+the model. NVIDIA's existing reset only clears wrapper FIFOs/SRC, and
+Specbleach's existing reset clears its noise profile and stereo adapter while
+the library may retain overlap history. For a strict new epoch, recreate the
+complete NVIDIA/Specbleach object. A2 must apply this lifecycle rule to main,
+legacy Kiwi and each managed Kiwi source, preserving effect configuration.
+
+The tests distinguish evidence layers. `nr_rate_domain_test` compiles the real
+DeepFilterNet/NVIDIA wrapper translation units and substitutes local C APIs
+with an explicit half-gain transfer function (plus DFN3's documented delay).
+It verifies rate conversion, full-bandwidth native input, algorithm call counts,
+irregular block queues, lifecycle, and concurrent-source isolation; it does not
+perform neural inference or load an SDK/GPU. `specbleach_rate_domain_test`
+executes the bundled library when enabled. `mac_nr_filter_test` executes vDSP
+on macOS. None opens a socket or an audio/radio device. Hardware/model inference,
+audible playback and the final AudioEngine route require their own evidence.

--- a/src/core/DeepFilterFilter.cpp
+++ b/src/core/DeepFilterFilter.cpp
@@ -177,10 +177,18 @@ static QByteArray findModelPath()
     return {};
 }
 
-DeepFilterFilter::DeepFilterFilter()
-    : m_up(std::make_unique<Resampler>(24000, 48000))
-    , m_down(std::make_unique<Resampler>(48000, 24000))
+DeepFilterFilter::DeepFilterFilter(int sampleRate)
+    : m_sampleRate(sampleRate)
+    , m_stereoAdapter(0, sampleRate)
 {
+    if (!m_stereoAdapter.isValid()) {
+        qWarning() << "DeepFilterFilter: unsupported sample rate" << sampleRate;
+        return;
+    }
+    if (sampleRate == 24000) {
+        m_up = std::make_unique<Resampler>(24000, 48000);
+        m_down = std::make_unique<Resampler>(48000, 24000);
+    }
     QByteArray modelPath = findModelPath();
     if (modelPath.isEmpty()) {
         return;
@@ -192,7 +200,7 @@ DeepFilterFilter::DeepFilterFilter()
         // The bundled DFN3 model uses fft_size=960, hop_size=480 and two
         // lookahead frames. Its documented delay is
         // (fft_size - hop_size) + lookahead * hop_size = 3 hops at 48 kHz.
-        m_stereoAdapter.setProcessingLatencyFrames(3 * m_frameSize / 2);
+        m_stereoAdapter.setProcessingLatencyFrames(3 * m_frameSize * m_sampleRate / 48000);
         qDebug() << "DeepFilterFilter: initialized, frame size =" << m_frameSize;
     } else {
         qWarning() << "DeepFilterFilter: df_create() failed!";
@@ -208,6 +216,9 @@ DeepFilterFilter::~DeepFilterFilter()
 
 void DeepFilterFilter::reset()
 {
+    if (!m_stereoAdapter.isValid()) {
+        return;
+    }
     if (m_state) {
         df_free(m_state);
         m_state = nullptr;
@@ -217,11 +228,13 @@ void DeepFilterFilter::reset()
         m_state = df_create(modelPath.constData(), m_attenLimit.load(), nullptr);
         if (m_state) {
             m_frameSize = static_cast<int>(df_get_frame_length(m_state));
-            m_stereoAdapter.setProcessingLatencyFrames(3 * m_frameSize / 2);
+            m_stereoAdapter.setProcessingLatencyFrames(3 * m_frameSize * m_sampleRate / 48000);
         }
     }
-    m_up = std::make_unique<Resampler>(24000, 48000);
-    m_down = std::make_unique<Resampler>(48000, 24000);
+    if (m_sampleRate == 24000) {
+        m_up = std::make_unique<Resampler>(24000, 48000);
+        m_down = std::make_unique<Resampler>(48000, 24000);
+    }
     m_inAccum.clear();
     m_outAccum.clear();
     m_stereoAdapter.reset();
@@ -240,10 +253,10 @@ void DeepFilterFilter::setPostFilterBeta(float beta)
     m_paramsDirty.store(true);
 }
 
-QByteArray DeepFilterFilter::process(const QByteArray& pcm24kStereo)
+QByteArray DeepFilterFilter::process(const QByteArray& pcmStereo)
 {
-    if (!m_state || m_frameSize <= 0 || pcm24kStereo.isEmpty()) {
-        return pcm24kStereo;
+    if (!m_state || m_frameSize <= 0 || pcmStereo.isEmpty()) {
+        return pcmStereo;
     }
 
     // Apply any pending parameter changes (main thread writes atomic, audio thread reads here)
@@ -252,17 +265,20 @@ QByteArray DeepFilterFilter::process(const QByteArray& pcm24kStereo)
         df_set_post_filter_beta(m_state, m_postFilterBeta.load());
     }
 
-    const auto* src = reinterpret_cast<const float*>(pcm24kStereo.constData());
-    const int stereoFrames = pcm24kStereo.size() / (2 * static_cast<int>(sizeof(float)));
-    m_stereoAdapter.pushDryStereo(pcm24kStereo);
+    const auto* src = reinterpret_cast<const float*>(pcmStereo.constData());
+    const int stereoFrames = pcmStereo.size() / (2 * static_cast<int>(sizeof(float)));
+    m_stereoAdapter.pushDryStereo(pcmStereo);
 
-    // 1. Downmix, then upsample 24kHz mono float32 → 48kHz mono float32 via r8brain.
+    // 1. Downmix, then upsample legacy24 or pass native48 directly to the model.
     // The dry stereo stays queued so DeepFilterNet attenuation preserves balance.
-    m_mono24k.resize(stereoFrames);
+    m_monoInput.resize(stereoFrames);
     for (int i = 0; i < stereoFrames; ++i) {
-        m_mono24k[i] = 0.5f * (src[i * 2] + src[i * 2 + 1]);
+        m_monoInput[i] = 0.5f * (src[i * 2] + src[i * 2 + 1]);
     }
-    QByteArray mono48k = m_up->process(m_mono24k.data(), stereoFrames);
+    QByteArray mono48k = m_up
+        ? m_up->process(m_monoInput.data(), stereoFrames)
+        : QByteArray(reinterpret_cast<const char*>(m_monoInput.data()),
+                     stereoFrames * static_cast<int>(sizeof(float)));
 
     // Already float32 in [-1, 1] range — DeepFilterNet's native format
     const auto* mono48kSamples = reinterpret_cast<const float*>(mono48k.constData());
@@ -305,12 +321,14 @@ QByteArray DeepFilterFilter::process(const QByteArray& pcm24kStereo)
             m_inAccum.clear();
         }
 
-        // 3. Downsample processed 48kHz mono float32 → 24kHz mono float32,
-        //    then apply the shared attenuation to delayed dry stereo.
+        // 3. Convert the model output only for legacy24, then restore the
+        //    existing delayed stereo level balance at the configured rate.
         const int outputMonoSamples = completeFrames * m_frameSize;
 
-        QByteArray downsampled = m_down->process(
-            m_processed48k.data(), outputMonoSamples);
+        QByteArray downsampled = m_down
+            ? m_down->process(m_processed48k.data(), outputMonoSamples)
+            : QByteArray(reinterpret_cast<const char*>(m_processed48k.data()),
+                         outputMonoSamples * static_cast<int>(sizeof(float)));
         const auto* downsampledMono = reinterpret_cast<const float*>(downsampled.constData());
         const int downsampledFrames = downsampled.size() / static_cast<int>(sizeof(float));
 
@@ -318,7 +336,7 @@ QByteArray DeepFilterFilter::process(const QByteArray& pcm24kStereo)
     }
 
     // 4. Return exactly the same number of bytes as input
-    const int needed = pcm24kStereo.size();
+    const int needed = pcmStereo.size();
     if (m_outAccum.size() >= needed) {
         QByteArray result = m_outAccum.left(needed);
         m_outAccum.remove(0, needed);

--- a/src/core/DeepFilterFilter.h
+++ b/src/core/DeepFilterFilter.h
@@ -16,8 +16,9 @@ namespace AetherSDR {
 class Resampler;
 
 // Client-side neural noise reduction using DeepFilterNet3.
-// Processes 24kHz stereo Int16 audio by upsampling to 48kHz mono,
-// running the DeepFilter model, and downsampling back to 24kHz stereo.
+// The immutable input/output domain is 24 or 48 kHz stereo float32. Legacy24
+// retains the existing SRC pair; native48 reaches the model without SRC.
+// The existing mono analysis and delayed stereo level-balance policy remain.
 //
 // DeepFilterNet expects 48kHz mono float [-1.0, 1.0] input.
 // Frame size determined at runtime via df_get_frame_length().
@@ -25,18 +26,21 @@ class Resampler;
 
 class DeepFilterFilter {
 public:
-    DeepFilterFilter();
+    // Unsupported rates leave isValid() false. Recreate for a new rate/source.
+    explicit DeepFilterFilter(int sampleRate = 24000);
     ~DeepFilterFilter();
 
     DeepFilterFilter(const DeepFilterFilter&) = delete;
     DeepFilterFilter& operator=(const DeepFilterFilter&) = delete;
 
-    // Process a block of 24kHz stereo Int16 PCM.
+    // Process a block of 24/48 kHz stereo float32 PCM.
     // Returns the processed block (same format, same size).
-    QByteArray process(const QByteArray& pcm24kStereo);
+    QByteArray process(const QByteArray& pcmStereo);
 
     // Returns true if df_create() succeeded.
     bool isValid() const { return m_state != nullptr; }
+
+    int sampleRate() const { return m_sampleRate; }
 
     // Reset internal state (e.g., on band change).
     void reset();
@@ -50,13 +54,14 @@ public:
     float postFilterBeta() const { return m_postFilterBeta.load(); }
 
 private:
+    const int m_sampleRate;
     DFState* m_state{nullptr};
     int m_frameSize{0};                     // samples per frame (from df_get_frame_length)
     std::unique_ptr<Resampler> m_up;        // 24kHz mono → 48kHz mono
     std::unique_ptr<Resampler> m_down;      // 48kHz mono → 24kHz mono
     QByteArray m_inAccum;                   // accumulate 48kHz mono float input
-    QByteArray m_outAccum;                  // accumulate 24kHz stereo float output
-    std::vector<float> m_mono24k;
+    QByteArray m_outAccum;                  // accumulate configured-rate stereo float output
+    std::vector<float> m_monoInput;
     std::vector<float> m_processed48k;
     MonoDspStereoAdapter m_stereoAdapter;
     std::atomic<float> m_attenLimit{100.0f};

--- a/src/core/MacNRFilter.cpp
+++ b/src/core/MacNRFilter.cpp
@@ -9,44 +9,53 @@ namespace AetherSDR {
 
 // ── Constructor / destructor ────────────────────────────────────────────────
 
-MacNRFilter::MacNRFilter()
+MacNRFilter::MacNRFilter(int sampleRate)
+    : m_sampleRate(sampleRate)
+    , m_log2n(sampleRate == 48000 ? 10 : 9)
+    , m_fftSize(1 << m_log2n)
+    , m_hopSize(m_fftSize / 2)
+    , m_bins(m_hopSize + 1)
+    , m_powerHistory(HIST * m_bins, 0.0f)
 {
-    m_fftSetup = vDSP_create_fftsetup(LOG2N, kFFTRadix2);
+    if (sampleRate != 24000 && sampleRate != 48000) {
+        return;
+    }
+    m_fftSetup = vDSP_create_fftsetup(m_log2n, kFFTRadix2);
     if (!m_fftSetup)
         return;
 
-    // vDSP split-complex scratch buffers (size H = N/2)
-    m_splitRe.assign(H, 0.0f);
-    m_splitIm.assign(H, 0.0f);
+    // vDSP split-complex scratch buffers (size m_hopSize = m_fftSize/2)
+    m_splitRe.assign(m_hopSize, 0.0f);
+    m_splitIm.assign(m_hopSize, 0.0f);
 
     // sqrt-Hann window (analysis × synthesis = Hann; perfect reconstruction
     // with 50 % overlap when frames are hop-sized)
-    m_window.resize(N);
-    for (int i = 0; i < N; ++i)
-        m_window[i] = std::sqrt(0.5f * (1.0f - std::cos(2.0f * M_PI * i / N)));
+    m_window.resize(m_fftSize);
+    for (int i = 0; i < m_fftSize; ++i)
+        m_window[i] = std::sqrt(0.5f * (1.0f - std::cos(2.0f * M_PI * i / m_fftSize)));
 
     // Pre-fill input accumulator with one full frame of zeros so that the
     // first call to process() sees a centred first frame immediately and
-    // latency is exactly one hop (H samples ≈ 10.7 ms at 24 kHz).
-    m_inAccum.assign(N, 0.0f);
-    m_inAccumL.assign(N, 0.0f);
-    m_inAccumR.assign(N, 0.0f);
+    // the existing one-frame delay (≈21.3 ms) stays constant at both rates.
+    m_inAccum.assign(m_fftSize, 0.0f);
+    m_inAccumL.assign(m_fftSize, 0.0f);
+    m_inAccumR.assign(m_fftSize, 0.0f);
 
     // OLA and scratch buffers
-    m_olaBufferL.assign(N, 0.0f);
-    m_olaBufferR.assign(N, 0.0f);
-    m_frameBuf .assign(N, 0.0f);
-    m_synthBuf .assign(N, 0.0f);
+    m_olaBufferL.assign(m_fftSize, 0.0f);
+    m_olaBufferR.assign(m_fftSize, 0.0f);
+    m_frameBuf .assign(m_fftSize, 0.0f);
+    m_synthBuf .assign(m_fftSize, 0.0f);
     m_outAccumL.clear();
     m_outAccumR.clear();
 
     // Noise estimator
-    m_noiseEst      .assign(NBINS, 0.0f);
-    m_smoothedPower .assign(NBINS, 0.0f);
-    m_prevPostSnr   .assign(NBINS, 1.0f);
-    m_filterGain    .assign(NBINS, 1.0f);
-    m_powerBuf      .assign(NBINS, 0.0f);
-    m_gainBuf       .assign(NBINS, 1.0f);
+    m_noiseEst      .assign(m_bins, 0.0f);
+    m_smoothedPower .assign(m_bins, 0.0f);
+    m_prevPostSnr   .assign(m_bins, 1.0f);
+    m_filterGain    .assign(m_bins, 1.0f);
+    m_powerBuf      .assign(m_bins, 0.0f);
+    m_gainBuf       .assign(m_bins, 1.0f);
 }
 
 MacNRFilter::~MacNRFilter()
@@ -68,10 +77,10 @@ void MacNRFilter::reset()
     m_outAccumL.clear();
     m_outAccumR.clear();
 
-    // Re-prime input accumulator for one-hop latency (same as constructor)
-    m_inAccum.assign(N, 0.0f);
-    m_inAccumL.assign(N, 0.0f);
-    m_inAccumR.assign(N, 0.0f);
+    // Re-prime the input accumulator (same delay as the constructor).
+    m_inAccum.assign(m_fftSize, 0.0f);
+    m_inAccumL.assign(m_fftSize, 0.0f);
+    m_inAccumR.assign(m_fftSize, 0.0f);
 
     // Reset noise estimator
     std::fill(m_noiseEst.begin(), m_noiseEst.end(), 0.0f);
@@ -79,7 +88,7 @@ void MacNRFilter::reset()
     std::fill(m_prevPostSnr.begin(), m_prevPostSnr.end(), 1.0f);
     std::fill(m_filterGain.begin(), m_filterGain.end(), 1.0f);
     std::fill(m_gainBuf.begin(), m_gainBuf.end(), 1.0f);
-    std::memset(m_powerHistory, 0, sizeof(m_powerHistory));
+    std::fill(m_powerHistory.begin(), m_powerHistory.end(), 0.0f);
 
     m_histIdx = 0;
     m_noiseInitialized = false;
@@ -87,27 +96,27 @@ void MacNRFilter::reset()
 
 // ── updateGainFromFrame ─────────────────────────────────────────────────────
 //
-// inBuf: N mono analysis samples. Updates m_filterGain, which is then reused for
+// inBuf: m_fftSize mono analysis samples. Updates m_filterGain, which is then reused for
 // independent left/right synthesis so balance survives the MNR stage.
 
 void MacNRFilter::updateGainFromFrame(const float* inBuf)
 {
     // ── 1. Apply analysis window and copy into frame buffer ─────────────────
-    vDSP_vmul(inBuf, 1, m_window.data(), 1, m_frameBuf.data(), 1, N);
+    vDSP_vmul(inBuf, 1, m_window.data(), 1, m_frameBuf.data(), 1, m_fftSize);
 
     // ── 2. Forward real FFT ─────────────────────────────────────────────────
-    // Pack N real samples into N/2 complex pairs for vDSP
+    // Pack m_fftSize real samples into m_fftSize/2 complex pairs for vDSP
     DSPSplitComplex sc{ m_splitRe.data(), m_splitIm.data() };
-    vDSP_ctoz(reinterpret_cast<const DSPComplex*>(m_frameBuf.data()), 2, &sc, 1, H);
-    vDSP_fft_zrip(m_fftSetup, &sc, 1, LOG2N, kFFTDirection_Forward);
+    vDSP_ctoz(reinterpret_cast<const DSPComplex*>(m_frameBuf.data()), 2, &sc, 1, m_hopSize);
+    vDSP_fft_zrip(m_fftSetup, &sc, 1, m_log2n, kFFTDirection_Forward);
 
-    // Extract power spectrum  (NBINS = N/2+1 unique bins)
-    // Bins 1 … H-1 : re² + im²
+    // Extract power spectrum  (m_bins = m_fftSize/2+1 unique bins)
+    // Bins 1 … m_hopSize-1 : re² + im²
     // Bin 0        : DC only  (im part holds Nyquist in vDSP packed format)
-    // Bin H        : Nyquist only
+    // Bin m_hopSize        : Nyquist only
     m_powerBuf[0] = m_splitRe[0] * m_splitRe[0];
-    m_powerBuf[H] = m_splitIm[0] * m_splitIm[0];
-    for (int k = 1; k < H; ++k)
+    m_powerBuf[m_hopSize] = m_splitIm[0] * m_splitIm[0];
+    for (int k = 1; k < m_hopSize; ++k)
         m_powerBuf[k] = m_splitRe[k] * m_splitRe[k] + m_splitIm[k] * m_splitIm[k];
 
     // ── 3. Smoothed-periodogram minimum-statistics noise update ─────────────
@@ -117,16 +126,16 @@ void MacNRFilter::updateGainFromFrame(const float* inBuf)
     // usable -80 dBFS RMS floor: latency prefill, mute/squelch, and TX silence
     // must not initialize or collapse the learned noise estimate.
     double framePowerSum = 0.0;
-    for (int i = 0; i < N; ++i) {
+    for (int i = 0; i < m_fftSize; ++i) {
         framePowerSum += static_cast<double>(inBuf[i]) * inBuf[i];
     }
-    const float meanFramePower = static_cast<float>(framePowerSum / N);
+    const float meanFramePower = static_cast<float>(framePowerSum / m_fftSize);
     if (meanFramePower < MIN_FRAME_POWER) {
         return;
     }
 
     if (!m_noiseInitialized) {
-        for (int k = 0; k < NBINS; ++k) {
+        for (int k = 0; k < m_bins; ++k) {
             m_smoothedPower[k] = m_powerBuf[k];
             // Enabling during speech must not initially classify the entire
             // wanted signal as noise. Start conservatively; NOISE_RISE then
@@ -134,21 +143,21 @@ void MacNRFilter::updateGainFromFrame(const float* inBuf)
             m_noiseEst[k] = std::max(INITIAL_NOISE_FRACTION * m_powerBuf[k],
                                      1e-10f);
             for (int h = 0; h < HIST; ++h) {
-                m_powerHistory[h][k] = m_smoothedPower[k];
+                m_powerHistory[h * m_bins + k] = m_smoothedPower[k];
             }
         }
         m_noiseInitialized = true;
     } else {
-        for (int k = 0; k < NBINS; ++k) {
+        for (int k = 0; k < m_bins; ++k) {
             m_smoothedPower[k] = POWER_SMOOTH * m_smoothedPower[k]
                               + (1.0f - POWER_SMOOTH) * m_powerBuf[k];
-            m_powerHistory[m_histIdx][k] = m_smoothedPower[k];
+            m_powerHistory[m_histIdx * m_bins + k] = m_smoothedPower[k];
         }
 
-        for (int k = 0; k < NBINS; ++k) {
-            float minPower = m_powerHistory[0][k];
+        for (int k = 0; k < m_bins; ++k) {
+            float minPower = m_powerHistory[0 * m_bins + k];
             for (int h = 1; h < HIST; ++h) {
-                minPower = std::min(minPower, m_powerHistory[h][k]);
+                minPower = std::min(minPower, m_powerHistory[h * m_bins + k]);
             }
             const float candidate = std::max(MINSTAT_BIAS * minPower, 1e-10f);
             m_noiseEst[k] = candidate < m_noiseEst[k]
@@ -159,7 +168,7 @@ void MacNRFilter::updateGainFromFrame(const float* inBuf)
     m_histIdx = (m_histIdx + 1) % HIST;
 
     // ── 4. Decision-directed MMSE-Wiener gain ────────────────────────────────
-    for (int k = 0; k < NBINS; ++k) {
+    for (int k = 0; k < m_bins; ++k) {
         // A-posteriori SNR
         const float postSnr = m_powerBuf[k] / std::max(m_noiseEst[k], 1e-10f);
 
@@ -182,40 +191,40 @@ void MacNRFilter::updateGainFromFrame(const float* inBuf)
 
 // ── synthesizeFrameWithCurrentGain ──────────────────────────────────────────
 //
-// inBuf  : N channel samples
-// outBuf : N synthesis samples (added into OLA buffer by caller)
+// inBuf  : m_fftSize channel samples
+// outBuf : m_fftSize synthesis samples (added into OLA buffer by caller)
 
 void MacNRFilter::synthesizeFrameWithCurrentGain(const float* inBuf, float* outBuf,
                                                   float synthesisStrength)
 {
-    vDSP_vmul(inBuf, 1, m_window.data(), 1, m_frameBuf.data(), 1, N);
+    vDSP_vmul(inBuf, 1, m_window.data(), 1, m_frameBuf.data(), 1, m_fftSize);
 
     DSPSplitComplex sc{ m_splitRe.data(), m_splitIm.data() };
-    vDSP_ctoz(reinterpret_cast<const DSPComplex*>(m_frameBuf.data()), 2, &sc, 1, H);
-    vDSP_fft_zrip(m_fftSetup, &sc, 1, LOG2N, kFFTDirection_Forward);
+    vDSP_ctoz(reinterpret_cast<const DSPComplex*>(m_frameBuf.data()), 2, &sc, 1, m_hopSize);
+    vDSP_fft_zrip(m_fftSetup, &sc, 1, m_log2n, kFFTDirection_Forward);
 
     // ── Apply shared gain to spectrum ───────────────────────────────────────
     const auto synthesisGain = [synthesisStrength](float filterGain) {
         return 1.0f - synthesisStrength * (1.0f - filterGain);
     };
     m_splitRe[0] *= synthesisGain(m_filterGain[0]);   // DC
-    m_splitIm[0] *= synthesisGain(m_filterGain[H]);   // Nyquist (stored in im[0] by vDSP)
-    for (int k = 1; k < H; ++k) {
+    m_splitIm[0] *= synthesisGain(m_filterGain[m_hopSize]);   // Nyquist (stored in im[0] by vDSP)
+    for (int k = 1; k < m_hopSize; ++k) {
         const float gain = synthesisGain(m_filterGain[k]);
         m_splitRe[k] *= gain;
         m_splitIm[k] *= gain;
     }
 
     // ── 6. Inverse real FFT ──────────────────────────────────────────────────
-    vDSP_fft_zrip(m_fftSetup, &sc, 1, LOG2N, kFFTDirection_Inverse);
-    vDSP_ztoc(&sc, 1, reinterpret_cast<DSPComplex*>(m_synthBuf.data()), 2, H);
+    vDSP_fft_zrip(m_fftSetup, &sc, 1, m_log2n, kFFTDirection_Inverse);
+    vDSP_ztoc(&sc, 1, reinterpret_cast<DSPComplex*>(m_synthBuf.data()), 2, m_hopSize);
 
     // Normalise (vDSP's FFT is un-normalised; factor = 1/(2N))
-    const float scale = 1.0f / (2.0f * N);
-    vDSP_vsmul(m_synthBuf.data(), 1, &scale, m_synthBuf.data(), 1, N);
+    const float scale = 1.0f / (2.0f * m_fftSize);
+    vDSP_vsmul(m_synthBuf.data(), 1, &scale, m_synthBuf.data(), 1, m_fftSize);
 
     // ── 7. Apply synthesis window ────────────────────────────────────────────
-    vDSP_vmul(m_synthBuf.data(), 1, m_window.data(), 1, outBuf, 1, N);
+    vDSP_vmul(m_synthBuf.data(), 1, m_window.data(), 1, outBuf, 1, m_fftSize);
 }
 
 // ── process ─────────────────────────────────────────────────────────────────
@@ -223,14 +232,14 @@ void MacNRFilter::synthesizeFrameWithCurrentGain(const float* inBuf, float* outB
 // Input:  24 kHz stereo float32 PCM (0.8.x format)
 // Output: same format, same byte count — guaranteed, no silence padding.
 
-QByteArray MacNRFilter::process(const QByteArray& pcm24kStereo)
+QByteArray MacNRFilter::process(const QByteArray& pcmStereo)
 {
-    if (!m_fftSetup || pcm24kStereo.isEmpty())
-        return pcm24kStereo;
+    if (!m_fftSetup || pcmStereo.isEmpty())
+        return pcmStereo;
 
-    const int nBytes   = pcm24kStereo.size();
+    const int nBytes   = pcmStereo.size();
     const int nFrames  = nBytes / (2 * sizeof(float));  // 2 ch × 4 bytes each
-    const auto* src    = reinterpret_cast<const float*>(pcm24kStereo.constData());
+    const auto* src    = reinterpret_cast<const float*>(pcmStereo.constData());
 
     // ── Stereo float32 → shared mono analysis plus dry L/R synthesis inputs ──
     for (int i = 0; i < nFrames; ++i) {
@@ -242,39 +251,39 @@ QByteArray MacNRFilter::process(const QByteArray& pcm24kStereo)
     }
 
     // ── OLA processing — emit one hop per iteration ──────────────────────────
-    while (static_cast<int>(m_inAccum.size()) >= N) {
+    while (static_cast<int>(m_inAccum.size()) >= m_fftSize) {
         updateGainFromFrame(m_inAccum.data());
         // Snapshot once per frame so both channels receive the same shared
         // mask even if the UI changes strength while this block is processed.
         const float synthesisStrength = m_strength.load();
 
-        std::vector<float> outFrameL(N, 0.0f);
-        std::vector<float> outFrameR(N, 0.0f);
+        std::vector<float> outFrameL(m_fftSize, 0.0f);
+        std::vector<float> outFrameR(m_fftSize, 0.0f);
         synthesizeFrameWithCurrentGain(m_inAccumL.data(), outFrameL.data(), synthesisStrength);
         synthesizeFrameWithCurrentGain(m_inAccumR.data(), outFrameR.data(), synthesisStrength);
 
         // Add into OLA buffer
-        for (int i = 0; i < N; ++i) {
+        for (int i = 0; i < m_fftSize; ++i) {
             m_olaBufferL[i] += outFrameL[i];
             m_olaBufferR[i] += outFrameR[i];
         }
 
-        // Flush the first H samples to output
-        for (int i = 0; i < H; ++i) {
+        // Flush the first m_hopSize samples to output
+        for (int i = 0; i < m_hopSize; ++i) {
             m_outAccumL.push_back(m_olaBufferL[i]);
             m_outAccumR.push_back(m_olaBufferR[i]);
         }
 
-        // Shift OLA buffer left by H
-        std::copy(m_olaBufferL.begin() + H, m_olaBufferL.end(), m_olaBufferL.begin());
-        std::copy(m_olaBufferR.begin() + H, m_olaBufferR.end(), m_olaBufferR.begin());
-        std::fill(m_olaBufferL.begin() + H, m_olaBufferL.end(), 0.0f);
-        std::fill(m_olaBufferR.begin() + H, m_olaBufferR.end(), 0.0f);
+        // Shift OLA buffer left by m_hopSize
+        std::copy(m_olaBufferL.begin() + m_hopSize, m_olaBufferL.end(), m_olaBufferL.begin());
+        std::copy(m_olaBufferR.begin() + m_hopSize, m_olaBufferR.end(), m_olaBufferR.begin());
+        std::fill(m_olaBufferL.begin() + m_hopSize, m_olaBufferL.end(), 0.0f);
+        std::fill(m_olaBufferR.begin() + m_hopSize, m_olaBufferR.end(), 0.0f);
 
-        // Consume H input samples
-        m_inAccum.erase(m_inAccum.begin(), m_inAccum.begin() + H);
-        m_inAccumL.erase(m_inAccumL.begin(), m_inAccumL.begin() + H);
-        m_inAccumR.erase(m_inAccumR.begin(), m_inAccumR.begin() + H);
+        // Consume m_hopSize input samples
+        m_inAccum.erase(m_inAccum.begin(), m_inAccum.begin() + m_hopSize);
+        m_inAccumL.erase(m_inAccumL.begin(), m_inAccumL.begin() + m_hopSize);
+        m_inAccumR.erase(m_inAccumR.begin(), m_inAccumR.begin() + m_hopSize);
     }
 
     // ── Drain exactly nFrames processed L/R samples → stereo float32 ────────

--- a/src/core/MacNRFilter.h
+++ b/src/core/MacNRFilter.h
@@ -16,10 +16,10 @@ namespace AetherSDR {
 // Uses vDSP's real FFT, hardware-accelerated on Apple Silicon via AMX.
 //
 // Design characteristics:
-//   - Processes at 24 kHz natively — no 24↔48 kHz resampling.
+//   - Processes at its immutable 24 or 48 kHz rate without resampling.
 //     Eliminates the double-resampler chain that caused clicks, phase
 //     distortion, and int16 mid-point quantisation noise.
-//   - 512-point FFT at 24 kHz → 46.9 Hz/bin (2× better than NR2).
+//   - 512-point FFT at 24 kHz, 1024 at 48 kHz: 46.9 Hz/bin in both domains.
 //   - Smoothed-periodogram minimum statistics with calibrated bias and
 //     rate-limited upward tracking, using a 25-frame history (~267 ms).
 //   - Near-silent frames freeze the learned noise floor so mute, squelch, and
@@ -27,21 +27,23 @@ namespace AetherSDR {
 //   - Per-bin Wiener gain is temporally smoothed (GSMOOTH) to suppress
 //     musical-noise artefacts caused by rapid frame-to-frame gain swings.
 //   - Output accumulator ensures exact byte-count match with no silence
-//     gaps; startup latency is one hop (≈10.7 ms) of pre-filled zeros.
+//     gaps; the pre-filled FFT frame retains the same ≈21.3 ms delay at both rates.
 //   - User-adjustable strength: 0 = bypass, 1 = full NR.
 //
-// Processing chain (all at 24 kHz):
+// Processing chain (entirely in the configured sample-rate domain):
 //   stereo float32 -> shared mono FFT NR mask -> independent L/R OLA synthesis
 
 class MacNRFilter {
 public:
-    MacNRFilter();
+    explicit MacNRFilter(int sampleRate = 24000);
     ~MacNRFilter();
 
     bool isValid() const { return m_fftSetup != nullptr; }
 
-    // Process 24 kHz stereo float32 PCM; returns same format, same byte count.
-    QByteArray process(const QByteArray& pcm24kStereo);
+    // Process configured-rate stereo float32 PCM; returns same format, same byte count.
+    QByteArray process(const QByteArray& pcmStereo);
+
+    int sampleRate() const { return m_sampleRate; }
 
     // Reset internal state (e.g. on band change or stream restart).
     void reset();
@@ -55,15 +57,16 @@ public:
     float strength()     const { return m_strength.load(); }
 
 private:
+    const int m_sampleRate;
     void updateGainFromFrame(const float* inBuf);
     void synthesizeFrameWithCurrentGain(const float* inBuf, float* outBuf,
                                         float synthesisStrength);
 
     // ── FFT parameters ─────────────────────────────────────────────────
-    static constexpr int LOG2N = 9;           // log2(512)
-    static constexpr int N     = 1 << LOG2N;  // 512-point real FFT
-    static constexpr int H     = N / 2;       // 256-sample hop (50 % overlap)
-    static constexpr int NBINS = N / 2 + 1;   // 257 unique spectral bins
+    const int m_log2n;
+    const int m_fftSize;
+    const int m_hopSize;
+    const int m_bins;
 
     // ── Algorithm tuning ───────────────────────────────────────────────
     static constexpr int   HIST             = 25;    // noise history frames (~267 ms)
@@ -97,7 +100,7 @@ private:
     std::vector<float> m_outAccumR; // processed 24 kHz right-channel output
 
     // ── Noise estimator state ─────────────────────────────────────────
-    float              m_powerHistory[HIST][NBINS]{}; // smoothed periodograms
+    std::vector<float> m_powerHistory; // HIST rows of m_bins powers // smoothed periodograms
     int                m_histIdx{0};
     std::vector<float> m_noiseEst;       // current noise floor estimate [NBINS]
     std::vector<float> m_smoothedPower;  // current smoothed periodogram [NBINS]

--- a/src/core/MacNRFilter.h
+++ b/src/core/MacNRFilter.h
@@ -85,29 +85,29 @@ private:
     // ── vDSP state ─────────────────────────────────────────────────────
     FFTSetup           m_fftSetup{nullptr};
     std::vector<float> m_splitRe;   // split-complex real  [H]
-    std::vector<float> m_splitIm;   // split-complex imag  [H]
+    std::vector<float> m_splitIm;   // split-complex imag  [m_hopSize]
 
     // ── OLA buffers ────────────────────────────────────────────────────
-    std::vector<float> m_window;    // sqrt-Hann analysis+synthesis window [N]
-    std::vector<float> m_inAccum;   // 24 kHz mono float input accumulator
-    std::vector<float> m_inAccumL;  // 24 kHz left-channel input accumulator
-    std::vector<float> m_inAccumR;  // 24 kHz right-channel input accumulator
-    std::vector<float> m_olaBufferL; // left overlap-add accumulator [N]
-    std::vector<float> m_olaBufferR; // right overlap-add accumulator [N]
-    std::vector<float> m_frameBuf;  // windowed analysis frame [N]
-    std::vector<float> m_synthBuf;  // synthesis frame [N]
-    std::vector<float> m_outAccumL; // processed 24 kHz left-channel output
-    std::vector<float> m_outAccumR; // processed 24 kHz right-channel output
+    std::vector<float> m_window;    // sqrt-Hann analysis+synthesis window [m_fftSize]
+    std::vector<float> m_inAccum;   // mono float input accumulator [m_fftSize]
+    std::vector<float> m_inAccumL;  // left-channel input accumulator [m_fftSize]
+    std::vector<float> m_inAccumR;  // right-channel input accumulator [m_fftSize]
+    std::vector<float> m_olaBufferL; // left overlap-add accumulator [m_fftSize]
+    std::vector<float> m_olaBufferR; // right overlap-add accumulator [m_fftSize]
+    std::vector<float> m_frameBuf;  // windowed analysis frame [m_fftSize]
+    std::vector<float> m_synthBuf;  // synthesis frame [m_fftSize]
+    std::vector<float> m_outAccumL; // processed left-channel output
+    std::vector<float> m_outAccumR; // processed right-channel output
 
     // ── Noise estimator state ─────────────────────────────────────────
-    std::vector<float> m_powerHistory; // HIST rows of m_bins powers // smoothed periodograms
+    std::vector<float> m_powerHistory; // smoothed periodograms, HIST rows of m_bins
     int                m_histIdx{0};
-    std::vector<float> m_noiseEst;       // current noise floor estimate [NBINS]
-    std::vector<float> m_smoothedPower;  // current smoothed periodogram [NBINS]
-    std::vector<float> m_prevPostSnr;    // previous a-posteriori SNR [NBINS]
-    std::vector<float> m_filterGain;     // unblended synthesis mask [NBINS]
-    std::vector<float> m_powerBuf;       // current power spectrum [NBINS]
-    std::vector<float> m_gainBuf;        // raw Wiener gain per bin [NBINS]
+    std::vector<float> m_noiseEst;       // current noise floor estimate [m_bins]
+    std::vector<float> m_smoothedPower;  // current smoothed periodogram [m_bins]
+    std::vector<float> m_prevPostSnr;    // previous a-posteriori SNR [m_bins]
+    std::vector<float> m_filterGain;     // unblended synthesis mask [m_bins]
+    std::vector<float> m_powerBuf;       // current power spectrum [m_bins]
+    std::vector<float> m_gainBuf;        // raw Wiener gain per bin [m_bins]
     bool               m_noiseInitialized{false};
 
     std::atomic<float> m_strength{1.0f};

--- a/src/core/MonoDspStereoAdapter.cpp
+++ b/src/core/MonoDspStereoAdapter.cpp
@@ -7,11 +7,7 @@ namespace AetherSDR {
 namespace {
 
 constexpr int kChannels = 2;
-constexpr int kSampleRate = 24000;
-constexpr int kMaxBufferedFrames = kSampleRate * 5;
 constexpr int kFrameBytes = kChannels * static_cast<int>(sizeof(float));
-constexpr int kMaxBufferedBytes = kMaxBufferedFrames * kFrameBytes;
-constexpr int kCompactThresholdBytes = kSampleRate * kFrameBytes;
 // Keep balance changes well below the audio envelope rate. The mono DSP owns
 // the program waveform; this estimate only distributes it between channels.
 constexpr float kBalanceEnvelopeCoeff = 4.0e-5f;
@@ -36,10 +32,21 @@ float updatePowerEnvelope(
 
 } // namespace
 
-MonoDspStereoAdapter::MonoDspStereoAdapter(int processingLatencyFrames)
-    : m_processingLatencyFrames(std::max(0, processingLatencyFrames))
+MonoDspStereoAdapter::MonoDspStereoAdapter(int processingLatencyFrames, int sampleRate)
+    : m_sampleRate(sampleRate)
+    , m_processingLatencyFrames(std::max(0, processingLatencyFrames))
     , m_latencyFramesRemaining(m_processingLatencyFrames)
-{}
+{
+    // Preserve the legacy coefficients bit-for-bit. At 48 kHz two updates
+    // cover the same elapsed time as one legacy update.
+    if (sampleRate == 48000) {
+        m_balanceEnvelopeCoeff = 1.0f - std::sqrt(1.0f - kBalanceEnvelopeCoeff);
+        m_monoObservabilityEnvelopeCoeff =
+            1.0f - std::sqrt(1.0f - kMonoObservabilityEnvelopeCoeff);
+    }
+    m_balancePowerFloor = sampleRate == 24000 ? kBalancePowerFloor
+        : kPowerFloor * (m_balanceEnvelopeCoeff / m_monoObservabilityEnvelopeCoeff);
+}
 
 void MonoDspStereoAdapter::reset()
 {
@@ -84,7 +91,7 @@ void MonoDspStereoAdapter::compactDryStereoFifoIfNeeded()
         return;
     }
 
-    if (m_dryStereoReadOffset >= kCompactThresholdBytes) {
+    if (m_dryStereoReadOffset >= m_sampleRate * kFrameBytes) {
         m_dryStereoFifo.remove(0, m_dryStereoReadOffset);
         m_dryStereoReadOffset = 0;
     }
@@ -92,14 +99,14 @@ void MonoDspStereoAdapter::compactDryStereoFifoIfNeeded()
 
 void MonoDspStereoAdapter::pushDryStereo(const QByteArray& stereoPcm)
 {
-    if (stereoPcm.isEmpty()) {
+    if (!isValid() || stereoPcm.isEmpty()) {
         return;
     }
 
     m_dryStereoFifo.append(stereoPcm);
 
     const int readableBytes = readableDryStereoBytes();
-    if (readableBytes > kMaxBufferedBytes) {
+    if (readableBytes > m_sampleRate * 5 * kFrameBytes) {
         // A rate mismatch this large means dry and processed timelines can no
         // longer be paired reliably. Drop the pending dry side and re-prime on
         // the next block instead of preserving a permanent offset.
@@ -115,7 +122,7 @@ void MonoDspStereoAdapter::pushDryStereo(const QByteArray& stereoPcm)
 
 QByteArray MonoDspStereoAdapter::takeProcessedMono(const float* processedMono, int frames)
 {
-    if (!processedMono || frames <= 0) {
+    if (!isValid() || !processedMono || frames <= 0) {
         return {};
     }
 
@@ -153,12 +160,12 @@ QByteArray MonoDspStereoAdapter::takeProcessedMono(const float* processedMono, i
         m_dryMonoPower = updatePowerEnvelope(
             m_dryMonoPower,
             dryMono * dryMono,
-            kMonoObservabilityEnvelopeCoeff,
+            m_monoObservabilityEnvelopeCoeff,
             kPowerFloor);
         m_dryStereoPower = updatePowerEnvelope(
             m_dryStereoPower,
             dryStereoPower,
-            kMonoObservabilityEnvelopeCoeff,
+            m_monoObservabilityEnvelopeCoeff,
             kPowerFloor);
 
         const float observableMonoFloor =
@@ -174,13 +181,13 @@ QByteArray MonoDspStereoAdapter::takeProcessedMono(const float* processedMono, i
             m_leftPower = updatePowerEnvelope(
                 m_leftPower,
                 left * left,
-                kBalanceEnvelopeCoeff,
-                kBalancePowerFloor);
+                m_balanceEnvelopeCoeff,
+                m_balancePowerFloor);
             m_rightPower = updatePowerEnvelope(
                 m_rightPower,
                 right * right,
-                kBalanceEnvelopeCoeff,
-                kBalancePowerFloor);
+                m_balanceEnvelopeCoeff,
+                m_balancePowerFloor);
             const float leftLevel = std::sqrt(std::max(m_leftPower, 0.0f));
             const float rightLevel = std::sqrt(std::max(m_rightPower, 0.0f));
             const float totalLevel = leftLevel + rightLevel;

--- a/src/core/MonoDspStereoAdapter.cpp
+++ b/src/core/MonoDspStereoAdapter.cpp
@@ -32,20 +32,29 @@ float updatePowerEnvelope(
 
 } // namespace
 
+// One envelope step at 48 kHz must cover half the time of a legacy 24 kHz step,
+// so that two of them span the same interval: (1 - a')^2 = 1 - a. At 24 kHz the
+// legacy coefficient is returned unchanged, bit-for-bit.
+static float rateScaledEnvelopeCoeff(float legacyCoeff, int sampleRate)
+{
+    return sampleRate == 48000 ? 1.0f - std::sqrt(1.0f - legacyCoeff) : legacyCoeff;
+}
+
 MonoDspStereoAdapter::MonoDspStereoAdapter(int processingLatencyFrames, int sampleRate)
     : m_sampleRate(sampleRate)
+    // Derived from the named constants above, never from a duplicated literal:
+    // the 24 kHz path is bit-identical only while these agree, and a default in
+    // the header would drift silently the first time a constant is retuned.
+    , m_balanceEnvelopeCoeff(rateScaledEnvelopeCoeff(kBalanceEnvelopeCoeff, sampleRate))
+    , m_monoObservabilityEnvelopeCoeff(
+          rateScaledEnvelopeCoeff(kMonoObservabilityEnvelopeCoeff, sampleRate))
+    // Same expression kBalancePowerFloor is defined by, so it holds the input
+    // threshold constant across the rescale instead of special-casing 24 kHz.
+    , m_balancePowerFloor(kPowerFloor
+          * (m_balanceEnvelopeCoeff / m_monoObservabilityEnvelopeCoeff))
     , m_processingLatencyFrames(std::max(0, processingLatencyFrames))
     , m_latencyFramesRemaining(m_processingLatencyFrames)
 {
-    // Preserve the legacy coefficients bit-for-bit. At 48 kHz two updates
-    // cover the same elapsed time as one legacy update.
-    if (sampleRate == 48000) {
-        m_balanceEnvelopeCoeff = 1.0f - std::sqrt(1.0f - kBalanceEnvelopeCoeff);
-        m_monoObservabilityEnvelopeCoeff =
-            1.0f - std::sqrt(1.0f - kMonoObservabilityEnvelopeCoeff);
-    }
-    m_balancePowerFloor = sampleRate == 24000 ? kBalancePowerFloor
-        : kPowerFloor * (m_balanceEnvelopeCoeff / m_monoObservabilityEnvelopeCoeff);
 }
 
 void MonoDspStereoAdapter::reset()

--- a/src/core/MonoDspStereoAdapter.h
+++ b/src/core/MonoDspStereoAdapter.h
@@ -10,7 +10,10 @@ namespace AetherSDR {
 // stereo content cannot survive a mono DSP path; only its level balance does.
 class MonoDspStereoAdapter {
 public:
-    explicit MonoDspStereoAdapter(int processingLatencyFrames = 0);
+    explicit MonoDspStereoAdapter(int processingLatencyFrames = 0, int sampleRate = 24000);
+
+    bool isValid() const { return m_sampleRate == 24000 || m_sampleRate == 48000; }
+    int sampleRate() const { return m_sampleRate; }
 
     void reset();
     void setProcessingLatencyFrames(int frames);
@@ -25,6 +28,10 @@ private:
     void compactDryStereoFifoIfNeeded();
     void resetEnvelopeState();
 
+    int m_sampleRate{24000};
+    float m_balanceEnvelopeCoeff{4.0e-5f};
+    float m_monoObservabilityEnvelopeCoeff{0.006f};
+    float m_balancePowerFloor{0.0f};
     QByteArray m_dryStereoFifo;
     int m_dryStereoReadOffset{0};
     int m_processingLatencyFrames{0};

--- a/src/core/MonoDspStereoAdapter.h
+++ b/src/core/MonoDspStereoAdapter.h
@@ -28,10 +28,13 @@ private:
     void compactDryStereoFifoIfNeeded();
     void resetEnvelopeState();
 
+    // All three are set in the constructor's init list from the named constants
+    // in the .cpp. Deliberately no default here: duplicating the literals let
+    // the 24 kHz path diverge from them unnoticed.
     int m_sampleRate{24000};
-    float m_balanceEnvelopeCoeff{4.0e-5f};
-    float m_monoObservabilityEnvelopeCoeff{0.006f};
-    float m_balancePowerFloor{0.0f};
+    float m_balanceEnvelopeCoeff;
+    float m_monoObservabilityEnvelopeCoeff;
+    float m_balancePowerFloor;
     QByteArray m_dryStereoFifo;
     int m_dryStereoReadOffset{0};
     int m_processingLatencyFrames{0};

--- a/src/core/NvidiaAfxFilter.cpp
+++ b/src/core/NvidiaAfxFilter.cpp
@@ -144,11 +144,19 @@ static QString findModel(const QString& packDir)
 }
 
 // ─── Lifecycle ──────────────────────────────────────────────────────────────
-NvidiaAfxFilter::NvidiaAfxFilter(const QString& packDir)
-    : m_api(std::make_unique<Api>())
-    , m_up(std::make_unique<Resampler>(24000, 48000))
-    , m_down(std::make_unique<Resampler>(48000, 24000))
+NvidiaAfxFilter::NvidiaAfxFilter(const QString& packDir, int sampleRate)
+    : m_sampleRate(sampleRate)
+    , m_api(std::make_unique<Api>())
+    , m_stereoAdapter(0, sampleRate)
 {
+    if (!m_stereoAdapter.isValid()) {
+        m_lastError = QStringLiteral("Unsupported sample rate: %1").arg(sampleRate);
+        return;
+    }
+    if (sampleRate == 24000) {
+        m_up = std::make_unique<Resampler>(24000, 48000);
+        m_down = std::make_unique<Resampler>(48000, 24000);
+    }
     const QString dir = resolvePackDir(packDir);
     if (!QDir(dir).exists()) {
         m_lastError = QStringLiteral("AFX pack directory not found: %1").arg(dir);
@@ -300,25 +308,28 @@ void NvidiaAfxFilter::setIntensity(float ratio)
 }
 
 // ─── Audio-thread processing (mirrors DeepFilterFilter) ──────────────────────
-QByteArray NvidiaAfxFilter::process(const QByteArray& pcm24kStereo)
+QByteArray NvidiaAfxFilter::process(const QByteArray& pcmStereo)
 {
-    if (!m_ready || m_afxFrame <= 0 || pcm24kStereo.isEmpty())
-        return pcm24kStereo;
+    if (!m_ready || m_afxFrame <= 0 || pcmStereo.isEmpty())
+        return pcmStereo;
 
     if (m_paramsDirty.exchange(false))
         m_api->SetFloat(m_handle, P_INTENSITY, m_intensity.load());
 
-    const auto* src = reinterpret_cast<const float*>(pcm24kStereo.constData());
-    const int stereoFrames = pcm24kStereo.size() / (2 * static_cast<int>(sizeof(float)));
-    m_stereoAdapter.pushDryStereo(pcm24kStereo);
+    const auto* src = reinterpret_cast<const float*>(pcmStereo.constData());
+    const int stereoFrames = pcmStereo.size() / (2 * static_cast<int>(sizeof(float)));
+    m_stereoAdapter.pushDryStereo(pcmStereo);
 
-    // 1. 24 kHz stereo float32 → 48 kHz mono float32. Keep the dry stereo
+    // 1. Downmix and convert legacy24 to48; native48 needs no SRC. Keep dry stereo
     // queued so the BNR attenuation can be applied without collapsing pan.
-    m_mono24k.resize(stereoFrames);
+    m_monoInput.resize(stereoFrames);
     for (int i = 0; i < stereoFrames; ++i) {
-        m_mono24k[i] = 0.5f * (src[i * 2] + src[i * 2 + 1]);
+        m_monoInput[i] = 0.5f * (src[i * 2] + src[i * 2 + 1]);
     }
-    QByteArray mono48k = m_up->process(m_mono24k.data(), stereoFrames);
+    QByteArray mono48k = m_up
+        ? m_up->process(m_monoInput.data(), stereoFrames)
+        : QByteArray(reinterpret_cast<const char*>(m_monoInput.data()),
+                     stereoFrames * static_cast<int>(sizeof(float)));
     const auto* mono = reinterpret_cast<const float*>(mono48k.constData());
     const int monoSamples = mono48k.size() / static_cast<int>(sizeof(float));
 
@@ -355,9 +366,12 @@ QByteArray NvidiaAfxFilter::process(const QByteArray& pcm24kStereo)
         } else {
             m_inAccum.clear();
         }
-        // 3. 48 kHz mono float32 → 24 kHz mono float32, then re-apply the
-        // shared BNR envelope to the delayed dry stereo.
-        const QByteArray downsampled = m_down->process(out, consumed);
+        // 3. Convert only legacy24, then restore the existing delayed stereo
+        // level balance at the configured rate.
+        const QByteArray downsampled = m_down
+            ? m_down->process(out, consumed)
+            : QByteArray(reinterpret_cast<const char*>(out),
+                         consumed * static_cast<int>(sizeof(float)));
         const auto* downsampledMono = reinterpret_cast<const float*>(downsampled.constData());
         const int downsampledFrames = downsampled.size() / static_cast<int>(sizeof(float));
         m_outAccum.append(m_stereoAdapter.takeProcessedMono(downsampledMono, downsampledFrames));
@@ -366,7 +380,7 @@ QByteArray NvidiaAfxFilter::process(const QByteArray& pcm24kStereo)
     // 4. Return exactly the input byte count. Use a read cursor instead of an
     //    O(n) front-erase every block; compact only once the consumed prefix
     //    grows past the unread tail.
-    const int needed = pcm24kStereo.size();
+    const int needed = pcmStereo.size();
     if (m_outAccum.size() - m_outReadPos >= needed) {
         QByteArray result(m_outAccum.constData() + m_outReadPos, needed);
         m_outReadPos += needed;
@@ -390,8 +404,10 @@ void NvidiaAfxFilter::reset()
     m_outAccum.clear();
     m_outReadPos = 0;
     m_stereoAdapter.reset();
-    m_up   = std::make_unique<Resampler>(24000, 48000);
-    m_down = std::make_unique<Resampler>(48000, 24000);
+    if (m_sampleRate == 24000) {
+        m_up = std::make_unique<Resampler>(24000, 48000);
+        m_down = std::make_unique<Resampler>(48000, 24000);
+    }
 }
 
 } // namespace AetherSDR

--- a/src/core/NvidiaAfxFilter.h
+++ b/src/core/NvidiaAfxFilter.h
@@ -20,10 +20,9 @@ class Resampler;
 // from a downloaded/cached "pack" so the shipped app carries none of the
 // ~2 GB GPU runtime. Requires an NVIDIA RTX/GeForce GPU (Turing+).
 //
-// Mirrors DeepFilterFilter's contract: processes 24 kHz stereo float32 audio
-// (the RX DSP path's canonical format) by upsampling to 48 kHz mono, running
-// the AFX denoiser, and downsampling back to 24 kHz stereo. Returns the same
-// number of bytes as the input.
+// The immutable input/output domain is 24 or 48 kHz stereo float32. Legacy24
+// retains its SRC pair; native48 reaches the model without SRC. Both keep
+// the existing mono analysis/stereo level-balance policy and byte count.
 //
 // Thread-safe parameter setters (GUI thread writes atomics, audio thread reads).
 // dlopen + TensorRT engine build happen in the constructor (call OFF the audio
@@ -36,19 +35,20 @@ public:
     // bin/ (NVAudioEffects.dll + sibling CUDA/TensorRT/feature DLLs) and the
     // same features/denoiser/models/sm_XX model tree. If empty, the pack is
     // resolved from $AETHER_NVAFX_DIR then the app data cache dir.
-    explicit NvidiaAfxFilter(const QString& packDir = QString());
+    explicit NvidiaAfxFilter(const QString& packDir = QString(), int sampleRate = 24000);
+    int sampleRate() const { return m_sampleRate; }
     ~NvidiaAfxFilter();
 
     NvidiaAfxFilter(const NvidiaAfxFilter&) = delete;
     NvidiaAfxFilter& operator=(const NvidiaAfxFilter&) = delete;
 
-    // Process a block of 24 kHz stereo float32 PCM. Returns the processed block
+    // Process configured-rate stereo float32 PCM. Returns the processed block
     // (same format, same byte count). No-op passthrough until the engine is ready.
-    QByteArray process(const QByteArray& pcm24kStereo);
+    QByteArray process(const QByteArray& pcmStereo);
 
-    // Flush all carried state — the jitter accumulators and the resamplers — so
-    // the next process() starts clean. Call on any audio discontinuity (stream
-    // restart, RX source switch, TX→RX) to avoid replaying stale/pre-gap audio.
+    // Flush wrapper jitter accumulators, stereo balance and resamplers.
+    // This does not reset SDK recurrent state. Recreate the complete filter
+    // for a new source or discontinuity that requires a clean algorithm epoch.
     void reset();
 
     // True once the effect is created, model loaded, and the engine is ready.
@@ -62,6 +62,7 @@ public:
     float intensity() const { return m_intensity.load(); }
 
 private:
+    const int m_sampleRate;
     bool loadRuntime(const QString& packDir);   // dlopen the pack libs + dlsym API
     bool createDenoiser(const QString& packDir); // CreateEffect..Load
     void teardown();
@@ -81,7 +82,7 @@ private:
     QByteArray m_outAccum;                       // 24 kHz stereo float output
     int        m_outReadPos{0};                 // read cursor into m_outAccum
     MonoDspStereoAdapter m_stereoAdapter;
-    std::vector<float> m_mono24k;
+    std::vector<float> m_monoInput;
     std::vector<float> m_runScratch;            // reused NvAFX_Run output buffer
 
     std::atomic<float> m_intensity{1.0f};

--- a/src/core/SpecbleachFilter.cpp
+++ b/src/core/SpecbleachFilter.cpp
@@ -8,12 +8,17 @@
 
 namespace AetherSDR {
 
-static constexpr int kSampleRate = 24000;
 static constexpr float kFrameSizeMs = 40.0f;  // 40ms frames (~960 samples)
 
-SpecbleachFilter::SpecbleachFilter()
+SpecbleachFilter::SpecbleachFilter(int sampleRate)
+    : m_sampleRate(sampleRate)
+    , m_stereoAdapter(0, sampleRate)
 {
-    m_handle = specbleach_initialize(kSampleRate, kFrameSizeMs);
+    if (!m_stereoAdapter.isValid()) {
+        qWarning() << "SpecbleachFilter: unsupported sample rate" << sampleRate;
+        return;
+    }
+    m_handle = specbleach_initialize(sampleRate, kFrameSizeMs);
     if (!m_handle) {
         qWarning() << "SpecbleachFilter: failed to initialize";
         return;
@@ -60,19 +65,19 @@ void SpecbleachFilter::applyParams()
     m_paramsDirty = false;
 }
 
-QByteArray SpecbleachFilter::process(const QByteArray& pcm24kStereo)
+QByteArray SpecbleachFilter::process(const QByteArray& pcmStereo)
 {
     if (!m_handle)
-        return pcm24kStereo;
+        return pcmStereo;
 
     // Apply parameter changes if dirty
     if (m_paramsDirty.load())
         applyParams();
 
-    const int totalFloats = pcm24kStereo.size() / static_cast<int>(sizeof(float));
+    const int totalFloats = pcmStereo.size() / static_cast<int>(sizeof(float));
     const int monoSamples = totalFloats / 2;
     if (monoSamples <= 0)
-        return pcm24kStereo;
+        return pcmStereo;
 
     // Resize buffers if needed
     if (static_cast<int>(m_monoIn.size()) < monoSamples) {
@@ -81,7 +86,7 @@ QByteArray SpecbleachFilter::process(const QByteArray& pcm24kStereo)
     }
 
     // Stereo float32 → mono float (average L+R)
-    const auto* in = reinterpret_cast<const float*>(pcm24kStereo.constData());
+    const auto* in = reinterpret_cast<const float*>(pcmStereo.constData());
     for (int i = 0; i < monoSamples; ++i)
         m_monoIn[i] = (in[i * 2] + in[i * 2 + 1]) * 0.5f;
 
@@ -94,10 +99,10 @@ QByteArray SpecbleachFilter::process(const QByteArray& pcm24kStereo)
     if (m_frameCount < kLearningFrames) {
         ++m_frameCount;
         m_stereoAdapter.reset();
-        return pcm24kStereo;
+        return pcmStereo;
     }
 
-    m_stereoAdapter.pushDryStereo(pcm24kStereo);
+    m_stereoAdapter.pushDryStereo(pcmStereo);
     return m_stereoAdapter.takeProcessedMono(m_monoOut.data(), monoSamples);
 }
 

--- a/src/core/SpecbleachFilter.h
+++ b/src/core/SpecbleachFilter.h
@@ -13,20 +13,22 @@ typedef void* SpectralBleachHandle;
 namespace AetherSDR {
 
 // SpecbleachFilter - wrapper around libspecbleach for NR4 noise reduction.
-// Processes 24 kHz stereo float32 audio (same interface as RNNoiseFilter).
+// Processes stereo float32 audio at an immutable 24 or 48 kHz sample rate.
 // Thread-safe parameter setters (main thread writes, audio thread reads).
 class SpecbleachFilter {
 public:
-    SpecbleachFilter();
+    explicit SpecbleachFilter(int sampleRate = 24000);
     ~SpecbleachFilter();
 
     SpecbleachFilter(const SpecbleachFilter&) = delete;
     SpecbleachFilter& operator=(const SpecbleachFilter&) = delete;
 
-    // Process stereo float32 PCM at 24 kHz. Returns processed audio.
-    QByteArray process(const QByteArray& pcm24kStereo);
+    // Process stereo float32 PCM at the configured sample rate. Returns processed audio.
+    QByteArray process(const QByteArray& pcmStereo);
 
     bool isValid() const { return m_handle != nullptr; }
+    // Reset the noise profile and stereo adapter. Recreate on a new source
+    // or discontinuity to also discard libspecbleach's internal overlap state.
     void reset();
 
     // User-adjustable parameters (thread-safe)
@@ -46,7 +48,10 @@ public:
     float maskingDepth() const { return m_maskingDepth.load(); }
     float suppressionStrength() const { return m_suppression.load(); }
 
+    int sampleRate() const { return m_sampleRate; }
+
 private:
+    const int m_sampleRate;
     void applyParams();
 
     SpectralBleachHandle m_handle{nullptr};

--- a/tests/mac_nr_filter_test.cpp
+++ b/tests/mac_nr_filter_test.cpp
@@ -49,9 +49,10 @@ private:
     uint32_t m_state;
 };
 
-std::vector<float> runFilter(const std::vector<float>& input, float strength)
+std::vector<float> runFilter(const std::vector<float>& input, float strength,
+                              int sampleRate = kRate)
 {
-    AetherSDR::MacNRFilter filter;
+    AetherSDR::MacNRFilter filter(sampleRate);
     if (!filter.isValid()) {
         return {};
     }
@@ -59,8 +60,9 @@ std::vector<float> runFilter(const std::vector<float>& input, float strength)
 
     std::vector<float> output;
     output.reserve(input.size());
-    for (int frame = 0; frame < static_cast<int>(input.size() / 2); frame += kBlockFrames) {
-        const int count = std::min(kBlockFrames,
+    const int blockFrames = sampleRate / 100;
+    for (int frame = 0; frame < static_cast<int>(input.size() / 2); frame += blockFrames) {
+        const int count = std::min(blockFrames,
                                    static_cast<int>(input.size() / 2) - frame);
         QByteArray block(count * 2 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
         std::copy_n(input.data() + 2 * frame, 2 * count,
@@ -74,6 +76,61 @@ std::vector<float> runFilter(const std::vector<float>& input, float strength)
                       values + processed.size() / static_cast<int>(sizeof(float)));
     }
     return output;
+}
+
+void test_native48_full_bandwidth_and_reset()
+{
+    constexpr int rate = 48000;
+    constexpr int total = rate * 3;
+    std::vector<float> input(2 * total);
+    for (int frame = 0; frame < total; ++frame) {
+        input[2 * frame] = 0.2f * std::sin(kTwoPi * 16000.0f * frame / rate);
+        input[2 * frame + 1] = 0.2f * std::cos(kTwoPi * 17000.0f * frame / rate);
+    }
+    const std::vector<float> output = runFilter(input, 0.0f, rate);
+    double error = 0.0;
+    if (output.size() == input.size()) {
+        // At native48 the FFT/hop doubles, retaining the existing elapsed
+        // processing delay (1024 samples; 512 samples at legacy24).
+        for (int frame = rate; frame < total; ++frame) {
+            for (int channel = 0; channel < 2; ++channel) {
+                error = std::max(error, std::abs(static_cast<double>(
+                    output[2 * frame + channel] - input[2 * (frame - 1024) + channel])));
+            }
+        }
+    } else {
+        error = 1.0;
+    }
+    char detail[128]{};
+    std::snprintf(detail, sizeof(detail), "max independent16/17k error=%.6f", error);
+    report("native48 retains independent stereo above12k", error < 1.0e-5, detail);
+
+    AetherSDR::MacNRFilter invalid(44100);
+    report("unsupported MNR domain fails initialization", !invalid.isValid(), "44100 Hz");
+    AetherSDR::MacNRFilter filter(rate);
+    filter.setStrength(0.6f);
+    const QByteArray block(reinterpret_cast<const char*>(input.data()), 4096 * sizeof(float));
+    const QByteArray first = filter.process(block);
+    filter.process(block);
+    filter.reset();
+    report("native48 reset discards all processing history",
+           filter.sampleRate() == rate && first == filter.process(block), "replayed initial block");
+
+    NoiseSource noise(0x52a7u);
+    for (int frame = 0; frame < total; ++frame) {
+        input[2 * frame] = input[2 * frame + 1] = 0.05f * noise.gaussian();
+    }
+    const std::vector<float> suppressed = runFilter(input, 1.0f, rate);
+    double inPower = 0.0;
+    double outPower = 0.0;
+    for (int frame = rate; frame < total && suppressed.size() == input.size(); ++frame) {
+        inPower += input[2 * frame] * input[2 * frame];
+        outPower += suppressed[2 * frame] * suppressed[2 * frame];
+    }
+    const double attenuation = 10.0 * std::log10(outPower / std::max(inPower, 1e-12));
+    std::snprintf(detail, sizeof(detail), "native48 white noise attenuation=%.2f dB", attenuation);
+    report("native48 executes enabled noise reduction", std::isfinite(attenuation)
+           && attenuation < -10.0 && attenuation > -30.0, detail);
 }
 
 double rms(const std::vector<float>& samples, int firstFrame, int lastFrame, int channel)
@@ -444,6 +501,7 @@ int main()
     test_silence_gap_preserves_learned_noise_floor();
     test_near_silence_does_not_seed_noise_floor();
     test_enable_during_speech_avoids_deep_ducking();
+    test_native48_full_bandwidth_and_reset();
     std::printf(g_failed == 0 ? "\nPASSED\n" : "\nFAILED (%d)\n", g_failed);
     return g_failed == 0 ? 0 : 1;
 }

--- a/tests/mono_dsp_stereo_adapter_test.cpp
+++ b/tests/mono_dsp_stereo_adapter_test.cpp
@@ -34,6 +34,22 @@ QByteArray makeStereoBlock(int frames, float leftScale, float rightScale)
     return block;
 }
 
+// Same tone and same elapsed time at any supported rate: the carrier is tied to
+// sampleRate, so a 48 kHz block of 2N frames spans exactly the wall-clock
+// interval a 24 kHz block of N frames does.
+QByteArray makeStereoBlockAtRate(int frames, int sampleRate, float leftScale, float rightScale)
+{
+    QByteArray block(frames * 2 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
+    auto* samples = reinterpret_cast<float*>(block.data());
+    for (int i = 0; i < frames; ++i) {
+        const float carrier = std::sin(
+            2.0f * kPi * 733.0f * static_cast<float>(i) / static_cast<float>(sampleRate));
+        samples[i * 2] = leftScale * carrier;
+        samples[i * 2 + 1] = rightScale * carrier;
+    }
+    return block;
+}
+
 QByteArray makeOppositePhaseStereoBlock(int frames, float scale)
 {
     QByteArray block(frames * 2 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
@@ -144,6 +160,64 @@ Rms measureRms(const QByteArray& stereoBlock, int discardFrames)
 bool nearlyEqual(double a, double b, double tolerance)
 {
     return std::abs(a - b) <= tolerance;
+}
+
+// The 48 kHz envelope rescale is the only genuinely new numerical logic in this
+// change, and the obvious assertions cannot see it. A steady-state balance ratio
+// is coefficient-independent: m_leftPower and m_rightPower are driven by the same
+// coefficient from the same zero initial condition, so their ratio is correct
+// from the first sample whatever that coefficient is.
+//
+// What the coefficient does govern is how fast the envelope TRACKS A CHANGE. So
+// converge the balance on one L/R ratio, flip to the opposite ratio, and measure
+// how far it has travelled after a fixed elapsed time — 24 kHz over N frames
+// against 48 kHz over 2N, which is the same wall clock. The rescale exists
+// precisely so those agree.
+//
+// Remove it and the legacy per-sample coefficient advances the 48 kHz envelope
+// twice as fast in wall-clock terms, so the two diverge and this fails. The
+// m_balancePowerFloor rescale rides on the same two coefficients.
+bool testEnvelopeTracksElapsedTimeAcrossRates()
+{
+    // ~1.04 s legacy time constant, so 0.25 s leaves the flip clearly in flight.
+    auto trackedRatioAfterFlip = [](int sampleRate) {
+        const int converge = sampleRate;           // 1.0 s
+        const int observe = sampleRate / 4;        // 0.25 s
+        MonoDspStereoAdapter adapter(0, sampleRate);
+
+        const QByteArray primed = makeStereoBlockAtRate(converge, sampleRate, 0.8f, 0.2f);
+        const std::vector<float> primedMono = makeProcessedMono(primed, 0.42f);
+        adapter.pushDryStereo(primed);
+        adapter.takeProcessedMono(primedMono.data(), static_cast<int>(primedMono.size()));
+
+        // Flip the balance; the envelope now has to travel the other way.
+        const QByteArray flipped = makeStereoBlockAtRate(observe, sampleRate, 0.2f, 0.8f);
+        const std::vector<float> flippedMono = makeProcessedMono(flipped, 0.42f);
+        adapter.pushDryStereo(flipped);
+        const QByteArray out =
+            adapter.takeProcessedMono(flippedMono.data(), static_cast<int>(flippedMono.size()));
+
+        const Rms rms = measureRms(out, 0);
+        return rms.left / std::max(rms.right, 1.0e-12);
+    };
+
+    const double tracked24 = trackedRatioAfterFlip(24000);
+    const double tracked48 = trackedRatioAfterFlip(48000);
+
+    // The flip must still be in flight at both rates, or the comparison is
+    // vacuous: fully converged (0.25) or untouched (4.0) would match regardless.
+    if (tracked24 <= 0.35 || tracked24 >= 3.5) {
+        std::printf("rate-domain envelope check is vacuous: 24k ratio %.6f is not mid-flight\n",
+                    tracked24);
+        return false;
+    }
+    if (!nearlyEqual(tracked24, tracked48, 0.05 * tracked24)) {
+        std::printf("envelope did not track elapsed time across rates: "
+                    "24k %.6f vs 48k %.6f over the same 0.25 s after a balance flip\n",
+                    tracked24, tracked48);
+        return false;
+    }
+    return true;
 }
 
 bool testPreservesRatioWithSharedGain()
@@ -513,6 +587,9 @@ int main()
         return 1;
     }
     if (!testPreservesRatioWithSharedGain()) {
+        return 1;
+    }
+    if (!testEnvelopeTracksElapsedTimeAcrossRates()) {
         return 1;
     }
     if (!testBuffersDryUntilProcessedArrives()) {

--- a/tests/mono_dsp_stereo_adapter_test.cpp
+++ b/tests/mono_dsp_stereo_adapter_test.cpp
@@ -482,6 +482,36 @@ bool testOverflowClearsInsteadOfMisaligning()
 
 int main()
 {
+    for (const int rate : {24000, 48000}) {
+        MonoDspStereoAdapter adapter(0, rate);
+        adapter.pushDryStereo(makeConstantStereoBlock(rate * 4, 0.8f, 0.2f));
+        if (!adapter.isValid() || adapter.sampleRate() != rate
+            || adapter.bufferedFrames() != rate * 4) {
+            std::printf("rate-aware queue discarded a valid four-second buffer\n");
+            return 1;
+        }
+        adapter.pushDryStereo(makeConstantStereoBlock(rate * 2, 0.8f, 0.2f));
+        if (adapter.bufferedFrames() != 0) {
+            std::printf("rate-aware queue failed its five-second cap\n");
+            return 1;
+        }
+    }
+    MonoDspStereoAdapter invalid(0, 44100);
+    invalid.pushDryStereo(makeConstantStereoBlock(100, 0.8f, 0.2f));
+    if (invalid.isValid() || invalid.bufferedFrames() != 0) {
+        return 1;
+    }
+    MonoDspStereoAdapter legacy;
+    MonoDspStereoAdapter explicit24(0, 24000);
+    const QByteArray dry = makeConstantStereoBlock(2400, 0.8f, 0.2f);
+    const std::vector<float> wet(2400, 0.25f);
+    legacy.pushDryStereo(dry);
+    explicit24.pushDryStereo(dry);
+    if (legacy.takeProcessedMono(wet.data(), wet.size())
+        != explicit24.takeProcessedMono(wet.data(), wet.size())) {
+        std::printf("explicit24 changed legacy adapter output\n");
+        return 1;
+    }
     if (!testPreservesRatioWithSharedGain()) {
         return 1;
     }

--- a/tests/nr_rate_domain_test.cpp
+++ b/tests/nr_rate_domain_test.cpp
@@ -1,0 +1,184 @@
+// Exercises the actual DFNR/NVIDIA wrapper source against deterministic
+// local C APIs. No SDK pack, model inference, network, or GPU is used.
+#include "core/DeepFilterFilter.h"
+#include "core/NvidiaAfxFilter.h"
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QLibrary>
+#include <QTemporaryDir>
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <numbers>
+
+unsigned aetherTestDfProcessedSamples();
+
+namespace {
+int g_failures{0};
+void check(bool condition, const char* name)
+{
+    std::printf("%s %s\n", condition ? "PASS" : "FAIL", name);
+    if (!condition) {
+        ++g_failures;
+    }
+}
+
+QByteArray tone(int rate, int first, int frames)
+{
+    QByteArray block(frames * 2 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
+    auto* samples = reinterpret_cast<float*>(block.data());
+    const double hz = rate == 48000 ? 16000.0 : 4000.0;
+    for (int frame = 0; frame < frames; ++frame) {
+        const float value = 0.2f * std::sin(
+            2.0 * std::numbers::pi * hz * (first + frame) / rate);
+        samples[2 * frame] = value;
+        samples[2 * frame + 1] = value;
+    }
+    return block;
+}
+
+template<class Filter>
+QByteArray run(Filter& filter, int rate, bool irregular = true)
+{
+    constexpr std::array<int, 5> kPartitions{13, 511, 960, 73, 480};
+    QByteArray result;
+    const int total = rate * 2;
+    for (int first = 0, part = 0; first < total; ++part) {
+        const int frames = std::min(total - first,
+            irregular ? kPartitions[part % kPartitions.size()] : 480);
+        const QByteArray input = tone(rate, first, frames);
+        const QByteArray output = filter.process(input);
+        if (output.size() != input.size()) {
+            check(false, "wrapper preserves sample-frame count");
+            return {};
+        }
+        result.append(output);
+        first += frames;
+    }
+    return result;
+}
+
+double rmsTail(const QByteArray& data, int rate)
+{
+    const auto* samples = reinterpret_cast<const float*>(data.constData());
+    const int frames = data.size() / (2 * static_cast<int>(sizeof(float)));
+    double power = 0;
+    for (int frame = rate; frame < frames; ++frame) {
+        if (!std::isfinite(samples[2 * frame])
+            || samples[2 * frame] != samples[2 * frame + 1]) {
+            return -1;
+        }
+        power += static_cast<double>(samples[2 * frame]) * samples[2 * frame];
+    }
+    return frames > rate ? std::sqrt(power / (frames - rate)) : -1;
+}
+
+bool writeFixture(const QString& path)
+{
+    QDir().mkpath(QFileInfo(path).absolutePath());
+    QFile file(path);
+    return file.open(QIODevice::WriteOnly) && file.write("test C API fixture") > 0;
+}
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    QTemporaryDir state;
+    if (!state.isValid() || argc != 2) {
+        return 1;
+    }
+    // CMake gives this test its own executable directory. The model lookup
+    // follows the production path, but the linked C API reads no model bytes.
+    const QString fixture = QDir(QCoreApplication::applicationDirPath())
+        .filePath(QStringLiteral("DeepFilterNet3_onnx.dfmodel"));
+    const bool createdFixture = !QFile::exists(fixture);
+    if (createdFixture && !writeFixture(fixture)) {
+        return 1;
+    }
+
+    const QString pack = state.path() + QStringLiteral("/pack");
+#if defined(_WIN32)
+    const QString libraryPath = pack + QStringLiteral("/bin/NVAudioEffects.dll");
+#else
+    const QString libraryPath = pack + QStringLiteral("/nvafx/lib/libnv_audiofx.so");
+#endif
+    QDir().mkpath(QFileInfo(libraryPath).absolutePath());
+    if (!QFile::copy(QString::fromLocal8Bit(argv[1]), libraryPath)
+        || !writeFixture(pack + QStringLiteral(
+            "/features/denoiser/models/sm_test/denoiser_48k.trtpkg"))) {
+        return 1;
+    }
+    QLibrary library(libraryPath);
+    library.load();
+    using Samples = unsigned (*)();
+    const Samples nvSamples = reinterpret_cast<Samples>(
+        library.resolve("aetherTestProcessedSamples"));
+    if (!nvSamples) {
+        return 1;
+    }
+
+    using AetherSDR::DeepFilterFilter;
+    using AetherSDR::NvidiaAfxFilter;
+    DeepFilterFilter invalidDf(44100);
+    NvidiaAfxFilter invalidNv(pack, 44100);
+    check(!invalidDf.isValid() && !invalidNv.isValid(), "unsupported domains fail initialization");
+
+    DeepFilterFilter legacyDf;
+    DeepFilterFilter explicitDf(24000);
+    check(legacyDf.isValid() && explicitDf.isValid(), "DFNR C API test instances initialize");
+    const QByteArray baselineDf = run(legacyDf, 24000);
+    check(baselineDf == run(explicitDf, 24000), "DFNR default and explicit24 match bit-for-bit");
+    NvidiaAfxFilter legacyNv(pack);
+    NvidiaAfxFilter explicitNv(pack, 24000);
+    check(legacyNv.isValid() && explicitNv.isValid(), "NVIDIA C API test instances initialize");
+    const QByteArray baselineNv = run(legacyNv, 24000);
+    check(baselineNv == run(explicitNv, 24000), "NVIDIA default and explicit24 match bit-for-bit");
+
+    DeepFilterFilter nativeDf(48000);
+    NvidiaAfxFilter nativeNv(pack, 48000);
+    check(nativeDf.sampleRate() == 48000 && nativeNv.sampleRate() == 48000,
+          "native wrappers keep immutable48 domain");
+    const unsigned dfBefore = aetherTestDfProcessedSamples();
+    const unsigned nvBefore = nvSamples();
+    const QByteArray df48 = run(nativeDf, 48000);
+    const QByteArray nv48 = run(nativeNv, 48000);
+    check(aetherTestDfProcessedSamples() - dfBefore == 96000,
+          "DFNR processes each native input sample exactly once");
+    check(nvSamples() - nvBefore == 96000,
+          "NVIDIA processes each native input sample exactly once");
+    check(std::abs(rmsTail(df48, 48000) - 0.0707107) < 0.001,
+          "DFNR native48 retains16k carrier with algorithm half-gain");
+    check(std::abs(rmsTail(nv48, 48000) - 0.0707107) < 0.001,
+          "NVIDIA native48 retains16k carrier with algorithm half-gain");
+    nativeDf.reset();
+    check(run(nativeDf, 48000) == df48, "DFNR reset clears algorithm and wrapper history");
+    NvidiaAfxFilter replacementNv(pack, 48000);
+    check(run(replacementNv, 48000) == nv48, "NVIDIA replacement creates a clean processing epoch");
+
+    DeepFilterFilter concurrentDf24(24000);
+    DeepFilterFilter concurrentDf48(48000);
+    NvidiaAfxFilter concurrentNv24(pack, 24000);
+    NvidiaAfxFilter concurrentNv48(pack, 48000);
+    QByteArray df24Concurrent;
+    QByteArray nv24Concurrent;
+    constexpr std::array<int, 5> kPartitions{13, 511, 960, 73, 480};
+    for (int first = 0, part = 0; first < 48000; ++part) {
+        const int frames = std::min(48000 - first, kPartitions[part % kPartitions.size()]);
+        const QByteArray input24 = tone(24000, first, frames);
+        df24Concurrent.append(concurrentDf24.process(input24));
+        nv24Concurrent.append(concurrentNv24.process(input24));
+        concurrentDf48.process(tone(48000, first * 2, frames * 2));
+        concurrentNv48.process(tone(48000, first * 2, frames * 2));
+        first += frames;
+    }
+    check(df24Concurrent == baselineDf, "concurrent48 leaves DFNR24 output unchanged");
+    check(nv24Concurrent == baselineNv, "concurrent48 leaves NVIDIA24 output unchanged");
+    if (createdFixture) {
+        QFile::remove(fixture);
+    }
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/nr_test_df_api.cpp
+++ b/tests/nr_test_df_api.cpp
@@ -1,0 +1,34 @@
+// Link-time C API substitute. It preserves DFN3's documented three-hop
+// latency but performs only a half-gain transfer function, not inference.
+#include "deep_filter.h"
+#include <array>
+#include <memory>
+
+struct DFState {
+    std::array<float, 1440> delay{};
+    int cursor{0};
+};
+namespace { unsigned g_samples{0}; }
+
+extern "C" DFState* df_create(const char*, float, const char*)
+{
+    return std::make_unique<DFState>().release();
+}
+extern "C" uintptr_t df_get_frame_length(DFState*) { return 480; }
+extern "C" void df_set_atten_lim(DFState*, float) {}
+extern "C" void df_set_post_filter_beta(DFState*, float) {}
+extern "C" float df_process_frame(DFState* state, float* input, float* output)
+{
+    for (int index = 0; index < 480; ++index) {
+        output[index] = state->delay[state->cursor] * 0.5f;
+        state->delay[state->cursor] = input[index];
+        state->cursor = (state->cursor + 1) % 1440;
+    }
+    g_samples += 480;
+    return 0.0f;
+}
+extern "C" void df_free(DFState* state)
+{
+    const std::unique_ptr<DFState> owned(state);
+}
+unsigned aetherTestDfProcessedSamples() { return g_samples; }

--- a/tests/nr_test_nvafx_api.cpp
+++ b/tests/nr_test_nvafx_api.cpp
@@ -1,0 +1,58 @@
+// Socket-free algorithm substitute for wrapper tests. This is a half-gain
+// transfer function, not NVIDIA inference or hardware qualification.
+#include <algorithm>
+#include <cstring>
+#include <memory>
+
+#if defined(_WIN32)
+#define TEST_EXPORT extern "C" __declspec(dllexport)
+#else
+#define TEST_EXPORT extern "C" __attribute__((visibility("default")))
+#endif
+
+namespace {
+struct State { unsigned rate{0}; };
+unsigned g_samples{0};
+}
+
+TEST_EXPORT int NvAFX_CreateEffect(const char*, void** handle)
+{
+    *handle = std::make_unique<State>().release();
+    return 0;
+}
+TEST_EXPORT int NvAFX_DestroyEffect(void* handle)
+{
+    const std::unique_ptr<State> state(static_cast<State*>(handle));
+    return 0;
+}
+TEST_EXPORT int NvAFX_SetU32(void* handle, const char* key, unsigned value)
+{
+    if (std::strcmp(key, "input_sample_rate") == 0) {
+        static_cast<State*>(handle)->rate = value;
+    }
+    return 0;
+}
+TEST_EXPORT int NvAFX_SetString(void*, const char*, const char*) { return 0; }
+TEST_EXPORT int NvAFX_SetFloat(void*, const char*, float) { return 0; }
+TEST_EXPORT int NvAFX_GetU32(void*, const char*, unsigned* value)
+{
+    *value = 480;
+    return 0;
+}
+TEST_EXPORT int NvAFX_Load(void* handle)
+{
+    return static_cast<State*>(handle)->rate == 48000 ? 0 : 1;
+}
+TEST_EXPORT int NvAFX_Run(void*, const float** input, float** output,
+                          unsigned samples, unsigned channels)
+{
+    if (samples != 480 || channels != 1) {
+        return 1;
+    }
+    for (unsigned index = 0; index < samples; ++index) {
+        output[0][index] = input[0][index] * 0.5f;
+    }
+    g_samples += samples;
+    return 0;
+}
+TEST_EXPORT unsigned aetherTestProcessedSamples() { return g_samples; }

--- a/tests/specbleach_rate_domain_test.cpp
+++ b/tests/specbleach_rate_domain_test.cpp
@@ -1,0 +1,143 @@
+// Real bundled libspecbleach, no radio, device, network, or model fixture.
+#include "core/SpecbleachFilter.h"
+#include <specbleach_denoiser.h>
+#include <QByteArray>
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <numbers>
+#include <memory>
+#include <vector>
+
+namespace {
+int g_failures{0};
+void check(bool condition, const char* message)
+{
+    std::printf("%s %s\n", condition ? "PASS" : "FAIL", message);
+    if (!condition) {
+        ++g_failures;
+    }
+}
+
+QByteArray inputBlock(int rate, int start, bool noise)
+{
+    const int frames = rate / 100;
+    QByteArray result(frames * 2 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
+    auto* samples = reinterpret_cast<float*>(result.data());
+    uint32_t state = static_cast<uint32_t>(start) + 17;
+    for (int frame = 0; frame < frames; ++frame) {
+        state = state * 1664525u + 1013904223u;
+        const float value = noise
+            ? 0.2f * (static_cast<float>(state >> 8) / 8388608.0f - 1.0f)
+            : 0.2f * std::sin(2.0 * std::numbers::pi * 16000.0 * (start + frame) / rate);
+        samples[2 * frame] = value;
+        samples[2 * frame + 1] = value;
+    }
+    return result;
+}
+
+void checkRate(int rate)
+{
+    AetherSDR::SpecbleachFilter filter(rate);
+    check(filter.isValid() && filter.sampleRate() == rate, "supported specbleach domain initializes");
+    double inputPower = 0;
+    double outputPower = 0;
+    bool valid = filter.isValid();
+    for (int start = 0; start < rate * 4; start += rate / 100) {
+        const QByteArray input = inputBlock(rate, start, true);
+        const QByteArray output = filter.process(input);
+        if (output.size() != input.size()) {
+            valid = false;
+            break;
+        }
+        if (start < rate * 2) {
+            continue;
+        }
+        const auto* in = reinterpret_cast<const float*>(input.constData());
+        const auto* out = reinterpret_cast<const float*>(output.constData());
+        for (int sample = 0; sample < input.size() / static_cast<int>(sizeof(float)); ++sample) {
+            valid = valid && std::isfinite(out[sample]);
+            inputPower += in[sample] * in[sample];
+            outputPower += out[sample] * out[sample];
+        }
+    }
+    const double gain = std::sqrt(outputPower / std::max(inputPower, 1e-20));
+    std::printf("rate=%d stationary-noise amplitude ratio=%.6f\n", rate, gain);
+    check(valid && gain > 0.01 && gain < 0.95, "real enabled algorithm suppresses noise with finite equal-length output");
+}
+
+void checkNativeLibraryContract()
+{
+    // Independently configure the published C API at48000. With duplicated
+    // mono and zero reduction, its output must equal the wrapper after the
+    // wrapper's existing 25-packet learning period.
+    const std::unique_ptr<void, decltype(&specbleach_free)> reference(
+        specbleach_initialize(48000, 40.0f), specbleach_free);
+    SpectralBleachDenoiserParameters params{};
+    params.adaptive_noise = 1;
+    params.masking_depth = 0.5f;
+    params.suppression_strength = 0.5f;
+    if (!reference || !specbleach_load_parameters(reference.get(), params)) {
+        check(false, "reference libspecbleach initializes");
+        return;
+    }
+    AetherSDR::SpecbleachFilter wrapper(48000);
+    wrapper.setReductionAmount(0);
+    std::vector<float> mono(480);
+    std::vector<float> output(480);
+    double maxError = 0;
+    for (int packet = 0; packet < 200; ++packet) {
+        const QByteArray input = inputBlock(48000, packet * 480, true);
+        const auto* stereo = reinterpret_cast<const float*>(input.constData());
+        for (int frame = 0; frame < 480; ++frame) {
+            mono[frame] = stereo[2 * frame];
+        }
+        specbleach_process(reference.get(), 480, mono.data(), output.data());
+        const QByteArray wrapped = wrapper.process(input);
+        const auto* actual = reinterpret_cast<const float*>(wrapped.constData());
+        if (packet >= 25) {
+            for (int frame = 0; frame < 480; ++frame) {
+                maxError = std::max(maxError, std::abs(static_cast<double>(
+                    actual[2 * frame] - output[frame])));
+            }
+        }
+    }
+    check(maxError < 1e-7, "wrapper output agrees with independently configured48000 C API");
+}
+}
+
+int main()
+{
+    AetherSDR::SpecbleachFilter invalid(44100);
+    check(!invalid.isValid(), "unsupported specbleach domain fails initialization");
+    AetherSDR::SpecbleachFilter legacy;
+    AetherSDR::SpecbleachFilter explicit24(24000);
+    bool equal = true;
+    for (int start = 0; start < 72000; start += 240) {
+        const QByteArray input = inputBlock(24000, start, true);
+        equal = equal && legacy.process(input) == explicit24.process(input);
+    }
+    check(equal, "default and explicit24 preserve identical output");
+    checkRate(24000);
+    checkRate(48000);
+    checkNativeLibraryContract();
+    AetherSDR::SpecbleachFilter native48(48000);
+    native48.setReductionAmount(0);
+    double power = 0;
+    int frames = 0;
+    for (int start = 0; start < 144000; start += 480) {
+        const QByteArray result = native48.process(inputBlock(48000, start, false));
+        if (start < 96000) {
+            continue;
+        }
+        const auto* values = reinterpret_cast<const float*>(result.constData());
+        for (int frame = 0; frame < result.size() / (2 * static_cast<int>(sizeof(float))); ++frame) {
+            power += values[2 * frame] * values[2 * frame];
+            ++frames;
+        }
+    }
+    check(frames > 0 && std::abs(std::sqrt(power / frames) - 0.141421356) < 0.003,
+          "native48 preserves16k at zero reduction");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -2031,6 +2031,48 @@ target_include_directories(mono_dsp_stereo_adapter_test PRIVATE src)
 target_link_libraries(mono_dsp_stereo_adapter_test PRIVATE Qt6::Core)
 add_test(NAME mono_dsp_stereo_adapter_test COMMAND mono_dsp_stereo_adapter_test)
 
+# Socket/device-free tests of the real optional wrappers. The local C API
+# substitutes only apply half-gain and expose sample counts; these tests do
+# not load a downloaded model, SDK pack or GPU and do not claim inference.
+add_library(nr_test_nvafx_api SHARED tests/nr_test_nvafx_api.cpp)
+set_target_properties(nr_test_nvafx_api PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+add_executable(nr_rate_domain_test
+    tests/nr_rate_domain_test.cpp
+    tests/nr_test_df_api.cpp
+    src/core/DeepFilterFilter.cpp
+    src/core/NvidiaAfxFilter.cpp
+    src/core/MonoDspStereoAdapter.cpp
+    src/core/Resampler.cpp
+)
+target_compile_definitions(nr_rate_domain_test PRIVATE HAVE_DFNR HAVE_NVIDIA_AFX)
+target_include_directories(nr_rate_domain_test PRIVATE
+    src third_party/deepfilter/include third_party/r8brain)
+target_link_libraries(nr_rate_domain_test PRIVATE Qt6::Core ${CMAKE_DL_LIBS})
+set_target_properties(nr_rate_domain_test PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/nr-rate-domain-tests")
+add_dependencies(nr_rate_domain_test nr_test_nvafx_api)
+add_test(NAME nr_rate_domain_test
+    COMMAND nr_rate_domain_test $<TARGET_FILE:nr_test_nvafx_api>)
+
+if(ENABLE_SPECBLEACH)
+    add_executable(specbleach_rate_domain_test
+        tests/specbleach_rate_domain_test.cpp
+        src/core/SpecbleachFilter.cpp
+        src/core/MonoDspStereoAdapter.cpp
+        ${SPECBLEACH_SOURCES}
+    )
+    target_compile_definitions(specbleach_rate_domain_test PRIVATE HAVE_SPECBLEACH)
+    target_include_directories(specbleach_rate_domain_test PRIVATE src
+        third_party/libspecbleach/include third_party/libspecbleach/src
+        ${FFTW3_INCLUDE_DIRS} ${FFTW3_H_DIR})
+    target_link_libraries(specbleach_rate_domain_test PRIVATE Qt6::Core ${FFTW3F_LIB})
+    if(MSVC AND SPECBLEACH_STATIC_LIB)
+        add_dependencies(specbleach_rate_domain_test specbleach_build)
+        target_link_libraries(specbleach_rate_domain_test PRIVATE ${SPECBLEACH_STATIC_LIB})
+    endif()
+    add_test(NAME specbleach_rate_domain_test COMMAND specbleach_rate_domain_test)
+endif()
+
 # tests/TestEventLoop.h is test infrastructure that makes correctness claims, so
 # it carries its own proof — including a negative case that pins the #4693
 # iteration-count idiom as genuinely broken, so the trap cannot quietly stop


### PR DESCRIPTION
Prepare optional RX noise filters for RFC #5468 A2: 48 kHz producer audio stays in that processing domain through DeepFilterNet, NVIDIA AFX, Specbleach and macOS MNR. Existing 24 kHz constructor defaults retain their conversion/processing contracts. The stereo adapter scales latency, envelope timing and queue bounds to its immutable producer rate.

**Signed linear stack #5608:** main `3b3312eb` → A1 `65e20686` (#5598) → NR `c50f9853` (#5604) → A2 `a9d9794b` (#5605). This PR targets `codex/rtl-pcm-contract`.

The rebase preserves the exact 18-file prerequisite delta and adds no feature change. Its complete tree matches the independent current-main/published-prerequisite reference. Each layer has one signed feature commit; upstream history, original author/date/message metadata and the full parent changes are retained. Former base/validation statements in retained commit messages are historical.

## Change

Each source owns its filter. Strict NVIDIA/Specbleach epoch changes require wrapper replacement; DFNR reset recreates model state. DFNR/NVIDIA retain their existing mono algorithm and stereo-balance limitation. The [rate-domain contract](https://github.com/aethersdr/AetherSDR/blob/99e00b0db0c87cb36f52d93fdb5bce65046ed090/docs/noise-filter-rate-domains.md) records lifecycle obligations and unavailable-platform behavior.

This prerequisite contains no AudioEngine routing or producer/device selection. It adds no dependency, setting, socket test or frozen CI-gate entry. RTL48 production and multi-receiver runtime remain disabled; A3 recording, A4 TCI and A5 decoder/clock remain separate. Principle XI is exercised through rate counts, bandwidth, queue/reset behavior, source independence and production mutations.

## New-head validation

Each result identifies its executed revision; integrated A2 results are explicitly distinguished from this prerequisite head. All seven current checks passed under native-stack trunk `main`. Local and GitHub signature verification passed; actual tested revisions are recorded below.

| Evidence | Result |
|---|---|
| Integrated Mac wrapper coverage | Four wrapper tests pass within A2 `011c2bf2715bca8018053be8bac5d267f29d569b`’s 37/37 run: stereo adapter, NR rate domain, Specbleach rate domain and macOS MNR. No standalone local execution of this new NR head is claimed. |
| GitHub signature and observed applicable checks, with tested refs | PASS; GitHub Verified and 7/7 current checks successful: [Code Quality: PR #5604](https://github.com/aethersdr/AetherSDR/actions/runs/34685207239), [Static Checks](https://github.com/aethersdr/AetherSDR/actions/runs/34685209275), [CI](https://github.com/aethersdr/AetherSDR/actions/runs/34685209264). Repository CI/static jobs checked out [`797ccfa3`](https://github.com/aethersdr/AetherSDR/commit/797ccfa325cb15c712a455244861e88659b6619f), whose tree equals this signed head; dynamic Code Quality checked out the exact head. Superseded auto-cancelled runs are excluded. |

Integrated Linux/build/sanitizer results belong to the exact A2 head reported in #5605. They must not be described as standalone executions of this prerequisite head.

## Historical evidence and limits

Earlier prerequisite head `c30bf2d28b905e84aef66aef9a7707b34b7b29c7` built all four wrapper targets on Mac and passed 4/4 focused tests. Earlier integrated A2 `bab557c5c2d2fea207c1c02927b5325a021e799f` passed Mac and full Nobara builds, the unfiltered software suite, ASan/UBSan and bounded instrumented-Qt TSan; exact counts and limits are recorded in #5605. These are historical results, not new-head execution.

Original prerequisite `eaeb192863c32c43c83e74194ba2fa4f2622d995` passed 4/4 Mac native and 4/4 ASan/UBSan tests, caught five rate-domain mutations, and passed after restoration. Recorded prerequisite source/test bytes remain unchanged. Bundled Specbleach and Apple MNR tests run real algorithms. Standalone DFNR/NVIDIA wrapper tests use explicit half-gain C API substitutes and establish wrapper behavior only. Integrated Linux evidence used the real cached DFNR model; NVIDIA GPU inference remains untested. Apple leak detection is unsupported.

Historical Mac builds lacked librtlsdr and Darwin DFNR. Native Nobara enabled RTL/RADE/DFNR/ASR CPU+Vulkan; sanitizer lanes disabled ASR. The private-state, isolated network/device harness had explicit hardware/platform/GL skips and missing inference fixtures; system/prebuilt libraries were not all instrumented. New-head integrated build options and skips are recorded in #5605.

No audible playback, native sink negotiation/reset, Windows runtime/native Linux ARM qualification, sustained latency/load or live radio/RF/TX is claimed. Native Flex slice-0 qualification requires separate authorization. The [#5554 §2.6 whole audio-track exit/sign-off](https://github.com/aethersdr/AetherSDR/issues/5554#issuecomment-5642853284) remains outstanding for producer/paired-route retirement, per-slice/DAX/pre-mute semantics and bounded latest-frame-wins queues. This prerequisite does not establish that exit. Independent review and applicable CODEOWNERS approval remain required; no merge is requested.

73, Ozy **K6OZY** · GPT-6 Astra-Ultra

---

## Review fixes applied (2026-09-12)

Review feedback on this stack was addressed directly on the branches; the layers
were rebased so the stack stays linear and each layer still carries its original
feature commit with its original author, date and message. The evidence tables
below describe the **pre-review-fix** heads and are retained as history; the
current heads were rebuilt and retested on Arch/GCC 16 as recorded here.

**Nit — the stereo adapter duplicated its own constants.**
`MonoDspStereoAdapter` kept `4.0e-5f` and `0.006f` as member defaults in the
header, duplicating `kBalanceEnvelopeCoeff` and `kMonoObservabilityEnvelopeCoeff`
in the `.cpp`. The 24 kHz path is bit-identical only while those agree, and the
constructor overwrote them on the 48 kHz branch alone — so retuning a constant
would have moved 48 kHz while leaving 24 kHz on the stale literal, invisibly.
All three members are now initialised in the constructor's init list from the
named constants, via a helper that states the half-step identity it implements:
`(1 - a')^2 = 1 - a`. `m_balancePowerFloor` uses the expression
`kBalancePowerFloor` is itself defined by rather than special-casing 24 kHz;
both branches of the old ternary already evaluated to the same value.

**Note on a comment correction carried in the original commit.** `MacNRFilter`'s
priming comment changed from "latency is exactly one hop (H samples, ~10.7 ms at
24 kHz)" to "the existing one-frame delay (~21.3 ms)". The code is unchanged —
it primes with `m_fftSize` zeros, i.e. one frame — so the new comment is the
accurate one. Flagging it so it does not read as a behaviour change.

**The 48 kHz rescale is now pinned.** It was the only genuinely new numerical
logic here and nothing exercised it: every existing balance test builds the
adapter at the default 24 kHz, and both wrapper tests feed identical L and R, so
the balance coefficients were never read at 48 kHz. A steady-state ratio
assertion would not have closed it either — `m_leftPower` and `m_rightPower`
share a coefficient and a zero initial condition, so their ratio is correct from
the first sample at any coefficient. Tracking *speed* is what the coefficient
governs, so the new case converges the balance, flips L/R, and compares how far
the envelope travels in the same 0.25 s at 24 and 48 kHz; deleting the rescale
makes them diverge. `MacNRFilter.h`'s buffer annotations were also refreshed —
they still read `[N]`, `[H]` and `[NBINS]` after this change replaced those
constants with members.

**Current-head evidence. Clean build, `422/422` CTests pass with the documented
three skips, including `nr_rate_domain_test`, `specbleach_rate_domain_test` and
`mono_dsp_stereo_adapter_test`. `mac_nr_filter_test` is macOS-only and is not
registered on Linux, so it was not executed here.

