### PR TITLE
RFC #5468 A2: rate-aware AudioEngine queueing, processing and output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -800,6 +800,7 @@ set(CORE_SOURCES
     src/core/AudioOutputRouter.cpp
     src/core/AetherDspModePolicy.cpp
     src/core/SharedCapturePolicy.cpp
+    src/core/RxClientEffects.cpp
     src/core/AudioEngine.cpp
     src/core/TxCaptureBuffer.cpp
     src/core/TxMicChannelNormalizer.cpp

--- a/docs/audio-engine-rate-domains.md
+++ b/docs/audio-engine-rate-domains.md
@@ -1,0 +1,89 @@
+# AudioEngine RX rate domains (RFC #5468 A2)
+
+The typed speaker route accepts 24 or 48 kHz producer PCM. The negotiated
+device format remains independent: `m_rxProducerRate` describes main input;
+`m_rxOutputRate` describes device output. `DEFAULT_SAMPLE_RATE` stays 24000.
+Legacy byte input and every Kiwi auxiliary route retain 24 kHz stereo.
+
+## Queues and processing
+
+Raw queues and whole NR2 packets count time in their producer domain. Each
+source's processed output FIFO counts time in the device domain. Presentation
+delays, input caps and output-to-input conversions use the appropriate rate.
+Main and auxiliary sources each own left/right output converters; conversion
+preserves channel separation, and equal-rate output needs no converter.
+
+Aggregate diagnostics retain the actual queued-byte count and separately sum
+durations in each queue's domain, including every auxiliary source and RADE.
+The duration peak is tracked independently of the byte peak, so a later rate
+change cannot reinterpret historical storage as a different elapsed duration.
+This is summed application queue occupancy, not end-to-end playback latency;
+the device queue remains a separate measurement.
+
+Main client EQ, gate, compressor, de-esser, tube and PUDU prepare at the main
+producer rate. Each Kiwi source has independent 24 kHz client-effect history.
+The existing main objects remain the UI parameter owners; auxiliary objects
+copy atomic parameter values without copying processing history. Concurrent
+sources never alternate through the same stateful processor. The RX EQ
+analyzer uses main input when a typed main source is present, otherwise Kiwi,
+so a single analysis window never combines different sample clocks.
+
+Noise filters follow the producer domain, including the optional wrappers
+described in [noise-filter-rate-domains.md](noise-filter-rate-domains.md).
+RNNoise uses its existing native 48 kHz stereo entrypoint. For noise-reduction
+algorithms compiled for the platform, missing or invalid selected processing
+withholds that source, and preparation failures are reported. A2 leaves
+unavailable-platform setter behavior, including non-macOS MNR, unchanged.
+Heavy preparation occurs on the engine owner or the existing auxiliary
+initialization worker, outside the device callback. This change does not
+establish real-time preparation latency.
+
+## Epochs and transitions
+
+The retained typed frame carries its producer's revocable lease. The ingress
+gate rejects malformed, obsolete, duplicate and replayed frames. One active
+speaker producer owns main playback; a distinct producer cannot replace it
+until the old lease is revoked. An auxiliary producer has one registered route;
+queued frames cannot recreate a removed route or feed multiple profile IDs.
+The compatibility byte feed cannot duplicate a live typed speaker feed.
+
+A format change, new epoch, discontinuity or replacement clears that source's
+raw/packet/output queues, converters and processing history before admission.
+Main optional filters are reconstructed with their settings; auxiliary
+Specbleach and NVIDIA objects are reconstructed because their ordinary reset
+does not promise complete algorithm-state retirement. Mute/disable also clears
+auxiliary client-effect and converter history. A device format change clears
+all device-domain queues and converters while preserving producer domains.
+
+Retirement runs on ingress where needed, on the speaker timer and immediately
+before device submission. Invalid sources lose their admitted application
+queues. Already submitted device audio is a mixed stream, so `QAudioSink::reset`
+flushes the complete short device queue and restarts it; other sources retain
+their application FIFOs. If revocation is observed after a mixed chunk was
+prepared, that chunk is discarded. This is bounded polling at the audio drain,
+not a claim that physical output can be recalled at the exact revocation instant.
+
+## Fixed contracts and scope
+
+CW decoder/sidetone conversion and decoded RADE speech keep their existing
+fixed-rate contracts. RADE output converts from 24 kHz to the device rate,
+independently of the main producer. TX admission, cancellation and deferred
+release continue through the inherited #5591 coordinator and wiring.
+
+The new RTL 48 kHz producer and multi-receiver runtime remain disabled.
+Recording/container changes (A3), TCI conversion (A4), and decoder/clock
+conversion (A5) remain separate; accepting test-injected speaker48 PCM does
+not qualify those consumers for a live 48 kHz producer.
+
+## Software evidence
+
+`audio_engine_rates_test` drives production ingress, queueing, effect processing
+and drain into a `QBuffer`. It covers the 24/48-to-24/44.1/48 matrix, stereo and
+frequency content, legacy equivalence, bounded queues, transitions, stale
+frames, concurrent Kiwi/effects and fixed CW/RADE domains. Optional unavailable
+algorithms are explicitly skipped. `pcm_compatibility_test` exercises actual
+backend/model routing. `audio_engine_pcm_lifetime_test` overlaps auxiliary
+ingress/retirement with the production DSP initializer; its race claim requires
+instrumented-Qt TSan. These tests open no audio device, radio transport or socket.
+They do not establish audible playback, native device negotiation/reset behavior,
+physical RX/TX, sustained performance or RF bandwidth.

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -1,4 +1,6 @@
 #include "AudioEngine.h"
+#include "RxClientEffects.h"
+#include <QSignalBlocker>
 #include "core/backends/RadioCapabilities.h"
 #include "AppSettings.h"
 #include "AudioSummaryLogger.h"
@@ -204,14 +206,15 @@ qsizetype audioBytesForMsAtRate(int sampleRate, int ms)
         * static_cast<qsizetype>(sizeof(float)) * ms / 1000);
 }
 
-qsizetype rawEquivalentAudioBytes(qsizetype bytes, int sampleRate)
+qsizetype rawEquivalentAudioBytes(qsizetype bytes, int sampleRate,
+                                  int producerRate = AudioEngine::DEFAULT_SAMPLE_RATE)
 {
     if (bytes <= 0 || sampleRate <= 0) {
         return 0;
     }
 
     return alignedStereoFloatBytes(
-        bytes * AudioEngine::DEFAULT_SAMPLE_RATE / sampleRate);
+        bytes * producerRate / sampleRate);
 }
 
 qsizetype quietStereoFloatTrimPoint(const QByteArray& buffer,
@@ -296,13 +299,14 @@ void trimReceivePresentationBuffers(QByteArray& rawBuffer,
                                     std::deque<QByteArray>& rawPackets,
                                     QByteArray& outputBuffer,
                                     int outputRate,
-                                    qsizetype targetRawBytes)
+                                    qsizetype targetRawBytes,
+                                    int producerRate = AudioEngine::DEFAULT_SAMPLE_RATE)
 {
     targetRawBytes = alignedStereoFloatBytes(targetRawBytes);
     const auto totalRawBytes = [&]() {
         return alignedStereoFloatBytes(rawBuffer.size())
                + queuedAudioBytes(rawPackets)
-               + rawEquivalentAudioBytes(outputBuffer.size(), outputRate);
+               + rawEquivalentAudioBytes(outputBuffer.size(), outputRate, producerRate);
     };
 
     qsizetype excessRawBytes = totalRawBytes() - targetRawBytes;
@@ -315,7 +319,7 @@ void trimReceivePresentationBuffers(QByteArray& rawBuffer,
             outputRate > 0
                 ? alignedStereoFloatBytes(
                       excessRawBytes * outputRate
-                      / AudioEngine::DEFAULT_SAMPLE_RATE)
+                      / producerRate)
                 : excessRawBytes;
         dropAudioBufferFront(outputBuffer, outputDropBytes, outputRate);
         excessRawBytes = totalRawBytes() - targetRawBytes;
@@ -323,7 +327,7 @@ void trimReceivePresentationBuffers(QByteArray& rawBuffer,
 
     if (excessRawBytes > 0 && !rawBuffer.isEmpty()) {
         dropAudioBufferFront(rawBuffer, excessRawBytes,
-                             AudioEngine::DEFAULT_SAMPLE_RATE);
+                             producerRate);
         excessRawBytes = totalRawBytes() - targetRawBytes;
     }
 
@@ -333,7 +337,7 @@ void trimReceivePresentationBuffers(QByteArray& rawBuffer,
                 0,
                 targetRawBytes
                     - alignedStereoFloatBytes(rawBuffer.size())
-                    - rawEquivalentAudioBytes(outputBuffer.size(), outputRate));
+                    - rawEquivalentAudioBytes(outputBuffer.size(), outputRate, producerRate));
         trimAudioPacketQueue(rawPackets, packetBudget);
     }
 }
@@ -772,6 +776,11 @@ void AudioEngine::emitTncRxTapFromFloat32Stereo(const QByteArray& pcm, int sampl
 
 void AudioEngine::updateRxBufferStats()
 {
+    const int outputRate = std::max(1, m_rxOutputRate.load());
+    const auto durationMs = [](qsizetype bytes, int rate) {
+        return static_cast<double>(bytes) * 1000.0
+            / (std::max(1, rate) * 2.0 * sizeof(float));
+    };
     const qsizetype flexRawBytes =
         m_rxBuffer.size() + queuedAudioBytes(m_rxPackets);
     const qsizetype kiwiSdrRawBytes =
@@ -781,6 +790,7 @@ void AudioEngine::updateRxBufferStats()
     qsizetype externalTotal = 0;
     qsizetype externalRawBytes = 0;
     qsizetype externalOutputBytes = 0;
+    double externalDurationMs = 0.0;
     for (const auto& source : m_externalKiwiSources) {
         if (!source) {
             continue;
@@ -789,6 +799,8 @@ void AudioEngine::updateRxBufferStats()
             source->rxBuffer.size() + queuedAudioBytes(source->rxPackets);
         const qsizetype sourceOutputBytes = source->outputBuffer.size();
         externalTotal += sourceRawBytes + sourceOutputBytes;
+        externalDurationMs += durationMs(sourceRawBytes, DEFAULT_SAMPLE_RATE)
+            + durationMs(sourceOutputBytes, outputRate);
         if (externalKiwiSourceProcessing(*source)) {
             externalRawBytes = std::max(externalRawBytes, sourceRawBytes);
             externalOutputBytes =
@@ -802,12 +814,21 @@ void AudioEngine::updateRxBufferStats()
     m_rxBufferBytes.store(total);
     m_rxBufferPeakBytes.store(std::max(m_rxBufferPeakBytes.load(), total));
 
-    const int outputRate = std::max(1, m_rxOutputRate.load());
+    // Retain the aggregate byte counter as actual storage. Durations must be
+    // summed in each queue's domain, including every concurrent source. The
+    // historical peak duration is independent of peak bytes and later rates.
+    const double totalDurationMs =
+        durationMs(flexRawBytes, m_rxProducerRate.load())
+        + durationMs(kiwiSdrRawBytes, DEFAULT_SAMPLE_RATE)
+        + durationMs(flexOutputBytes + kiwiSdrOutputBytes + m_radeRxBuffer.size(), outputRate)
+        + externalDurationMs;
+    m_rxBufferMs.store(totalDurationMs);
+    m_rxBufferPeakMs.store(std::max(m_rxBufferPeakMs.load(), totalDurationMs));
     m_receivePresentationPlaybackQueuedMs.store(
         m_rxPlaybackQueuedMs.load(std::memory_order_relaxed),
         std::memory_order_relaxed);
     m_receivePresentationFlexRawBufferMs.store(
-        audioBytesToMs(flexRawBytes, DEFAULT_SAMPLE_RATE),
+        audioBytesToMs(flexRawBytes, m_rxProducerRate.load()),
         std::memory_order_relaxed);
     m_receivePresentationFlexOutputBufferMs.store(
         audioBytesToMs(flexOutputBytes, outputRate),
@@ -888,7 +909,8 @@ void AudioEngine::setReceivePresentationDelays(
     if (flexDelay < previousFlex) {
         trimReceivePresentationBuffers(
             m_rxBuffer, m_rxPackets, m_rxOutputBuffer, outputRate,
-            audioBytesForMsAtRate(DEFAULT_SAMPLE_RATE, flexDelay));
+            audioBytesForMsAtRate(m_rxProducerRate.load(), flexDelay),
+            m_rxProducerRate.load());
     }
     if (legacyKiwiDelay < previousKiwi) {
         const qsizetype targetBytes =
@@ -1019,12 +1041,14 @@ AudioEngine::externalKiwiSource(const QString& sourceId, bool create)
         id, m_externalKiwiReceivePresentationDelaySourceId,
         m_externalKiwiReceivePresentationDelayMs);
     source->prebuffering = true;
+    source->clientEffects = std::make_unique<RxClientEffects>();
     m_externalKiwiSources.push_back(std::move(source));
     return m_externalKiwiSources.back().get();
 }
 
 std::unique_ptr<SpectralNR>
-AudioEngine::createNr2Filter(const QString& label, bool forceLegacyGeometry) const
+AudioEngine::createNr2Filter(const QString& label, bool forceLegacyGeometry,
+                            int producerRate) const
 {
     // The demo (SimBackend) delivers native 128-sample frames — exactly one hop of
     // the ORIGINAL 256/2 geometry, but only half a hop of the improved 1024/4
@@ -1037,7 +1061,7 @@ AudioEngine::createNr2Filter(const QString& label, bool forceLegacyGeometry) con
     const int fftSize = useOriginal ? kNr2OriginalFftSize : kNr2FftSize;
     const int overlap = useOriginal ? kNr2OriginalOverlap : kNr2Overlap;
     auto filter = std::make_unique<SpectralNR>(
-        fftSize, DEFAULT_SAMPLE_RATE, overlap, useOriginal);
+        fftSize * producerRate / DEFAULT_SAMPLE_RATE, producerRate, overlap, useOriginal);
     if (filter->hasPlanFailed()) {
         qCWarning(lcAudio).noquote()
             << "AudioEngine: NR2 plan creation failed for" << label;
@@ -1047,9 +1071,12 @@ AudioEngine::createNr2Filter(const QString& label, bool forceLegacyGeometry) con
 }
 
 std::unique_ptr<RNNoiseFilter>
-AudioEngine::createRn2Filter(const QString& label) const
+AudioEngine::createRn2Filter(const QString& label, int producerRate) const
 {
-    auto filter = std::make_unique<RNNoiseFilter>();
+    auto filter = std::make_unique<RNNoiseFilter>(
+        RNNoiseFilter::OutputMode::PreserveRxStereo,
+        producerRate == 48000 ? RNNoiseFilter::RateDomain::Native48k
+                              : RNNoiseFilter::RateDomain::Legacy24k);
     if (!filter->isValid()) {
         qCWarning(lcAudio).noquote()
             << "AudioEngine: RN2 rnnoise_create() failed for" << label;
@@ -1062,9 +1089,9 @@ AudioEngine::createRn2Filter(const QString& label) const
 
 #ifdef HAVE_SPECBLEACH
 std::unique_ptr<SpecbleachFilter>
-AudioEngine::createNr4Filter(const QString& label) const
+AudioEngine::createNr4Filter(const QString& label, int producerRate) const
 {
-    auto filter = std::make_unique<SpecbleachFilter>();
+    auto filter = std::make_unique<SpecbleachFilter>(producerRate);
     if (!filter->isValid()) {
         qCWarning(lcAudio).noquote()
             << "AudioEngine: NR4 initialization failed for" << label;
@@ -1076,9 +1103,9 @@ AudioEngine::createNr4Filter(const QString& label) const
 
 #ifdef __APPLE__
 std::unique_ptr<MacNRFilter>
-AudioEngine::createMnrFilter(const QString& label) const
+AudioEngine::createMnrFilter(const QString& label, int producerRate) const
 {
-    auto filter = std::make_unique<MacNRFilter>();
+    auto filter = std::make_unique<MacNRFilter>(producerRate);
     if (!filter->isValid()) {
         qCWarning(lcAudio).noquote()
             << "AudioEngine: MNR vDSP setup failed for" << label;
@@ -1091,9 +1118,9 @@ AudioEngine::createMnrFilter(const QString& label) const
 
 #ifdef HAVE_DFNR
 std::unique_ptr<DeepFilterFilter>
-AudioEngine::createDfnrFilter(const QString& label) const
+AudioEngine::createDfnrFilter(const QString& label, int producerRate) const
 {
-    auto filter = std::make_unique<DeepFilterFilter>();
+    auto filter = std::make_unique<DeepFilterFilter>(producerRate);
     if (!filter->isValid()) {
         qCWarning(lcAudio).noquote()
             << "AudioEngine: DFNR df_create() failed for" << label;
@@ -1105,9 +1132,9 @@ AudioEngine::createDfnrFilter(const QString& label) const
 
 #ifdef HAVE_NVIDIA_AFX
 std::unique_ptr<NvidiaAfxFilter>
-AudioEngine::createNvAfxFilter(const QString& label) const
+AudioEngine::createNvAfxFilter(const QString& label, int producerRate) const
 {
-    auto filter = std::make_unique<NvidiaAfxFilter>();
+    auto filter = std::make_unique<NvidiaAfxFilter>(QString(), producerRate);
     if (!filter->isValid()) {
         qCWarning(lcAudio).noquote()
             << "AudioEngine: NVIDIA AFX denoiser unavailable for" << label
@@ -1511,6 +1538,9 @@ void AudioEngine::scheduleAllKiwiDspStateInitialization()
 
 void AudioEngine::resetLegacyKiwiDspState()
 {
+    if (m_legacyKiwiClientEffects) {
+        m_legacyKiwiClientEffects->reset();
+    }
     if (m_nr2Enabled && m_kiwiSdrNr2) {
         m_kiwiSdrNr2->reset();
     }
@@ -1519,7 +1549,10 @@ void AudioEngine::resetLegacyKiwiDspState()
     }
 #ifdef HAVE_SPECBLEACH
     if (m_nr4Enabled && m_kiwiSdrNr4) {
-        m_kiwiSdrNr4->reset();
+        m_kiwiSdrNr4 = createNr4Filter(QStringLiteral("Kiwi epoch"));
+        if (m_kiwiSdrNr4) {
+            applyNr4SettingsFromAppSettings(*m_kiwiSdrNr4);
+        }
     }
 #endif
 #ifdef __APPLE__
@@ -1534,13 +1567,21 @@ void AudioEngine::resetLegacyKiwiDspState()
 #endif
 #ifdef HAVE_NVIDIA_AFX
     if (m_nvAfxEnabled && m_kiwiSdrNvAfx) {
-        m_kiwiSdrNvAfx->reset();
+        m_kiwiSdrNvAfx = createNvAfxFilter(QStringLiteral("Kiwi epoch"));
+        if (m_kiwiSdrNvAfx) {
+            m_kiwiSdrNvAfx->setIntensity(NvidiaBnrSettings::intensity());
+        }
     }
 #endif
 }
 
 void AudioEngine::clearLegacyKiwiDspState()
 {
+    m_kiwiSdrRxResampler.reset();
+    m_kiwiSdrRxResamplerR.reset();
+    if (m_legacyKiwiClientEffects) {
+        m_legacyKiwiClientEffects->reset();
+    }
     m_kiwiSdrNr2.reset();
     m_kiwiSdrNr2Output.clear();
     m_kiwiSdrRn2.reset();
@@ -1560,6 +1601,9 @@ void AudioEngine::clearLegacyKiwiDspState()
 
 void AudioEngine::resetExternalKiwiDspState(ExternalRxAudioSourceState& source)
 {
+    if (source.clientEffects) {
+        source.clientEffects->reset();
+    }
     if (m_nr2Enabled && source.nr2) {
         source.nr2->reset();
     }
@@ -1568,7 +1612,10 @@ void AudioEngine::resetExternalKiwiDspState(ExternalRxAudioSourceState& source)
     }
 #ifdef HAVE_SPECBLEACH
     if (m_nr4Enabled && source.nr4) {
-        source.nr4->reset();
+        source.nr4 = createNr4Filter(QStringLiteral("Kiwi epoch"));
+        if (source.nr4) {
+            applyNr4SettingsFromAppSettings(*source.nr4);
+        }
     }
 #endif
 #ifdef __APPLE__
@@ -1583,13 +1630,21 @@ void AudioEngine::resetExternalKiwiDspState(ExternalRxAudioSourceState& source)
 #endif
 #ifdef HAVE_NVIDIA_AFX
     if (m_nvAfxEnabled && source.nvAfx) {
-        source.nvAfx->reset();
+        source.nvAfx = createNvAfxFilter(QStringLiteral("Kiwi epoch"));
+        if (source.nvAfx) {
+            source.nvAfx->setIntensity(NvidiaBnrSettings::intensity());
+        }
     }
 #endif
 }
 
 void AudioEngine::clearExternalKiwiDspState(ExternalRxAudioSourceState& source)
 {
+    source.rxResampler.reset();
+    source.rxResamplerR.reset();
+    if (source.clientEffects) {
+        source.clientEffects->reset();
+    }
     source.nr2.reset();
     source.nr2Output.clear();
     source.rn2.reset();
@@ -1803,6 +1858,7 @@ AudioEngine::AudioEngine(QObject* parent)
 
     // RX remains radio-native at 24 kHz. TX voice is prepared below through
     // TxVoiceProcessor in its fixed 48 kHz float processing domain.
+    m_legacyKiwiClientEffects = std::make_unique<RxClientEffects>();
     m_clientEqRx->prepare(DEFAULT_SAMPLE_RATE);
     m_clientGateRx->prepare(DEFAULT_SAMPLE_RATE);
     m_clientCompRx->prepare(DEFAULT_SAMPLE_RATE);
@@ -1897,136 +1953,724 @@ AudioEngine::AudioEngine(QObject* parent)
     m_rxTimer->setTimerType(Qt::PreciseTimer);
     m_rxTimer->setInterval(10);
     connect(m_rxTimer, &QTimer::timeout, this, [this]() {
-        if (!m_audioSink || !m_audioDevice || !m_audioDevice->isOpen() || m_audioSink->state() == QAudio::StoppedState) return;
-
-        // Cap buffer to bound latency. Default 100ms, user-adjustable for
-        // high-jitter connections (VPN, SmartLink) where drops cause choppy audio.
-        const int sampleRate = m_rxOutputRate.load();
-        const bool kiwiAudio = kiwiSdrAudioActive();
-        const bool externalKiwiAudio = anyExternalKiwiAudioEnabled();
-        const bool anyKiwiAudio = kiwiAudio || externalKiwiAudio;
-        const int configuredBufMs = m_rxBufferCapMs.load();
-        const int flexPresentationDelayMs =
-            m_flexReceivePresentationDelayMs.load(std::memory_order_relaxed);
-        const int kiwiPresentationDelayMs =
-            m_kiwiReceivePresentationDelayMs.load(std::memory_order_relaxed);
-        int externalKiwiPresentationDelayMs = 0;
-        for (const auto& source : m_externalKiwiSources) {
-            if (source && externalKiwiSourceProcessing(*source)) {
-                externalKiwiPresentationDelayMs =
-                    std::max(externalKiwiPresentationDelayMs,
-                             source->presentationDelayMs);
-            }
+        retireInvalidPcmSources();
+        if (!m_audioSink || !m_audioDevice || !m_audioDevice->isOpen()
+            || m_audioSink->state() == QAudio::StoppedState) {
+            return;
         }
-        const int kiwiPresentationBufferMs =
-            anyKiwiAudio
-                ? std::max(kiwiPresentationDelayMs,
-                           externalKiwiPresentationDelayMs)
-                : 0;
-        const int presentationBufMs =
-            std::max(flexPresentationDelayMs, kiwiPresentationBufferMs);
-        const int effectiveBufMs =
-            std::max({configuredBufMs,
-                      anyKiwiAudio ? kKiwiSdrBufferCapMs : configuredBufMs,
-                      presentationBufMs > 0 ? presentationBufMs + 100 : 0});
-        const qsizetype sourceMaxBufBytes =
-            DEFAULT_SAMPLE_RATE * 2 * static_cast<qsizetype>(sizeof(float))
-            * effectiveBufMs / 1000;
-        const qsizetype outputMaxBufBytes =
-            sampleRate * 2 * static_cast<qsizetype>(sizeof(float))
-            * effectiveBufMs / 1000;
+        drainRxAudio(m_audioSink->bytesFree());
+    });
+    m_rxTimer->start();
+}
+
+// The device supplies a byte budget; the same queue, DSP and mix path can be
+// driven with an in-memory QIODevice without opening audio or radio hardware.
+void AudioEngine::drainRxAudio(qsizetype freeBytes)
+{
+    retireInvalidPcmSources();
+    if (!m_audioDevice || !m_audioDevice->isOpen()) {
+        return;
+    }
+
+    // Cap buffer to bound latency. Default 100ms, user-adjustable for
+    // high-jitter connections (VPN, SmartLink) where drops cause choppy audio.
+    const int sampleRate = m_rxOutputRate.load();
+    const bool kiwiAudio = kiwiSdrAudioActive();
+    const bool externalKiwiAudio = anyExternalKiwiAudioEnabled();
+    const bool anyKiwiAudio = kiwiAudio || externalKiwiAudio;
+    const int configuredBufMs = m_rxBufferCapMs.load();
+    const int flexPresentationDelayMs =
+        m_flexReceivePresentationDelayMs.load(std::memory_order_relaxed);
+    const int kiwiPresentationDelayMs =
+        m_kiwiReceivePresentationDelayMs.load(std::memory_order_relaxed);
+    int externalKiwiPresentationDelayMs = 0;
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && externalKiwiSourceProcessing(*source)) {
+            externalKiwiPresentationDelayMs =
+                std::max(externalKiwiPresentationDelayMs,
+                         source->presentationDelayMs);
+        }
+    }
+    const int kiwiPresentationBufferMs =
+        anyKiwiAudio
+            ? std::max(kiwiPresentationDelayMs,
+                       externalKiwiPresentationDelayMs)
+            : 0;
+    const int presentationBufMs =
+        std::max(flexPresentationDelayMs, kiwiPresentationBufferMs);
+    const int effectiveBufMs =
+        std::max({configuredBufMs,
+                  anyKiwiAudio ? kKiwiSdrBufferCapMs : configuredBufMs,
+                  presentationBufMs > 0 ? presentationBufMs + 100 : 0});
+    const qsizetype sourceMaxBufBytes =
+        DEFAULT_SAMPLE_RATE * 2 * static_cast<qsizetype>(sizeof(float))
+        * effectiveBufMs / 1000;
+    const qsizetype outputMaxBufBytes =
+        sampleRate * 2 * static_cast<qsizetype>(sizeof(float))
+        * effectiveBufMs / 1000;
+    trimReceivePresentationBuffers(
+        m_rxBuffer, m_rxPackets, m_rxOutputBuffer, sampleRate,
+        audioBytesForMsAtRate(m_rxProducerRate.load(), effectiveBufMs),
+        m_rxProducerRate.load());
+    trimReceivePresentationBuffers(
+        m_kiwiSdrRxBuffer, m_kiwiSdrRxPackets, m_kiwiSdrOutputBuffer,
+        sampleRate, sourceMaxBufBytes);
+    for (const auto& source : m_externalKiwiSources) {
+        if (!source) {
+            continue;
+        }
         trimReceivePresentationBuffers(
-            m_rxBuffer, m_rxPackets, m_rxOutputBuffer, sampleRate,
-            sourceMaxBufBytes);
-        trimReceivePresentationBuffers(
-            m_kiwiSdrRxBuffer, m_kiwiSdrRxPackets, m_kiwiSdrOutputBuffer,
+            source->rxBuffer, source->rxPackets, source->outputBuffer,
             sampleRate, sourceMaxBufBytes);
-        for (const auto& source : m_externalKiwiSources) {
-            if (!source) {
-                continue;
-            }
-            trimReceivePresentationBuffers(
-                source->rxBuffer, source->rxPackets, source->outputBuffer,
-                sampleRate, sourceMaxBufBytes);
-        }
-        if (m_radeRxBuffer.size() > outputMaxBufBytes) {
-            m_radeRxBuffer.remove(0, m_radeRxBuffer.size() - outputMaxBufBytes);
-        }
+    }
+    if (m_radeRxBuffer.size() > outputMaxBufBytes) {
+        m_radeRxBuffer.remove(0, m_radeRxBuffer.size() - outputMaxBufBytes);
+    }
 
-        const qsizetype freeBytes = m_audioSink->bytesFree();
-        if (freeBytes > 0 && m_rxBuffer.isEmpty()
-            && m_rxPackets.empty()
-            && m_kiwiSdrRxBuffer.isEmpty() && m_kiwiSdrRxPackets.empty()
-            && m_rxOutputBuffer.isEmpty()
-            && m_kiwiSdrOutputBuffer.isEmpty()
-            && m_radeRxBuffer.isEmpty()
-            && !anyExternalKiwiBufferQueued()) {
-            if (anyKiwiAudio) {
-                m_kiwiSdrPrebuffering.store(true, std::memory_order_relaxed);
-                for (const auto& source : m_externalKiwiSources) {
-                    if (source && externalKiwiSourceProcessing(*source)) {
-                        source->prebuffering = true;
-                    }
+    if (freeBytes > 0 && m_rxBuffer.isEmpty()
+        && m_rxPackets.empty()
+        && m_kiwiSdrRxBuffer.isEmpty() && m_kiwiSdrRxPackets.empty()
+        && m_rxOutputBuffer.isEmpty()
+        && m_kiwiSdrOutputBuffer.isEmpty()
+        && m_radeRxBuffer.isEmpty()
+        && !anyExternalKiwiBufferQueued()) {
+        if (anyKiwiAudio) {
+            m_kiwiSdrPrebuffering.store(true, std::memory_order_relaxed);
+            for (const auto& source : m_externalKiwiSources) {
+                if (source && externalKiwiSourceProcessing(*source)) {
+                    source->prebuffering = true;
                 }
-            } else {
-                m_rxBufferUnderrunCount.fetch_add(1);
             }
-            if (flexPresentationDelayMs > 0) {
-                m_rxPresentationPrebuffering.store(true,
-                                                   std::memory_order_relaxed);
-            }
+        } else {
+            m_rxBufferUnderrunCount.fetch_add(1);
         }
-
-        // Align to stereo float32 frame boundaries before any arithmetic.
-        const qsizetype floatBytes = static_cast<qsizetype>(sizeof(float));
-        const qsizetype frameBytes = 2 * floatBytes;
-        const qsizetype freeFrames = freeBytes / frameBytes;
-        const bool nr2PacketMode = m_nr2Enabled.load(std::memory_order_relaxed);
-        const qsizetype flexPrebufferBytes =
-            DEFAULT_SAMPLE_RATE * 2 * static_cast<qsizetype>(sizeof(float))
-            * flexPresentationDelayMs / 1000;
-        const qsizetype kiwiPresentationDelayBytes =
-            DEFAULT_SAMPLE_RATE * 2 * static_cast<qsizetype>(sizeof(float))
-            * kiwiPresentationDelayMs / 1000;
-        const auto externalKiwiPresentationDelayBytes =
-            [](const ExternalRxAudioSourceState& source) {
-                return DEFAULT_SAMPLE_RATE * 2
-                       * static_cast<qsizetype>(sizeof(float))
-                       * source.presentationDelayMs / 1000;
-            };
-        if (flexPresentationDelayMs <= 0) {
-            m_rxPresentationPrebuffering.store(false,
-                                               std::memory_order_relaxed);
-        } else if (m_rxPresentationPrebuffering.load(std::memory_order_relaxed)) {
-            const qsizetype flexQueuedBytes =
-                nr2PacketMode ? queuedAudioBytes(m_rxPackets) : m_rxBuffer.size();
-            if (flexQueuedBytes >= flexPrebufferBytes) {
-                m_rxPresentationPrebuffering.store(false,
-                                                   std::memory_order_relaxed);
-            }
-        } else if (m_rxBuffer.isEmpty() && m_rxPackets.empty()
-                   && m_rxOutputBuffer.isEmpty()) {
+        if (flexPresentationDelayMs > 0) {
             m_rxPresentationPrebuffering.store(true,
                                                std::memory_order_relaxed);
         }
-        const bool flexPresentationPrebuffering =
-            m_rxPresentationPrebuffering.load(std::memory_order_relaxed);
+    }
 
-        // Zombie sink watchdog: if we have data waiting but the sink reports
-        // zero bytes free for ~2 seconds, the WASAPI handle is likely stale
-        // (e.g. after screensaver/idle on Windows with USB audio). (#1361)
-        if (freeBytes == 0 && (!m_rxBuffer.isEmpty()
-                               || !m_rxPackets.empty()
-                               || !m_radeRxBuffer.isEmpty()
-                               || !m_kiwiSdrRxBuffer.isEmpty()
-                               || !m_kiwiSdrRxPackets.empty()
-                               || !m_rxOutputBuffer.isEmpty()
-                               || !m_kiwiSdrOutputBuffer.isEmpty()
-                               || anyExternalKiwiBufferQueued())) {
-            if (++m_rxZombieTickCount >= kZombieTickThreshold) {
-                m_rxZombieTickCount = 0;
-                qCWarning(lcAudio) << "AudioEngine: sink appears zombie (bytesFree stuck at 0 for"
-                                   << kZombieTickThreshold * 10 << "ms), restarting RX (#1361)";
+    // Align to stereo float32 frame boundaries before any arithmetic.
+    const qsizetype floatBytes = static_cast<qsizetype>(sizeof(float));
+    const qsizetype frameBytes = 2 * floatBytes;
+    const qsizetype freeFrames = freeBytes / frameBytes;
+    const bool nr2PacketMode = m_nr2Enabled.load(std::memory_order_relaxed);
+    const qsizetype flexPrebufferBytes =
+        m_rxProducerRate.load() * 2 * static_cast<qsizetype>(sizeof(float))
+        * flexPresentationDelayMs / 1000;
+    const qsizetype kiwiPresentationDelayBytes =
+        DEFAULT_SAMPLE_RATE * 2 * static_cast<qsizetype>(sizeof(float))
+        * kiwiPresentationDelayMs / 1000;
+    const auto externalKiwiPresentationDelayBytes =
+        [](const ExternalRxAudioSourceState& source) {
+            return DEFAULT_SAMPLE_RATE * 2
+                   * static_cast<qsizetype>(sizeof(float))
+                   * source.presentationDelayMs / 1000;
+        };
+    if (flexPresentationDelayMs <= 0) {
+        m_rxPresentationPrebuffering.store(false,
+                                           std::memory_order_relaxed);
+    } else if (m_rxPresentationPrebuffering.load(std::memory_order_relaxed)) {
+        const qsizetype flexQueuedBytes =
+            nr2PacketMode ? queuedAudioBytes(m_rxPackets) : m_rxBuffer.size();
+        if (flexQueuedBytes >= flexPrebufferBytes) {
+            m_rxPresentationPrebuffering.store(false,
+                                               std::memory_order_relaxed);
+        }
+    } else if (m_rxBuffer.isEmpty() && m_rxPackets.empty()
+               && m_rxOutputBuffer.isEmpty()) {
+        m_rxPresentationPrebuffering.store(true,
+                                           std::memory_order_relaxed);
+    }
+    const bool flexPresentationPrebuffering =
+        m_rxPresentationPrebuffering.load(std::memory_order_relaxed);
+
+    // Zombie sink watchdog: if we have data waiting but the sink reports
+    // zero bytes free for ~2 seconds, the WASAPI handle is likely stale
+    // (e.g. after screensaver/idle on Windows with USB audio). (#1361)
+    if (m_audioSink && freeBytes == 0 && (!m_rxBuffer.isEmpty()
+                           || !m_rxPackets.empty()
+                           || !m_radeRxBuffer.isEmpty()
+                           || !m_kiwiSdrRxBuffer.isEmpty()
+                           || !m_kiwiSdrRxPackets.empty()
+                           || !m_rxOutputBuffer.isEmpty()
+                           || !m_kiwiSdrOutputBuffer.isEmpty()
+                           || anyExternalKiwiBufferQueued())) {
+        if (++m_rxZombieTickCount >= kZombieTickThreshold) {
+            m_rxZombieTickCount = 0;
+            qCWarning(lcAudio) << "AudioEngine: sink appears zombie (bytesFree stuck at 0 for"
+                               << kZombieTickThreshold * 10 << "ms), restarting RX (#1361)";
+            QMetaObject::invokeMethod(this, [this]() {
+                if (!m_audioSink) return;
+                stopRxStream();
+                startRxStream();
+            }, Qt::QueuedConnection);
+            return;
+        }
+    } else {
+        m_rxZombieTickCount = 0;
+    }
+
+    // Audio liveness watchdog: if no audio data has arrived via
+    // feedAudioData() for ~15 seconds while the sink is still running,
+    // the audio backend may have silently stopped (CoreAudio after
+    // extended idle, or the radio stopped sending VITA-49 packets).
+    // Restart the sink to re-acquire a fresh handle. (#1411)
+    if (m_lastAudioFeedTime.isValid()
+        && m_lastAudioFeedTime.elapsed() > kAudioLivenessTimeoutMs
+        && m_rxBuffer.isEmpty()
+        && m_rxPackets.empty()
+        && m_rxOutputBuffer.isEmpty()
+        && m_radeRxBuffer.isEmpty()
+        && m_kiwiSdrOutputBuffer.isEmpty()
+        && m_kiwiSdrRxBuffer.isEmpty()
+        && m_kiwiSdrRxPackets.empty()
+        && !anyExternalKiwiBufferQueued()) {
+        qCWarning(lcAudio) << "AudioEngine: no audio data received for"
+                           << m_lastAudioFeedTime.elapsed() << "ms, restarting RX (#1411)";
+        m_lastAudioFeedTime.start();  // prevent repeated rapid restarts
+        QMetaObject::invokeMethod(this, [this]() {
+            if (!m_audioSink) return;
+            stopRxStream();
+            startRxStream();
+        }, Qt::QueuedConnection);
+        return;
+    }
+
+    if (nr2PacketMode) {
+        std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+        auto queuedRawEquivalent = [this, sampleRate](qsizetype rawBytes,
+                                                qsizetype outputBytes) {
+            return rawBytes
+                   + rawEquivalentAudioBytes(outputBytes, sampleRate, m_rxProducerRate.load());
+        };
+        while (!flexPresentationPrebuffering
+               && !m_rxPackets.empty()
+               && (m_rxOutputBuffer.size() / frameBytes) < freeFrames
+               && (flexPrebufferBytes <= 0
+                   || queuedRawEquivalent(queuedAudioBytes(m_rxPackets),
+                                         m_rxOutputBuffer.size())
+                          > flexPrebufferBytes)) {
+            QByteArray packet = std::move(m_rxPackets.front());
+            m_rxPackets.pop_front();
+            processMixedRxAudioData(packet, RxDspSource::Main);
+        }
+        while (kiwiAudio
+               && !m_kiwiSdrPrebuffering.load(std::memory_order_relaxed)
+               && !m_kiwiSdrRxPackets.empty()
+               && (m_kiwiSdrOutputBuffer.size() / frameBytes) < freeFrames
+               && queuedAudioBytes(m_kiwiSdrRxPackets)
+                      + rawEquivalentAudioBytes(m_kiwiSdrOutputBuffer.size(),
+                                                sampleRate)
+                      > kiwiPresentationDelayBytes) {
+            QByteArray packet = std::move(m_kiwiSdrRxPackets.front());
+            m_kiwiSdrRxPackets.pop_front();
+            processMixedRxAudioData(packet, RxDspSource::KiwiSdr);
+        }
+        for (const auto& source : m_externalKiwiSources) {
+            if (!source || !externalKiwiSourceProcessing(*source)) {
+                continue;
+            }
+            const qsizetype sourcePresentationDelayBytes =
+                externalKiwiPresentationDelayBytes(*source);
+            while (!source->prebuffering
+                   && !source->rxPackets.empty()
+                   && (source->outputBuffer.size() / frameBytes) < freeFrames
+                   && queuedAudioBytes(source->rxPackets)
+                          + rawEquivalentAudioBytes(source->outputBuffer.size(),
+                                                    sampleRate)
+                          > sourcePresentationDelayBytes) {
+                QByteArray packet = std::move(source->rxPackets.front());
+                source->rxPackets.pop_front();
+                processMixedRxAudioData(packet, RxDspSource::KiwiSdr, source.get());
+            }
+        }
+    }
+
+    if (kiwiAudio
+        && m_kiwiSdrPrebuffering.load(std::memory_order_relaxed)) {
+        // KiwiSDR uncompressed audio is observed as 512-sample 12 kHz
+        // blocks (~43 ms), but WebSocket delivery bunches frames with
+        // >100 ms gaps. Hold only the Kiwi jitter buffer before mixing;
+        // the normal Flex RX buffer must keep draining while Kiwi fills.
+        const int prebufferMs = std::min(
+            std::max(kKiwiSdrJitterTargetMs, kiwiPresentationDelayMs),
+            effectiveBufMs);
+        const qsizetype prebufferBytes =
+            DEFAULT_SAMPLE_RATE * 2 * static_cast<qsizetype>(sizeof(float))
+            * prebufferMs / 1000;
+        const qsizetype bufferedBytes =
+            nr2PacketMode
+                ? queuedAudioBytes(m_kiwiSdrRxPackets)
+                      + rawEquivalentAudioBytes(m_kiwiSdrOutputBuffer.size(),
+                                                sampleRate)
+                : m_kiwiSdrRxBuffer.size();
+        if (bufferedBytes >= prebufferBytes) {
+            m_kiwiSdrPrebuffering.store(false, std::memory_order_relaxed);
+        }
+    }
+    for (const auto& source : m_externalKiwiSources) {
+        if (!source || !externalKiwiSourceProcessing(*source)
+            || !source->prebuffering) {
+            continue;
+        }
+        const int prebufferMs = std::min(
+            std::max(kKiwiSdrJitterTargetMs,
+                     source->presentationDelayMs),
+            effectiveBufMs);
+        const qsizetype prebufferBytes =
+            DEFAULT_SAMPLE_RATE * 2 * static_cast<qsizetype>(sizeof(float))
+            * prebufferMs / 1000;
+        const qsizetype bufferedBytes =
+            nr2PacketMode
+                ? queuedAudioBytes(source->rxPackets)
+                      + rawEquivalentAudioBytes(source->outputBuffer.size(),
+                                                sampleRate)
+                : source->rxBuffer.size();
+        if (bufferedBytes >= prebufferBytes) {
+            source->prebuffering = false;
+        }
+    }
+
+    const bool kiwiNr2PacketMode = kiwiAudio && nr2PacketMode;
+    // Queued packets below the delay target are intentional delay growth,
+    // not an underrun; keep playback state live while the queue catches up.
+    if (kiwiNr2PacketMode
+        && !m_kiwiSdrPrebuffering.load(std::memory_order_relaxed)
+        && m_kiwiSdrOutputBuffer.isEmpty()
+        && m_kiwiSdrRxPackets.empty()) {
+        m_kiwiSdrPrebuffering.store(true, std::memory_order_relaxed);
+    }
+    const bool kiwiMixActive =
+        kiwiAudio && !kiwiNr2PacketMode
+        && !m_kiwiSdrPrebuffering.load(std::memory_order_relaxed);
+    for (const auto& source : m_externalKiwiSources) {
+        if (!source || !externalKiwiSourceProcessing(*source)
+            || source->prebuffering) {
+            continue;
+        }
+        // Same as the legacy Kiwi path: packets held for presentation delay
+        // should not flip an already-live source back into prebuffering.
+        const bool sourceEmpty =
+            nr2PacketMode
+                ? source->outputBuffer.isEmpty()
+                      && source->rxPackets.empty()
+                : source->rxBuffer.isEmpty();
+        if (sourceEmpty) {
+            source->prebuffering = true;
+        }
+    }
+    const qsizetype kiwiMixBytes =
+        kiwiMixActive
+            ? std::max<qsizetype>(
+                  0, m_kiwiSdrRxBuffer.size() - kiwiPresentationDelayBytes)
+            : 0;
+    // Fill each post-DSP FIFO independently. A prebuffered Kiwi FIFO must
+    // not make the timer skip Flex processing, otherwise Flex only leaks
+    // into the final mix when the Kiwi FIFO briefly drains.
+    const qsizetype queuedMainFrames = m_rxOutputBuffer.size() / frameBytes;
+    const qsizetype wantedMainOutputFrames =
+        freeFrames > queuedMainFrames ? freeFrames - queuedMainFrames : 0;
+    const qsizetype wantedMainNativeFrames =
+        sampleRate > 0
+            ? (wantedMainOutputFrames * m_rxProducerRate.load() + sampleRate - 1) / sampleRate
+            : wantedMainOutputFrames;
+    const qsizetype wantedMainNativeBytes = wantedMainNativeFrames * frameBytes;
+    const qsizetype availableMainBytes =
+        (!nr2PacketMode && !flexPresentationPrebuffering)
+            ? std::max<qsizetype>(0, m_rxBuffer.size() - flexPrebufferBytes)
+            : 0;
+    const qsizetype mainBytes =
+        (std::min(wantedMainNativeBytes, availableMainBytes) / frameBytes)
+        * frameBytes;
+    if (mainBytes > 0) {
+        const QByteArray mainPcm = m_rxBuffer.left(mainBytes);
+        m_rxBuffer.remove(0, mainBytes);
+        processMixedRxAudioData(mainPcm, RxDspSource::Main);
+    }
+
+    // NR2 regression guard:
+    // With NR2 enabled, Kiwi packets stay whole until this timer processes
+    // them through their Kiwi-only NR2 state into post-DSP Kiwi FIFOs.
+    // Do not chop raw Kiwi into timer-sized pieces and feed NR2 here; that
+    // reintroduced speech-correlated static. Raw Kiwi draining below is
+    // only used while NR2 is off.
+    const qsizetype queuedKiwiFrames = m_kiwiSdrOutputBuffer.size() / frameBytes;
+    const qsizetype wantedKiwiOutputFrames =
+        freeFrames > queuedKiwiFrames ? freeFrames - queuedKiwiFrames : 0;
+    const qsizetype wantedKiwiNativeFrames =
+        sampleRate > 0
+            ? (wantedKiwiOutputFrames * DEFAULT_SAMPLE_RATE) / sampleRate
+            : wantedKiwiOutputFrames;
+    const qsizetype wantedKiwiNativeBytes = wantedKiwiNativeFrames * frameBytes;
+    const qsizetype kiwiBytes =
+        (std::min(wantedKiwiNativeBytes, kiwiMixBytes) / frameBytes)
+        * frameBytes;
+    if (kiwiBytes > 0) {
+        const QByteArray kiwiPcm = m_kiwiSdrRxBuffer.left(kiwiBytes);
+        m_kiwiSdrRxBuffer.remove(0, kiwiBytes);
+        processMixedRxAudioData(kiwiPcm, RxDspSource::KiwiSdr);
+    }
+
+    // Managed Kiwi RX antennas must keep the same per-source output FIFO
+    // boundary with NR2 off as they do with NR2 on. If they are collapsed
+    // into the legacy applet Kiwi buffer here, the final mixer ignores
+    // them unless the applet-level Kiwi Audio toggle is also enabled.
+    if (!nr2PacketMode) {
+        for (const auto& source : m_externalKiwiSources) {
+            if (!source || !externalKiwiSourceProcessing(*source)
+                || source->prebuffering) {
+                continue;
+            }
+
+            const qsizetype queuedSourceFrames =
+                source->outputBuffer.size() / frameBytes;
+            const qsizetype wantedSourceOutputFrames =
+                freeFrames > queuedSourceFrames
+                    ? freeFrames - queuedSourceFrames
+                    : 0;
+            const qsizetype wantedSourceNativeFrames =
+                sampleRate > 0
+                    ? (wantedSourceOutputFrames * DEFAULT_SAMPLE_RATE) / sampleRate
+                    : wantedSourceOutputFrames;
+            const qsizetype wantedSourceNativeBytes =
+                wantedSourceNativeFrames * frameBytes;
+            const qsizetype availableSourceBytes =
+                std::max<qsizetype>(
+                    0,
+                    source->rxBuffer.size()
+                        - externalKiwiPresentationDelayBytes(*source));
+            const qsizetype sourceBytes =
+                (std::min(wantedSourceNativeBytes, availableSourceBytes)
+                 / frameBytes) * frameBytes;
+            if (sourceBytes <= 0) {
+                continue;
+            }
+
+            const QByteArray sourcePcm = source->rxBuffer.left(sourceBytes);
+            source->rxBuffer.remove(0, sourceBytes);
+            processMixedRxAudioData(
+                sourcePcm, RxDspSource::KiwiSdr, source.get());
+        }
+    }
+
+    const qsizetype kiwiOutputBytes =
+        (kiwiAudio
+         && !m_kiwiSdrPrebuffering.load(std::memory_order_relaxed))
+            ? m_kiwiSdrOutputBuffer.size()
+            : 0;
+    const qsizetype externalKiwiOutputBytes =
+        externalKiwiOutputBufferBytes();
+    const qsizetype aggregateKiwiOutputBytes =
+        std::max(kiwiOutputBytes, externalKiwiOutputBytes);
+    qsizetype len = (freeBytes / frameBytes) * frameBytes;
+    len = std::min(len, std::max({m_rxOutputBuffer.size(),
+                                  aggregateKiwiOutputBytes,
+                                  m_radeRxBuffer.size()}));
+    len = (len / frameBytes) * frameBytes;
+    if (len > 0)
+    {
+        QByteArray chunk;
+        // While the transmit gate silences every Kiwi source, pause the
+        // receive-presentation feed on BOTH sides (Flex and Kiwi), like
+        // the pre-warm-pipeline mute froze both correlator buffers. A
+        // TX-gated source's ramp-zeroed chunks (or a one-sided Flex feed
+        // against them) would pollute the GCC-PHAT delay estimate and
+        // drop the auto-assist confidence on every over. A source's gate
+        // stays held through its pending post-unkey resume hold ("Resume
+        // audio after TX delay"), so the pause must cover that window
+        // too; it lifts as soon as any source is audible through the
+        // gate (keepAudioDuringTx during TX, or a source with no pending
+        // hold after unkey).
+        const bool kiwiTxGateEngaged = kiwiSdrAudioTransmitMuted();
+        bool anyKiwiGateHeld = false;
+        bool anyKiwiAudibleThroughGate = false;
+        for (const auto& s : m_externalKiwiSources) {
+            if (!s || !externalKiwiSourceProcessing(*s)) {
+                continue;
+            }
+            const bool held = !s->keepAudioDuringTx
+                && (kiwiTxGateEngaged
+                    || !s->txResumeDeadline.hasExpired());
+            anyKiwiGateHeld = anyKiwiGateHeld || held;
+            anyKiwiAudibleThroughGate =
+                anyKiwiAudibleThroughGate || !held;
+        }
+        const bool presentationPausedForTx =
+            (kiwiTxGateEngaged || anyKiwiGateHeld)
+            && !anyKiwiAudibleThroughGate;
+        // Per-frame gate ramp step; depends only on the device rate, so
+        // compute it once for the Flex gate and every Kiwi source alike.
+        const float gateStep =
+            sampleRate > 0
+                ? 1000.0f
+                      / (static_cast<float>(kKiwiSdrTxGateRampMs)
+                         * static_cast<float>(sampleRate))
+                : 1.0f;
+        // Delayed-Flex transmit gate: with a Receive Sync delay applied,
+        // the Flex presentation buffer holds flexDelayMs of pre-key-down
+        // RX audio that would keep playing into the transmission — the
+        // radio's own TX-time zero-fill only reaches the speaker after
+        // the delay. Mirror the Kiwi design: buffers stay warm and
+        // aligned, only the mix contribution ramps. Inactive with no
+        // delay so undelayed TX monitor audio is untouched, and FDX
+        // never engages the TX mute in the first place.
+        const float flexGateTarget =
+            (kiwiTxGateEngaged && flexPresentationDelayMs > 0)
+                ? 0.0f : 1.0f;
+        bool flexGateApplied = false;
+        auto applyFlexTxGate = [this, flexGateTarget, gateStep,
+                                &flexGateApplied](QByteArray& pcm) {
+            flexGateApplied = true;
+            if (m_flexTxGateGain == 1.0f && flexGateTarget == 1.0f) {
+                return;
+            }
+            auto* samples = reinterpret_cast<float*>(pcm.data());
+            const qsizetype count =
+                pcm.size() / static_cast<qsizetype>(sizeof(float));
+            float gate = m_flexTxGateGain;
+            for (qsizetype i = 0; i + 1 < count; i += 2) {
+                if (gate < flexGateTarget) {
+                    gate = std::min(flexGateTarget, gate + gateStep);
+                } else if (gate > flexGateTarget) {
+                    gate = std::max(flexGateTarget, gate - gateStep);
+                }
+                samples[i] *= gate;
+                samples[i + 1] *= gate;
+            }
+            m_flexTxGateGain = gate;
+        };
+        auto emitOutputSource = [this, sampleRate, anyKiwiAudio](
+                                    const QString& source,
+                                    const QString& sourceId,
+                                    const QByteArray& pcm,
+                                    bool txGated = false) {
+            if (!pcm.isEmpty()) {
+                captureAutomationAudio(QStringLiteral("output"), source,
+                                       sourceId, pcm, sampleRate, 2);
+                if (!anyKiwiAudio || txGated) {
+                    m_receivePresentationOutputSignalSuppressedCount
+                        .fetch_add(1, std::memory_order_relaxed);
+                    return;
+                }
+
+                m_receivePresentationOutputSignalEmitCount.fetch_add(
+                    1, std::memory_order_relaxed);
+                emit receivePresentationOutputAudioReady(
+                    source, sourceId, pcm, sampleRate);
+            }
+        };
+        if (m_radeRxBuffer.isEmpty() && aggregateKiwiOutputBytes <= 0) {
+            // Fast path: no decoded overlay active -- write the
+            // already-processed RX output directly.
+            chunk = m_rxOutputBuffer.left(len);
+            m_rxOutputBuffer.remove(0, chunk.size());
+            applyFlexTxGate(chunk);
+            emitOutputSource(QStringLiteral("flex"), QString(), chunk,
+                             presentationPausedForTx);
+        } else if (m_rxOutputBuffer.isEmpty() && m_radeRxBuffer.isEmpty()
+                   && kiwiOutputBytes > 0 && externalKiwiOutputBytes <= 0) {
+            // Fast path: only Kiwi decoded audio is active.
+            chunk = m_kiwiSdrOutputBuffer.left(len);
+            m_kiwiSdrOutputBuffer.remove(0, chunk.size());
+            emitOutputSource(QStringLiteral("kiwi"), QString(), chunk,
+                             presentationPausedForTx);
+        } else {
+            // Mix path: add post-DSP Flex, every post-DSP Kiwi stream,
+            // and decoded RADE sample-wise at the output device rate.
+            chunk = QByteArray(len, '\0');
+            auto* out = reinterpret_cast<float*>(chunk.data());
+            int activeOutputSources = 0;
+            constexpr float kOutputSilenceThreshold = 1.0e-6f;
+
+            const qsizetype rxTake =
+                (std::min(len, m_rxOutputBuffer.size()) / floatBytes)
+                * floatBytes;
+            if (rxTake > 0) {
+                QByteArray rxChunk = m_rxOutputBuffer.left(rxTake);
+                applyFlexTxGate(rxChunk);
+                const auto* rx =
+                    reinterpret_cast<const float*>(rxChunk.constData());
+                const qsizetype rxSamples = rxTake / floatBytes;
+                bool sourceActive = false;
+                for (qsizetype i = 0; i < rxSamples; ++i) {
+                    sourceActive = sourceActive
+                        || std::fabs(rx[i]) > kOutputSilenceThreshold;
+                    out[i] += rx[i];
+                }
+                if (sourceActive) {
+                    ++activeOutputSources;
+                }
+                m_rxOutputBuffer.remove(0, rxTake);
+                emitOutputSource(QStringLiteral("flex"), QString(), rxChunk,
+                                 presentationPausedForTx);
+            }
+
+            const qsizetype kiwiTake =
+                (std::min(len, kiwiOutputBytes) / floatBytes)
+                * floatBytes;
+            if (kiwiTake > 0) {
+                const QByteArray kiwiChunk =
+                    m_kiwiSdrOutputBuffer.left(kiwiTake);
+                const auto* kiwi =
+                    reinterpret_cast<const float*>(kiwiChunk.constData());
+                const qsizetype kiwiSamples = kiwiTake / floatBytes;
+                bool sourceActive = false;
+                for (qsizetype i = 0; i < kiwiSamples; ++i) {
+                    sourceActive = sourceActive
+                        || std::fabs(kiwi[i]) > kOutputSilenceThreshold;
+                    out[i] += kiwi[i];
+                }
+                if (sourceActive) {
+                    ++activeOutputSources;
+                }
+                m_kiwiSdrOutputBuffer.remove(0, kiwiTake);
+                emitOutputSource(QStringLiteral("kiwi"), QString(), kiwiChunk,
+                                 presentationPausedForTx);
+            }
+
+            for (const auto& source : m_externalKiwiSources) {
+                if (!source) {
+                    continue;
+                }
+                // Transmit gate: the source keeps draining at real-time
+                // rate through TX so playback rejoins the live stream at
+                // unkey; only its mix contribution ramps to zero. The
+                // short ramp avoids a hard-mute click on both edges. A
+                // pending resume deadline extends the hold past unkey
+                // ("Resume audio after TX delay").
+                const bool gateOpen = source->keepAudioDuringTx
+                    || (!kiwiSdrAudioTransmitMuted()
+                        && source->txResumeDeadline.hasExpired());
+                const float gateTarget = gateOpen ? 1.0f : 0.0f;
+                if (!externalKiwiSourceProcessing(*source)
+                    || source->prebuffering) {
+                    // Silent while skipped: snap the gate DOWNWARD only —
+                    // a dry tick or prebuffer stretch spanning the unkey
+                    // edge holds the gate and finishes the up-ramp on
+                    // the next tick with data instead of hard-stepping
+                    // to full amplitude. Mid-TX entry with a stale
+                    // full-gain gate is closed at the source setters
+                    // (enable/unmute snap the gate to zero while the
+                    // transmit gate is engaged), since this loop never
+                    // runs for a lone prebuffering source.
+                    source->txGateGain =
+                        std::min(source->txGateGain, gateTarget);
+                    continue;
+                }
+                const qsizetype sourceTake =
+                    (std::min(len, source->outputBuffer.size()) / floatBytes)
+                    * floatBytes;
+                if (sourceTake <= 0) {
+                    source->txGateGain =
+                        std::min(source->txGateGain, gateTarget);
+                    continue;
+                }
+                QByteArray sourceChunk = source->outputBuffer.left(sourceTake);
+                const auto* kiwi =
+                    reinterpret_cast<const float*>(sourceChunk.constData());
+                auto* capturedKiwi =
+                    reinterpret_cast<float*>(sourceChunk.data());
+                const qsizetype kiwiSamples = sourceTake / floatBytes;
+                // Whole stereo frames only: len and every outputBuffer
+                // append are frame-aligned, so kiwiSamples is even and
+                // the unrolled per-frame writes below stay in bounds.
+                Q_ASSERT((kiwiSamples & 1) == 0);
+                float gate = source->txGateGain;
+                bool sourceActive = false;
+                for (qsizetype i = 0; i + 1 < kiwiSamples; i += 2) {
+                    if (gate < gateTarget) {
+                        gate = std::min(gateTarget, gate + gateStep);
+                    } else if (gate > gateTarget) {
+                        gate = std::max(gateTarget, gate - gateStep);
+                    }
+                    const float scale = source->gain * gate;
+                    const float s0 = kiwi[i] * scale;
+                    const float s1 = kiwi[i + 1] * scale;
+                    sourceActive = sourceActive
+                        || std::fabs(s0) > kOutputSilenceThreshold
+                        || std::fabs(s1) > kOutputSilenceThreshold;
+                    out[i] += s0;
+                    out[i + 1] += s1;
+                    capturedKiwi[i] = s0;
+                    capturedKiwi[i + 1] = s1;
+                }
+                source->txGateGain = gate;
+                if (sourceActive) {
+                    ++activeOutputSources;
+                }
+                source->outputBuffer.remove(0, sourceTake);
+                // Suppress the correlator feed exactly while the mix
+                // gate holds this source closed — including the
+                // post-unkey resume hold, when the chunks above were
+                // just ramped to zero.
+                emitOutputSource(QStringLiteral("kiwi"), source->id,
+                                 sourceChunk, !gateOpen);
+            }
+
+            const qsizetype radeTake = (std::min(len, m_radeRxBuffer.size()) / floatBytes) * floatBytes;
+            if (radeTake > 0) {
+                const auto* rade = reinterpret_cast<const float*>(m_radeRxBuffer.constData());
+                const qsizetype radeSamples = radeTake / floatBytes;
+                bool sourceActive = false;
+                for (qsizetype i = 0; i < radeSamples; ++i) {
+                    sourceActive = sourceActive
+                        || std::fabs(rade[i]) > kOutputSilenceThreshold;
+                    out[i] += rade[i];
+                }
+                if (sourceActive) {
+                    ++activeOutputSources;
+                }
+                m_radeRxBuffer.remove(0, radeTake);
+            }
+
+            // Single gain/clamp pass after all sources are mixed. Use
+            // strict 1/N active-source scaling here: 1/sqrt(N) preserves
+            // more loudness but still lets three speech streams hard-clip
+            // and sound like NR2 static.
+            const qsizetype totalSamples = len / floatBytes;
+            const float mixGain = activeOutputSources > 1
+                ? 1.0f / static_cast<float>(activeOutputSources)
+                : 1.0f;
+            for (qsizetype i = 0; i < totalSamples; ++i) {
+                out[i] = std::clamp(out[i] * mixGain, -1.0f, 1.0f);
+            }
+        }
+
+        if (!flexGateApplied) {
+            // Flex produced nothing this tick: snap its gate downward
+            // only, mirroring the per-source skip snap above.
+            m_flexTxGateGain = std::min(m_flexTxGateGain, flexGateTarget);
+        }
+
+        // Recheck after processing, before exposing a mixed chunk. If an epoch
+        // was revoked during DSP, none of that chunk may reach the device.
+        if (retireInvalidPcmSources() || !m_audioDevice) {
+            return;
+        }
+        len = m_audioDevice->write(chunk);
+        if (len > 0) {
+            const qsizetype capturedBytes =
+                alignedStereoFloatBytes(
+                    std::min<qsizetype>(len, chunk.size()));
+            if (capturedBytes > 0) {
+                captureAutomationAudio(
+                    QStringLiteral("final"), QStringLiteral("mix"),
+                    QString(), chunk.left(capturedBytes),
+                    sampleRate, 2);
+            }
+        }
+
+        // Stale session watchdog: if we're writing data but processedUSecs()
+        // hasn't advanced, the WASAPI session is silently discarding audio
+        // (e.g. after Teams/Zoom reconfigures the audio endpoint). (#1569)
+        qint64 processed = m_audioSink ? m_audioSink->processedUSecs() : m_lastProcessedUSecs + 1;
+        if (processed == m_lastProcessedUSecs) {
+            if (++m_rxStaleTickCount >= kStaleTickThreshold) {
+                m_rxStaleTickCount = 0;
+                qCWarning(lcAudio) << "AudioEngine: sink appears stale (processedUSecs stuck at"
+                                   << processed << "for" << kStaleTickThreshold * 10
+                                   << "ms), restarting RX (#1569)";
                 QMetaObject::invokeMethod(this, [this]() {
                     if (!m_audioSink) return;
                     stopRxStream();
@@ -2035,595 +2679,27 @@ AudioEngine::AudioEngine(QObject* parent)
                 return;
             }
         } else {
-            m_rxZombieTickCount = 0;
+            m_rxStaleTickCount = 0;
+            m_lastProcessedUSecs = processed;
         }
+    }
 
-        // Audio liveness watchdog: if no audio data has arrived via
-        // feedAudioData() for ~15 seconds while the sink is still running,
-        // the audio backend may have silently stopped (CoreAudio after
-        // extended idle, or the radio stopped sending VITA-49 packets).
-        // Restart the sink to re-acquire a fresh handle. (#1411)
-        if (m_lastAudioFeedTime.isValid()
-            && m_lastAudioFeedTime.elapsed() > kAudioLivenessTimeoutMs
-            && m_rxBuffer.isEmpty()
-            && m_rxPackets.empty()
-            && m_rxOutputBuffer.isEmpty()
-            && m_radeRxBuffer.isEmpty()
-            && m_kiwiSdrOutputBuffer.isEmpty()
-            && m_kiwiSdrRxBuffer.isEmpty()
-            && m_kiwiSdrRxPackets.empty()
-            && !anyExternalKiwiBufferQueued()) {
-            qCWarning(lcAudio) << "AudioEngine: no audio data received for"
-                               << m_lastAudioFeedTime.elapsed() << "ms, restarting RX (#1411)";
-            m_lastAudioFeedTime.start();  // prevent repeated rapid restarts
-            QMetaObject::invokeMethod(this, [this]() {
-                if (!m_audioSink) return;
-                stopRxStream();
-                startRxStream();
-            }, Qt::QueuedConnection);
-            return;
-        }
+    if (m_audioSink && sampleRate > 0) {
+        const qsizetype sinkBufferBytes = m_audioSink->bufferSize();
+        const qsizetype sinkFreeBytes = m_audioSink->bytesFree();
+        const qsizetype sinkQueuedBytes =
+            std::clamp(sinkBufferBytes - sinkFreeBytes,
+                       static_cast<qsizetype>(0),
+                       std::max<qsizetype>(0, sinkBufferBytes));
+        const int playbackQueuedMs =
+            qBound(0, audioBytesToMs(sinkQueuedBytes, sampleRate), 1000);
+        m_rxPlaybackQueuedMs.store(playbackQueuedMs,
+                                   std::memory_order_relaxed);
+    } else {
+        m_rxPlaybackQueuedMs.store(0, std::memory_order_relaxed);
+    }
 
-        if (nr2PacketMode) {
-            std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
-            auto queuedRawEquivalent = [sampleRate](qsizetype rawBytes,
-                                                    qsizetype outputBytes) {
-                return rawBytes
-                       + rawEquivalentAudioBytes(outputBytes, sampleRate);
-            };
-            while (!flexPresentationPrebuffering
-                   && !m_rxPackets.empty()
-                   && (m_rxOutputBuffer.size() / frameBytes) < freeFrames
-                   && (flexPrebufferBytes <= 0
-                       || queuedRawEquivalent(queuedAudioBytes(m_rxPackets),
-                                             m_rxOutputBuffer.size())
-                              > flexPrebufferBytes)) {
-                QByteArray packet = std::move(m_rxPackets.front());
-                m_rxPackets.pop_front();
-                processMixedRxAudioData(packet, RxDspSource::Main);
-            }
-            while (kiwiAudio
-                   && !m_kiwiSdrPrebuffering.load(std::memory_order_relaxed)
-                   && !m_kiwiSdrRxPackets.empty()
-                   && (m_kiwiSdrOutputBuffer.size() / frameBytes) < freeFrames
-                   && queuedAudioBytes(m_kiwiSdrRxPackets)
-                          + rawEquivalentAudioBytes(m_kiwiSdrOutputBuffer.size(),
-                                                    sampleRate)
-                          > kiwiPresentationDelayBytes) {
-                QByteArray packet = std::move(m_kiwiSdrRxPackets.front());
-                m_kiwiSdrRxPackets.pop_front();
-                processMixedRxAudioData(packet, RxDspSource::KiwiSdr);
-            }
-            for (const auto& source : m_externalKiwiSources) {
-                if (!source || !externalKiwiSourceProcessing(*source)) {
-                    continue;
-                }
-                const qsizetype sourcePresentationDelayBytes =
-                    externalKiwiPresentationDelayBytes(*source);
-                while (!source->prebuffering
-                       && !source->rxPackets.empty()
-                       && (source->outputBuffer.size() / frameBytes) < freeFrames
-                       && queuedAudioBytes(source->rxPackets)
-                              + rawEquivalentAudioBytes(source->outputBuffer.size(),
-                                                        sampleRate)
-                              > sourcePresentationDelayBytes) {
-                    QByteArray packet = std::move(source->rxPackets.front());
-                    source->rxPackets.pop_front();
-                    processMixedRxAudioData(packet, RxDspSource::KiwiSdr, source.get());
-                }
-            }
-        }
-
-        if (kiwiAudio
-            && m_kiwiSdrPrebuffering.load(std::memory_order_relaxed)) {
-            // KiwiSDR uncompressed audio is observed as 512-sample 12 kHz
-            // blocks (~43 ms), but WebSocket delivery bunches frames with
-            // >100 ms gaps. Hold only the Kiwi jitter buffer before mixing;
-            // the normal Flex RX buffer must keep draining while Kiwi fills.
-            const int prebufferMs = std::min(
-                std::max(kKiwiSdrJitterTargetMs, kiwiPresentationDelayMs),
-                effectiveBufMs);
-            const qsizetype prebufferBytes =
-                DEFAULT_SAMPLE_RATE * 2 * static_cast<qsizetype>(sizeof(float))
-                * prebufferMs / 1000;
-            const qsizetype bufferedBytes =
-                nr2PacketMode
-                    ? queuedAudioBytes(m_kiwiSdrRxPackets)
-                          + rawEquivalentAudioBytes(m_kiwiSdrOutputBuffer.size(),
-                                                    sampleRate)
-                    : m_kiwiSdrRxBuffer.size();
-            if (bufferedBytes >= prebufferBytes) {
-                m_kiwiSdrPrebuffering.store(false, std::memory_order_relaxed);
-            }
-        }
-        for (const auto& source : m_externalKiwiSources) {
-            if (!source || !externalKiwiSourceProcessing(*source)
-                || !source->prebuffering) {
-                continue;
-            }
-            const int prebufferMs = std::min(
-                std::max(kKiwiSdrJitterTargetMs,
-                         source->presentationDelayMs),
-                effectiveBufMs);
-            const qsizetype prebufferBytes =
-                DEFAULT_SAMPLE_RATE * 2 * static_cast<qsizetype>(sizeof(float))
-                * prebufferMs / 1000;
-            const qsizetype bufferedBytes =
-                nr2PacketMode
-                    ? queuedAudioBytes(source->rxPackets)
-                          + rawEquivalentAudioBytes(source->outputBuffer.size(),
-                                                    sampleRate)
-                    : source->rxBuffer.size();
-            if (bufferedBytes >= prebufferBytes) {
-                source->prebuffering = false;
-            }
-        }
-
-        const bool kiwiNr2PacketMode = kiwiAudio && nr2PacketMode;
-        // Queued packets below the delay target are intentional delay growth,
-        // not an underrun; keep playback state live while the queue catches up.
-        if (kiwiNr2PacketMode
-            && !m_kiwiSdrPrebuffering.load(std::memory_order_relaxed)
-            && m_kiwiSdrOutputBuffer.isEmpty()
-            && m_kiwiSdrRxPackets.empty()) {
-            m_kiwiSdrPrebuffering.store(true, std::memory_order_relaxed);
-        }
-        const bool kiwiMixActive =
-            kiwiAudio && !kiwiNr2PacketMode
-            && !m_kiwiSdrPrebuffering.load(std::memory_order_relaxed);
-        for (const auto& source : m_externalKiwiSources) {
-            if (!source || !externalKiwiSourceProcessing(*source)
-                || source->prebuffering) {
-                continue;
-            }
-            // Same as the legacy Kiwi path: packets held for presentation delay
-            // should not flip an already-live source back into prebuffering.
-            const bool sourceEmpty =
-                nr2PacketMode
-                    ? source->outputBuffer.isEmpty()
-                          && source->rxPackets.empty()
-                    : source->rxBuffer.isEmpty();
-            if (sourceEmpty) {
-                source->prebuffering = true;
-            }
-        }
-        const qsizetype kiwiMixBytes =
-            kiwiMixActive
-                ? std::max<qsizetype>(
-                      0, m_kiwiSdrRxBuffer.size() - kiwiPresentationDelayBytes)
-                : 0;
-        // Fill each post-DSP FIFO independently. A prebuffered Kiwi FIFO must
-        // not make the timer skip Flex processing, otherwise Flex only leaks
-        // into the final mix when the Kiwi FIFO briefly drains.
-        const qsizetype queuedMainFrames = m_rxOutputBuffer.size() / frameBytes;
-        const qsizetype wantedMainOutputFrames =
-            freeFrames > queuedMainFrames ? freeFrames - queuedMainFrames : 0;
-        const qsizetype wantedMainNativeFrames =
-            sampleRate > 0
-                ? (wantedMainOutputFrames * DEFAULT_SAMPLE_RATE) / sampleRate
-                : wantedMainOutputFrames;
-        const qsizetype wantedMainNativeBytes = wantedMainNativeFrames * frameBytes;
-        const qsizetype availableMainBytes =
-            (!nr2PacketMode && !flexPresentationPrebuffering)
-                ? std::max<qsizetype>(0, m_rxBuffer.size() - flexPrebufferBytes)
-                : 0;
-        const qsizetype mainBytes =
-            (std::min(wantedMainNativeBytes, availableMainBytes) / frameBytes)
-            * frameBytes;
-        if (mainBytes > 0) {
-            const QByteArray mainPcm = m_rxBuffer.left(mainBytes);
-            m_rxBuffer.remove(0, mainBytes);
-            processMixedRxAudioData(mainPcm, RxDspSource::Main);
-        }
-
-        // NR2 regression guard:
-        // With NR2 enabled, Kiwi packets stay whole until this timer processes
-        // them through their Kiwi-only NR2 state into post-DSP Kiwi FIFOs.
-        // Do not chop raw Kiwi into timer-sized pieces and feed NR2 here; that
-        // reintroduced speech-correlated static. Raw Kiwi draining below is
-        // only used while NR2 is off.
-        const qsizetype queuedKiwiFrames = m_kiwiSdrOutputBuffer.size() / frameBytes;
-        const qsizetype wantedKiwiOutputFrames =
-            freeFrames > queuedKiwiFrames ? freeFrames - queuedKiwiFrames : 0;
-        const qsizetype wantedKiwiNativeFrames =
-            sampleRate > 0
-                ? (wantedKiwiOutputFrames * DEFAULT_SAMPLE_RATE) / sampleRate
-                : wantedKiwiOutputFrames;
-        const qsizetype wantedKiwiNativeBytes = wantedKiwiNativeFrames * frameBytes;
-        const qsizetype kiwiBytes =
-            (std::min(wantedKiwiNativeBytes, kiwiMixBytes) / frameBytes)
-            * frameBytes;
-        if (kiwiBytes > 0) {
-            const QByteArray kiwiPcm = m_kiwiSdrRxBuffer.left(kiwiBytes);
-            m_kiwiSdrRxBuffer.remove(0, kiwiBytes);
-            processMixedRxAudioData(kiwiPcm, RxDspSource::KiwiSdr);
-        }
-
-        // Managed Kiwi RX antennas must keep the same per-source output FIFO
-        // boundary with NR2 off as they do with NR2 on. If they are collapsed
-        // into the legacy applet Kiwi buffer here, the final mixer ignores
-        // them unless the applet-level Kiwi Audio toggle is also enabled.
-        if (!nr2PacketMode) {
-            for (const auto& source : m_externalKiwiSources) {
-                if (!source || !externalKiwiSourceProcessing(*source)
-                    || source->prebuffering) {
-                    continue;
-                }
-
-                const qsizetype queuedSourceFrames =
-                    source->outputBuffer.size() / frameBytes;
-                const qsizetype wantedSourceOutputFrames =
-                    freeFrames > queuedSourceFrames
-                        ? freeFrames - queuedSourceFrames
-                        : 0;
-                const qsizetype wantedSourceNativeFrames =
-                    sampleRate > 0
-                        ? (wantedSourceOutputFrames * DEFAULT_SAMPLE_RATE) / sampleRate
-                        : wantedSourceOutputFrames;
-                const qsizetype wantedSourceNativeBytes =
-                    wantedSourceNativeFrames * frameBytes;
-                const qsizetype availableSourceBytes =
-                    std::max<qsizetype>(
-                        0,
-                        source->rxBuffer.size()
-                            - externalKiwiPresentationDelayBytes(*source));
-                const qsizetype sourceBytes =
-                    (std::min(wantedSourceNativeBytes, availableSourceBytes)
-                     / frameBytes) * frameBytes;
-                if (sourceBytes <= 0) {
-                    continue;
-                }
-
-                const QByteArray sourcePcm = source->rxBuffer.left(sourceBytes);
-                source->rxBuffer.remove(0, sourceBytes);
-                processMixedRxAudioData(
-                    sourcePcm, RxDspSource::KiwiSdr, source.get());
-            }
-        }
-
-        const qsizetype kiwiOutputBytes =
-            (kiwiAudio
-             && !m_kiwiSdrPrebuffering.load(std::memory_order_relaxed))
-                ? m_kiwiSdrOutputBuffer.size()
-                : 0;
-        const qsizetype externalKiwiOutputBytes =
-            externalKiwiOutputBufferBytes();
-        const qsizetype aggregateKiwiOutputBytes =
-            std::max(kiwiOutputBytes, externalKiwiOutputBytes);
-        qsizetype len = (freeBytes / frameBytes) * frameBytes;
-        len = std::min(len, std::max({m_rxOutputBuffer.size(),
-                                      aggregateKiwiOutputBytes,
-                                      m_radeRxBuffer.size()}));
-        len = (len / frameBytes) * frameBytes;
-        if (len > 0)
-        {
-            QByteArray chunk;
-            // While the transmit gate silences every Kiwi source, pause the
-            // receive-presentation feed on BOTH sides (Flex and Kiwi), like
-            // the pre-warm-pipeline mute froze both correlator buffers. A
-            // TX-gated source's ramp-zeroed chunks (or a one-sided Flex feed
-            // against them) would pollute the GCC-PHAT delay estimate and
-            // drop the auto-assist confidence on every over. A source's gate
-            // stays held through its pending post-unkey resume hold ("Resume
-            // audio after TX delay"), so the pause must cover that window
-            // too; it lifts as soon as any source is audible through the
-            // gate (keepAudioDuringTx during TX, or a source with no pending
-            // hold after unkey).
-            const bool kiwiTxGateEngaged = kiwiSdrAudioTransmitMuted();
-            bool anyKiwiGateHeld = false;
-            bool anyKiwiAudibleThroughGate = false;
-            for (const auto& s : m_externalKiwiSources) {
-                if (!s || !externalKiwiSourceProcessing(*s)) {
-                    continue;
-                }
-                const bool held = !s->keepAudioDuringTx
-                    && (kiwiTxGateEngaged
-                        || !s->txResumeDeadline.hasExpired());
-                anyKiwiGateHeld = anyKiwiGateHeld || held;
-                anyKiwiAudibleThroughGate =
-                    anyKiwiAudibleThroughGate || !held;
-            }
-            const bool presentationPausedForTx =
-                (kiwiTxGateEngaged || anyKiwiGateHeld)
-                && !anyKiwiAudibleThroughGate;
-            // Per-frame gate ramp step; depends only on the device rate, so
-            // compute it once for the Flex gate and every Kiwi source alike.
-            const float gateStep =
-                sampleRate > 0
-                    ? 1000.0f
-                          / (static_cast<float>(kKiwiSdrTxGateRampMs)
-                             * static_cast<float>(sampleRate))
-                    : 1.0f;
-            // Delayed-Flex transmit gate: with a Receive Sync delay applied,
-            // the Flex presentation buffer holds flexDelayMs of pre-key-down
-            // RX audio that would keep playing into the transmission — the
-            // radio's own TX-time zero-fill only reaches the speaker after
-            // the delay. Mirror the Kiwi design: buffers stay warm and
-            // aligned, only the mix contribution ramps. Inactive with no
-            // delay so undelayed TX monitor audio is untouched, and FDX
-            // never engages the TX mute in the first place.
-            const float flexGateTarget =
-                (kiwiTxGateEngaged && flexPresentationDelayMs > 0)
-                    ? 0.0f : 1.0f;
-            bool flexGateApplied = false;
-            auto applyFlexTxGate = [this, flexGateTarget, gateStep,
-                                    &flexGateApplied](QByteArray& pcm) {
-                flexGateApplied = true;
-                if (m_flexTxGateGain == 1.0f && flexGateTarget == 1.0f) {
-                    return;
-                }
-                auto* samples = reinterpret_cast<float*>(pcm.data());
-                const qsizetype count =
-                    pcm.size() / static_cast<qsizetype>(sizeof(float));
-                float gate = m_flexTxGateGain;
-                for (qsizetype i = 0; i + 1 < count; i += 2) {
-                    if (gate < flexGateTarget) {
-                        gate = std::min(flexGateTarget, gate + gateStep);
-                    } else if (gate > flexGateTarget) {
-                        gate = std::max(flexGateTarget, gate - gateStep);
-                    }
-                    samples[i] *= gate;
-                    samples[i + 1] *= gate;
-                }
-                m_flexTxGateGain = gate;
-            };
-            auto emitOutputSource = [this, sampleRate, anyKiwiAudio](
-                                        const QString& source,
-                                        const QString& sourceId,
-                                        const QByteArray& pcm,
-                                        bool txGated = false) {
-                if (!pcm.isEmpty()) {
-                    captureAutomationAudio(QStringLiteral("output"), source,
-                                           sourceId, pcm, sampleRate, 2);
-                    if (!anyKiwiAudio || txGated) {
-                        m_receivePresentationOutputSignalSuppressedCount
-                            .fetch_add(1, std::memory_order_relaxed);
-                        return;
-                    }
-
-                    m_receivePresentationOutputSignalEmitCount.fetch_add(
-                        1, std::memory_order_relaxed);
-                    emit receivePresentationOutputAudioReady(
-                        source, sourceId, pcm, sampleRate);
-                }
-            };
-            if (m_radeRxBuffer.isEmpty() && aggregateKiwiOutputBytes <= 0) {
-                // Fast path: no decoded overlay active -- write the
-                // already-processed RX output directly.
-                chunk = m_rxOutputBuffer.left(len);
-                m_rxOutputBuffer.remove(0, chunk.size());
-                applyFlexTxGate(chunk);
-                emitOutputSource(QStringLiteral("flex"), QString(), chunk,
-                                 presentationPausedForTx);
-            } else if (m_rxOutputBuffer.isEmpty() && m_radeRxBuffer.isEmpty()
-                       && kiwiOutputBytes > 0 && externalKiwiOutputBytes <= 0) {
-                // Fast path: only Kiwi decoded audio is active.
-                chunk = m_kiwiSdrOutputBuffer.left(len);
-                m_kiwiSdrOutputBuffer.remove(0, chunk.size());
-                emitOutputSource(QStringLiteral("kiwi"), QString(), chunk,
-                                 presentationPausedForTx);
-            } else {
-                // Mix path: add post-DSP Flex, every post-DSP Kiwi stream,
-                // and decoded RADE sample-wise at the output device rate.
-                chunk = QByteArray(len, '\0');
-                auto* out = reinterpret_cast<float*>(chunk.data());
-                int activeOutputSources = 0;
-                constexpr float kOutputSilenceThreshold = 1.0e-6f;
-
-                const qsizetype rxTake =
-                    (std::min(len, m_rxOutputBuffer.size()) / floatBytes)
-                    * floatBytes;
-                if (rxTake > 0) {
-                    QByteArray rxChunk = m_rxOutputBuffer.left(rxTake);
-                    applyFlexTxGate(rxChunk);
-                    const auto* rx =
-                        reinterpret_cast<const float*>(rxChunk.constData());
-                    const qsizetype rxSamples = rxTake / floatBytes;
-                    bool sourceActive = false;
-                    for (qsizetype i = 0; i < rxSamples; ++i) {
-                        sourceActive = sourceActive
-                            || std::fabs(rx[i]) > kOutputSilenceThreshold;
-                        out[i] += rx[i];
-                    }
-                    if (sourceActive) {
-                        ++activeOutputSources;
-                    }
-                    m_rxOutputBuffer.remove(0, rxTake);
-                    emitOutputSource(QStringLiteral("flex"), QString(), rxChunk,
-                                     presentationPausedForTx);
-                }
-
-                const qsizetype kiwiTake =
-                    (std::min(len, kiwiOutputBytes) / floatBytes)
-                    * floatBytes;
-                if (kiwiTake > 0) {
-                    const QByteArray kiwiChunk =
-                        m_kiwiSdrOutputBuffer.left(kiwiTake);
-                    const auto* kiwi =
-                        reinterpret_cast<const float*>(kiwiChunk.constData());
-                    const qsizetype kiwiSamples = kiwiTake / floatBytes;
-                    bool sourceActive = false;
-                    for (qsizetype i = 0; i < kiwiSamples; ++i) {
-                        sourceActive = sourceActive
-                            || std::fabs(kiwi[i]) > kOutputSilenceThreshold;
-                        out[i] += kiwi[i];
-                    }
-                    if (sourceActive) {
-                        ++activeOutputSources;
-                    }
-                    m_kiwiSdrOutputBuffer.remove(0, kiwiTake);
-                    emitOutputSource(QStringLiteral("kiwi"), QString(), kiwiChunk,
-                                     presentationPausedForTx);
-                }
-
-                for (const auto& source : m_externalKiwiSources) {
-                    if (!source) {
-                        continue;
-                    }
-                    // Transmit gate: the source keeps draining at real-time
-                    // rate through TX so playback rejoins the live stream at
-                    // unkey; only its mix contribution ramps to zero. The
-                    // short ramp avoids a hard-mute click on both edges. A
-                    // pending resume deadline extends the hold past unkey
-                    // ("Resume audio after TX delay").
-                    const bool gateOpen = source->keepAudioDuringTx
-                        || (!kiwiSdrAudioTransmitMuted()
-                            && source->txResumeDeadline.hasExpired());
-                    const float gateTarget = gateOpen ? 1.0f : 0.0f;
-                    if (!externalKiwiSourceProcessing(*source)
-                        || source->prebuffering) {
-                        // Silent while skipped: snap the gate DOWNWARD only —
-                        // a dry tick or prebuffer stretch spanning the unkey
-                        // edge holds the gate and finishes the up-ramp on
-                        // the next tick with data instead of hard-stepping
-                        // to full amplitude. Mid-TX entry with a stale
-                        // full-gain gate is closed at the source setters
-                        // (enable/unmute snap the gate to zero while the
-                        // transmit gate is engaged), since this loop never
-                        // runs for a lone prebuffering source.
-                        source->txGateGain =
-                            std::min(source->txGateGain, gateTarget);
-                        continue;
-                    }
-                    const qsizetype sourceTake =
-                        (std::min(len, source->outputBuffer.size()) / floatBytes)
-                        * floatBytes;
-                    if (sourceTake <= 0) {
-                        source->txGateGain =
-                            std::min(source->txGateGain, gateTarget);
-                        continue;
-                    }
-                    QByteArray sourceChunk = source->outputBuffer.left(sourceTake);
-                    const auto* kiwi =
-                        reinterpret_cast<const float*>(sourceChunk.constData());
-                    auto* capturedKiwi =
-                        reinterpret_cast<float*>(sourceChunk.data());
-                    const qsizetype kiwiSamples = sourceTake / floatBytes;
-                    // Whole stereo frames only: len and every outputBuffer
-                    // append are frame-aligned, so kiwiSamples is even and
-                    // the unrolled per-frame writes below stay in bounds.
-                    Q_ASSERT((kiwiSamples & 1) == 0);
-                    float gate = source->txGateGain;
-                    bool sourceActive = false;
-                    for (qsizetype i = 0; i + 1 < kiwiSamples; i += 2) {
-                        if (gate < gateTarget) {
-                            gate = std::min(gateTarget, gate + gateStep);
-                        } else if (gate > gateTarget) {
-                            gate = std::max(gateTarget, gate - gateStep);
-                        }
-                        const float scale = source->gain * gate;
-                        const float s0 = kiwi[i] * scale;
-                        const float s1 = kiwi[i + 1] * scale;
-                        sourceActive = sourceActive
-                            || std::fabs(s0) > kOutputSilenceThreshold
-                            || std::fabs(s1) > kOutputSilenceThreshold;
-                        out[i] += s0;
-                        out[i + 1] += s1;
-                        capturedKiwi[i] = s0;
-                        capturedKiwi[i + 1] = s1;
-                    }
-                    source->txGateGain = gate;
-                    if (sourceActive) {
-                        ++activeOutputSources;
-                    }
-                    source->outputBuffer.remove(0, sourceTake);
-                    // Suppress the correlator feed exactly while the mix
-                    // gate holds this source closed — including the
-                    // post-unkey resume hold, when the chunks above were
-                    // just ramped to zero.
-                    emitOutputSource(QStringLiteral("kiwi"), source->id,
-                                     sourceChunk, !gateOpen);
-                }
-
-                const qsizetype radeTake = (std::min(len, m_radeRxBuffer.size()) / floatBytes) * floatBytes;
-                if (radeTake > 0) {
-                    const auto* rade = reinterpret_cast<const float*>(m_radeRxBuffer.constData());
-                    const qsizetype radeSamples = radeTake / floatBytes;
-                    bool sourceActive = false;
-                    for (qsizetype i = 0; i < radeSamples; ++i) {
-                        sourceActive = sourceActive
-                            || std::fabs(rade[i]) > kOutputSilenceThreshold;
-                        out[i] += rade[i];
-                    }
-                    if (sourceActive) {
-                        ++activeOutputSources;
-                    }
-                    m_radeRxBuffer.remove(0, radeTake);
-                }
-
-                // Single gain/clamp pass after all sources are mixed. Use
-                // strict 1/N active-source scaling here: 1/sqrt(N) preserves
-                // more loudness but still lets three speech streams hard-clip
-                // and sound like NR2 static.
-                const qsizetype totalSamples = len / floatBytes;
-                const float mixGain = activeOutputSources > 1
-                    ? 1.0f / static_cast<float>(activeOutputSources)
-                    : 1.0f;
-                for (qsizetype i = 0; i < totalSamples; ++i) {
-                    out[i] = std::clamp(out[i] * mixGain, -1.0f, 1.0f);
-                }
-            }
-
-            if (!flexGateApplied) {
-                // Flex produced nothing this tick: snap its gate downward
-                // only, mirroring the per-source skip snap above.
-                m_flexTxGateGain = std::min(m_flexTxGateGain, flexGateTarget);
-            }
-
-            len = m_audioDevice->write(chunk);
-            if (len > 0) {
-                const qsizetype capturedBytes =
-                    alignedStereoFloatBytes(
-                        std::min<qsizetype>(len, chunk.size()));
-                if (capturedBytes > 0) {
-                    captureAutomationAudio(
-                        QStringLiteral("final"), QStringLiteral("mix"),
-                        QString(), chunk.left(capturedBytes),
-                        sampleRate, 2);
-                }
-            }
-
-            // Stale session watchdog: if we're writing data but processedUSecs()
-            // hasn't advanced, the WASAPI session is silently discarding audio
-            // (e.g. after Teams/Zoom reconfigures the audio endpoint). (#1569)
-            qint64 processed = m_audioSink->processedUSecs();
-            if (processed == m_lastProcessedUSecs) {
-                if (++m_rxStaleTickCount >= kStaleTickThreshold) {
-                    m_rxStaleTickCount = 0;
-                    qCWarning(lcAudio) << "AudioEngine: sink appears stale (processedUSecs stuck at"
-                                       << processed << "for" << kStaleTickThreshold * 10
-                                       << "ms), restarting RX (#1569)";
-                    QMetaObject::invokeMethod(this, [this]() {
-                        if (!m_audioSink) return;
-                        stopRxStream();
-                        startRxStream();
-                    }, Qt::QueuedConnection);
-                    return;
-                }
-            } else {
-                m_rxStaleTickCount = 0;
-                m_lastProcessedUSecs = processed;
-            }
-        }
-
-        if (m_audioSink && sampleRate > 0) {
-            const qsizetype sinkBufferBytes = m_audioSink->bufferSize();
-            const qsizetype sinkFreeBytes = m_audioSink->bytesFree();
-            const qsizetype sinkQueuedBytes =
-                std::clamp(sinkBufferBytes - sinkFreeBytes,
-                           static_cast<qsizetype>(0),
-                           std::max<qsizetype>(0, sinkBufferBytes));
-            const int playbackQueuedMs =
-                qBound(0, audioBytesToMs(sinkQueuedBytes, sampleRate), 1000);
-            m_rxPlaybackQueuedMs.store(playbackQueuedMs,
-                                       std::memory_order_relaxed);
-        } else {
-            m_rxPlaybackQueuedMs.store(0, std::memory_order_relaxed);
-        }
-
-        updateRxBufferStats();
-    });
-    m_rxTimer->start();
+    updateRxBufferStats();
 }
 
 AudioEngine::~AudioEngine()
@@ -2702,11 +2778,14 @@ QJsonArray AudioEngine::audioEndpointDiagnostics() const
     rx["sample_rate_hz"] = rxRunning ? QJsonValue(m_rxBufferSampleRate.load()) : QJsonValue();
     rx["channel_count"] = rxRunning ? QJsonValue(2) : QJsonValue();
     rx["sample_format"] = rxRunning ? QStringLiteral("Float") : QString();
-    rx["resampling_active"] = rxRunning ? QJsonValue(m_rxOutputRate.load() != DEFAULT_SAMPLE_RATE) : QJsonValue();
+    rx["producer_sample_rate"] = m_rxProducerRate.load();
+    rx["resampling_active"] = rxRunning ? QJsonValue(m_rxOutputRate.load() != m_rxProducerRate.load()) : QJsonValue();
     rx["buffer_bytes"] = static_cast<double>(m_rxBufferBytes.load());
+    rx["buffer_ms"] = m_rxBufferMs.load();
     rx["buffer_capacity_bytes"] = rxRunning
         ? static_cast<double>(m_audioSink->bufferSize()) : 0.0;
     rx["buffer_peak_bytes"] = static_cast<double>(m_rxBufferPeakBytes.load());
+    rx["buffer_peak_ms"] = m_rxBufferPeakMs.load();
     rx["underrun_count"] = static_cast<double>(m_rxBufferUnderrunCount.load());
     QJsonObject presentation;
     presentation["flex_delay_ms"] =
@@ -3849,6 +3928,8 @@ bool AudioEngine::startRxStream()
     }
     m_rxBufferBytes.store(0);
     m_rxBufferPeakBytes.store(0);
+    m_rxBufferMs.store(0.0);
+    m_rxBufferPeakMs.store(0.0);
     m_rxBufferUnderrunCount.store(0);
     m_rxBufferSampleRate.store(DEFAULT_SAMPLE_RATE);
     m_rxZombieTickCount = 0;
@@ -3967,7 +4048,7 @@ bool AudioEngine::startRxStream()
         if (io) {
             m_audioSink = sink;
             m_audioDevice = io;
-            m_rxOutputRate.store(candidate.sampleRate());
+            setRxDeviceRate(candidate.sampleRate());
             if (triedFloatRung) {
                 noteRxFallback(QStringLiteral("preferred RX format unavailable -> %1 Hz")
                                    .arg(candidate.sampleRate()));
@@ -4035,7 +4116,7 @@ bool AudioEngine::startRxStream()
     summary.sampleRate = m_rxOutputRate.load();
     summary.channelCount = 2;
     summary.sampleFormat = QAudioFormat::Float;
-    summary.resamplingActive = (m_rxOutputRate.load() != DEFAULT_SAMPLE_RATE);
+    summary.resamplingActive = (m_rxOutputRate.load() != m_rxProducerRate.load());
     summary.fallbackOccurred = rxFallbackOccurred;
     summary.fallbackReason = rxFallbackReasons.join(QStringLiteral("; "));
     AudioSummaryLogger::logRxSink(summary);
@@ -4053,6 +4134,7 @@ void AudioEngine::stopRxStream()
 {
     stopSidetoneStream();
     stopQuindarLocalSink();
+    resetRxChainStateForSourceSwitch();
     m_rxBuffer.clear();
     m_rxPackets.clear();
     m_kiwiSdrRxBuffer.clear();
@@ -4074,6 +4156,8 @@ void AudioEngine::stopRxStream()
     }
     m_rxBufferBytes.store(0);
     m_rxBufferPeakBytes.store(0);
+    m_rxBufferMs.store(0.0);
+    m_rxBufferPeakMs.store(0.0);
     m_rxBufferSampleRate.store(DEFAULT_SAMPLE_RATE);
     m_rxPlaybackQueuedMs.store(0, std::memory_order_relaxed);
 
@@ -4309,7 +4393,7 @@ static void applyRxPanInPlace(float* stereo, int nFrames, int pan)
     }
 }
 
-// Resample 24kHz stereo float32 → 48kHz stereo float32 via r8brain.
+// Resample producer-rate stereo float32 to the device rate via r8brain.
 // L and R are processed through separate Resampler instances so that any
 // per-channel difference (radio-applied audio_pan) is preserved.
 // processStereoToStereo() collapses L+R to mono — do NOT use it here.
@@ -4326,11 +4410,19 @@ QByteArray AudioEngine::resampleStereo(const QByteArray& pcm,
     std::unique_ptr<Resampler>& rightResampler = externalSource
         ? externalSource->rxResamplerR
         : (source == RxDspSource::KiwiSdr ? m_kiwiSdrRxResamplerR : m_rxResamplerR);
-    if (!leftResampler) {
-        leftResampler = std::make_unique<Resampler>(24000, m_rxOutputRate.load());
+    const int producerRate = source == RxDspSource::Main
+        ? m_rxProducerRate.load() : DEFAULT_SAMPLE_RATE;
+    const int deviceRate = m_rxOutputRate.load();
+    if (producerRate == deviceRate) {
+        return pcm;
     }
-    if (!rightResampler) {
-        rightResampler = std::make_unique<Resampler>(24000, m_rxOutputRate.load());
+    if (!leftResampler || leftResampler->srcRate() != producerRate
+        || leftResampler->dstRate() != deviceRate) {
+        leftResampler = std::make_unique<Resampler>(producerRate, deviceRate);
+    }
+    if (!rightResampler || rightResampler->srcRate() != producerRate
+        || rightResampler->dstRate() != deviceRate) {
+        rightResampler = std::make_unique<Resampler>(producerRate, deviceRate);
     }
 
     const int frames = pcm.size() / (2 * static_cast<int>(sizeof(float)));
@@ -4363,38 +4455,314 @@ QByteArray AudioEngine::resampleStereo(const QByteArray& pcm,
     return result;
 }
 
-void AudioEngine::feedPcmFrame(const PcmFrame& frame)
+void AudioEngine::flushRxDevice()
 {
-    if (frame.stream().purpose != PcmPurpose::Speaker
-        || frame.stream().format != PcmFormat{} || !m_pcmIngress.accept(frame)) {
+    if (!m_audioSink) {
         return;
     }
-    const QByteArray pcm = frame.legacyStereo24();
-    if (!pcm.isEmpty()) {
-        feedAudioData(pcm);
+    // QAudioSink contains an already mixed stream. It cannot retract just one
+    // source, so retirement flushes that short device queue as a whole; the
+    // other sources' application FIFOs remain intact.
+    {
+        const QSignalBlocker blocker(m_audioSink);
+        m_audioSink->reset();
+        m_audioDevice = m_audioSink->start();
     }
+    m_rxPlaybackQueuedMs.store(0);
+    if (!m_audioDevice) {
+        qCWarning(lcAudio) << "AudioEngine: RX sink restart after PCM retirement failed"
+                          << m_audioSink->error();
+        // A failed restart must not leave a nonnull sink that makes a later
+        // startRxStream() report success while the timer has no device.
+        stopRxStream();
+    }
+}
+
+bool AudioEngine::prepareMainPcmDsp()
+{
+    const int rate = m_rxProducerRate.load();
+    m_nr2.reset();
+    m_rn2.reset();
+    if (m_nr2Enabled) {
+        m_nr2 = createNr2Filter(QStringLiteral("main RX"),
+            m_mainSourceLegacyNr2.load(), rate);
+        if (m_nr2) {
+            applyNr2Settings(*m_nr2);
+        }
+    }
+    if (m_rn2Enabled) {
+        m_rn2 = createRn2Filter(QStringLiteral("main RX"), rate);
+    }
+#ifdef HAVE_SPECBLEACH
+    m_nr4.reset();
+    if (m_nr4Enabled) {
+        m_nr4 = createNr4Filter(QStringLiteral("main RX"), rate);
+        if (m_nr4) {
+            applyNr4SettingsFromAppSettings(*m_nr4);
+        }
+    }
+#endif
+#ifdef HAVE_DFNR
+    m_dfnr.reset();
+    if (m_dfnrEnabled) {
+        m_dfnr = createDfnrFilter(QStringLiteral("main RX"), rate);
+        if (m_dfnr) {
+            applyDfnrSettingsFromAppSettings(*m_dfnr);
+        }
+    }
+#endif
+#ifdef HAVE_NVIDIA_AFX
+    m_nvAfx.reset();
+    if (m_nvAfxEnabled) {
+        m_nvAfx = createNvAfxFilter(QStringLiteral("main RX"), rate);
+        if (m_nvAfx) {
+            m_nvAfx->setIntensity(NvidiaBnrSettings::intensity());
+        }
+    }
+#endif
+#ifdef __APPLE__
+    m_mnr.reset();
+    if (m_mnrEnabled) {
+        m_mnr = createMnrFilter(QStringLiteral("main RX"), rate);
+    }
+#endif
+    return (!m_nr2Enabled || m_nr2) && (!m_rn2Enabled || m_rn2)
+#ifdef HAVE_SPECBLEACH
+        && (!m_nr4Enabled || m_nr4)
+#endif
+#ifdef HAVE_DFNR
+        && (!m_dfnrEnabled || m_dfnr)
+#endif
+#ifdef HAVE_NVIDIA_AFX
+        && (!m_nvAfxEnabled || m_nvAfx)
+#endif
+#ifdef __APPLE__
+        && (!m_mnrEnabled || m_mnr)
+#endif
+        ;
+}
+
+void AudioEngine::resetMainPcmState(int producerRate)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
+    m_rxBuffer.clear();
+    m_rxPackets.clear();
+    m_rxOutputBuffer.clear();
+    m_nr2Output.clear();
+    m_rxResampler.reset();
+    m_rxResamplerR.reset();
+    m_rxProducerRate.store(producerRate);
+    m_clientEqRx->prepare(producerRate);
+    m_clientGateRx->prepare(producerRate);
+    m_clientCompRx->prepare(producerRate);
+    m_clientDeEssRx->prepare(producerRate);
+    m_clientTubeRx->prepare(producerRate);
+    m_clientPuduRx->prepare(producerRate);
+    {
+        std::lock_guard<std::mutex> tapLock(m_clientEqTapMutex);
+        std::fill(std::begin(m_clientEqTapRx), std::end(m_clientEqTapRx), 0.0f);
+        m_clientEqTapRxWrite = 0;
+    }
+    m_mainPcmDspReady = prepareMainPcmDsp();
+    if (!m_mainPcmDspReady) {
+        qCWarning(lcAudio) << "AudioEngine: enabled RX processing could not prepare at"
+                          << producerRate << "Hz; withholding this source";
+    }
+    m_rxPresentationPrebuffering.store(m_flexReceivePresentationDelayMs.load() > 0);
+    updateRxBufferStats();
+}
+
+bool AudioEngine::retireInvalidPcmSources()
+{
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
+    bool retired = false;
+    if (m_mainPcmFrame && !m_mainPcmFrame->current()) {
+        m_mainPcmFrame.reset();
+        resetMainPcmState(DEFAULT_SAMPLE_RATE);
+        retired = true;
+    }
+    if (m_legacyKiwiPcmFrame && !m_legacyKiwiPcmFrame->current()) {
+        m_legacyKiwiPcmFrame.reset();
+        m_kiwiSdrRxBuffer.clear();
+        m_kiwiSdrRxPackets.clear();
+        m_kiwiSdrOutputBuffer.clear();
+        m_kiwiSdrRxResampler.reset();
+        m_kiwiSdrRxResamplerR.reset();
+        resetLegacyKiwiDspState();
+        retired = true;
+    }
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->pcmFrame && !source->pcmFrame->current()) {
+            source->pcmFrame.reset();
+            source->rxBuffer.clear();
+            source->rxPackets.clear();
+            source->outputBuffer.clear();
+            source->nr2Output.clear();
+            source->rxResampler.reset();
+            source->rxResamplerR.reset();
+            resetExternalKiwiDspState(*source);
+            source->prebuffering = true;
+            retired = true;
+        }
+    }
+    if (retired) {
+        flushRxDevice();
+        updateRxBufferStats();
+    }
+    return retired;
+}
+
+void AudioEngine::setRxDeviceRate(int rate)
+{
+    // Called only after successful output negotiation. The producer rate is
+    // unchanged; old device-format bytes and every converter history expire.
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
+    m_rxOutputRate.store(rate);
+    resetMainPcmState(m_rxProducerRate.load());
+    m_radeRxBuffer.clear();
+    m_radeRxResampler.reset();
+    m_kiwiSdrRxBuffer.clear();
+    m_kiwiSdrRxPackets.clear();
+    m_kiwiSdrOutputBuffer.clear();
+    m_kiwiSdrRxResampler.reset();
+    m_kiwiSdrRxResamplerR.reset();
+    resetLegacyKiwiDspState();
+    for (const auto& source : m_externalKiwiSources) {
+        if (!source) {
+            continue;
+        }
+        source->rxBuffer.clear();
+        source->rxPackets.clear();
+        source->outputBuffer.clear();
+        source->nr2Output.clear();
+        source->rxResampler.reset();
+        source->rxResamplerR.reset();
+        resetExternalKiwiDspState(*source);
+        source->prebuffering = true;
+    }
+    updateRxBufferStats();
+}
+
+void AudioEngine::feedPcmFrame(const PcmFrame& frame)
+{
+    if (frame.stream().purpose != PcmPurpose::Speaker || !frame.current()
+        || !frame.stream().format.valid()) {
+        return;
+    }
+    // A speaker route has one producer. A second live producer must not
+    // alternate format/state with it; the route owner retires the old epoch.
+    if (m_mainPcmFrame && m_mainPcmFrame->current()
+        && m_mainPcmFrame->stream().source != frame.stream().source) {
+        return;
+    }
+    if (!m_pcmIngress.accept(frame)) {
+        return;
+    }
+    const bool transition = !m_mainPcmFrame
+        || m_mainPcmFrame->stream() != frame.stream() || frame.discontinuity();
+    if (transition) {
+        resetMainPcmState(frame.stream().format.sampleRateHz);
+        flushRxDevice();
+    }
+    m_mainPcmFrame = frame;
+    const int channels = frame.stream().format.channels();
+    QByteArray pcm(frame.frameCount() * 2 * sizeof(float), Qt::Uninitialized);
+    auto* output = reinterpret_cast<float*>(pcm.data());
+    for (qsizetype i = 0; i < frame.frameCount(); ++i) {
+        output[i * 2] = frame.samples()[i * channels];
+        output[i * 2 + 1] = frame.samples()[i * channels + channels - 1];
+    }
+    captureAutomationAudio(QStringLiteral("raw"), QStringLiteral("flex"),
+                           QString(), pcm, frame.stream().format.sampleRateHz, 2);
+    processRxAudioData(pcm, true);
 }
 
 void AudioEngine::feedKiwiPcmFrame(const QString& sourceId, const PcmFrame& frame)
 {
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (frame.stream().purpose != PcmPurpose::Auxiliary
-        || frame.stream().format != PcmFormat{} || !m_kiwiPcmIngress.accept(frame)) {
+        || frame.stream().format != PcmFormat{} || !frame.current()) {
         return;
     }
-    const QByteArray pcm = frame.legacyStereo24();
-    if (!pcm.isEmpty()) {
-        feedKiwiSdrAudioData(sourceId, pcm);
+    const QString id = sourceId.trimmed();
+    ExternalRxAudioSourceState* source = id.isEmpty() ? nullptr : externalKiwiSource(id, false);
+    if (!id.isEmpty() && !source) {
+        return; // removed/unregistered route cannot be recreated by queued PCM
+    }
+    std::optional<PcmFrame>& previous = source ? source->pcmFrame : m_legacyKiwiPcmFrame;
+    PcmFrameGate& ingress = source ? source->pcmIngress : m_kiwiPcmIngress;
+    // A producer belongs to one intended auxiliary route, even if a caller
+    // accidentally binds its signal to multiple profile IDs.
+    if ((m_legacyKiwiPcmFrame && !id.isEmpty()
+         && m_legacyKiwiPcmFrame->stream().source == frame.stream().source)) {
+        return;
+    }
+    for (const auto& other : m_externalKiwiSources) {
+        if (other && other.get() != source && other->pcmFrame
+            && other->pcmFrame->stream().source == frame.stream().source) {
+            return;
+        }
+    }
+    if (previous && previous->current()
+        && previous->stream().source != frame.stream().source) {
+        return;
+    }
+    if (!ingress.accept(frame)) {
+        return;
+    }
+    if (!previous || previous->stream() != frame.stream() || frame.discontinuity()) {
+        if (source) {
+            source->rxBuffer.clear();
+            source->rxPackets.clear();
+            source->outputBuffer.clear();
+            source->nr2Output.clear();
+            source->rxResampler.reset();
+            source->rxResamplerR.reset();
+            resetExternalKiwiDspState(*source);
+            source->prebuffering = true;
+        } else {
+            m_kiwiSdrRxBuffer.clear();
+            m_kiwiSdrRxPackets.clear();
+            m_kiwiSdrOutputBuffer.clear();
+            m_kiwiSdrRxResampler.reset();
+            m_kiwiSdrRxResamplerR.reset();
+            resetLegacyKiwiDspState();
+        }
+        flushRxDevice();
+    }
+    previous = frame;
+    if (id.isEmpty()) {
+        queueLegacyKiwiAudioData(frame.legacyStereo24());
+    } else {
+        queueKiwiAudioData(id, frame.legacyStereo24());
     }
 }
 
 void AudioEngine::feedAudioData(const QByteArray& pcm)
 {
+    retireInvalidPcmSources();
+    if (m_mainPcmFrame && m_mainPcmFrame->current()) {
+        return; // typed producer already owns the intended speaker route
+    }
+    if (m_rxProducerRate.load() != DEFAULT_SAMPLE_RATE) {
+        resetMainPcmState(DEFAULT_SAMPLE_RATE);
+    }
     captureAutomationAudio(QStringLiteral("raw"), QStringLiteral("flex"),
                            QString(), pcm, DEFAULT_SAMPLE_RATE, 2);
     processRxAudioData(pcm, true);
 }
 
 void AudioEngine::feedKiwiSdrAudioData(const QByteArray& pcm24kStereoFloat)
+{
+    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+    retireInvalidPcmSources();
+    if (m_legacyKiwiPcmFrame && m_legacyKiwiPcmFrame->current()) {
+        return;
+    }
+    queueLegacyKiwiAudioData(pcm24kStereoFloat);
+}
+
+void AudioEngine::queueLegacyKiwiAudioData(const QByteArray& pcm24kStereoFloat)
 {
     if (!m_kiwiSdrAudioEnabled.load(std::memory_order_relaxed)) {
         return;
@@ -4422,6 +4790,9 @@ void AudioEngine::feedKiwiSdrAudioData(const QByteArray& pcm24kStereoFloat)
     if (m_nr2Enabled.load(std::memory_order_relaxed)) {
         std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
         m_kiwiSdrRxPackets.push_back(alignedPcm);
+        trimAudioPacketQueue(m_kiwiSdrRxPackets, audioBytesForMsAtRate(
+            DEFAULT_SAMPLE_RATE,
+            std::max(kKiwiSdrBufferCapMs, m_kiwiReceivePresentationDelayMs.load() + 100)));
         updateRxBufferStats();
         return;
     }
@@ -4431,6 +4802,18 @@ void AudioEngine::feedKiwiSdrAudioData(const QByteArray& pcm24kStereoFloat)
 
 void AudioEngine::feedKiwiSdrAudioData(const QString& sourceId,
                                        const QByteArray& pcm24kStereoFloat)
+{
+    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+    retireInvalidPcmSources();
+    const ExternalRxAudioSourceState* source = externalKiwiSource(sourceId, false);
+    if (source && source->pcmFrame && source->pcmFrame->current()) {
+        return;
+    }
+    queueKiwiAudioData(sourceId, pcm24kStereoFloat);
+}
+
+void AudioEngine::queueKiwiAudioData(const QString& sourceId,
+                                   const QByteArray& pcm24kStereoFloat)
 {
     std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
     ExternalRxAudioSourceState* source = externalKiwiSource(sourceId, true);
@@ -4712,6 +5095,9 @@ void AudioEngine::removeKiwiSdrAudioSource(const QString& sourceId)
         });
     if (it != m_externalKiwiSources.end()) {
         m_externalKiwiSources.erase(it, m_externalKiwiSources.end());
+        // Removal can precede the timer's revoked-lease check. Once erased,
+        // no retained lease remains to retire this source's submitted audio.
+        flushRxDevice();
         qCDebug(lcKiwiSdrAudio).noquote() << "Audio source removed" << id;
         updateRxBufferStats();
     }
@@ -4721,6 +5107,9 @@ void AudioEngine::resetRxChainStateForSourceSwitch()
 {
     std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
 
+    if (m_legacyKiwiClientEffects) {
+        m_legacyKiwiClientEffects->reset();
+    }
     m_rxResampler.reset();
     m_rxResamplerR.reset();
     m_rxPackets.clear();
@@ -4783,7 +5172,10 @@ void AudioEngine::resetRxChainStateForSourceSwitch()
         m_nr4->reset();
     }
     if (m_nr4Enabled && m_kiwiSdrNr4) {
-        m_kiwiSdrNr4->reset();
+        m_kiwiSdrNr4 = createNr4Filter(QStringLiteral("Kiwi epoch"));
+        if (m_kiwiSdrNr4) {
+            applyNr4SettingsFromAppSettings(*m_kiwiSdrNr4);
+        }
     }
 #endif
 #ifdef HAVE_DFNR
@@ -4807,7 +5199,10 @@ void AudioEngine::resetRxChainStateForSourceSwitch()
         m_nvAfx->reset();
     }
     if (m_nvAfxEnabled && m_kiwiSdrNvAfx) {
-        m_kiwiSdrNvAfx->reset();
+        m_kiwiSdrNvAfx = createNvAfxFilter(QStringLiteral("Kiwi epoch"));
+        if (m_kiwiSdrNvAfx) {
+            m_kiwiSdrNvAfx->setIntensity(NvidiaBnrSettings::intensity());
+        }
     }
 #endif
 }
@@ -4815,15 +5210,15 @@ void AudioEngine::resetRxChainStateForSourceSwitch()
 void AudioEngine::processRxAudioData(const QByteArray& pcm, bool emitTncTap,
                                      RxAudioBuffer targetBuffer)
 {
-    if (!m_audioSink) return;  // PC audio disabled
+    if (!m_audioDevice) return;  // PC audio disabled
     m_lastAudioFeedTime.start();  // reset liveness watchdog (#1411)
 
-    // Source callbacks queue native 24 kHz stereo PCM only. With NR2 enabled,
+    // Source callbacks queue stereo PCM at their declared producer rate. With NR2 enabled,
     // each receive source keeps whole packet-sized blocks until the timer
     // processes that source through its own NR2/output path. The speaker drain
     // mixes post-DSP output FIFOs at the sink.
     if (emitTncTap && m_tncRxTapEnabled.load(std::memory_order_relaxed)) {
-        emitTncRxTapFromFloat32Stereo(pcm, DEFAULT_SAMPLE_RATE);
+        emitTncRxTapFromFloat32Stereo(pcm, m_rxProducerRate.load());
     }
 
     constexpr qsizetype kFrameBytes = 2 * static_cast<qsizetype>(sizeof(float));
@@ -4835,10 +5230,19 @@ void AudioEngine::processRxAudioData(const QByteArray& pcm, bool emitTncTap,
     const QByteArray alignedPcm =
         alignedBytes == pcm.size() ? pcm : pcm.left(alignedBytes);
 
+    const int producerRate = targetBuffer == RxAudioBuffer::Main
+        ? m_rxProducerRate.load() : DEFAULT_SAMPLE_RATE;
+    const int presentationDelay = targetBuffer == RxAudioBuffer::Main
+        ? m_flexReceivePresentationDelayMs.load() : m_kiwiReceivePresentationDelayMs.load();
+    const qsizetype cap = audioBytesForMsAtRate(producerRate,
+        std::max({m_rxBufferCapMs.load(), presentationDelay + 100,
+            (targetBuffer == RxAudioBuffer::KiwiSdr || kiwiSdrAudioActive()
+             || anyExternalKiwiAudioEnabled()) ? kKiwiSdrBufferCapMs : 0}));
     if (targetBuffer == RxAudioBuffer::Main
         && m_nr2Enabled.load(std::memory_order_relaxed)) {
         std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
         m_rxPackets.push_back(alignedPcm);
+        trimAudioPacketQueue(m_rxPackets, cap);
         updateRxBufferStats();
         return;
     }
@@ -4847,6 +5251,9 @@ void AudioEngine::processRxAudioData(const QByteArray& pcm, bool emitTncTap,
         targetBuffer == RxAudioBuffer::KiwiSdr ? m_kiwiSdrRxBuffer
                                                : m_rxBuffer;
     target.append(alignedPcm);
+    if (target.size() > cap) {
+        dropAudioBufferFront(target, target.size() - cap, producerRate);
+    }
     updateRxBufferStats();
 }
 
@@ -4854,7 +5261,7 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
                                           RxDspSource source,
                                           ExternalRxAudioSourceState* externalSource)
 {
-    if (!m_audioSink) return;  // PC audio disabled
+    if (!m_audioDevice) return;  // PC audio disabled
 
     const auto sourcePan = [this, externalSource]() {
         return externalSource ? externalSource->pan : m_rxPan.load();
@@ -4886,28 +5293,42 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
     // feedAudioData() handles all remote_audio_rx paths: SSB/CW/digital on any
     // pan, and the zero-filled frames the radio sends for muted slices
     // (audio_mute=1 zeroes the payload; it does NOT suppress packets).
-    // The caller supplies exactly one native 24 kHz stereo source stream:
+    // The caller supplies exactly one producer-rate stereo source stream:
     // Flex audio, the legacy Kiwi stream, or one virtual Kiwi antenna stream.
     // Stateful NR/output resamplers must never see alternating Flex/Kiwi or
     // different Kiwi endpoints on the same DSP state.
-    auto writeAudio = [this, source, externalSource, sourcePan,
+    RxClientEffects* auxiliaryEffects = externalSource
+        ? externalSource->clientEffects.get()
+        : (source == RxDspSource::KiwiSdr ? m_legacyKiwiClientEffects.get() : nullptr);
+    if (auxiliaryEffects) {
+        auxiliaryEffects->syncParametersFrom(*m_clientEqRx, *m_clientGateRx,
+            *m_clientCompRx, *m_clientDeEssRx, *m_clientTubeRx, *m_clientPuduRx);
+    }
+    auto writeAudio = [this, source, externalSource, sourcePan, auxiliaryEffects,
                        txPresentationGated, bypassRxChainForTx](
                           const QByteArray& data,
                           bool applyOutputPan = false) {
         if (!m_audioDevice || !m_audioDevice->isOpen()) return;
+        ClientEq* eq = auxiliaryEffects ? &auxiliaryEffects->eq() : m_clientEqRx.get();
+        ClientGate* gate = auxiliaryEffects ? &auxiliaryEffects->gate() : m_clientGateRx.get();
+        ClientComp* comp = auxiliaryEffects ? &auxiliaryEffects->comp() : m_clientCompRx.get();
+        ClientDeEss* deEss = auxiliaryEffects ? &auxiliaryEffects->deEss() : m_clientDeEssRx.get();
+        ClientTube* tube = auxiliaryEffects ? &auxiliaryEffects->tube() : m_clientTubeRx.get();
+        ClientPudu* pudu = auxiliaryEffects ? &auxiliaryEffects->pudu() : m_clientPuduRx.get();
 
-        // Client-side parametric EQ runs at the native 24 kHz rate, after
-        // any NR chain, before resample-to-48k and soft boost. Copy-then-
+
+        // Client-side parametric EQ runs at this source's producer rate, after
+        // any NR chain, before device-rate conversion and soft boost. Copy-then-
         // process because the caller owns `data`. Skip when disabled or
         // during TX (matches the NR-chain TX bypass policy) — except for
         // managed Kiwi sources, whose input stays live signal during TX.
         const QByteArray* eqSource = &data;
-        if (m_clientEqRx && m_clientEqRx->isEnabled()
+        if (eq && eq->isEnabled()
             && !bypassRxChainForTx) {
             m_clientEqRxScratch = data;
             const int frames = m_clientEqRxScratch.size()
                              / (2 * static_cast<int>(sizeof(float)));
-            m_clientEqRx->process(
+            eq->process(
                 reinterpret_cast<float*>(m_clientEqRxScratch.data()),
                 frames, 2);
             eqSource = &m_clientEqRxScratch;
@@ -4917,7 +5338,8 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
         // analyzer. Runs whether EQ is active or bypassed — the tap shows
         // the signal actually heading to the sink at native 24 kHz.
         const int tapFrames = eqSource->size() / (2 * static_cast<int>(sizeof(float)));
-        if (tapFrames > 0 && !txPresentationGated) {
+        if (tapFrames > 0 && !txPresentationGated
+            && (!auxiliaryEffects || !m_mainPcmFrame)) {
             tapClientEqRxStereo(
                 reinterpret_cast<const float*>(eqSource->constData()),
                 tapFrames);
@@ -4928,54 +5350,65 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
         // (matches the user's signal-flow expectation).  Skip during TX
         // for the same reason as EQ.
         const QByteArray* gateSource = eqSource;
-        if (m_clientGateRx && m_clientGateRx->isEnabled()
+        if (gate && gate->isEnabled()
             && !bypassRxChainForTx) {
             m_clientGateRxScratch = *eqSource;
-            applyClientGateRxFloat32(m_clientGateRxScratch);
+            gate->process(reinterpret_cast<float*>(m_clientGateRxScratch.data()),
+                m_clientGateRxScratch.size() / (2 * static_cast<int>(sizeof(float))), 2);
             gateSource = &m_clientGateRxScratch;
         }
 
         // RX chain stage: COMP — runs after GATE.  Same scratch-copy
         // pattern.
         const QByteArray* compSource = gateSource;
-        if (m_clientCompRx && m_clientCompRx->isEnabled()
+        if (comp && comp->isEnabled()
             && !bypassRxChainForTx) {
             m_clientCompRxScratch = *gateSource;
-            applyClientCompRxFloat32(m_clientCompRxScratch);
+            comp->process(reinterpret_cast<float*>(m_clientCompRxScratch.data()),
+                m_clientCompRxScratch.size() / (2 * static_cast<int>(sizeof(float))), 2);
             compSource = &m_clientCompRxScratch;
         }
 
         // RX chain stage: DESS — runs after COMP, before TUBE.  Same
         // scratch-copy pattern as the surrounding stages.
         const QByteArray* deEssSource = compSource;
-        if (m_clientDeEssRx && m_clientDeEssRx->isEnabled()
+        if (deEss && deEss->isEnabled()
             && !bypassRxChainForTx) {
             m_clientDeEssRxScratch = *compSource;
-            applyClientDeEssRxFloat32(m_clientDeEssRxScratch);
+            deEss->process(reinterpret_cast<float*>(m_clientDeEssRxScratch.data()),
+                m_clientDeEssRxScratch.size() / (2 * static_cast<int>(sizeof(float))), 2);
             deEssSource = &m_clientDeEssRxScratch;
         }
 
         // RX chain stage: TUBE — runs after DESS.
         const QByteArray* tubeSource = deEssSource;
-        if (m_clientTubeRx && m_clientTubeRx->isEnabled()
+        if (tube && tube->isEnabled()
             && !bypassRxChainForTx) {
             m_clientTubeRxScratch = *deEssSource;
-            applyClientTubeRxFloat32(m_clientTubeRxScratch);
+            tube->process(reinterpret_cast<float*>(m_clientTubeRxScratch.data()),
+                m_clientTubeRxScratch.size() / (2 * static_cast<int>(sizeof(float))), 2);
             tubeSource = &m_clientTubeRxScratch;
         }
 
         // RX chain stage: PUDU — runs after TUBE.
         const QByteArray* puduSource = tubeSource;
-        if (m_clientPuduRx && m_clientPuduRx->isEnabled()
+        if (pudu && pudu->isEnabled()
             && !bypassRxChainForTx) {
             m_clientPuduRxScratch = *tubeSource;
-            applyClientPuduRxFloat32(m_clientPuduRxScratch);
+            pudu->process(reinterpret_cast<float*>(m_clientPuduRxScratch.data()),
+                m_clientPuduRxScratch.size() / (2 * static_cast<int>(sizeof(float))), 2);
             puduSource = &m_clientPuduRxScratch;
+        }
+
+        if (auxiliaryEffects && !txPresentationGated && !bypassRxChainForTx
+            && !data.isEmpty()) {
+            updateAuxiliaryClientEffectMeters(*auxiliaryEffects);
         }
 
         const int scopeSampleRate = m_rxOutputRate.load();
         const QByteArray& resampled =
-            (m_rxOutputRate.load() != DEFAULT_SAMPLE_RATE)
+            (m_rxOutputRate.load() != (source == RxDspSource::Main
+                    ? m_rxProducerRate.load() : DEFAULT_SAMPLE_RATE))
                 ? resampleStereo(*puduSource, source, externalSource)
                 : *puduSource;
         const QByteArray* output = &resampled;
@@ -5063,13 +5496,21 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
             writeAudioAndLevel(pcm);
         } else if (m_rn2Enabled) {
             RNNoiseFilter* rn2 = rn2ForSource(source, externalSource);
-            if (!rn2) {
-                writeAudioAndLevel(pcm);
+            if (!rn2 || !rn2->isValid()) {
+                return; // enabled processor is still preparing or failed
+            }
+            QByteArray processed;
+            if (source == RxDspSource::Main && m_rxProducerRate.load() == 48000) {
+                rn2->process48kStereo(pcm, processed);
+            } else {
+                processed = rn2->process(pcm);
+            }
+            writeAudioAndLevel(processed);
+        } else if (m_nr2Enabled) {
+            if (!(externalSource ? externalSource->nr2.get()
+                  : (source == RxDspSource::KiwiSdr ? m_kiwiSdrNr2.get() : m_nr2.get()))) {
                 return;
             }
-            QByteArray processed = rn2->process(pcm);
-            writeAudioAndLevel(processed);
-        } else if (m_nr2Enabled && m_nr2) {
             processNr2(pcm, source, externalSource);
             const QByteArray& nr2Output = externalSource
                 ? externalSource->nr2Output
@@ -5080,9 +5521,8 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
 #ifdef HAVE_SPECBLEACH
         } else if (m_nr4Enabled) {
             SpecbleachFilter* nr4 = nr4ForSource(source, externalSource);
-            if (!nr4) {
-                writeAudioAndLevel(pcm);
-                return;
+            if (!nr4 || !nr4->isValid()) {
+                return; // enabled processor is still preparing or failed
             }
             QByteArray processed = nr4->process(pcm);
             writeAudioAndLevel(processed);
@@ -5090,9 +5530,8 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
 #ifdef HAVE_DFNR
         } else if (m_dfnrEnabled) {
             DeepFilterFilter* dfnr = dfnrForSource(source, externalSource);
-            if (!dfnr) {
-                writeAudioAndLevel(pcm);
-                return;
+            if (!dfnr || !dfnr->isValid()) {
+                return; // enabled processor is still preparing or failed
             }
             QByteArray processed = dfnr->process(pcm);
             writeAudioAndLevel(processed);
@@ -5100,9 +5539,8 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
 #ifdef HAVE_NVIDIA_AFX
         } else if (m_nvAfxEnabled) {
             NvidiaAfxFilter* nvAfx = nvAfxForSource(source, externalSource);
-            if (!nvAfx) {
-                writeAudioAndLevel(pcm);
-                return;
+            if (!nvAfx || !nvAfx->isValid()) {
+                return; // enabled processor is still preparing or failed
             }
             QByteArray processed = nvAfx->process(pcm);
             writeAudioAndLevel(processed);
@@ -5110,9 +5548,8 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
 #ifdef __APPLE__
         } else if (m_mnrEnabled) {
             MacNRFilter* mnr = mnrForSource(source, externalSource);
-            if (!mnr) {
-                writeAudioAndLevel(pcm);
-                return;
+            if (!mnr || !mnr->isValid()) {
+                return; // enabled processor is still preparing or failed
             }
             QByteArray processed = mnr->process(pcm);
             writeAudioAndLevel(processed);
@@ -5121,6 +5558,21 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
             writeAudioAndLevel(pcm);
         }
     }
+}
+
+void AudioEngine::updateAuxiliaryClientEffectMeters(RxClientEffects& source)
+{
+    // The main source owns the RX display whenever its typed stream is live.
+    // With auxiliary-only playback, retain the existing last-presented-source
+    // meter behavior without redirecting UI parameter writes to a DSP replica.
+    if (m_mainPcmFrame && m_mainPcmFrame->current()) {
+        return;
+    }
+    m_clientGateRx->copyMeteringFrom(source.gate());
+    m_clientCompRx->copyMeteringFrom(source.comp());
+    m_clientDeEssRx->copyMeteringFrom(source.deEss());
+    m_clientTubeRx->copyMeteringFrom(source.tube());
+    m_clientPuduRx->copyMeteringFrom(source.pudu());
 }
 
 namespace {
@@ -6799,7 +7251,7 @@ void AudioEngine::setNr2Enabled(bool on)
 #endif
         m_nr2 = createNr2Filter(
             QStringLiteral("main RX"),
-            m_mainSourceLegacyNr2.load(std::memory_order_relaxed));
+            m_mainSourceLegacyNr2.load(std::memory_order_relaxed), m_rxProducerRate.load());
         if (!m_nr2) {
             emit nr2EnabledChanged(false);
             return;
@@ -6997,7 +7449,7 @@ void AudioEngine::setNr4Enabled(bool on)
         if (m_dfnrEnabled) setDfnrEnabled(false);
         if (m_nvAfxEnabled) setNvAfxEnabled(false);
         if (m_mnrEnabled)  setMnrEnabled(false);
-        m_nr4 = createNr4Filter(QStringLiteral("Flex"));
+        m_nr4 = createNr4Filter(QStringLiteral("Flex"), m_rxProducerRate.load());
         if (!m_nr4) {
             m_nr4.reset();
             emit nr4EnabledChanged(false);
@@ -7156,7 +7608,7 @@ void AudioEngine::setMnrEnabled(bool on)
         // Restore strength from settings (default 1.0 = full suppression)
         m_mnrStrength.store(std::clamp(
             AppSettings::instance().value("MnrStrength", "1.00").toFloat(), 0.0f, 1.0f));
-        m_mnr = createMnrFilter(QStringLiteral("Flex"));
+        m_mnr = createMnrFilter(QStringLiteral("Flex"), m_rxProducerRate.load());
         if (!m_mnr) {
             m_mnr.reset();
             emit mnrEnabledChanged(false);
@@ -7219,7 +7671,7 @@ void AudioEngine::setRn2Enabled(bool on)
         if (m_dfnrEnabled) setDfnrEnabled(false);
         if (m_nvAfxEnabled) setNvAfxEnabled(false);
         if (m_mnrEnabled)  setMnrEnabled(false);
-        m_rn2 = createRn2Filter(QStringLiteral("Flex"));
+        m_rn2 = createRn2Filter(QStringLiteral("Flex"), m_rxProducerRate.load());
         if (!m_rn2) {
             m_rn2.reset();
             emit rn2EnabledChanged(false);
@@ -7323,7 +7775,7 @@ void AudioEngine::setDfnrEnabled(bool on)
         if (m_nr4Enabled)  setNr4Enabled(false);
         if (m_mnrEnabled)  setMnrEnabled(false);
         if (m_nvAfxEnabled) setNvAfxEnabled(false);
-        m_dfnr = createDfnrFilter(QStringLiteral("Flex"));
+        m_dfnr = createDfnrFilter(QStringLiteral("Flex"), m_rxProducerRate.load());
         if (!m_dfnr) {
             m_dfnr.reset();
             emit dfnrEnabledChanged(false);
@@ -7411,7 +7863,7 @@ void AudioEngine::setNvAfxEnabled(bool on)
         if (m_dfnrEnabled) setDfnrEnabled(false);
         if (m_nvAfxEnabled) setNvAfxEnabled(false);
         if (m_mnrEnabled)  setMnrEnabled(false);
-        m_nvAfx = createNvAfxFilter(QStringLiteral("Flex"));
+        m_nvAfx = createNvAfxFilter(QStringLiteral("Flex"), m_rxProducerRate.load());
         if (!m_nvAfx) {
             m_nvAfx.reset();
             emit nvAfxEnabledChanged(false);
@@ -9458,7 +9910,7 @@ void AudioEngine::pumpWsprBeacon()
 
 void AudioEngine::feedDecodedSpeech(const QByteArray& pcm)
 {
-    if (!m_audioSink || !m_audioDevice || !m_audioDevice->isOpen()) return;
+    if (!m_audioDevice || !m_audioDevice->isOpen()) return;
 
     // Decoded RADE speech goes into its own output-rate buffer. The drain
     // timer mixes it with m_rxOutputBuffer sample-wise so both are heard

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -4542,7 +4542,17 @@ bool AudioEngine::prepareMainPcmDsp()
         ;
 }
 
-void AudioEngine::resetMainPcmState(int producerRate)
+// Whether the main typed source owns the RX display right now. The EQ analyzer
+// tap and the auxiliary meter mirror must agree on this: testing only for a
+// non-null frame left a revoked-but-not-yet-retired frame counting as live for
+// up to one 10 ms drain tick, so the tap stayed suppressed after the meters had
+// already handed back to the auxiliary source.
+bool AudioEngine::mainPcmSourceOwnsDisplay() const
+{
+    return m_mainPcmFrame && m_mainPcmFrame->current();
+}
+
+void AudioEngine::resetMainPcmState(int producerRate, bool rebuildDsp)
 {
     std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     m_rxBuffer.clear();
@@ -4563,8 +4573,14 @@ void AudioEngine::resetMainPcmState(int producerRate)
         std::fill(std::begin(m_clientEqTapRx), std::end(m_clientEqTapRx), 0.0f);
         m_clientEqTapRxWrite = 0;
     }
-    m_mainPcmDspReady = prepareMainPcmDsp();
-    if (!m_mainPcmDspReady) {
+    // Only a PRODUCER-rate change invalidates these filters — they are built
+    // for the producer domain and never see the device rate. Rebuilding costs a
+    // model load (DFNR measures ~450 ms), so a caller that has not moved the
+    // producer rate keeps them, history included: the stream behind them did
+    // not change, and dropping their state would inject an NR transient.
+    // Withholding on failed preparation is enforced per call in
+    // processMixedRxAudioData(), not by a flag here.
+    if (rebuildDsp && !prepareMainPcmDsp()) {
         qCWarning(lcAudio) << "AudioEngine: enabled RX processing could not prepare at"
                           << producerRate << "Hz; withholding this source";
     }
@@ -4616,9 +4632,17 @@ void AudioEngine::setRxDeviceRate(int rate)
 {
     // Called only after successful output negotiation. The producer rate is
     // unchanged; old device-format bytes and every converter history expire.
+    //
+    // The optional NR chain is deliberately NOT rebuilt here. startRxStream()
+    // reaches this on every sink open — including the #1361 zombie-sink and
+    // #1411 liveness watchdogs, which fire on real hardware and run on the GUI
+    // thread — and those filters belong to the producer domain, which this call
+    // does not touch. Rebuilding them anyway put a model load on each of those
+    // recovery paths, freezing the UI at the exact moment the user is already
+    // hearing a glitch.
     std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     m_rxOutputRate.store(rate);
-    resetMainPcmState(m_rxProducerRate.load());
+    resetMainPcmState(m_rxProducerRate.load(), /*rebuildDsp=*/false);
     m_radeRxBuffer.clear();
     m_radeRxResampler.reset();
     m_kiwiSdrRxBuffer.clear();
@@ -5339,7 +5363,7 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
         // the signal actually heading to the sink at native 24 kHz.
         const int tapFrames = eqSource->size() / (2 * static_cast<int>(sizeof(float)));
         if (tapFrames > 0 && !txPresentationGated
-            && (!auxiliaryEffects || !m_mainPcmFrame)) {
+            && (!auxiliaryEffects || !mainPcmSourceOwnsDisplay())) {
             tapClientEqRxStereo(
                 reinterpret_cast<const float*>(eqSource->constData()),
                 tapFrames);
@@ -5565,7 +5589,7 @@ void AudioEngine::updateAuxiliaryClientEffectMeters(RxClientEffects& source)
     // The main source owns the RX display whenever its typed stream is live.
     // With auxiliary-only playback, retain the existing last-presented-source
     // meter behavior without redirecting UI parameter writes to a DSP replica.
-    if (m_mainPcmFrame && m_mainPcmFrame->current()) {
+    if (mainPcmSourceOwnsDisplay()) {
         return;
     }
     m_clientGateRx->copyMeteringFrom(source.gate());

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -61,6 +61,7 @@ class ClientPuduMonitor;
 class ClientReverb;
 class ClientFinalLimiter;
 class ClientTxTestTone;
+class RxClientEffects;
 class ClientQuindarTone;
 class WsprBeacon;
 class QuindarLocalSink;
@@ -72,11 +73,10 @@ class MacNRFilter;
 // AudioEngine handles audio playback (RX) and capture (TX).
 //
 // RX path:
-//   Audio PCM arrives via PanadapterStream::pcmFrameReady() — the radio sends
-//   VITA-49 IF-Data packets to the single "client udpport" socket owned by
-//   PanadapterStream. PanadapterStream strips the header and emits the raw PCM;
-//   connect that signal to feedAudioData() then call startRxStream() to open
-//   the QAudioSink.
+//   Typed producer PCM reaches feedPcmFrame() at its declared 24/48 kHz rate.
+//   Legacy byte input and auxiliary Kiwi routes remain 24 kHz. Per-source
+//   processing precedes stereo-preserving conversion to the negotiated sink.
+//   See docs/audio-engine-rate-domains.md for queue and epoch lifetimes.
 //
 // TX path:
 //   Captures mic/input audio via QAudioSource, frames it as VITA-49
@@ -267,7 +267,7 @@ public:
     int  txInputBytesPerSample() const { return txInputIsFloat32() ? 4 : 2; }
     bool txInputNormalizationTo48k() const;
     bool txRadeResamplingTo24k() const { return m_radeTxNeedsResample; }
-    bool rxOutputResamplingActive() const { return m_rxOutputRate.load() != DEFAULT_SAMPLE_RATE; }
+    bool rxOutputResamplingActive() const { return m_rxOutputRate.load() != m_rxProducerRate.load(); }
     QJsonArray audioEndpointDiagnostics() const;
     QJsonObject startAutomationAudioCapture(int durationMs,
                                             const QStringList& points);
@@ -610,6 +610,10 @@ public:
     QAudioDevice inputDevice()  const { return m_inputDevice; }
     qsizetype rxBufferBytes() const { return m_rxBufferBytes.load(); }
     qsizetype rxBufferPeakBytes() const { return m_rxBufferPeakBytes.load(); }
+    // Sum of queued durations across sources, excluding the device queue.
+    // Bytes span producer and device domains; no single rate converts them.
+    double rxBufferMs() const { return m_rxBufferMs.load(); }
+    double rxBufferPeakMs() const { return m_rxBufferPeakMs.load(); }
     quint64 rxBufferUnderrunCount() const { return m_rxBufferUnderrunCount.load(); }
     int rxBufferSampleRate() const { return m_rxBufferSampleRate.load(); }
     int rxPlaybackQueuedMs() const
@@ -819,6 +823,9 @@ private:
 
     struct ExternalRxAudioSourceState {
         QString id;
+        std::optional<PcmFrame> pcmFrame;
+        PcmFrameGate pcmIngress;
+        std::unique_ptr<RxClientEffects> clientEffects;
         QByteArray rxBuffer;
         std::deque<QByteArray> rxPackets;
         QByteArray outputBuffer;
@@ -920,29 +927,35 @@ private:
     void resetExternalKiwiDspState(ExternalRxAudioSourceState& source);
     void clearExternalKiwiDspState(ExternalRxAudioSourceState& source);
     std::unique_ptr<SpectralNR> createNr2Filter(
-        const QString& label, bool forceLegacyGeometry = false) const;
-    std::unique_ptr<RNNoiseFilter> createRn2Filter(const QString& label) const;
+        const QString& label, bool forceLegacyGeometry = false,
+        int producerRate = DEFAULT_SAMPLE_RATE) const;
+    std::unique_ptr<RNNoiseFilter> createRn2Filter(const QString& label,
+        int producerRate = DEFAULT_SAMPLE_RATE) const;
     RNNoiseFilter* rn2ForSource(RxDspSource source,
                                 ExternalRxAudioSourceState* externalSource) const;
 #ifdef HAVE_SPECBLEACH
-    std::unique_ptr<SpecbleachFilter> createNr4Filter(const QString& label) const;
+    std::unique_ptr<SpecbleachFilter> createNr4Filter(const QString& label,
+        int producerRate = DEFAULT_SAMPLE_RATE) const;
     SpecbleachFilter* nr4ForSource(
         RxDspSource source,
         ExternalRxAudioSourceState* externalSource) const;
 #endif
 #ifdef __APPLE__
-    std::unique_ptr<MacNRFilter> createMnrFilter(const QString& label) const;
+    std::unique_ptr<MacNRFilter> createMnrFilter(const QString& label,
+        int producerRate = DEFAULT_SAMPLE_RATE) const;
     MacNRFilter* mnrForSource(RxDspSource source,
                               ExternalRxAudioSourceState* externalSource) const;
 #endif
 #ifdef HAVE_DFNR
-    std::unique_ptr<DeepFilterFilter> createDfnrFilter(const QString& label) const;
+    std::unique_ptr<DeepFilterFilter> createDfnrFilter(const QString& label,
+        int producerRate = DEFAULT_SAMPLE_RATE) const;
     DeepFilterFilter* dfnrForSource(
         RxDspSource source,
         ExternalRxAudioSourceState* externalSource) const;
 #endif
 #ifdef HAVE_NVIDIA_AFX
-    std::unique_ptr<NvidiaAfxFilter> createNvAfxFilter(const QString& label) const;
+    std::unique_ptr<NvidiaAfxFilter> createNvAfxFilter(const QString& label,
+        int producerRate = DEFAULT_SAMPLE_RATE) const;
     NvidiaAfxFilter* nvAfxForSource(
         RxDspSource source,
         ExternalRxAudioSourceState* externalSource) const;
@@ -957,6 +970,7 @@ private:
     void applyClientTubeRxFloat32(QByteArray& float32);
     // RX pudu operates on the post-Tube float32 stereo buffer.
     void applyClientPuduRxFloat32(QByteArray& float32);
+    void updateAuxiliaryClientEffectMeters(RxClientEffects& source);
 
     void accumulatePcMicMeterInt16Stereo(const QByteArray& int16stereo);
     void logTxInputChannelDiagnostics(const TxMicChannelNormalizer::Diagnostics& diagnostics,
@@ -1205,6 +1219,20 @@ private:
     QElapsedTimer m_lastDaxRadioChannelLog;
     std::unique_ptr<Resampler> m_txResampler;  // RADE e.g. 48k -> 24k (lazy init)
 
+    friend class AudioEngineRatesTestAccess;
+    void drainRxAudio(qsizetype freeBytes);
+    bool retireInvalidPcmSources();
+    void queueLegacyKiwiAudioData(const QByteArray& pcm24kStereoFloat);
+    void queueKiwiAudioData(const QString& sourceId, const QByteArray& pcm24kStereoFloat);
+    void resetMainPcmState(int producerRate);
+    void flushRxDevice();
+    void setRxDeviceRate(int rate);
+    bool prepareMainPcmDsp();
+    std::optional<PcmFrame> m_mainPcmFrame;
+    std::optional<PcmFrame> m_legacyKiwiPcmFrame;
+    std::atomic<int> m_rxProducerRate{DEFAULT_SAMPLE_RATE};
+    bool m_mainPcmDspReady{true};
+    std::unique_ptr<RxClientEffects> m_legacyKiwiClientEffects;
 
     // DSP lifecycle mutex: held during feedAudioData() DSP section AND
     // during enable/disable to prevent use-after-free (#502)
@@ -1422,6 +1450,8 @@ private:
     std::vector<std::unique_ptr<ExternalRxAudioSourceState>> m_externalKiwiSources;
     std::atomic<qsizetype> m_rxBufferBytes{0};
     std::atomic<qsizetype> m_rxBufferPeakBytes{0};
+    std::atomic<double>    m_rxBufferMs{0.0};
+    std::atomic<double>    m_rxBufferPeakMs{0.0};
     std::atomic<quint64>   m_rxBufferUnderrunCount{0};
     std::atomic<int>       m_rxBufferSampleRate{DEFAULT_SAMPLE_RATE};
     std::atomic<int>       m_rxPlaybackQueuedMs{0};

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -1224,14 +1224,16 @@ private:
     bool retireInvalidPcmSources();
     void queueLegacyKiwiAudioData(const QByteArray& pcm24kStereoFloat);
     void queueKiwiAudioData(const QString& sourceId, const QByteArray& pcm24kStereoFloat);
-    void resetMainPcmState(int producerRate);
+    bool mainPcmSourceOwnsDisplay() const;
+    // rebuildDsp=false keeps the optional NR chain: it is built for the
+    // producer domain, so a device-rate change must not pay to recreate it.
+    void resetMainPcmState(int producerRate, bool rebuildDsp = true);
     void flushRxDevice();
     void setRxDeviceRate(int rate);
     bool prepareMainPcmDsp();
     std::optional<PcmFrame> m_mainPcmFrame;
     std::optional<PcmFrame> m_legacyKiwiPcmFrame;
     std::atomic<int> m_rxProducerRate{DEFAULT_SAMPLE_RATE};
-    bool m_mainPcmDspReady{true};
     std::unique_ptr<RxClientEffects> m_legacyKiwiClientEffects;
 
     // DSP lifecycle mutex: held during feedAudioData() DSP section AND

--- a/src/core/ClientComp.cpp
+++ b/src/core/ClientComp.cpp
@@ -159,6 +159,9 @@ void ClientComp::reset() noexcept
 {
     m_envLin = 0.0f;
     m_limEnvLin = 0.0f;
+    if (m_phaseRotator) {
+        m_phaseRotator->reset();
+    }
 }
 
 float ClientComp::inputPeakDb() const noexcept
@@ -171,6 +174,15 @@ float ClientComp::limiterGrDb() const noexcept
 { return m_meters.limiterGrDb.load(std::memory_order_relaxed); }
 bool  ClientComp::limiterActive() const noexcept
 { return m_meters.limiterActive.load(std::memory_order_relaxed); }
+
+void ClientComp::copyMeteringFrom(const ClientComp& source) noexcept
+{
+    m_meters.inputPeakDb.store(source.inputPeakDb(), std::memory_order_relaxed);
+    m_meters.outputPeakDb.store(source.outputPeakDb(), std::memory_order_relaxed);
+    m_meters.gainReductionDb.store(source.gainReductionDb(), std::memory_order_relaxed);
+    m_meters.limiterGrDb.store(source.limiterGrDb(), std::memory_order_relaxed);
+    m_meters.limiterActive.store(source.limiterActive(), std::memory_order_relaxed);
+}
 
 void ClientComp::recacheIfDirty() noexcept
 {

--- a/src/core/ClientComp.h
+++ b/src/core/ClientComp.h
@@ -30,7 +30,8 @@ public:
     ClientComp(const ClientComp&)            = delete;
     ClientComp& operator=(const ClientComp&) = delete;
 
-    // Main thread — call before first process() and on sample-rate change.
+    // Audio owner — call before first process() and on sample-rate change.
+    // Never call concurrently with process(); parameter setters remain atomic.
     void prepare(double sampleRate);
 
     // Main thread — global enable / bypass. Lock-free.
@@ -86,7 +87,12 @@ public:
     bool  limiterActive() const noexcept;     // true while limiter is clamping
 
     // Sample rate this comp was prepared at.
-    double sampleRate() const noexcept { return m_sampleRate; }
+    // Audio owner: mirror a presented auxiliary source into UI-facing meters.
+    // Copies atomic snapshots only; parameters and processing histories stay local.
+    void copyMeteringFrom(const ClientComp& source) noexcept;
+
+    double sampleRate() const noexcept
+    { return m_sampleRate.load(std::memory_order_relaxed); }
 
 private:
     struct Atomics {
@@ -132,7 +138,8 @@ private:
     void recacheIfDirty() noexcept;
     float staticCurveGainDb(float envDb) const noexcept;
 
-    double   m_sampleRate{24000.0};
+    // Audio owner writes in prepare(); UI reads the displayed processing rate.
+    std::atomic<double> m_sampleRate{24000.0};
     Atomics  m_atomics;
     Cached   m_cached;
     Meters   m_meters;

--- a/src/core/ClientDeEss.cpp
+++ b/src/core/ClientDeEss.cpp
@@ -156,6 +156,13 @@ float ClientDeEss::sidechainPeakDb() const noexcept
 float ClientDeEss::gainReductionDb() const noexcept
 { return m_meters.gainReductionDb.load(std::memory_order_relaxed); }
 
+void ClientDeEss::copyMeteringFrom(const ClientDeEss& source) noexcept
+{
+    m_meters.inputPeakDb.store(source.inputPeakDb(), std::memory_order_relaxed);
+    m_meters.sidechainPeakDb.store(source.sidechainPeakDb(), std::memory_order_relaxed);
+    m_meters.gainReductionDb.store(source.gainReductionDb(), std::memory_order_relaxed);
+}
+
 void ClientDeEss::recacheIfDirty() noexcept
 {
     const uint64_t v = m_atomics.version.load(std::memory_order_acquire);

--- a/src/core/ClientDeEss.h
+++ b/src/core/ClientDeEss.h
@@ -28,6 +28,8 @@ public:
     ClientDeEss(const ClientDeEss&)            = delete;
     ClientDeEss& operator=(const ClientDeEss&) = delete;
 
+    // Audio owner only; never concurrently with process(). GUI rate reads
+    // and parameter setters remain safe while a new producer is prepared.
     void prepare(double sampleRate);
 
     void setEnabled(bool on) noexcept;
@@ -75,7 +77,12 @@ public:
     float sidechainPeakDb() const noexcept;         // HF-band sidechain peak
     float gainReductionDb() const noexcept;         // ≤ 0 dB
 
-    double sampleRate() const noexcept { return m_sampleRate; }
+    // Audio owner: mirror a presented auxiliary source into UI-facing meters.
+    // Copies atomic snapshots only; parameters and processing histories stay local.
+    void copyMeteringFrom(const ClientDeEss& source) noexcept;
+
+    double sampleRate() const noexcept
+    { return m_sampleRate.load(std::memory_order_relaxed); }
 
     // Public because the cpp-local biquad helper takes references to
     // these.  Not part of the user-facing API.
@@ -118,7 +125,8 @@ private:
     void recacheIfDirty() noexcept;
     float staticCurveGainDb(float envDb) const noexcept;
 
-    double m_sampleRate{24000.0};
+    // Audio owner writes in prepare(); UI reads the displayed processing rate.
+    std::atomic<double> m_sampleRate{24000.0};
     Atomics m_atomics;
     Cached  m_cached;
     Meters  m_meters;

--- a/src/core/ClientEq.h
+++ b/src/core/ClientEq.h
@@ -60,7 +60,8 @@ public:
     ClientEq(const ClientEq&)            = delete;
     ClientEq& operator=(const ClientEq&) = delete;
 
-    // Main thread — call before first process() and on sample-rate change.
+    // Audio owner — call before first process() and on sample-rate change.
+    // Never call concurrently with process(); parameter setters remain atomic.
     void prepare(double sampleRate);
 
     // Main thread — global enable (bypass when false). Lock-free.
@@ -97,7 +98,8 @@ public:
 
     // Sample rate this EQ was prepared at. UI uses this when computing
     // the displayed magnitude response.
-    double sampleRate() const noexcept { return m_sampleRate; }
+    double sampleRate() const noexcept
+    { return m_sampleRate.load(std::memory_order_relaxed); }
 
     // Compute the analytic magnitude of one band at a probe frequency,
     // in dB, from its target parameters. Pure function, stateless, safe
@@ -172,7 +174,8 @@ private:
                             const AtomicBand& target,
                             float smoothCoeff) noexcept;
 
-    double             m_sampleRate{24000.0};
+    // Audio owner writes in prepare(); UI reads the displayed processing rate.
+    std::atomic<double> m_sampleRate{24000.0};
     float              m_smoothCoeff{0.0f};   // recomputed in prepare()
     std::atomic<bool>  m_enabled{false};
     std::atomic<int>   m_activeBandCount{0};

--- a/src/core/ClientGate.cpp
+++ b/src/core/ClientGate.cpp
@@ -169,6 +169,14 @@ float ClientGate::gainReductionDb() const noexcept
 bool  ClientGate::gateOpen() const noexcept
 { return m_meters.gateOpen.load(std::memory_order_relaxed); }
 
+void ClientGate::copyMeteringFrom(const ClientGate& source) noexcept
+{
+    m_meters.inputPeakDb.store(source.inputPeakDb(), std::memory_order_relaxed);
+    m_meters.outputPeakDb.store(source.outputPeakDb(), std::memory_order_relaxed);
+    m_meters.gainReductionDb.store(source.gainReductionDb(), std::memory_order_relaxed);
+    m_meters.gateOpen.store(source.gateOpen(), std::memory_order_relaxed);
+}
+
 void ClientGate::recacheIfDirty() noexcept
 {
     const uint64_t v = m_atomics.version.load(std::memory_order_acquire);

--- a/src/core/ClientGate.h
+++ b/src/core/ClientGate.h
@@ -31,7 +31,8 @@ public:
     ClientGate(const ClientGate&)            = delete;
     ClientGate& operator=(const ClientGate&) = delete;
 
-    // Main thread — call before first process() and on sample-rate change.
+    // Audio owner — call before first process() and on sample-rate change.
+    // Never call concurrently with process(); parameter setters remain atomic.
     void prepare(double sampleRate);
 
     // Main thread — global enable / bypass. Lock-free.
@@ -75,7 +76,12 @@ public:
     float gainReductionDb() const noexcept;   // ≤ 0 dB (attenuation)
     bool  gateOpen() const noexcept;          // true when signal is above threshold
 
-    double sampleRate() const noexcept { return m_sampleRate; }
+    // Audio owner: mirror a presented auxiliary source into UI-facing meters.
+    // Copies atomic snapshots only; parameters and processing histories stay local.
+    void copyMeteringFrom(const ClientGate& source) noexcept;
+
+    double sampleRate() const noexcept
+    { return m_sampleRate.load(std::memory_order_relaxed); }
 
 private:
     struct Atomics {
@@ -114,7 +120,8 @@ private:
     void recacheIfDirty() noexcept;
     float staticCurveGainDb(float envDb) const noexcept;
 
-    double   m_sampleRate{24000.0};
+    // Audio owner writes in prepare(); UI reads the displayed processing rate.
+    std::atomic<double> m_sampleRate{24000.0};
     Atomics  m_atomics;
     Cached   m_cached;
     Meters   m_meters;

--- a/src/core/ClientPudu.cpp
+++ b/src/core/ClientPudu.cpp
@@ -185,6 +185,13 @@ float ClientPudu::outputPeakDb() const noexcept
 float ClientPudu::wetRmsDb() const noexcept
 { return m_meters.wetRmsDb.load(std::memory_order_relaxed); }
 
+void ClientPudu::copyMeteringFrom(const ClientPudu& source) noexcept
+{
+    m_meters.inputPeakDb.store(source.inputPeakDb(), std::memory_order_relaxed);
+    m_meters.outputPeakDb.store(source.outputPeakDb(), std::memory_order_relaxed);
+    m_meters.wetRmsDb.store(source.wetRmsDb(), std::memory_order_relaxed);
+}
+
 void ClientPudu::recacheIfDirty() noexcept
 {
     const uint64_t v = m_atomics.version.load(std::memory_order_acquire);

--- a/src/core/ClientPudu.h
+++ b/src/core/ClientPudu.h
@@ -52,6 +52,8 @@ public:
     ClientPudu(const ClientPudu&)            = delete;
     ClientPudu& operator=(const ClientPudu&) = delete;
 
+    // Audio owner only; never concurrently with process(). GUI rate reads
+    // and parameter setters remain safe while a new producer is prepared.
     void prepare(double sampleRate);
 
     void setEnabled(bool on) noexcept;
@@ -90,7 +92,12 @@ public:
     // actively adding content.
     float wetRmsDb() const noexcept;
 
-    double sampleRate() const noexcept { return m_sampleRate; }
+    // Audio owner: mirror a presented auxiliary source into UI-facing meters.
+    // Copies atomic snapshots only; parameters and processing histories stay local.
+    void copyMeteringFrom(const ClientPudu& source) noexcept;
+
+    double sampleRate() const noexcept
+    { return m_sampleRate.load(std::memory_order_relaxed); }
 
     // Public because the cpp-local biquad helper takes references.
     // Not part of the user-facing API.
@@ -146,7 +153,8 @@ private:
         float dcY1{0.0f};
     };
 
-    double  m_sampleRate{24000.0};
+    // Audio owner writes in prepare(); UI reads the displayed processing rate.
+    std::atomic<double> m_sampleRate{24000.0};
     Atomics m_atomics;
     Cached  m_cached;
     Meters  m_meters;

--- a/src/core/ClientTube.cpp
+++ b/src/core/ClientTube.cpp
@@ -152,6 +152,13 @@ float ClientTube::outputPeakDb() const noexcept
 float ClientTube::driveAppliedDb() const noexcept
 { return m_meters.driveAppliedDb.load(std::memory_order_relaxed); }
 
+void ClientTube::copyMeteringFrom(const ClientTube& source) noexcept
+{
+    m_meters.inputPeakDb.store(source.inputPeakDb(), std::memory_order_relaxed);
+    m_meters.outputPeakDb.store(source.outputPeakDb(), std::memory_order_relaxed);
+    m_meters.driveAppliedDb.store(source.driveAppliedDb(), std::memory_order_relaxed);
+}
+
 void ClientTube::recacheIfDirty() noexcept
 {
     const uint64_t v = m_atomics.version.load(std::memory_order_acquire);

--- a/src/core/ClientTube.h
+++ b/src/core/ClientTube.h
@@ -39,6 +39,8 @@ public:
     ClientTube(const ClientTube&)            = delete;
     ClientTube& operator=(const ClientTube&) = delete;
 
+    // Audio owner only; never concurrently with process(). GUI rate reads
+    // and parameter setters remain safe while a new producer is prepared.
     void prepare(double sampleRate);
 
     void setEnabled(bool on) noexcept;
@@ -89,7 +91,12 @@ public:
     float outputPeakDb() const noexcept;
     float driveAppliedDb() const noexcept;   // dynamic instantaneous drive
 
-    double sampleRate() const noexcept { return m_sampleRate; }
+    // Audio owner: mirror a presented auxiliary source into UI-facing meters.
+    // Copies atomic snapshots only; parameters and processing histories stay local.
+    void copyMeteringFrom(const ClientTube& source) noexcept;
+
+    double sampleRate() const noexcept
+    { return m_sampleRate.load(std::memory_order_relaxed); }
 
 private:
     struct Atomics {
@@ -129,7 +136,8 @@ private:
     void recacheIfDirty() noexcept;
     float shape(float x) const noexcept;   // waveshaper per Model + bias
 
-    double m_sampleRate{24000.0};
+    // Audio owner writes in prepare(); UI reads the displayed processing rate.
+    std::atomic<double> m_sampleRate{24000.0};
     Atomics m_atomics;
     Cached  m_cached;
     Meters  m_meters;

--- a/src/core/RxClientEffects.cpp
+++ b/src/core/RxClientEffects.cpp
@@ -1,0 +1,121 @@
+#include "RxClientEffects.h"
+
+namespace AetherSDR {
+namespace {
+
+// Avoid marking every effect dirty for every packet. Setters publish atomics
+// and some invalidate coefficients; a parameter that has not changed must not
+// interrupt its source's smoothing or force another coefficient calculation.
+template <typename Effect, typename Value>
+void syncParameter(Effect& target, const Effect& source,
+                   Value (Effect::*getter)() const noexcept,
+                   void (Effect::*setter)(Value) noexcept) noexcept
+{
+    const Value value = (source.*getter)();
+    if ((target.*getter)() != value) {
+        (target.*setter)(value);
+    }
+}
+
+bool equalBands(const ClientEq::BandParams& first,
+                const ClientEq::BandParams& second) noexcept
+{
+    return first.freqHz == second.freqHz && first.gainDb == second.gainDb
+        && first.q == second.q && first.type == second.type
+        && first.enabled == second.enabled
+        && first.slopeDbPerOct == second.slopeDbPerOct;
+}
+
+} // namespace
+
+RxClientEffects::RxClientEffects(int sampleRate)
+{
+    m_eq.prepare(sampleRate);
+    m_gate.prepare(sampleRate);
+    m_comp.prepare(sampleRate);
+    m_deEss.prepare(sampleRate);
+    m_tube.prepare(sampleRate);
+    m_pudu.prepare(sampleRate);
+}
+
+void RxClientEffects::syncParametersFrom(
+    const ClientEq& eq, const ClientGate& gate, const ClientComp& comp,
+    const ClientDeEss& deEss, const ClientTube& tube, const ClientPudu& pudu) noexcept
+{
+    syncParameter(m_eq, eq, &ClientEq::isEnabled, &ClientEq::setEnabled);
+    syncParameter(m_eq, eq, &ClientEq::masterGain, &ClientEq::setMasterGain);
+    syncParameter(m_eq, eq, &ClientEq::filterFamily, &ClientEq::setFilterFamily);
+    syncParameter(m_eq, eq, &ClientEq::activeBandCount, &ClientEq::setActiveBandCount);
+    for (int index = 0; index < ClientEq::kMaxBands; ++index) {
+        const ClientEq::BandParams parameters = eq.band(index);
+        if (!equalBands(m_eq.band(index), parameters)) {
+            m_eq.setBand(index, parameters);
+        }
+    }
+
+    syncParameter(m_gate, gate, &ClientGate::isEnabled, &ClientGate::setEnabled);
+    // Mode applies presets. Restore the explicit ratio/floor afterwards so
+    // changes to the mode do not discard the operator's fine-tuned values.
+    syncParameter(m_gate, gate, &ClientGate::mode, &ClientGate::setMode);
+    syncParameter(m_gate, gate, &ClientGate::thresholdDb, &ClientGate::setThresholdDb);
+    syncParameter(m_gate, gate, &ClientGate::ratio, &ClientGate::setRatio);
+    syncParameter(m_gate, gate, &ClientGate::attackMs, &ClientGate::setAttackMs);
+    syncParameter(m_gate, gate, &ClientGate::releaseMs, &ClientGate::setReleaseMs);
+    syncParameter(m_gate, gate, &ClientGate::holdMs, &ClientGate::setHoldMs);
+    syncParameter(m_gate, gate, &ClientGate::floorDb, &ClientGate::setFloorDb);
+    syncParameter(m_gate, gate, &ClientGate::returnDb, &ClientGate::setReturnDb);
+    syncParameter(m_gate, gate, &ClientGate::lookaheadMs, &ClientGate::setLookaheadMs);
+
+    syncParameter(m_comp, comp, &ClientComp::isEnabled, &ClientComp::setEnabled);
+    syncParameter(m_comp, comp, &ClientComp::thresholdDb, &ClientComp::setThresholdDb);
+    syncParameter(m_comp, comp, &ClientComp::ratio, &ClientComp::setRatio);
+    syncParameter(m_comp, comp, &ClientComp::attackMs, &ClientComp::setAttackMs);
+    syncParameter(m_comp, comp, &ClientComp::releaseMs, &ClientComp::setReleaseMs);
+    syncParameter(m_comp, comp, &ClientComp::kneeDb, &ClientComp::setKneeDb);
+    syncParameter(m_comp, comp, &ClientComp::makeupDb, &ClientComp::setMakeupDb);
+    syncParameter(m_comp, comp, &ClientComp::limiterEnabled, &ClientComp::setLimiterEnabled);
+    syncParameter(m_comp, comp, &ClientComp::limiterCeilingDb, &ClientComp::setLimiterCeilingDb);
+    syncParameter(m_comp, comp, &ClientComp::driveDb, &ClientComp::setDriveDb);
+    syncParameter(m_comp, comp, &ClientComp::phaseRotatorStages, &ClientComp::setPhaseRotatorStages);
+
+    syncParameter(m_deEss, deEss, &ClientDeEss::isEnabled, &ClientDeEss::setEnabled);
+    syncParameter(m_deEss, deEss, &ClientDeEss::frequencyHz, &ClientDeEss::setFrequencyHz);
+    syncParameter(m_deEss, deEss, &ClientDeEss::q, &ClientDeEss::setQ);
+    syncParameter(m_deEss, deEss, &ClientDeEss::thresholdDb, &ClientDeEss::setThresholdDb);
+    syncParameter(m_deEss, deEss, &ClientDeEss::amountDb, &ClientDeEss::setAmountDb);
+    syncParameter(m_deEss, deEss, &ClientDeEss::attackMs, &ClientDeEss::setAttackMs);
+    syncParameter(m_deEss, deEss, &ClientDeEss::releaseMs, &ClientDeEss::setReleaseMs);
+    syncParameter(m_deEss, deEss, &ClientDeEss::slopeStages, &ClientDeEss::setSlopeStages);
+
+    syncParameter(m_tube, tube, &ClientTube::isEnabled, &ClientTube::setEnabled);
+    syncParameter(m_tube, tube, &ClientTube::model, &ClientTube::setModel);
+    syncParameter(m_tube, tube, &ClientTube::driveDb, &ClientTube::setDriveDb);
+    syncParameter(m_tube, tube, &ClientTube::biasAmount, &ClientTube::setBiasAmount);
+    syncParameter(m_tube, tube, &ClientTube::tone, &ClientTube::setTone);
+    syncParameter(m_tube, tube, &ClientTube::outputGainDb, &ClientTube::setOutputGainDb);
+    syncParameter(m_tube, tube, &ClientTube::dryWet, &ClientTube::setDryWet);
+    syncParameter(m_tube, tube, &ClientTube::envelopeAmount, &ClientTube::setEnvelopeAmount);
+    syncParameter(m_tube, tube, &ClientTube::attackMs, &ClientTube::setAttackMs);
+    syncParameter(m_tube, tube, &ClientTube::releaseMs, &ClientTube::setReleaseMs);
+
+    syncParameter(m_pudu, pudu, &ClientPudu::isEnabled, &ClientPudu::setEnabled);
+    syncParameter(m_pudu, pudu, &ClientPudu::mode, &ClientPudu::setMode);
+    syncParameter(m_pudu, pudu, &ClientPudu::pooDriveDb, &ClientPudu::setPooDriveDb);
+    syncParameter(m_pudu, pudu, &ClientPudu::pooTuneHz, &ClientPudu::setPooTuneHz);
+    syncParameter(m_pudu, pudu, &ClientPudu::pooMix, &ClientPudu::setPooMix);
+    syncParameter(m_pudu, pudu, &ClientPudu::dooTuneHz, &ClientPudu::setDooTuneHz);
+    syncParameter(m_pudu, pudu, &ClientPudu::dooHarmonicsDb, &ClientPudu::setDooHarmonicsDb);
+    syncParameter(m_pudu, pudu, &ClientPudu::dooMix, &ClientPudu::setDooMix);
+}
+
+void RxClientEffects::reset() noexcept
+{
+    m_eq.reset();
+    m_gate.reset();
+    m_comp.reset();
+    m_deEss.reset();
+    m_tube.reset();
+    m_pudu.reset();
+}
+
+} // namespace AetherSDR

--- a/src/core/RxClientEffects.h
+++ b/src/core/RxClientEffects.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "ClientComp.h"
+#include "ClientDeEss.h"
+#include "ClientEq.h"
+#include "ClientGate.h"
+#include "ClientPudu.h"
+#include "ClientTube.h"
+
+namespace AetherSDR {
+
+// One source's client RX effect histories. The UI continues to own the main
+// source's parameter objects; auxiliary sources copy those atomic parameters,
+// never the filters, envelopes, lookahead samples or meter state. In particular,
+// a 24 kHz Kiwi stream must not advance the main producer's 48 kHz effect state.
+//
+// Construct/prepare before processing. All other calls belong to the source's
+// audio owner, while syncParametersFrom() may read UI-updated parameter objects.
+// Neither synchronization nor processing allocates or locks. The caller retains
+// the existing stage order and post-EQ tap through the individual accessors.
+class RxClientEffects {
+public:
+    explicit RxClientEffects(int sampleRate = 24000);
+
+    void syncParametersFrom(const ClientEq& eq, const ClientGate& gate,
+                            const ClientComp& comp, const ClientDeEss& deEss,
+                            const ClientTube& tube, const ClientPudu& pudu) noexcept;
+    void reset() noexcept;
+
+    ClientEq& eq() noexcept { return m_eq; }
+    ClientGate& gate() noexcept { return m_gate; }
+    ClientComp& comp() noexcept { return m_comp; }
+    ClientDeEss& deEss() noexcept { return m_deEss; }
+    ClientTube& tube() noexcept { return m_tube; }
+    ClientPudu& pudu() noexcept { return m_pudu; }
+
+private:
+    ClientEq m_eq;
+    ClientGate m_gate;
+    ClientComp m_comp;
+    ClientDeEss m_deEss;
+    ClientTube m_tube;
+    ClientPudu m_pudu;
+};
+
+} // namespace AetherSDR

--- a/src/gui/NetworkDiagnosticsDialog.cpp
+++ b/src/gui/NetworkDiagnosticsDialog.cpp
@@ -1877,6 +1877,16 @@ static QString formatAudioBuffer(qsizetype bytes, double ms)
     return QString("%1 bytes (%2 ms)").arg(bytes).arg(ms, 0, 'f', 1);
 }
 
+// The peak row pairs two INDEPENDENT maxima: peak bytes and peak duration are
+// tracked separately on purpose, so that a later rate change cannot reinterpret
+// historical bytes through the current rate. They therefore need not come from
+// the same instant, and rendering them as "N bytes (M ms)" would assert that M
+// is N's duration. Show them as two separate maxima instead.
+static QString formatAudioBufferPeaks(qsizetype bytes, double ms)
+{
+    return QString("%1 bytes peak / %2 ms peak").arg(bytes).arg(ms, 0, 'f', 1);
+}
+
 static QString formatMsValue(int value)
 {
     return value < 1 ? "< 1 ms" : QString("%1 ms").arg(value);
@@ -2734,7 +2744,7 @@ void NetworkDiagnosticsDialog::refresh()
         const QStringList sliceLabels = audibleSliceLabels(m_model);
         m_audioBufferLabel->setText(formatAudioBuffer(m_audio->rxBufferBytes(), m_audio->rxBufferMs()));
         m_overviewAudioValue->setText(QString("%1 ms").arg(m_audio->rxBufferMs(), 0, 'f', 1));
-        m_audioBufferPeakLabel->setText(formatAudioBuffer(m_audio->rxBufferPeakBytes(), m_audio->rxBufferPeakMs()));
+        m_audioBufferPeakLabel->setText(formatAudioBufferPeaks(m_audio->rxBufferPeakBytes(), m_audio->rxBufferPeakMs()));
         m_audioUnderrunLabel->setText(QString::number(underruns));
         m_audioUnderrunRateLabel->setText(QString::number(sample.underrunsPerSecond, 'f', 0));
 

--- a/src/gui/NetworkDiagnosticsDialog.cpp
+++ b/src/gui/NetworkDiagnosticsDialog.cpp
@@ -1872,24 +1872,8 @@ static double kbpsFromBytes(qint64 bytesDelta, double elapsedSeconds)
     return (bytesDelta * 8.0) / (1000.0 * elapsedSeconds);
 }
 
-static double audioBufferMs(qsizetype bytes, int sampleRate)
+static QString formatAudioBuffer(qsizetype bytes, double ms)
 {
-    if (sampleRate <= 0) {
-        return 0.0;
-    }
-
-    static constexpr int kStereoChannels = 2;
-    static constexpr int kFloatBytesPerSample = 4;
-    return (bytes * 1000.0) / (sampleRate * kStereoChannels * kFloatBytesPerSample);
-}
-
-static QString formatAudioBuffer(qsizetype bytes, int sampleRate)
-{
-    if (sampleRate <= 0) {
-        return QString("%1 bytes").arg(bytes);
-    }
-
-    const double ms = audioBufferMs(bytes, sampleRate);
     return QString("%1 bytes (%2 ms)").arg(bytes).arg(ms, 0, 'f', 1);
 }
 
@@ -2204,7 +2188,6 @@ void NetworkDiagnosticsHistory::sampleNow()
     sample.packetLossPct = m_model->packetLossPercent();
 
     if (m_audio) {
-        const int sampleRate = m_audio->rxBufferSampleRate();
         const quint64 underruns = m_audio->rxBufferUnderrunCount();
         quint64 underrunDelta = 0;
         if (underruns >= m_lastAudioUnderrunCount) {
@@ -2213,7 +2196,7 @@ void NetworkDiagnosticsHistory::sampleNow()
         m_lastAudioUnderrunCount = underruns;
         sample.audioGapMs = m_model->audioPacketGapMs();
         sample.audioJitterMs = m_model->audioPacketJitterMs();
-        sample.audioBufferMs = audioBufferMs(m_audio->rxBufferBytes(), sampleRate);
+        sample.audioBufferMs = m_audio->rxBufferMs();
         sample.underrunsPerSecond = static_cast<double>(underrunDelta) / elapsedSeconds;
     }
 
@@ -2745,14 +2728,13 @@ void NetworkDiagnosticsDialog::refresh()
     }
 
     if (m_audio) {
-        const int sampleRate = m_audio->rxBufferSampleRate();
         const quint64 underruns = m_audio->rxBufferUnderrunCount();
         const QVector<PanadapterStream::AudioStreamDiagnostics> audioStreams =
             m_model->audioStreamDiagnostics();
         const QStringList sliceLabels = audibleSliceLabels(m_model);
-        m_audioBufferLabel->setText(formatAudioBuffer(m_audio->rxBufferBytes(), sampleRate));
-        m_overviewAudioValue->setText(QString("%1 ms").arg(audioBufferMs(m_audio->rxBufferBytes(), sampleRate), 0, 'f', 1));
-        m_audioBufferPeakLabel->setText(formatAudioBuffer(m_audio->rxBufferPeakBytes(), sampleRate));
+        m_audioBufferLabel->setText(formatAudioBuffer(m_audio->rxBufferBytes(), m_audio->rxBufferMs()));
+        m_overviewAudioValue->setText(QString("%1 ms").arg(m_audio->rxBufferMs(), 0, 'f', 1));
+        m_audioBufferPeakLabel->setText(formatAudioBuffer(m_audio->rxBufferPeakBytes(), m_audio->rxBufferPeakMs()));
         m_audioUnderrunLabel->setText(QString::number(underruns));
         m_audioUnderrunRateLabel->setText(QString::number(sample.underrunsPerSecond, 'f', 0));
 

--- a/tests/audio_engine_pcm_lifetime_test.cpp
+++ b/tests/audio_engine_pcm_lifetime_test.cpp
@@ -7,6 +7,7 @@
 #include "core/ClientComp.h"
 #include "core/DeepFilterFilter.h"
 #include "core/SpecbleachFilter.h"
+#include "core/SpectralNR.h"
 
 #include <QBuffer>
 #include <QCoreApplication>
@@ -206,11 +207,208 @@ public:
         engine.drainRxAudio(pcm.size());
         return invalid && engine.rxBufferBytes() == 0;
     }
+
+    static void feedMainPcm(AudioEngine& engine, const PcmFrame& frame)
+    {
+        engine.feedPcmFrame(frame);
+    }
+
+    static void drain(AudioEngine& engine, qsizetype freeBytes)
+    {
+        engine.drainRxAudio(freeBytes);
+    }
+
+    static const void* mainNr2Identity(AudioEngine& engine)
+    {
+        std::lock_guard<std::recursive_mutex> lock(engine.m_dspMutex);
+        return engine.m_nr2.get();
+    }
+
+    // NR2's FFT size scales with the producer rate it was built for, so it
+    // identifies the domain a filter belongs to.
+    static int mainNr2FftSize(AudioEngine& engine)
+    {
+        std::lock_guard<std::recursive_mutex> lock(engine.m_dspMutex);
+        return engine.m_nr2 ? engine.m_nr2->fftSize() : 0;
+    }
+
+    // Overlap-add output for one block. A filter that has been rebuilt starts
+    // cold, so its output differs from one that has been running — which is the
+    // only reliable way to tell a retained filter from a replacement. Neither
+    // pointer identity nor FFT size can: a same-rate rebuild frees and
+    // reallocates, and the allocator commonly returns the same address.
+    static QByteArray mainNr2Process(AudioEngine& engine, const QByteArray& stereo)
+    {
+        std::lock_guard<std::recursive_mutex> lock(engine.m_dspMutex);
+        if (!engine.m_nr2) {
+            return {};
+        }
+        QByteArray out = stereo;
+        const int frames = out.size() / (2 * static_cast<int>(sizeof(float)));
+        engine.m_nr2->processStereoSharedMask(
+            reinterpret_cast<const float*>(stereo.constData()),
+            reinterpret_cast<float*>(out.data()), frames);
+        return out;
+    }
+
+    static void setDeviceRate(AudioEngine& engine, int rate)
+    {
+        engine.setRxDeviceRate(rate);
+    }
+
+    static void setProducerRate(AudioEngine& engine, int rate)
+    {
+        engine.resetMainPcmState(rate);
+    }
+
+    static bool mainPcmFrameHeld(AudioEngine& engine)
+    {
+        std::lock_guard<std::recursive_mutex> lock(engine.m_dspMutex);
+        return engine.m_mainPcmFrame.has_value();
+    }
 };
 
 } // namespace AetherSDR
 
 namespace {
+
+// A producer revoked WHILE the drain is mixing must not reach the device. The
+// top-of-drain retirement cannot see it — the epoch is still live when the drain
+// starts — so the recheck immediately before the device write is the only thing
+// standing between a dead radio and a chunk of its audio being played.
+//
+// receivePresentationOutputAudioReady fires from inside the mix, after the chunk
+// is assembled and before that recheck, so a direct-connected slot revoking the
+// producer there reproduces the concurrent case deterministically, on the real
+// production path, with no test hook in the engine. Without the recheck this
+// test observes the chunk arriving at the device.
+bool checkRevocationDuringDspWithheld()
+{
+    AetherSDR::AudioEngine engine;
+    AetherSDR::AudioEngineRatesTestAccess::stopTimer(engine);
+    // The presentation signal is only emitted while a Kiwi source is active.
+    const QString kiwiId = QStringLiteral("revocation-during-dsp");
+    AetherSDR::AudioEngineRatesTestAccess::enableSource(engine, kiwiId);
+
+    QBuffer output;
+    output.open(QIODevice::ReadWrite);
+    AetherSDR::AudioEngineRatesTestAccess::attachMemoryOutput(engine, output);
+
+    AetherSDR::PcmProducer producer;
+    if (!producer.start(AetherSDR::PcmPurpose::Speaker)) {
+        std::fprintf(stderr, "FAIL: speaker producer would not start\n");
+        return false;
+    }
+    const int frames = 480;
+    QByteArray pcm(frames * 2 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
+    auto* samples = reinterpret_cast<float*>(pcm.data());
+    for (int i = 0; i < frames * 2; ++i) {
+        samples[i] = 0.25f;
+    }
+    const auto frame = producer.legacyStereo24(pcm);
+    if (!frame) {
+        std::fprintf(stderr, "FAIL: producer would not publish the test block\n");
+        return false;
+    }
+    AetherSDR::AudioEngineRatesTestAccess::feedMainPcm(engine, *frame);
+
+    int revocations = 0;
+    QObject::connect(&engine, &AetherSDR::AudioEngine::receivePresentationOutputAudioReady,
+                     &engine, [&](const QString&, const QString&, const QByteArray&, int) {
+        // Mid-mix: exactly where a disconnect on the radio thread would land.
+        if (revocations++ == 0) {
+            producer.invalidate();
+        }
+    }, Qt::DirectConnection);
+
+    AetherSDR::AudioEngineRatesTestAccess::drain(engine, pcm.size());
+
+    const bool fired = revocations > 0;
+    const bool withheld = output.data().isEmpty();
+    const bool retired = !AetherSDR::AudioEngineRatesTestAccess::mainPcmFrameHeld(engine);
+    AetherSDR::AudioEngineRatesTestAccess::detachMemoryOutput(engine);
+
+    if (!fired) {
+        std::fprintf(stderr,
+            "FAIL: presentation signal never fired; the revocation seam did not run\n");
+        return false;
+    }
+    std::printf("%s: revoked-during-DSP chunk withheld from the device\n",
+                withheld ? "PASS" : "FAIL");
+    std::printf("%s: revoked main source retired by the pre-write recheck\n",
+                retired ? "PASS" : "FAIL");
+    return withheld && retired;
+}
+
+// The optional NR chain belongs to the PRODUCER domain: its filters are built
+// for a producer rate and never see the device rate. startRxStream() reaches
+// setRxDeviceRate() on every sink open — including the #1361 zombie-sink and
+// #1411 liveness watchdogs, which run on the GUI thread — so rebuilding there
+// charged each of those recovery paths a full model construction (DFNR measures
+// ~450 ms) for no change. Pin both directions: a device-rate change keeps the
+// filters, a producer-rate change replaces them.
+bool checkDeviceRateKeepsNrChain()
+{
+    // 480 stereo frames of a steady tone: enough to drive the overlap-add.
+    const int frames = 480;
+    QByteArray block(frames * 2 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
+    auto* samples = reinterpret_cast<float*>(block.data());
+    for (int i = 0; i < frames; ++i) {
+        const float v = 0.3f * std::sin(2.0f * float(M_PI) * 1000.0f * float(i) / 24000.0f);
+        samples[i * 2] = v;
+        samples[i * 2 + 1] = v;
+    }
+
+    auto primed = [&](AetherSDR::AudioEngine& engine) {
+        engine.setNr2Enabled(true);
+        for (int i = 0; i < 8; ++i) {
+            AetherSDR::AudioEngineRatesTestAccess::mainNr2Process(engine, block);
+        }
+    };
+
+    // A: primed, no device-rate change. The reference "still running" output.
+    AetherSDR::AudioEngine warmEngine;
+    AetherSDR::AudioEngineRatesTestAccess::stopTimer(warmEngine);
+    primed(warmEngine);
+    const QByteArray warm =
+        AetherSDR::AudioEngineRatesTestAccess::mainNr2Process(warmEngine, block);
+
+    // B: fresh filter, never primed. The "was rebuilt" output.
+    AetherSDR::AudioEngine coldEngine;
+    AetherSDR::AudioEngineRatesTestAccess::stopTimer(coldEngine);
+    coldEngine.setNr2Enabled(true);
+    const QByteArray cold =
+        AetherSDR::AudioEngineRatesTestAccess::mainNr2Process(coldEngine, block);
+
+    // The detector is only meaningful if warm and cold actually differ.
+    const bool sensitive = !warm.isEmpty() && warm != cold;
+    std::printf("%s: primed and cold NR2 outputs differ (detector is sensitive)\n",
+                sensitive ? "PASS" : "FAIL");
+
+    // C: primed, then two device-rate changes. Must still match the warm output.
+    AetherSDR::AudioEngine engine;
+    AetherSDR::AudioEngineRatesTestAccess::stopTimer(engine);
+    primed(engine);
+    const int builtFft = AetherSDR::AudioEngineRatesTestAccess::mainNr2FftSize(engine);
+    AetherSDR::AudioEngineRatesTestAccess::setDeviceRate(engine, 48000);
+    AetherSDR::AudioEngineRatesTestAccess::setDeviceRate(engine, 44100);
+    const QByteArray afterDevice =
+        AetherSDR::AudioEngineRatesTestAccess::mainNr2Process(engine, block);
+    const bool kept = afterDevice == warm
+        && AetherSDR::AudioEngineRatesTestAccess::mainNr2FftSize(engine) == builtFft;
+    std::printf("%s: device-rate change keeps the producer-domain NR chain and its history\n",
+                kept ? "PASS" : "FAIL");
+
+    // A real producer-rate move must still replace the chain; FFT size scales
+    // with the producer rate, so it survives allocator address reuse.
+    AetherSDR::AudioEngineRatesTestAccess::setProducerRate(engine, 48000);
+    const int afterProducerFft = AetherSDR::AudioEngineRatesTestAccess::mainNr2FftSize(engine);
+    const bool rebuilt = builtFft > 0 && afterProducerFft == builtFft * 2;
+    std::printf("%s: producer-rate change still rebuilds the NR chain (fft %d -> %d)\n",
+                rebuilt ? "PASS" : "FAIL", builtFft, afterProducerFft);
+
+    return sensitive && kept && rebuilt;
+}
 
 bool checkAggregateDurations()
 {
@@ -389,6 +587,8 @@ int main(int argc, char** argv)
     QCoreApplication app(argc, argv);
     const bool durationChecks = checkAggregateDurations();
     const bool invalidProcessingChecks = checkInvalidProcessingWithheld();
+    const bool revocationDuringDspChecks = checkRevocationDuringDspWithheld();
+    const bool deviceRateNrChecks = checkDeviceRateKeepsNrChain();
     const bool meterChecks = checkPresentedMeters();
     const bool singleFeedChecks = checkSingleAuxiliaryFeed();
     AetherSDR::AudioEngine engine;
@@ -446,7 +646,8 @@ int main(int argc, char** argv)
     const bool prepared = AetherSDR::AudioEngineRatesTestAccess::initializeSource(engine, sourceId)
         && AetherSDR::AudioEngineRatesTestAccess::sourcePrepared(engine, sourceId);
     const unsigned initializations = completedInitializations.load(std::memory_order_relaxed);
-    const bool passed = durationChecks && invalidProcessingChecks && meterChecks && singleFeedChecks
+    const bool passed = durationChecks && invalidProcessingChecks && revocationDuringDspChecks
+        && deviceRateNrChecks && meterChecks && singleFeedChecks
         && initialized.load(std::memory_order_relaxed)
         && initializations > 0 && retiredEpochs == 300 && prepared;
     std::printf("%s: %d typed epochs retired; %u concurrent initialization attempts; final source %s\n",

--- a/tests/audio_engine_pcm_lifetime_test.cpp
+++ b/tests/audio_engine_pcm_lifetime_test.cpp
@@ -1,0 +1,455 @@
+// RFC #5468 A2: the real AudioEngine auxiliary ingress/retirement methods
+// overlap its production asynchronous DSP initializer. No sink, audio device,
+// socket, radio transport, hardware or transmitter is opened. Run under TSan
+// for the lifetime claim; the native checks alone cannot establish race freedom.
+#include "TestSettingsProfile.h"
+#include "core/AudioEngine.h"
+#include "core/ClientComp.h"
+#include "core/DeepFilterFilter.h"
+#include "core/SpecbleachFilter.h"
+
+#include <QBuffer>
+#include <QCoreApplication>
+#include <QJsonArray>
+#include <QTimer>
+
+#include <atomic>
+#include <cmath>
+#include <cstdio>
+#include <thread>
+
+namespace AetherSDR {
+
+// Same friend seam as audio_engine_rates_test, in a separate executable.
+class AudioEngineRatesTestAccess {
+public:
+    static void stopTimer(AudioEngine& engine)
+    {
+        engine.m_rxTimer->stop();
+    }
+
+    static void waitInitialization(AudioEngine& engine)
+    {
+        engine.m_dspInitializationTasks.waitForFinished();
+    }
+
+    static void enableSource(AudioEngine& engine, const QString& id)
+    {
+        std::lock_guard<std::recursive_mutex> lock(engine.m_dspMutex);
+        AudioEngine::ExternalRxAudioSourceState* source = engine.externalKiwiSource(id, true);
+        source->enabled = true;
+    }
+
+    static void clearSourceDsp(AudioEngine& engine, const QString& id)
+    {
+        std::lock_guard<std::recursive_mutex> lock(engine.m_dspMutex);
+        AudioEngine::ExternalRxAudioSourceState* source = engine.externalKiwiSource(id, false);
+        if (source) {
+            engine.clearExternalKiwiDspState(*source);
+        }
+    }
+
+    static bool initializeSource(AudioEngine& engine, const QString& id)
+    {
+        return engine.ensureExternalKiwiSourceDspState(id);
+    }
+
+    static bool retireAndCheck(AudioEngine& engine, const QString& id)
+    {
+        // Do not lock around retirement here: the production method itself
+        // must serialize its filter reset against the initializer's install.
+        const bool retired = engine.retireInvalidPcmSources();
+        std::lock_guard<std::recursive_mutex> lock(engine.m_dspMutex);
+        AudioEngine::ExternalRxAudioSourceState* source = engine.externalKiwiSource(id, false);
+        return retired && source && !source->pcmFrame
+            && source->rxBuffer.isEmpty() && source->rxPackets.empty()
+            && source->outputBuffer.isEmpty() && source->prebuffering;
+    }
+
+    static bool sourcePrepared(AudioEngine& engine, const QString& id)
+    {
+        std::lock_guard<std::recursive_mutex> lock(engine.m_dspMutex);
+        const AudioEngine::ExternalRxAudioSourceState* source = engine.externalKiwiSource(id, false);
+        return source && source->rn2 && !source->dspInitializationPending;
+    }
+
+    static void attachMemoryOutput(AudioEngine& engine, QBuffer& output)
+    {
+        engine.m_audioDevice = &output;
+        engine.setRxDeviceRate(24000);
+    }
+
+    static void detachMemoryOutput(AudioEngine& engine)
+    {
+        engine.m_audioDevice = nullptr;
+    }
+
+    static void processSource(AudioEngine& engine, const QString& id, const QByteArray& pcm)
+    {
+        std::lock_guard<std::recursive_mutex> lock(engine.m_dspMutex);
+        engine.processMixedRxAudioData(pcm, AudioEngine::RxDspSource::KiwiSdr,
+                                      engine.externalKiwiSource(id, true));
+    }
+
+    static void processMain(AudioEngine& engine, const QByteArray& pcm)
+    {
+        engine.processMixedRxAudioData(pcm, AudioEngine::RxDspSource::Main);
+    }
+
+    static qsizetype queuedKiwiBytes(AudioEngine& engine, const QString& id)
+    {
+        std::lock_guard<std::recursive_mutex> lock(engine.m_dspMutex);
+        if (id.isEmpty()) {
+            qsizetype bytes = engine.m_kiwiSdrRxBuffer.size() + engine.m_kiwiSdrOutputBuffer.size();
+            for (const QByteArray& packet : engine.m_kiwiSdrRxPackets) {
+                bytes += packet.size();
+            }
+            return bytes;
+        }
+        const AudioEngine::ExternalRxAudioSourceState* source = engine.externalKiwiSource(id, false);
+        if (!source) {
+            return 0;
+        }
+        qsizetype bytes = source->rxBuffer.size() + source->outputBuffer.size();
+        for (const QByteArray& packet : source->rxPackets) {
+            bytes += packet.size();
+        }
+        return bytes;
+    }
+
+    static void retire(AudioEngine& engine)
+    {
+        engine.retireInvalidPcmSources();
+    }
+
+    static void populateDurationQueues(AudioEngine& engine, int producerRate,
+                                       int deviceRate, int scale)
+    {
+        engine.setRxDeviceRate(deviceRate);
+        engine.resetMainPcmState(producerRate);
+        const auto queued = [scale](int rate, int milliseconds) {
+            return QByteArray(rate / 1000 * milliseconds * scale * 2 * sizeof(float), '\0');
+        };
+        engine.m_rxBuffer = queued(producerRate, 10);
+        engine.m_rxPackets.push_back(queued(producerRate, 5));
+        engine.m_rxPackets.push_back(queued(producerRate, 3));
+        engine.m_rxOutputBuffer = queued(deviceRate, 7);
+        engine.m_kiwiSdrRxBuffer = queued(24000, 11);
+        engine.m_kiwiSdrRxPackets.push_back(queued(24000, 13));
+        engine.m_kiwiSdrOutputBuffer = queued(deviceRate, 17);
+        AudioEngine::ExternalRxAudioSourceState* first =
+            engine.externalKiwiSource(QStringLiteral("duration-first"), true);
+        first->enabled = true;
+        first->rxBuffer = queued(24000, 19);
+        first->rxPackets.push_back(queued(24000, 23));
+        first->outputBuffer = queued(deviceRate, 29);
+        AudioEngine::ExternalRxAudioSourceState* second =
+            engine.externalKiwiSource(QStringLiteral("duration-second"), true);
+        second->enabled = true;
+        second->rxBuffer = queued(24000, 31);
+        second->rxPackets.push_back(queued(24000, 37));
+        second->outputBuffer = queued(deviceRate, 41);
+        engine.m_radeRxBuffer = queued(deviceRate, 43);
+        engine.updateRxBufferStats();
+    }
+
+    static bool drainWithInvalidProcessor(AudioEngine& engine, const QString& route,
+                                         bool deepFilter, const QByteArray& pcm)
+    {
+        // Unsupported construction supplies a real, nonnull wrapper whose
+        // model state is invalid, as after failed model preparation/reset.
+        // No substitute algorithm or SDK/model load is involved.
+        AudioEngine::ExternalRxAudioSourceState* source = nullptr;
+        if (route == QStringLiteral("legacy")) {
+            engine.m_kiwiSdrAudioEnabled = true;
+        } else if (route == QStringLiteral("managed")) {
+            source = engine.externalKiwiSource(route, true);
+            source->enabled = true;
+        }
+        bool invalid = false;
+        if (deepFilter) {
+#ifdef HAVE_DFNR
+            std::unique_ptr<DeepFilterFilter> filter = std::make_unique<DeepFilterFilter>(32000);
+            invalid = !filter->isValid();
+            engine.m_dfnrEnabled = true;
+            if (source) {
+                source->dfnr = std::move(filter);
+            } else if (route == QStringLiteral("legacy")) {
+                engine.m_kiwiSdrDfnr = std::move(filter);
+            } else {
+                engine.m_dfnr = std::move(filter);
+            }
+#endif
+        } else {
+#ifdef HAVE_SPECBLEACH
+            std::unique_ptr<SpecbleachFilter> filter = std::make_unique<SpecbleachFilter>(32000);
+            invalid = !filter->isValid();
+            engine.m_nr4Enabled = true;
+            if (source) {
+                source->nr4 = std::move(filter);
+            } else if (route == QStringLiteral("legacy")) {
+                engine.m_kiwiSdrNr4 = std::move(filter);
+            } else {
+                engine.m_nr4 = std::move(filter);
+            }
+#endif
+        }
+        if (source) {
+            engine.feedKiwiSdrAudioData(route, pcm);
+            source->prebuffering = false;
+        } else if (route == QStringLiteral("legacy")) {
+            engine.feedKiwiSdrAudioData(pcm);
+            engine.m_kiwiSdrPrebuffering = false;
+        } else {
+            engine.feedAudioData(pcm);
+        }
+        engine.drainRxAudio(pcm.size());
+        return invalid && engine.rxBufferBytes() == 0;
+    }
+};
+
+} // namespace AetherSDR
+
+namespace {
+
+bool checkAggregateDurations()
+{
+    AetherSDR::AudioEngine engine;
+    AetherSDR::AudioEngineRatesTestAccess::stopTimer(engine);
+    bool passed = true;
+    for (int producerRate : {24000, 48000}) {
+        for (int deviceRate : {24000, 44100, 48000}) {
+            // 44100 cannot represent every integer millisecond exactly. Each
+            // device queue uses explicit whole frames; account for those below.
+            const double expectedMs = 152.0 + 137.0 * (deviceRate / 1000) * 1000.0 / deviceRate;
+            const qsizetype expectedBytes =
+                (producerRate / 1000 * 18 + 24000 / 1000 * 134
+                 + deviceRate / 1000 * 137) * 2 * sizeof(float);
+            AetherSDR::AudioEngineRatesTestAccess::populateDurationQueues(
+                engine, producerRate, deviceRate, 2);
+            passed = passed && std::abs(engine.rxBufferMs() - expectedMs * 2) < 0.00001
+                && engine.rxBufferBytes() == expectedBytes * 2;
+            const double peakMs = engine.rxBufferPeakMs();
+            const qsizetype peakBytes = engine.rxBufferPeakBytes();
+            AetherSDR::AudioEngineRatesTestAccess::populateDurationQueues(
+                engine, producerRate, deviceRate, 1);
+            passed = passed && std::abs(engine.rxBufferMs() - expectedMs) < 0.00001
+                && engine.rxBufferBytes() == expectedBytes
+                && engine.rxBufferPeakMs() == peakMs
+                && engine.rxBufferPeakBytes() == peakBytes;
+        }
+    }
+    engine.stopRxStream();
+    passed = passed && engine.rxBufferMs() == 0.0 && engine.rxBufferPeakMs() == 0.0
+        && engine.rxBufferBytes() == 0 && engine.rxBufferPeakBytes() == 0;
+    std::printf("%s: aggregate durations sum all producer/device queues and retain independent peaks across rate changes\n",
+                passed ? "PASS" : "FAIL");
+    return passed;
+}
+
+bool checkInvalidProcessingWithheld()
+{
+    bool passed = true;
+    for (bool deepFilter : {false, true}) {
+#ifndef HAVE_DFNR
+        if (deepFilter) {
+            std::printf("SKIP: invalid DFNR state admission (DFNR unavailable in this build)\n");
+            continue;
+        }
+#endif
+#ifndef HAVE_SPECBLEACH
+        if (!deepFilter) {
+            std::printf("SKIP: invalid Specbleach state admission (Specbleach unavailable in this build)\n");
+            continue;
+        }
+#endif
+        for (const QString& route : {QStringLiteral("main"), QStringLiteral("legacy"), QStringLiteral("managed")}) {
+            AetherSDR::AudioEngine engine;
+            AetherSDR::AudioEngineRatesTestAccess::stopTimer(engine);
+            QBuffer output;
+            output.open(QIODevice::WriteOnly);
+            AetherSDR::AudioEngineRatesTestAccess::attachMemoryOutput(engine, output);
+            const QVector<float> samples(480, 0.25f);
+            const QByteArray pcm(reinterpret_cast<const char*>(samples.constData()),
+                                 samples.size() * static_cast<qsizetype>(sizeof(float)));
+            const bool casePassed = AetherSDR::AudioEngineRatesTestAccess::drainWithInvalidProcessor(
+                engine, route, deepFilter, pcm) && output.data().isEmpty();
+            AetherSDR::AudioEngineRatesTestAccess::detachMemoryOutput(engine);
+            passed = passed && casePassed;
+            std::printf("%s: %s %s invalid nonnull processor withholds device output\n",
+                casePassed ? "PASS" : "FAIL", deepFilter ? "DFNR" : "Specbleach", qPrintable(route));
+        }
+    }
+    return passed;
+}
+
+bool checkPresentedMeters()
+{
+    AetherSDR::AudioEngine engine;
+    AetherSDR::AudioEngineRatesTestAccess::stopTimer(engine);
+    QBuffer output;
+    output.open(QIODevice::WriteOnly);
+    AetherSDR::AudioEngineRatesTestAccess::attachMemoryOutput(engine, output);
+    const QString sourceId = QStringLiteral("meter-test-kiwi");
+    AetherSDR::AudioEngineRatesTestAccess::enableSource(engine, sourceId);
+    AetherSDR::ClientComp* const parameters = engine.clientCompRx();
+    parameters->setEnabled(true);
+    parameters->setThresholdDb(-30.0f);
+    parameters->setRatio(6.0f);
+    parameters->setAttackMs(1.0f);
+    parameters->setLimiterEnabled(false);
+    const QVector<float> loudSamples(480, 0.5f);
+    const QByteArray loud(reinterpret_cast<const char*>(loudSamples.constData()),
+                         loudSamples.size() * static_cast<qsizetype>(sizeof(float)));
+    for (int block = 0; block < 20; ++block) {
+        AetherSDR::AudioEngineRatesTestAccess::processSource(engine, sourceId, loud);
+    }
+    const bool auxiliaryMeterVisible = parameters->gainReductionDb() < -10.0f;
+
+    AetherSDR::PcmProducer main;
+    main.start();
+    const std::optional<AetherSDR::PcmFrame> frame = main.produce(QVector<float>(480, 0.0f));
+    engine.feedPcmFrame(*frame);
+    AetherSDR::AudioEngineRatesTestAccess::processMain(engine, QByteArray(loud.size(), '\0'));
+    const float mainGainReduction = parameters->gainReductionDb();
+    AetherSDR::AudioEngineRatesTestAccess::processSource(engine, sourceId, loud);
+    const bool mainPreferred = mainGainReduction == 0.0f
+        && parameters->gainReductionDb() == mainGainReduction;
+
+    main.invalidate();
+    AetherSDR::AudioEngineRatesTestAccess::processSource(engine, sourceId, loud);
+    const bool auxiliaryReturns = parameters->gainReductionDb() < -10.0f;
+    const bool stableParameterOwner = engine.clientCompRx() == parameters
+        && parameters->thresholdDb() == -30.0f;
+    AetherSDR::AudioEngineRatesTestAccess::detachMemoryOutput(engine);
+    const bool passed = auxiliaryMeterVisible && mainPreferred
+        && auxiliaryReturns && stableParameterOwner;
+    std::printf("%s: Kiwi-only dynamics meters, current-main preference and stable UI parameter owner\n",
+                passed ? "PASS" : "FAIL");
+    return passed;
+}
+
+bool checkSingleAuxiliaryFeed()
+{
+    bool passed = true;
+    for (const QString& sourceId : {QString(), QStringLiteral("single-feed-kiwi")}) {
+        AetherSDR::AudioEngine engine;
+        AetherSDR::AudioEngineRatesTestAccess::stopTimer(engine);
+        QBuffer output;
+        output.open(QIODevice::WriteOnly);
+        AetherSDR::AudioEngineRatesTestAccess::attachMemoryOutput(engine, output);
+        if (sourceId.isEmpty()) {
+            engine.setKiwiSdrAudioEnabled(true);
+        } else {
+            AetherSDR::AudioEngineRatesTestAccess::enableSource(engine, sourceId);
+        }
+        AetherSDR::PcmProducer producer;
+        producer.start(AetherSDR::PcmPurpose::Auxiliary);
+        const std::optional<AetherSDR::PcmFrame> frame = producer.produce(QVector<float>(480, 0.25f));
+        const QByteArray pcm = frame->legacyStereo24();
+        const bool captureStarted = engine.startAutomationAudioCapture(
+            5000, {QStringLiteral("raw")}).value(QStringLiteral("ok")).toBool();
+        engine.feedKiwiPcmFrame(sourceId, *frame);
+        const auto feedRaw = [&]() {
+            if (sourceId.isEmpty()) {
+                engine.feedKiwiSdrAudioData(pcm);
+            } else {
+                engine.feedKiwiSdrAudioData(sourceId, pcm);
+            }
+        };
+        feedRaw();
+        const bool once = AetherSDR::AudioEngineRatesTestAccess::queuedKiwiBytes(engine, sourceId) == pcm.size()
+            && engine.automationAudioCaptureSnapshot(false).value(QStringLiteral("chunks")).toArray().size() == 1;
+        producer.invalidate();
+        feedRaw();
+        // A subsequent timer retirement must not discard the newly admitted
+        // compatibility replacement because its old typed lease was stale.
+        AetherSDR::AudioEngineRatesTestAccess::retire(engine);
+        const bool replacementKept = AetherSDR::AudioEngineRatesTestAccess::queuedKiwiBytes(engine, sourceId) == pcm.size()
+            && engine.automationAudioCaptureSnapshot(false).value(QStringLiteral("chunks")).toArray().size() == 2;
+        AetherSDR::AudioEngineRatesTestAccess::detachMemoryOutput(engine);
+        const bool casePassed = captureStarted && once && replacementKept;
+        std::printf("%s: %s Kiwi typed/raw route feeds once and preserves raw replacement after revocation\n",
+                    casePassed ? "PASS" : "FAIL", sourceId.isEmpty() ? "legacy" : "named");
+        passed = passed && casePassed;
+    }
+    return passed;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    const TestSettingsProfile profile(QStringLiteral("audio-engine-pcm-lifetime"));
+    if (!profile.isValid()) {
+        std::fprintf(stderr, "FAIL: isolated settings profile unavailable\n");
+        return 1;
+    }
+    qputenv("AETHER_AUTOMATION", "1");
+    QCoreApplication app(argc, argv);
+    const bool durationChecks = checkAggregateDurations();
+    const bool invalidProcessingChecks = checkInvalidProcessingWithheld();
+    const bool meterChecks = checkPresentedMeters();
+    const bool singleFeedChecks = checkSingleAuxiliaryFeed();
+    AetherSDR::AudioEngine engine;
+    AetherSDR::AudioEngineRatesTestAccess::stopTimer(engine);
+    engine.setRn2Enabled(true);
+    AetherSDR::AudioEngineRatesTestAccess::waitInitialization(engine);
+    const QString sourceId = QStringLiteral("lifetime-test-kiwi");
+    AetherSDR::AudioEngineRatesTestAccess::enableSource(engine, sourceId);
+    if (!AetherSDR::AudioEngineRatesTestAccess::initializeSource(engine, sourceId)
+        || !AetherSDR::AudioEngineRatesTestAccess::sourcePrepared(engine, sourceId)) {
+        std::fprintf(stderr, "FAIL: production RN2 initialization did not prepare auxiliary source\n");
+        return 1;
+    }
+
+    std::atomic<bool> done{false};
+    std::atomic<bool> initialized{true};
+    std::atomic<unsigned> completedInitializations{0};
+    std::thread initializer([&]() {
+        // This is the method scheduleAllKiwiDspStateInitialization dispatches
+        // off-thread. Repeated attempts overlap typed ingress, epoch retirement
+        // and source removal/recreation on the engine's owning thread.
+        while (!done.load(std::memory_order_acquire)) {
+            if (!AetherSDR::AudioEngineRatesTestAccess::initializeSource(engine, sourceId)) {
+                initialized.store(false, std::memory_order_relaxed);
+            }
+            completedInitializations.fetch_add(1, std::memory_order_relaxed);
+            std::this_thread::yield();
+        }
+    });
+
+    AetherSDR::PcmProducer producer;
+    int retiredEpochs = 0;
+    for (int cycle = 0; cycle < 300; ++cycle) {
+        if (cycle % 8 == 0) {
+            engine.removeKiwiSdrAudioSource(sourceId);
+            AetherSDR::AudioEngineRatesTestAccess::enableSource(engine, sourceId);
+        }
+        AetherSDR::AudioEngineRatesTestAccess::clearSourceDsp(engine, sourceId);
+        if (!producer.start(AetherSDR::PcmPurpose::Auxiliary)) {
+            break;
+        }
+        const std::optional<AetherSDR::PcmFrame> frame = producer.produce(QVector<float>(480, 0.25f));
+        if (!frame) {
+            break;
+        }
+        engine.feedKiwiPcmFrame(sourceId, *frame);
+        std::this_thread::yield();
+        producer.invalidate();
+        if (AetherSDR::AudioEngineRatesTestAccess::retireAndCheck(engine, sourceId)) {
+            ++retiredEpochs;
+        }
+    }
+    done.store(true, std::memory_order_release);
+    initializer.join();
+    const bool prepared = AetherSDR::AudioEngineRatesTestAccess::initializeSource(engine, sourceId)
+        && AetherSDR::AudioEngineRatesTestAccess::sourcePrepared(engine, sourceId);
+    const unsigned initializations = completedInitializations.load(std::memory_order_relaxed);
+    const bool passed = durationChecks && invalidProcessingChecks && meterChecks && singleFeedChecks
+        && initialized.load(std::memory_order_relaxed)
+        && initializations > 0 && retiredEpochs == 300 && prepared;
+    std::printf("%s: %d typed epochs retired; %u concurrent initialization attempts; final source %s\n",
+        passed ? "PASS" : "FAIL", retiredEpochs, initializations, prepared ? "prepared" : "unprepared");
+    return passed ? 0 : 1;
+}

--- a/tests/audio_engine_rates_test.cpp
+++ b/tests/audio_engine_rates_test.cpp
@@ -1,0 +1,845 @@
+// RFC #5468 A2: drive the production RX queue/DSP/mixer with a memory-backed
+// output device. No QAudioSink, socket peer, radio connection, or RF is used.
+#include "TestSettingsProfile.h"
+#include "core/AudioEngine.h"
+#include "core/ClientComp.h"
+#include "core/ClientDeEss.h"
+#include "core/ClientEq.h"
+#include "core/ClientGate.h"
+#include "core/ClientPudu.h"
+#include "core/ClientTube.h"
+#include "core/CwSidetoneGenerator.h"
+#include "core/Resampler.h"
+
+#include <QBuffer>
+#include <QCoreApplication>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QTimer>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+#include <numbers>
+#include <optional>
+
+namespace AetherSDR {
+class AudioEngineRatesTestAccess {
+public:
+    static void attach(AudioEngine& engine, QBuffer& output, int deviceRate)
+    {
+        engine.m_rxTimer->stop();
+        engine.m_audioDevice = &output;
+        engine.setRxDeviceRate(deviceRate);
+    }
+    static void detach(AudioEngine& engine) { engine.m_audioDevice = nullptr; }
+    static void drain(AudioEngine& engine, qsizetype bytes) { engine.drainRxAudio(bytes); }
+    static qsizetype rawBytes(const AudioEngine& engine)
+    {
+        qsizetype result = engine.m_rxBuffer.size();
+        for (const QByteArray& packet : engine.m_rxPackets) {
+            result += packet.size();
+        }
+        return result;
+    }
+    static qsizetype outputBytes(const AudioEngine& engine)
+    {
+        return engine.m_rxOutputBuffer.size();
+    }
+    static qsizetype legacyKiwiRawBytes(const AudioEngine& engine)
+    {
+        qsizetype result = engine.m_kiwiSdrRxBuffer.size();
+        for (const QByteArray& packet : engine.m_kiwiSdrRxPackets) {
+            result += packet.size();
+        }
+        return result;
+    }
+    static int producerRate(const AudioEngine& engine) { return engine.m_rxProducerRate.load(); }
+    static int outputRate(const AudioEngine& engine) { return engine.m_rxOutputRate.load(); }
+    static void deviceRate(AudioEngine& engine, int rate) { engine.setRxDeviceRate(rate); }
+    static bool prepareKiwi(AudioEngine& engine)
+    {
+        engine.m_dspInitializationTasks.waitForFinished();
+        return engine.ensureAllKiwiDspState();
+    }
+    static qsizetype kiwiBytes(AudioEngine& engine, const QString& id)
+    {
+        const auto* source = engine.externalKiwiSource(id, false);
+        if (!source) {
+            return 0;
+        }
+        qsizetype result = source->rxBuffer.size() + source->outputBuffer.size();
+        for (const QByteArray& packet : source->rxPackets) {
+            result += packet.size();
+        }
+        return result;
+    }
+    static void renderCwDecodeSilence(AudioEngine& engine, int rate)
+    {
+        engine.m_cwSidetone->setSampleRateHz(rate);
+        QVector<float> silence(rate / 100 * 2, 0.0f);
+        engine.m_cwSidetone->process(silence.data(), rate / 100);
+    }
+    static int recordedCwRate(const AudioEngine& engine)
+    {
+        return engine.m_cwRecordSidetone->sampleRateHz();
+    }
+    static double radeSourceRate(const AudioEngine& engine)
+    {
+        return engine.m_radeRxResampler ? engine.m_radeRxResampler->srcRate() : 24000.0;
+    }
+};
+} // namespace AetherSDR
+
+using namespace AetherSDR;
+
+namespace {
+constexpr qsizetype kFrameBytes = 2 * static_cast<qsizetype>(sizeof(float));
+constexpr double kTau = 2.0 * std::numbers::pi;
+const QString kKiwiId = QStringLiteral("rate-test-kiwi");
+int checks = 0;
+int failures = 0;
+
+void check(bool condition, const char* message)
+{
+    ++checks;
+    if (!condition) {
+        ++failures;
+        std::fprintf(stderr, "FAIL: %s\n", message);
+    }
+}
+
+QByteArray bytes(const QVector<float>& samples)
+{
+    return {reinterpret_cast<const char*>(samples.constData()),
+            samples.size() * static_cast<qsizetype>(sizeof(float))};
+}
+
+QVector<float> tone(int rate, int frames, quint64 offset = 0,
+                    double leftHz = 1000.0, double rightHz = 2300.0,
+                    PcmLayout layout = PcmLayout::Stereo)
+{
+    const int channels = layout == PcmLayout::Mono ? 1 : 2;
+    QVector<float> result(frames * channels);
+    for (int frame = 0; frame < frames; ++frame) {
+        const double time = static_cast<double>(offset + static_cast<quint64>(frame)) / rate;
+        result[frame * channels] = static_cast<float>(0.3 * std::sin(kTau * leftHz * time));
+        if (channels == 2) {
+            result[frame * channels + 1] = static_cast<float>(0.17 * std::sin(kTau * rightHz * time));
+        }
+    }
+    return result;
+}
+
+double amplitude(const QByteArray& pcm, int rate, int channel, double frequency)
+{
+    const qsizetype frames = pcm.size() / kFrameBytes;
+    // Ignore startup/filter transients, then measure half a second at most.
+    const qsizetype count = std::min<qsizetype>(rate / 2, frames / 2);
+    if (count < 100) {
+        return 0.0;
+    }
+    const auto* samples = reinterpret_cast<const float*>(pcm.constData());
+    double real = 0.0;
+    double imaginary = 0.0;
+    for (qsizetype index = 0; index < count; ++index) {
+        const double phase = kTau * frequency * static_cast<double>(index) / rate;
+        const float value = samples[(frames - count + index) * 2 + channel];
+        real += value * std::cos(phase);
+        imaginary += value * std::sin(phase);
+    }
+    return 2.0 * std::hypot(real, imaginary) / static_cast<double>(count);
+}
+
+bool finite(const QByteArray& pcm)
+{
+    if (pcm.size() % kFrameBytes != 0) {
+        return false;
+    }
+    const auto* samples = reinterpret_cast<const float*>(pcm.constData());
+    const qsizetype count = pcm.size() / static_cast<qsizetype>(sizeof(float));
+    return std::all_of(samples, samples + count, [](float value) { return std::isfinite(value); });
+}
+
+struct Fixture {
+    QBuffer output;
+    AudioEngine engine;
+    int deviceRate;
+
+    explicit Fixture(int rate) : deviceRate(rate)
+    {
+        check(output.open(QIODevice::ReadWrite), "memory output opens");
+        AudioEngineRatesTestAccess::attach(engine, output, rate);
+        engine.setMuted(false);
+        engine.setRxBoost(false);
+        engine.setRxOutputTrimDb(0.0f);
+        engine.setRxBufferCapMs(1000);
+        engine.clientEqRx()->setEnabled(false);
+        engine.clientGateRx()->setEnabled(false);
+        engine.clientCompRx()->setEnabled(false);
+        engine.clientDeEssRx()->setEnabled(false);
+        engine.clientTubeRx()->setEnabled(false);
+        engine.clientPuduRx()->setEnabled(false);
+    }
+    ~Fixture() { AudioEngineRatesTestAccess::detach(engine); }
+    void capture()
+    {
+        check(engine.startAutomationAudioCapture(30000,
+                  {QStringLiteral("raw"), QStringLiteral("post"),
+                   QStringLiteral("output"), QStringLiteral("final")})
+                  .value("ok").toBool(), "capture starts");
+    }
+    void tick() { AudioEngineRatesTestAccess::drain(engine, deviceRate / 100 * kFrameBytes); }
+    void finish()
+    {
+        for (int tick = 0; tick < 8; ++tick) {
+            AudioEngineRatesTestAccess::drain(engine, deviceRate * kFrameBytes);
+        }
+    }
+    QByteArray captured(const QString& point, const QString& source = QStringLiteral("flex"),
+                        const QString& sourceId = QString()) const
+    {
+        QByteArray result;
+        const QJsonArray chunks = engine.automationAudioCaptureSnapshot(true).value("chunks").toArray();
+        for (const QJsonValue& value : chunks) {
+            const QJsonObject chunk = value.toObject();
+            if (chunk.value("point").toString() == point
+                && chunk.value("source").toString() == source
+                && chunk.value("sourceId").toString() == sourceId) {
+                const int expectedRate = point == QStringLiteral("raw")
+                    ? (source == QStringLiteral("kiwi") ? 24000
+                        : AudioEngineRatesTestAccess::producerRate(engine)) : deviceRate;
+                check(chunk.value("sampleRate").toInt() == expectedRate,
+                      "capture labels producer and device domains distinctly");
+                result += QByteArray::fromBase64(chunk.value("pcmBase64").toString().toLatin1());
+            }
+        }
+        return result;
+    }
+};
+
+void feed(AudioEngine& engine, PcmProducer& producer, QVector<float> samples)
+{
+    const std::optional<PcmFrame> frame = producer.produce(std::move(samples));
+    check(frame.has_value(), "test producer creates a valid frame");
+    if (frame) {
+        engine.feedPcmFrame(*frame);
+    }
+}
+
+void rateMatrix()
+{
+    for (int producerRate : {24000, 48000}) {
+        for (int deviceRate : {24000, 44100, 48000}) {
+            Fixture fixture(deviceRate);
+            fixture.capture();
+            PcmProducer producer;
+            check(producer.start(PcmPurpose::Speaker, -1, {producerRate, PcmLayout::Stereo}),
+                  "matrix producer starts");
+            QByteArray original;
+            for (int tick = 0; tick < 100; ++tick) {
+                const QVector<float> samples = tone(producerRate, producerRate / 100,
+                    static_cast<quint64>(tick * (producerRate / 100)));
+                original += bytes(samples);
+                feed(fixture.engine, producer, samples);
+                fixture.tick();
+            }
+            fixture.finish();
+            const QByteArray output = fixture.output.data();
+            const qsizetype frames = output.size() / kFrameBytes;
+            std::printf("matrix producer=%d device=%d outputFrames=%lld\n",
+                        producerRate, deviceRate, static_cast<long long>(frames));
+            check(frames == deviceRate,
+                  "one second producer input yields one second device output");
+            check(finite(output), "matrix output is finite aligned stereo");
+            check(amplitude(output, deviceRate, 0, 1000) > 0.27,
+                  "matrix preserves left frequency and amplitude");
+            check(amplitude(output, deviceRate, 1, 2300) > 0.15,
+                  "matrix preserves independent right frequency and amplitude");
+            check(amplitude(output, deviceRate, 1, 1000) < 0.002,
+                  "matrix does not fold left into right");
+            check(AudioEngineRatesTestAccess::producerRate(fixture.engine) == producerRate
+                  && AudioEngineRatesTestAccess::outputRate(fixture.engine) == deviceRate,
+                  "producer metadata never replaces device rate");
+            check(fixture.engine.clientEqRx()->sampleRate() == producerRate
+                  && fixture.engine.clientGateRx()->sampleRate() == producerRate
+                  && fixture.engine.clientCompRx()->sampleRate() == producerRate
+                  && fixture.engine.clientDeEssRx()->sampleRate() == producerRate
+                  && fixture.engine.clientTubeRx()->sampleRate() == producerRate
+                  && fixture.engine.clientPuduRx()->sampleRate() == producerRate,
+                  "every main client effect is prepared in the producer domain");
+            check(fixture.captured(QStringLiteral("raw")) == original,
+                  "typed producer capture is byte exact");
+            check(fixture.captured(QStringLiteral("output")) == output,
+                  "exactly one output feed reaches memory device");
+            if (producerRate == 24000 && deviceRate == 24000) {
+                check(output == original, "legacy 24 kHz bypass remains byte exact");
+            }
+        }
+    }
+}
+
+void bandwidthAndMono()
+{
+    for (int deviceRate : {24000, 44100, 48000}) {
+        Fixture fixture(deviceRate);
+        PcmProducer producer;
+        producer.start(PcmPurpose::Speaker, -1, {48000, PcmLayout::Stereo});
+        for (int tick = 0; tick < 100; ++tick) {
+            feed(fixture.engine, producer, tone(48000, 480, tick * 480, 15000, 1000));
+            fixture.tick();
+        }
+        fixture.finish();
+        check(amplitude(fixture.output.data(), deviceRate, 1, 1000) > 0.15,
+              "wide producer preserves low-band stereo channel");
+        if (deviceRate >= 44100) {
+            check(amplitude(fixture.output.data(), deviceRate, 0, 15000) > 0.27,
+                  "48 kHz producer retains 15 kHz audio bandwidth");
+        } else {
+            check(amplitude(fixture.output.data(), deviceRate, 0, 9000) < 0.003,
+                  "48 to 24 conversion rejects the 15 kHz alias");
+        }
+    }
+    for (int producerRate : {24000, 48000}) {
+        Fixture fixture(48000);
+        PcmProducer producer;
+        producer.start(PcmPurpose::Speaker, -1, {producerRate, PcmLayout::Mono});
+        for (int tick = 0; tick < 100; ++tick) {
+            feed(fixture.engine, producer,
+                 tone(producerRate, producerRate / 100, tick * (producerRate / 100),
+                      1000, 1000, PcmLayout::Mono));
+            fixture.tick();
+        }
+        fixture.finish();
+        const QByteArray output = fixture.output.data();
+        const auto* samples = reinterpret_cast<const float*>(output.constData());
+        bool identical = !output.isEmpty();
+        for (qsizetype frame = 0; frame < output.size() / kFrameBytes; ++frame) {
+            identical = identical && samples[frame * 2] == samples[frame * 2 + 1];
+        }
+        check(identical && amplitude(output, 48000, 0, 1000) > 0.27,
+              "mono producers duplicate into stereo at the producer domain");
+    }
+}
+
+void transitionsAndRejection()
+{
+    Fixture fixture(48000);
+    fixture.capture();
+    PcmProducer producer;
+    producer.start();
+    const PcmFrame first = *producer.produce(tone(24000, 240));
+    fixture.engine.feedPcmFrame(first);
+    const qsizetype queued = AudioEngineRatesTestAccess::rawBytes(fixture.engine);
+    fixture.engine.feedPcmFrame(first);
+    fixture.engine.feedPcmFrame(PcmFrame{});
+    check(queued == 240 * kFrameBytes
+          && AudioEngineRatesTestAccess::rawBytes(fixture.engine) == queued,
+          "duplicate and invalid frames never enter the queue");
+    check(fixture.captured(QStringLiteral("raw")).size() == queued,
+          "duplicate first frame cannot reset and replace the queue as a second feed");
+    fixture.engine.feedAudioData(bytes(tone(24000, 240)));
+    check(AudioEngineRatesTestAccess::rawBytes(fixture.engine) == queued
+          && fixture.captured(QStringLiteral("raw")).size() == queued,
+          "legacy callback cannot double-feed a speaker route owned by typed PCM");
+    check(!producer.produce({std::numeric_limits<float>::quiet_NaN(), 0.0f})
+          && !producer.produce({0.0f})
+          && !producer.setFormat({44100, PcmLayout::Stereo}),
+          "malformed samples and unsupported producer rate are refused");
+
+    PcmProducer competing;
+    competing.start(PcmPurpose::Speaker, -1, {48000, PcmLayout::Stereo});
+    feed(fixture.engine, competing, tone(48000, 480));
+    check(AudioEngineRatesTestAccess::rawBytes(fixture.engine) == queued
+          && AudioEngineRatesTestAccess::producerRate(fixture.engine) == 24000,
+          "a second live producer cannot take over the speaker route");
+
+    const PcmFrame next = *producer.produce(tone(24000, 240, 240));
+    fixture.engine.feedPcmFrame(next);
+    const qsizetype orderedBytes = AudioEngineRatesTestAccess::rawBytes(fixture.engine);
+    fixture.engine.feedPcmFrame(next);
+    fixture.engine.feedPcmFrame(first);
+    check(orderedBytes == 2 * queued
+          && AudioEngineRatesTestAccess::rawBytes(fixture.engine) == orderedBytes
+          && fixture.captured(QStringLiteral("raw")).size() == orderedBytes,
+          "midstream duplicates and older same-epoch frames are rejected before any feed");
+
+    producer.setFormat({48000, PcmLayout::Stereo});
+    feed(fixture.engine, producer, QVector<float>(960, 0.0f));
+    check(AudioEngineRatesTestAccess::rawBytes(fixture.engine) == 480 * kFrameBytes
+          && AudioEngineRatesTestAccess::producerRate(fixture.engine) == 48000,
+          "format change replaces queued samples and producer rate together");
+    fixture.engine.feedPcmFrame(first);
+    check(AudioEngineRatesTestAccess::rawBytes(fixture.engine) == 480 * kFrameBytes,
+          "old-format frame cannot enter the new-format queue");
+    fixture.tick();
+    check(fixture.output.data() == QByteArray(480 * kFrameBytes, '\0'),
+          "format transition discards old waveform and resampler tail");
+
+    feed(fixture.engine, producer, tone(48000, 960));
+    const PcmFrame discontinuity = *producer.produce(QVector<float>(960, 0.0f), 4800, true);
+    fixture.engine.feedPcmFrame(discontinuity);
+    check(AudioEngineRatesTestAccess::rawBytes(fixture.engine) == 480 * kFrameBytes,
+          "discontinuity flushes pending raw input before admitting new samples");
+    fixture.tick();
+    check(fixture.output.data().right(480 * kFrameBytes) == QByteArray(480 * kFrameBytes, '\0'),
+          "discontinuity does not replay pre-gap processing state");
+
+    feed(fixture.engine, producer, tone(48000, 480));
+    producer.invalidate();
+    fixture.tick();
+    check(AudioEngineRatesTestAccess::rawBytes(fixture.engine) == 0
+          && AudioEngineRatesTestAccess::outputBytes(fixture.engine) == 0,
+          "disconnect revocation flushes queues without another producer frame");
+    producer.start();
+    feed(fixture.engine, producer, tone(24000, 240));
+    check(AudioEngineRatesTestAccess::producerRate(fixture.engine) == 24000,
+          "reconnected producer returns to its declared 24 kHz domain");
+    producer.invalidate();
+    feed(fixture.engine, competing, tone(48000, 480, 480));
+    check(AudioEngineRatesTestAccess::producerRate(fixture.engine) == 48000
+          && AudioEngineRatesTestAccess::rawBytes(fixture.engine) == 480 * kFrameBytes,
+          "replacement producer is accepted after prior lease revocation");
+}
+
+void queueBudgetsAndDeviceTransitions()
+{
+    for (int producerRate : {24000, 48000}) {
+        Fixture fixture(44100);
+        fixture.engine.setRxBufferCapMs(100);
+        PcmProducer producer;
+        producer.start(PcmPurpose::Speaker, -1, {producerRate, PcmLayout::Stereo});
+        feed(fixture.engine, producer, tone(producerRate, producerRate / 4));
+        AudioEngineRatesTestAccess::drain(fixture.engine, 0);
+        check(AudioEngineRatesTestAccess::rawBytes(fixture.engine)
+                  == producerRate / 10 * kFrameBytes,
+              "raw queue cap uses producer duration at either producer rate");
+        check(fixture.engine.receivePresentationAudioQueues().flexRawBufferMs == 100,
+              "raw queue diagnostics report producer milliseconds");
+        fixture.engine.setRxBufferCapMs(1000);
+        fixture.engine.setReceivePresentationDelays(100, 0);
+        feed(fixture.engine, producer, tone(producerRate, producerRate / 5, producerRate / 4));
+        fixture.tick();
+        check(fixture.engine.receivePresentationAudioQueues().flexRawBufferMs >= 100,
+              "presentation delay retains the configured producer duration");
+
+        AudioEngineRatesTestAccess::deviceRate(fixture.engine, 24000);
+        fixture.deviceRate = 24000;
+        check(AudioEngineRatesTestAccess::rawBytes(fixture.engine) == 0
+              && AudioEngineRatesTestAccess::outputBytes(fixture.engine) == 0,
+              "device format transition discards queued old-rate samples");
+        check(AudioEngineRatesTestAccess::producerRate(fixture.engine) == producerRate
+              && AudioEngineRatesTestAccess::outputRate(fixture.engine) == 24000,
+              "device renegotiation retains the producer rate");
+        fixture.engine.setReceivePresentationDelays(0, 0);
+        const qsizetype before = fixture.output.data().size();
+        for (int tick = 0; tick < 100; ++tick) {
+            feed(fixture.engine, producer, tone(producerRate, producerRate / 100,
+                static_cast<quint64>(tick * (producerRate / 100))));
+            fixture.tick();
+        }
+        fixture.finish();
+        const QByteArray changed = fixture.output.data().mid(before);
+        check(std::abs(changed.size() / kFrameBytes - 24000) <= 512
+              && amplitude(changed, 24000, 0, 1000) > 0.27,
+              "remaining producer continues at the new device rate without retiming");
+    }
+}
+
+enum class Effect { None, Eq, Nr2, Rn2, Nr4, Dfnr, Mnr };
+
+const char* effectName(Effect effect)
+{
+    switch (effect) {
+    case Effect::None: return "bypass";
+    case Effect::Eq: return "EQ";
+    case Effect::Nr2: return "NR2";
+    case Effect::Rn2: return "RN2";
+    case Effect::Nr4: return "NR4";
+    case Effect::Dfnr: return "DFNR";
+    case Effect::Mnr: return "MNR";
+    }
+    return "unknown";
+}
+
+bool enableEffect(AudioEngine& engine, Effect effect)
+{
+    switch (effect) {
+    case Effect::None:
+        return true;
+    case Effect::Eq: {
+        ClientEq::BandParams band;
+        band.type = ClientEq::FilterType::LowPass;
+        band.freqHz = 1800.0f;
+        band.enabled = true;
+        engine.clientEqRx()->setActiveBandCount(1);
+        engine.clientEqRx()->setBand(0, band);
+        engine.clientEqRx()->setMasterGain(0.5f);
+        engine.clientEqRx()->setEnabled(true);
+        return true;
+    }
+    case Effect::Nr2:
+        engine.setNr2Enabled(true);
+        return engine.nr2Enabled();
+    case Effect::Rn2:
+        engine.setRn2Enabled(true);
+        engine.setRn2DryMix(0.5f);
+        return engine.rn2Enabled();
+    case Effect::Nr4:
+        engine.setNr4Enabled(true);
+        return engine.nr4Enabled();
+    case Effect::Dfnr:
+        engine.setDfnrEnabled(true);
+        return engine.dfnrEnabled();
+    case Effect::Mnr:
+#ifdef Q_OS_MAC
+        engine.setMnrEnabled(true);
+        return engine.mnrEnabled();
+#else
+        return false;
+#endif
+    }
+    return false;
+}
+
+struct Rendered {
+    bool enabled = false;
+    QByteArray main;
+    QByteArray kiwi;
+    QByteArray final;
+};
+
+Rendered renderSources(int mainRate, Effect effect, bool mainEnabled, bool kiwiEnabled)
+{
+    Fixture fixture(48000);
+    PcmProducer main;
+    PcmProducer kiwi;
+    if (mainEnabled) {
+        main.start(PcmPurpose::Speaker, -1, {mainRate, PcmLayout::Stereo});
+        feed(fixture.engine, main, QVector<float>(mainRate / 100 * 2, 0.0f));
+        fixture.tick();
+    }
+    Rendered result;
+    result.enabled = enableEffect(fixture.engine, effect);
+    if (!result.enabled) {
+        return result;
+    }
+    if (kiwiEnabled) {
+        fixture.engine.setKiwiSdrAudioSourceEnabled(kKiwiId, true);
+        check(AudioEngineRatesTestAccess::prepareKiwi(fixture.engine),
+              "selected Kiwi effect initializes before audio is measured");
+        kiwi.start(PcmPurpose::Auxiliary);
+    }
+    fixture.output.buffer().clear();
+    fixture.output.seek(0);
+    fixture.capture();
+    quint64 kiwiOffset = 0;
+    if (kiwiEnabled) {
+        // Exercise the real 360 ms Kiwi prebuffer instead of defeating it.
+        for (int packet = 0; packet < 40; ++packet) {
+            fixture.engine.feedKiwiPcmFrame(kKiwiId,
+                *kiwi.produce(tone(24000, 240, kiwiOffset, 700, 3200)));
+            kiwiOffset += 240;
+        }
+    }
+    for (int tick = 0; tick < 150; ++tick) {
+        if (mainEnabled) {
+            feed(fixture.engine, main, tone(mainRate, mainRate / 100,
+                static_cast<quint64>(tick * (mainRate / 100))));
+        }
+        if (kiwiEnabled) {
+            fixture.engine.feedKiwiPcmFrame(kKiwiId,
+                *kiwi.produce(tone(24000, 240, kiwiOffset, 700, 3200)));
+            kiwiOffset += 240;
+        }
+        fixture.tick();
+    }
+    fixture.finish();
+    result.main = fixture.captured(QStringLiteral("post"));
+    result.kiwi = fixture.captured(QStringLiteral("post"), QStringLiteral("kiwi"), kKiwiId);
+    result.final = fixture.output.data();
+    return result;
+}
+
+bool samePcm(const QByteArray& lhs, const QByteArray& rhs)
+{
+    if (lhs.isEmpty() || lhs.size() != rhs.size()) {
+        return false;
+    }
+    const auto* first = reinterpret_cast<const float*>(lhs.constData());
+    const auto* second = reinterpret_cast<const float*>(rhs.constData());
+    for (qsizetype index = 0; index < lhs.size() / static_cast<qsizetype>(sizeof(float)); ++index) {
+        if (!std::isfinite(first[index]) || !std::isfinite(second[index])
+            || std::abs(first[index] - second[index]) > 0.00002f) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void concurrentSourcesAndEffects()
+{
+    for (int mainRate : {24000, 48000}) {
+        for (Effect effect : {Effect::None, Effect::Eq, Effect::Nr2, Effect::Rn2,
+                              Effect::Nr4, Effect::Dfnr, Effect::Mnr}) {
+            const Rendered mainOnly = renderSources(mainRate, effect, true, false);
+            if (!mainOnly.enabled) {
+                const bool optional = effect == Effect::Nr4 || effect == Effect::Dfnr
+                    || effect == Effect::Mnr;
+                check(optional, "mandatory NR2/RN2 effect must be available");
+                std::printf("SKIP: optional effect %s unavailable at %d Hz\n",
+                            effectName(effect), mainRate);
+                continue;
+            }
+            const Rendered kiwiOnly = renderSources(mainRate, effect, false, true);
+            const Rendered combined = renderSources(mainRate, effect, true, true);
+            std::printf("effects mainRate=%d effect=%s main=%lld kiwi=%lld combined=%lld/%lld\n",
+                        mainRate, effectName(effect),
+                        static_cast<long long>(mainOnly.main.size()),
+                        static_cast<long long>(kiwiOnly.kiwi.size()),
+                        static_cast<long long>(combined.main.size()),
+                        static_cast<long long>(combined.kiwi.size()));
+            check(kiwiOnly.enabled && combined.enabled,
+                  "selected effect is enabled for concurrent-source comparison");
+            check(samePcm(mainOnly.main, combined.main),
+                  "concurrent Kiwi24 does not alter main processing state");
+            check(samePcm(kiwiOnly.kiwi, combined.kiwi),
+                  "main producer rate does not alter independent Kiwi24 processing");
+            check(finite(combined.final) && !combined.final.isEmpty(),
+                  "concurrent effects mix finite output through the real device writer");
+            if (effect == Effect::Eq) {
+                const double gain = amplitude(mainOnly.main, 48000, 0, 1000);
+                check(gain > 0.11 && gain < 0.16,
+                      "enabled EQ applies its configured gain in the producer domain");
+            }
+        }
+    }
+
+    Fixture fixture(48000);
+    PcmProducer main;
+    PcmProducer kiwi;
+    PcmProducer collision;
+    main.start(PcmPurpose::Speaker, -1, {48000, PcmLayout::Stereo});
+    kiwi.start(PcmPurpose::Auxiliary);
+    collision.start(PcmPurpose::Auxiliary);
+    fixture.engine.setKiwiSdrAudioSourceEnabled(kKiwiId, true);
+    fixture.engine.setKiwiSdrAudioSourceEnabled(QStringLiteral("second-kiwi"), true);
+    feed(fixture.engine, main, tone(48000, 480));
+    const PcmFrame kiwiFrame = *kiwi.produce(tone(24000, 240));
+    fixture.engine.feedKiwiPcmFrame(kKiwiId, kiwiFrame);
+    const qsizetype kiwiBytes = AudioEngineRatesTestAccess::kiwiBytes(fixture.engine, kKiwiId);
+    fixture.engine.feedKiwiPcmFrame(kKiwiId, kiwiFrame);
+    fixture.engine.feedKiwiPcmFrame(QStringLiteral("second-kiwi"), kiwiFrame);
+    fixture.engine.feedKiwiPcmFrame(kKiwiId, *collision.produce(tone(24000, 240)));
+    check(kiwiBytes == 240 * kFrameBytes
+          && AudioEngineRatesTestAccess::kiwiBytes(fixture.engine, kKiwiId) == kiwiBytes
+          && AudioEngineRatesTestAccess::kiwiBytes(fixture.engine, QStringLiteral("second-kiwi")) == 0,
+          "Kiwi duplicate, duplicate route and live-producer replacement are refused");
+    main.invalidate();
+    AudioEngineRatesTestAccess::drain(fixture.engine, 0);
+    check(AudioEngineRatesTestAccess::kiwiBytes(fixture.engine, kKiwiId) == kiwiBytes,
+          "main revocation preserves a different source's pending PCM");
+    kiwi.invalidate();
+    AudioEngineRatesTestAccess::drain(fixture.engine, 0);
+    check(AudioEngineRatesTestAccess::kiwiBytes(fixture.engine, kKiwiId) == 0,
+          "Kiwi revocation drains its own pending PCM without a later feed");
+}
+
+void kiwiDeviceRateMatrix()
+{
+    for (int deviceRate : {24000, 44100, 48000}) {
+        for (bool legacy : {false, true}) {
+            Fixture fixture(deviceRate);
+            PcmProducer kiwi;
+            if (legacy) {
+                fixture.engine.setKiwiSdrAudioEnabled(true);
+            } else {
+                fixture.engine.setKiwiSdrAudioSourceEnabled(kKiwiId, true);
+                check(kiwi.start(PcmPurpose::Auxiliary), "Kiwi matrix producer starts");
+            }
+            check(AudioEngineRatesTestAccess::prepareKiwi(fixture.engine),
+                  "Kiwi matrix processing state initializes");
+            for (int packet = 0; packet < 100; ++packet) {
+                const QVector<float> samples = tone(24000, 240, packet * 240);
+                if (legacy) {
+                    fixture.engine.feedKiwiSdrAudioData(bytes(samples));
+                } else {
+                    fixture.engine.feedKiwiPcmFrame(kKiwiId, *kiwi.produce(samples));
+                }
+                if (packet >= 40) {
+                    fixture.tick();
+                }
+            }
+            fixture.finish();
+            const QByteArray output = fixture.output.data();
+            std::printf("Kiwi route=%s device=%d outputFrames=%lld\n",
+                        legacy ? "legacy" : "typed", deviceRate,
+                        static_cast<long long>(output.size() / kFrameBytes));
+            check(output.size() / kFrameBytes == deviceRate,
+                  "one second Kiwi24 input yields one second at every device rate");
+            check(finite(output) && amplitude(output, deviceRate, 0, 1000) > 0.27
+                  && amplitude(output, deviceRate, 1, 2300) > 0.15,
+                  "Kiwi rate conversion preserves independent stereo frequencies");
+        }
+    }
+}
+
+void processingStateReset()
+{
+    for (Effect effect : {Effect::Eq, Effect::Nr2, Effect::Rn2}) {
+        Fixture fixture(48000);
+        PcmProducer producer;
+        producer.start(PcmPurpose::Speaker, -1, {24000, PcmLayout::Stereo});
+        feed(fixture.engine, producer, QVector<float>(480, 0.0f));
+        fixture.tick();
+        check(enableEffect(fixture.engine, effect), "state-reset effect enables");
+        for (int tick = 0; tick < 20; ++tick) {
+            feed(fixture.engine, producer, tone(24000, 240, tick * 240));
+            fixture.tick();
+        }
+        producer.setFormat({48000, PcmLayout::Stereo});
+        fixture.output.buffer().clear();
+        fixture.output.seek(0);
+        for (int tick = 0; tick < 40; ++tick) {
+            feed(fixture.engine, producer, QVector<float>(960, 0.0f));
+            fixture.tick();
+        }
+        fixture.finish();
+        const QByteArray silence = fixture.output.data();
+        const auto* samples = reinterpret_cast<const float*>(silence.constData());
+        check(!silence.isEmpty() && std::all_of(samples,
+                  samples + silence.size() / static_cast<qsizetype>(sizeof(float)),
+                  [](float value) { return std::isfinite(value) && std::abs(value) < 0.00001f; }),
+              "producer format change discards enabled-effect and resampler history");
+
+        for (int tick = 0; tick < 20; ++tick) {
+            feed(fixture.engine, producer, tone(48000, 480, tick * 480));
+            fixture.tick();
+        }
+        fixture.output.buffer().clear();
+        fixture.output.seek(0);
+        const std::optional<PcmFrame> gap = producer.produce(QVector<float>(960, 0.0f),
+                                                             std::nullopt, true);
+        check(gap.has_value(), "explicit discontinuity creates a frame");
+        if (gap) {
+            fixture.engine.feedPcmFrame(*gap);
+        }
+        fixture.tick();
+        for (int tick = 0; tick < 39; ++tick) {
+            feed(fixture.engine, producer, QVector<float>(960, 0.0f));
+            fixture.tick();
+        }
+        fixture.finish();
+        check(samePcm(silence, fixture.output.data()),
+              "discontinuity resets selected effect to the same silent initial state");
+    }
+}
+
+void legacyReplacementAndKiwiReset()
+{
+    Fixture fixture(48000);
+    PcmProducer producer;
+    producer.start(PcmPurpose::Speaker, -1, {48000, PcmLayout::Stereo});
+    feed(fixture.engine, producer, tone(48000, 480));
+    producer.invalidate();
+    fixture.engine.feedAudioData(bytes(tone(24000, 240)));
+    check(AudioEngineRatesTestAccess::producerRate(fixture.engine) == 24000
+          && AudioEngineRatesTestAccess::rawBytes(fixture.engine) == 240 * kFrameBytes,
+          "legacy24 replacement retires typed48 before choosing its processing rate");
+
+    Fixture kiwiFixture(48000);
+    enableEffect(kiwiFixture.engine, Effect::Eq);
+    kiwiFixture.engine.setKiwiSdrAudioSourceEnabled(kKiwiId, true);
+    AudioEngineRatesTestAccess::prepareKiwi(kiwiFixture.engine);
+    PcmProducer kiwi;
+    kiwi.start(PcmPurpose::Auxiliary);
+    for (int packet = 0; packet < 40; ++packet) {
+        kiwiFixture.engine.feedKiwiPcmFrame(kKiwiId,
+            *kiwi.produce(QVector<float>(480, 0.3f)));
+    }
+    kiwiFixture.finish();
+    check(!kiwiFixture.output.data().isEmpty(), "Kiwi EQ history is exercised before mute");
+    kiwiFixture.engine.setKiwiSdrAudioSourceMuted(kKiwiId, true);
+    kiwiFixture.engine.setKiwiSdrAudioSourceMuted(kKiwiId, false);
+    AudioEngineRatesTestAccess::prepareKiwi(kiwiFixture.engine);
+    kiwiFixture.output.buffer().clear();
+    kiwiFixture.output.seek(0);
+    for (int packet = 0; packet < 40; ++packet) {
+        kiwiFixture.engine.feedKiwiPcmFrame(kKiwiId,
+            *kiwi.produce(QVector<float>(480, 0.0f)));
+    }
+    kiwiFixture.finish();
+    const QByteArray muted = kiwiFixture.output.data();
+    check(!muted.isEmpty() && muted == QByteArray(muted.size(), '\0'),
+          "Kiwi unmute cannot replay the previous client-effect or resampler tail");
+
+    Fixture stopped(48000);
+    stopped.engine.setNr2Enabled(true);
+    stopped.engine.setKiwiSdrAudioEnabled(true);
+    AudioEngineRatesTestAccess::prepareKiwi(stopped.engine);
+    stopped.output.close();
+    const QByteArray packet = bytes(tone(24000, 240));
+    for (int index = 0; index < 300; ++index) {
+        stopped.engine.feedKiwiSdrAudioData(packet);
+    }
+    const qsizetype queued = AudioEngineRatesTestAccess::legacyKiwiRawBytes(stopped.engine);
+    check(queued > 0 && queued <= 24000 * kFrameBytes,
+          "legacy Kiwi NR2 ingress stays bounded while the device drain is stopped");
+}
+
+void fixedProcessingDomains()
+{
+    for (int deviceRate : {24000, 44100, 48000}) {
+        Fixture fixture(deviceRate);
+        PcmProducer producer;
+        producer.start(PcmPurpose::Speaker, -1, {48000, PcmLayout::Stereo});
+        feed(fixture.engine, producer, QVector<float>(960, 0.0f));
+        fixture.tick();
+        QByteArray cw;
+        QObject::connect(&fixture.engine, &AudioEngine::txDecodeAudioReady,
+                         &fixture.engine, [&](const QByteArray& pcm) { cw = pcm; });
+        fixture.engine.setCwDecodeTxTapEnabled(true);
+        AudioEngineRatesTestAccess::renderCwDecodeSilence(fixture.engine, deviceRate);
+        check(cw.size() == 240 * kFrameBytes,
+              "CW decoder tap remains 24 kHz independently of RX producer/device rate");
+        check(AudioEngineRatesTestAccess::recordedCwRate(fixture.engine) == 24000,
+              "CW recorder generator retains its fixed 24 kHz contract");
+        const qsizetype before = fixture.output.data().size();
+        for (int tick = 0; tick < 100; ++tick) {
+            fixture.engine.feedDecodedSpeech(bytes(tone(24000, 240, tick * 240, 1000, 1000)));
+            fixture.tick();
+        }
+        fixture.finish();
+        const QByteArray rade = fixture.output.data().mid(before);
+        std::printf("RADE device=%d frames=%lld amplitude=%f\n", deviceRate,
+                    static_cast<long long>(rade.size() / kFrameBytes),
+                    amplitude(rade, deviceRate, 0, 1000));
+        check(std::abs(rade.size() / kFrameBytes - deviceRate) <= 512
+              && amplitude(rade, deviceRate, 0, 1000) > 0.20,
+              "RADE speech remains 24 kHz and resamples directly to the device");
+        check(AudioEngineRatesTestAccess::radeSourceRate(fixture.engine) == 24000.0,
+              "RADE resampler never adopts main producer's 48 kHz rate");
+    }
+}
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile settings(QStringLiteral("audio-engine-rates"));
+    qputenv("AETHER_AUTOMATION", "1");
+    QCoreApplication application(argc, argv);
+    check(settings.isValid(), "isolated settings profile");
+    rateMatrix();
+    bandwidthAndMono();
+    transitionsAndRejection();
+    queueBudgetsAndDeviceTransitions();
+    concurrentSourcesAndEffects();
+    kiwiDeviceRateMatrix();
+    processingStateReset();
+    legacyReplacementAndKiwiReset();
+    fixedProcessingDomains();
+    std::printf("AudioEngine rates: %d checks, %d failures\n", checks, failures);
+    return failures ? 1 : 0;
+}

--- a/tests/pcm_compatibility_test.cpp
+++ b/tests/pcm_compatibility_test.cpp
@@ -180,7 +180,7 @@ void backendAndAudioRouting()
     future.start(PcmPurpose::Speaker, -1, {48000, PcmLayout::Stereo});
     audio.feedPcmFrame(*future.produce({0.2f, -0.2f}));
     check(audio.automationAudioCaptureSnapshot(false).value("chunks").toArray().size() == 2,
-          "A1 AudioEngine refuses native 48 kHz until A2");
+          "AudioEngine refuses a competing 48 kHz producer while its speaker route is owned");
     source->retirePcmStreams();
     const int retiredTaps = taps;
     const int retiredSlices = slices;

--- a/tests/rx_client_effects_test.cpp
+++ b/tests/rx_client_effects_test.cpp
@@ -1,0 +1,414 @@
+// Socket-free production-effect checks: source isolation, rate-specific delay
+// and bandwidth, live parameter changes and discontinuity reset.
+#include "core/RxClientEffects.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <cstdio>
+#include <numbers>
+#include <thread>
+#include <vector>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* message)
+{
+    std::printf("%s %s\n", condition ? "PASS" : "FAIL", message);
+    if (!condition) {
+        ++g_failures;
+    }
+}
+
+// Independent reference uses the six original effect classes directly in the
+// shipped playback order; it does not call the helper's parameter copier.
+struct ReferenceEffects {
+    ClientEq eq;
+    ClientGate gate;
+    ClientComp comp;
+    ClientDeEss deEss;
+    ClientTube tube;
+    ClientPudu pudu;
+
+    explicit ReferenceEffects(int sampleRate)
+    {
+        prepare(sampleRate);
+    }
+
+    void prepare(int sampleRate)
+    {
+        eq.prepare(sampleRate);
+        gate.prepare(sampleRate);
+        comp.prepare(sampleRate);
+        deEss.prepare(sampleRate);
+        tube.prepare(sampleRate);
+        pudu.prepare(sampleRate);
+    }
+
+    void reset()
+    {
+        eq.reset();
+        gate.reset();
+        comp.reset();
+        deEss.reset();
+        tube.reset();
+        pudu.reset();
+    }
+
+    void process(std::vector<float>& audio)
+    {
+        const int frames = static_cast<int>(audio.size() / 2);
+        eq.process(audio.data(), frames, 2);
+        gate.process(audio.data(), frames, 2);
+        comp.process(audio.data(), frames, 2);
+        deEss.process(audio.data(), frames, 2);
+        tube.process(audio.data(), frames, 2);
+        pudu.process(audio.data(), frames, 2);
+    }
+};
+
+void configure(ReferenceEffects& effects, int variant)
+{
+    effects.eq.setEnabled(true);
+    effects.eq.setMasterGain(variant == 0 ? 0.8f : 1.2f);
+    effects.eq.setFilterFamily(variant == 0 ? ClientEq::FilterFamily::Bessel
+                                           : ClientEq::FilterFamily::Chebyshev);
+    effects.eq.setActiveBandCount(3);
+    effects.eq.setBand(0, {180.0f, 0.0f, 0.8f, ClientEq::FilterType::HighPass, true, 24});
+    effects.eq.setBand(1, {1700.0f, variant == 0 ? 5.0f : -4.0f, 1.8f,
+                          ClientEq::FilterType::Peak, true, 12});
+    effects.eq.setBand(2, {6000.0f, -3.0f, 0.9f,
+                          ClientEq::FilterType::HighShelf, variant == 0, 12});
+
+    effects.gate.setEnabled(true);
+    effects.gate.setMode(variant == 0 ? ClientGate::Mode::Gate : ClientGate::Mode::Expander);
+    effects.gate.setThresholdDb(-26.0f);
+    effects.gate.setRatio(4.2f);
+    effects.gate.setAttackMs(1.8f);
+    effects.gate.setReleaseMs(70.0f);
+    effects.gate.setHoldMs(7.0f);
+    effects.gate.setFloorDb(-21.0f);
+    effects.gate.setReturnDb(4.5f);
+    effects.gate.setLookaheadMs(variant == 0 ? 2.5f : 0.5f);
+
+    effects.comp.setEnabled(true);
+    effects.comp.setThresholdDb(-23.0f);
+    effects.comp.setRatio(5.5f);
+    effects.comp.setAttackMs(3.0f);
+    effects.comp.setReleaseMs(90.0f);
+    effects.comp.setKneeDb(2.0f);
+    effects.comp.setMakeupDb(variant == 0 ? 2.0f : 4.0f);
+    effects.comp.setLimiterEnabled(true);
+    effects.comp.setLimiterCeilingDb(-5.0f);
+    effects.comp.setDriveDb(6.0f);
+    effects.comp.setPhaseRotatorStages(4);
+
+    effects.deEss.setEnabled(true);
+    effects.deEss.setFrequencyHz(5500.0f);
+    effects.deEss.setQ(1.3f);
+    effects.deEss.setThresholdDb(-43.0f);
+    effects.deEss.setAmountDb(-10.0f);
+    effects.deEss.setAttackMs(2.0f);
+    effects.deEss.setReleaseMs(40.0f);
+    effects.deEss.setSlopeStages(3);
+
+    effects.tube.setEnabled(true);
+    effects.tube.setModel(variant == 0 ? ClientTube::Model::C : ClientTube::Model::B);
+    effects.tube.setDriveDb(8.0f);
+    effects.tube.setBiasAmount(0.2f);
+    effects.tube.setTone(-0.3f);
+    effects.tube.setOutputGainDb(-3.0f);
+    effects.tube.setDryWet(0.6f);
+    effects.tube.setEnvelopeAmount(-0.5f);
+    effects.tube.setAttackMs(3.0f);
+    effects.tube.setReleaseMs(55.0f);
+
+    effects.pudu.setEnabled(true);
+    effects.pudu.setMode(variant == 0 ? ClientPudu::Mode::Behringer : ClientPudu::Mode::Aphex);
+    effects.pudu.setPooDriveDb(8.0f);
+    effects.pudu.setPooTuneHz(130.0f);
+    effects.pudu.setPooMix(0.2f);
+    effects.pudu.setDooTuneHz(4200.0f);
+    effects.pudu.setDooHarmonicsDb(9.0f);
+    effects.pudu.setDooMix(0.35f);
+}
+
+void sync(RxClientEffects& effects, const ReferenceEffects& source)
+{
+    effects.syncParametersFrom(source.eq, source.gate, source.comp,
+                               source.deEss, source.tube, source.pudu);
+}
+
+void process(RxClientEffects& effects, std::vector<float>& audio)
+{
+    const int frames = static_cast<int>(audio.size() / 2);
+    effects.eq().process(audio.data(), frames, 2);
+    effects.gate().process(audio.data(), frames, 2);
+    effects.comp().process(audio.data(), frames, 2);
+    effects.deEss().process(audio.data(), frames, 2);
+    effects.tube().process(audio.data(), frames, 2);
+    effects.pudu().process(audio.data(), frames, 2);
+}
+
+std::vector<float> signal(int sampleRate, int frames, int offset, int source)
+{
+    std::vector<float> audio(static_cast<size_t>(frames * 2));
+    for (int frame = 0; frame < frames; ++frame) {
+        const double time = static_cast<double>(frame + offset) / sampleRate;
+        const float envelope = (frame + offset) % 1900 < 500 ? 0.03f : 0.4f;
+        audio[frame * 2] = envelope * static_cast<float>(
+            std::sin(2.0 * std::numbers::pi * (650.0 + source * 193.0) * time)
+            + 0.2 * std::sin(2.0 * std::numbers::pi * 5500.0 * time));
+        audio[frame * 2 + 1] = envelope * static_cast<float>(
+            std::sin(2.0 * std::numbers::pi * (1900.0 + source * 719.0) * time));
+    }
+    return audio;
+}
+
+bool equalAudio(const std::vector<float>& first, const std::vector<float>& second)
+{
+    return first.size() == second.size()
+        && std::equal(first.begin(), first.end(), second.begin(), [](float a, float b) {
+            return std::isfinite(a) && std::isfinite(b) && std::abs(a - b) < 1.0e-6f;
+        });
+}
+
+void checkConcurrentSources()
+{
+    ReferenceEffects main(48000);
+    ReferenceEffects legacyReference(24000);
+    ReferenceEffects profileReference(24000);
+    ReferenceEffects otherProfileReference(24000);
+    RxClientEffects legacy(24000);
+    RxClientEffects profile(24000);
+    RxClientEffects otherProfile(24000);
+    configure(main, 0);
+    configure(legacyReference, 0);
+    configure(profileReference, 0);
+    configure(otherProfileReference, 0);
+
+    bool legacyMatches = true;
+    bool profileMatches = true;
+    bool otherProfileMatches = true;
+    for (int block = 0; block < 160; ++block) {
+        if (block == 50) {
+            configure(main, 1);
+            configure(legacyReference, 1);
+            configure(profileReference, 1);
+            configure(otherProfileReference, 1);
+        }
+        if (block == 90) {
+            // One endpoint's discontinuity must not flush a concurrent source.
+            profile.reset();
+            profileReference.reset();
+        }
+        if (block == 110) {
+            // A main-source format replacement does not change Kiwi's rate or
+            // histories, nor copy the main signal's state into an auxiliary bank.
+            main.prepare(24000);
+        }
+        sync(legacy, main);
+        sync(profile, main);
+        sync(otherProfile, main);
+        std::vector<float> mainAudio = signal(block < 110 ? 48000 : 24000, 240, block * 240, 0);
+        main.process(mainAudio);
+        std::vector<float> legacyAudio = signal(24000, 120, block * 120, 1);
+        std::vector<float> referenceAudio = legacyAudio;
+        legacyReference.process(referenceAudio);
+        process(legacy, legacyAudio);
+        legacyMatches = legacyMatches && equalAudio(legacyAudio, referenceAudio);
+        std::vector<float> profileAudio = signal(24000, 120, block * 120, 2);
+        referenceAudio = profileAudio;
+        profileReference.process(referenceAudio);
+        process(profile, profileAudio);
+        profileMatches = profileMatches && equalAudio(profileAudio, referenceAudio);
+        std::vector<float> otherAudio = signal(24000, 120, block * 120, 3);
+        referenceAudio = otherAudio;
+        otherProfileReference.process(referenceAudio);
+        process(otherProfile, otherAudio);
+        otherProfileMatches = otherProfileMatches && equalAudio(otherAudio, referenceAudio);
+    }
+    check(legacyMatches, "Kiwi24 legacy effects match independent 24 kHz chain beside main48");
+    check(profileMatches, "Kiwi24 profile effects retain independent state and reset locally");
+    check(otherProfileMatches, "second Kiwi24 profile survives other source resets and rate changes");
+    check(legacy.gate().mode() == ClientGate::Mode::Expander
+          && legacy.gate().ratio() == 4.2f && legacy.gate().floorDb() == -21.0f,
+          "mode synchronization preserves explicit gate ratio and floor overrides");
+}
+
+void checkRateDomains()
+{
+    for (const int rate : {24000, 48000}) {
+        ReferenceEffects reference(rate);
+        RxClientEffects actual(rate);
+        configure(reference, 0);
+        bool matches = true;
+        for (int block = 0; block < 80; ++block) {
+            if (block == 30) {
+                configure(reference, 1);
+            }
+            sync(actual, reference);
+            std::vector<float> audio = signal(rate, 120, block * 120, 1);
+            std::vector<float> expected = audio;
+            process(actual, audio);
+            reference.process(expected);
+            matches = matches && equalAudio(audio, expected);
+        }
+        check(matches, rate == 24000 ? "24 kHz enabled effects preserve original processing and parameter changes"
+                                   : "48 kHz enabled effects match independently prepared original processors");
+
+        RxClientEffects effects(rate);
+        effects.gate().setEnabled(true);
+        effects.gate().setRatio(1.0f);
+        effects.gate().setFloorDb(0.0f);
+        effects.gate().setLookaheadMs(2.5f);
+        std::vector<float> impulse(static_cast<size_t>(rate / 100 * 2), 0.0f);
+        impulse[0] = 0.5f;
+        impulse[1] = -0.5f;
+        process(effects, impulse);
+        const int delayFrames = rate / 400;
+        const bool onlyAtDelay = std::all_of(impulse.begin(), impulse.begin() + delayFrames * 2,
+                                           [](float value) { return value == 0.0f; });
+        check(onlyAtDelay && impulse[delayFrames * 2] == 0.5f
+              && impulse[delayFrames * 2 + 1] == -0.5f,
+              rate == 24000 ? "24 kHz gate lookahead is 2.5 ms" : "48 kHz gate lookahead is 2.5 ms");
+        // Leave a pulse pending inside the lookahead, then mark the source
+        // discontinuous. A reset that forgets delayed samples leaks this pulse.
+        std::vector<float> queuedPulse{0.5f, -0.5f};
+        process(effects, queuedPulse);
+        effects.reset();
+        std::vector<float> silence(impulse.size(), 0.0f);
+        process(effects, silence);
+        check(std::all_of(silence.begin(), silence.end(), [](float value) { return value == 0.0f; }),
+              rate == 24000 ? "24 kHz reset removes lookahead samples" : "48 kHz reset removes lookahead samples");
+    }
+
+    RxClientEffects wideband(48000);
+    wideband.eq().setEnabled(true);
+    wideband.eq().setActiveBandCount(1);
+    wideband.eq().setBand(0, {15000.0f, 6.0f, 1.0f, ClientEq::FilterType::Peak, true, 12});
+    double inputEnergy = 0.0;
+    double outputEnergy = 0.0;
+    for (int block = 0; block < 300; ++block) {
+        std::vector<float> tone(480);
+        for (int frame = 0; frame < 240; ++frame) {
+            const float value = 0.1f * static_cast<float>(std::sin(
+                2.0 * std::numbers::pi * 15000.0 * (block * 240 + frame) / 48000.0));
+            tone[frame * 2] = tone[frame * 2 + 1] = value;
+            if (block > 200) {
+                inputEnergy += value * value * 2;
+            }
+        }
+        process(wideband, tone);
+        if (block > 200) {
+            for (const float value : tone) {
+                outputEnergy += value * value;
+            }
+        }
+    }
+    const double gainDb = 10.0 * std::log10(outputEnergy / inputEnergy);
+    check(std::isfinite(gainDb) && std::abs(gainDb - 6.0) < 0.1,
+          "48 kHz EQ applies requested gain at 15 kHz without a 24 kHz bandwidth ceiling");
+}
+
+void checkConcurrentRateReaders()
+{
+    ReferenceEffects main(24000);
+    std::atomic<bool> finished{false};
+    std::atomic<bool> valid{true};
+    std::thread reader([&]() {
+        while (!finished.load(std::memory_order_acquire)) {
+            for (const double rate : {main.eq.sampleRate(), main.gate.sampleRate(),
+                                     main.comp.sampleRate(), main.deEss.sampleRate(),
+                                     main.tube.sampleRate(), main.pudu.sampleRate()}) {
+                if (rate != 24000.0 && rate != 48000.0) {
+                    valid.store(false, std::memory_order_relaxed);
+                }
+            }
+        }
+    });
+    for (int change = 0; change < 1000; ++change) {
+        main.prepare(change % 2 == 0 ? 48000 : 24000);
+    }
+    finished.store(true, std::memory_order_release);
+    reader.join();
+    check(valid.load(std::memory_order_relaxed),
+          "GUI rate snapshots remain valid while audio owner prepares replacement rates");
+}
+
+void checkMeterCopies()
+{
+    ReferenceEffects presented(24000);
+    ReferenceEffects main(48000);
+    ReferenceEffects untouchedMain(48000);
+    configure(presented, 1);
+    configure(main, 0);
+    configure(untouchedMain, 0);
+    presented.comp.setThresholdDb(-35.0f);
+    for (int block = 0; block < 100; ++block) {
+        std::vector<float> audio = signal(24000, 240, block * 240, 1);
+        presented.process(audio);
+    }
+    main.gate.copyMeteringFrom(presented.gate);
+    main.comp.copyMeteringFrom(presented.comp);
+    main.deEss.copyMeteringFrom(presented.deEss);
+    main.tube.copyMeteringFrom(presented.tube);
+    main.pudu.copyMeteringFrom(presented.pudu);
+    check(main.gate.inputPeakDb() == presented.gate.inputPeakDb()
+          && main.gate.outputPeakDb() == presented.gate.outputPeakDb()
+          && main.gate.gainReductionDb() == presented.gate.gainReductionDb()
+          && main.gate.gateOpen() == presented.gate.gateOpen()
+          && main.comp.inputPeakDb() == presented.comp.inputPeakDb()
+          && main.comp.outputPeakDb() == presented.comp.outputPeakDb()
+          && main.comp.gainReductionDb() == presented.comp.gainReductionDb()
+          && main.comp.limiterGrDb() == presented.comp.limiterGrDb()
+          && main.comp.limiterActive() == presented.comp.limiterActive()
+          && main.deEss.inputPeakDb() == presented.deEss.inputPeakDb()
+          && main.deEss.sidechainPeakDb() == presented.deEss.sidechainPeakDb()
+          && main.deEss.gainReductionDb() == presented.deEss.gainReductionDb()
+          && main.tube.inputPeakDb() == presented.tube.inputPeakDb()
+          && main.tube.outputPeakDb() == presented.tube.outputPeakDb()
+          && main.tube.driveAppliedDb() == presented.tube.driveAppliedDb()
+          && main.pudu.inputPeakDb() == presented.pudu.inputPeakDb()
+          && main.pudu.outputPeakDb() == presented.pudu.outputPeakDb()
+          && main.pudu.wetRmsDb() == presented.pudu.wetRmsDb(),
+          "auxiliary meter copies update every UI-facing dynamics snapshot");
+    std::vector<float> actual = signal(48000, 2400, 0, 2);
+    std::vector<float> expected = actual;
+    main.process(actual);
+    untouchedMain.process(expected);
+    check(main.comp.thresholdDb() == -23.0f && equalAudio(actual, expected),
+          "copying auxiliary meters preserves main parameters and processing histories");
+}
+
+void checkPhaseHistoryReset()
+{
+    RxClientEffects effects(24000);
+    effects.comp().setEnabled(true);
+    effects.comp().setRatio(1.0f);
+    effects.comp().setLimiterEnabled(false);
+    effects.comp().setPhaseRotatorStages(4);
+    std::vector<float> pulse{0.5f, -0.5f};
+    process(effects, pulse);
+    effects.reset();
+    std::vector<float> silence(480, 0.0f);
+    process(effects, silence);
+    check(std::all_of(silence.begin(), silence.end(), [](float sample) { return sample == 0.0f; }),
+          "source reset clears compressor phase-rotator history as well as envelopes");
+}
+
+} // namespace
+
+int main()
+{
+    checkConcurrentSources();
+    checkRateDomains();
+    checkConcurrentRateReaders();
+    checkMeterCopies();
+    checkPhaseHistoryReset();
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -79,6 +79,26 @@ target_link_libraries(pcm_compatibility_test PRIVATE aethercore Qt6::Core)
 add_test(NAME pcm_compatibility_test COMMAND pcm_compatibility_test)
 set_tests_properties(pcm_compatibility_test PROPERTIES TIMEOUT 60)
 
+# Socket/device-free production RX queue, processing-domain and output checks.
+add_executable(audio_engine_rates_test tests/audio_engine_rates_test.cpp)
+target_link_libraries(audio_engine_rates_test PRIVATE aethercore Qt6::Core)
+add_test(NAME audio_engine_rates_test COMMAND audio_engine_rates_test)
+set_tests_properties(audio_engine_rates_test PROPERTIES TIMEOUT 120)
+
+# Production auxiliary ingress/retirement versus DSP initialization; no sockets/devices.
+add_executable(audio_engine_pcm_lifetime_test tests/audio_engine_pcm_lifetime_test.cpp)
+target_link_libraries(audio_engine_pcm_lifetime_test PRIVATE aethercore Qt6::Core)
+add_test(NAME audio_engine_pcm_lifetime_test COMMAND audio_engine_pcm_lifetime_test)
+set_tests_properties(audio_engine_pcm_lifetime_test PROPERTIES TIMEOUT 120)
+
+add_executable(rx_client_effects_test tests/rx_client_effects_test.cpp
+    src/core/RxClientEffects.cpp src/core/ClientEq.cpp src/core/ClientGate.cpp
+    src/core/ClientComp.cpp src/core/ClientDeEss.cpp src/core/ClientTube.cpp
+    src/core/ClientPudu.cpp src/core/ClientPhaseRotator.cpp)
+target_include_directories(rx_client_effects_test PRIVATE src)
+add_test(NAME rx_client_effects_test COMMAND rx_client_effects_test)
+set_tests_properties(rx_client_effects_test PROPERTIES TIMEOUT 30)
+
 # Pure shared-capture geometry policy: no sockets, settings, DSP or hardware.
 add_executable(shared_capture_policy_test
     tests/shared_capture_policy_test.cpp
@@ -5090,6 +5110,8 @@ target_link_libraries(CAT_Flex_test PRIVATE Qt6::Core Qt6::Network)
 # directly (rather than linking aethercore) needs the vendored SQLite engine.
 # Conditional targets are guarded with if(TARGET ...).
 set(AETHER_SETTINGS_CONSUMERS
+    audio_engine_rates_test
+    audio_engine_pcm_lifetime_test
     pcm_compatibility_test
     firmware_close_dialog_test
     atu_seam_gate_test


### PR DESCRIPTION
Implement RFC #5468 A2: AudioEngine queues and processes typed 24/48 kHz speaker PCM in its producer domain, then converts each source independently to negotiated 24/44.1/48 kHz output. `DEFAULT_SAMPLE_RATE` stays 24000 and `m_rxOutputRate` remains the device rate.

**Signed linear stack #5608:** main `3b3312eb` → A1 `65e20686` (#5598) → NR `c50f9853` (#5604) → A2 `a9d9794b` (#5605). This PR targets `codex/rtl-nr-rate-domains`.

The rebase adds no feature change: the exact 23-file A2 delta is preserved, and the complete tree matches the independently computed current-main/published-A2 reference. Each layer has one signed feature commit, retaining upstream history and original author/date/message metadata. Former base/validation statements in retained commit messages are historical.

## Change

- Queue timing, NR2 packets, presentation delays, resamplers and enabled effects follow explicit domains. Each Kiwi24 source owns independent histories.
- Format/discontinuity/source changes retire queues and processing state. Typed/raw guards prevent duplicate feeds; removed/revoked routes reject stale deliveries. For algorithms compiled for the platform, invalid selected processors withhold output instead of silently passing dry audio.
- Flush the mixed device queue on transitions while retaining unrelated application FIFOs. Diagnostics sum durations in each queue's own rate domain; Kiwi-only dynamics meters retain stable parameter owners. Compressor reset clears phase-rotator history.
- Preserve fixed CW/RADE contracts, #5591 TX admission/cancellation/deferred-release guards and inherited main changes. RTL48/multi-receiver runtime stays disabled; A3 recording, A4 TCI and A5 decoder/clock remain separate.

The [AudioEngine domain contract](https://github.com/aethersdr/AetherSDR/blob/011c2bf2715bca8018053be8bac5d267f29d569b/docs/audio-engine-rate-domains.md) records transitions and limits. This feature adds no dependencies, settings, socket tests or frozen CI-gate entries. Principle XI is exercised through actual ingress, queue, DSP, lifetime and output paths.

## New-head validation

Local results execute `011c2bf2715bca8018053be8bac5d267f29d569b`; CI records its actual checkout refs. All seven current checks passed under native-stack trunk `main`. Local and GitHub signature verification passed; actual tested revisions are recorded below.

| Evidence | Result |
|---|---|
| Mac application/daemon build and focused tests | PASS at `011c2bf2`; application/daemon and 36 C++ test targets built; 37/37 CTests, zero test-level skips (40.08 s). macOS arm64, clang 21/Qt 6.11.1, RelWithDebInfo `-O2 -g1 -DNDEBUG`, ASR OFF; requested RTL/DFNR unavailable on this Mac, RADE/MQTT/Specbleach and real MNR available. |
| RTL-enabled Nobara build and unfiltered suite | PASS at `011c2bf2`; full RTL-enabled incremental native build; 420 tests, 417 passed, 3 skipped, zero failures (246 s). Real DFNR exercised at 24/48 kHz with Kiwi24. |
| Nobara ASan/UBSan | PASS at `011c2bf2`; 42/42 focused tests, zero CTest skips or sanitizer failures; GCC 16.2.1/Qt 6.11.1 Debug, address+undefined, ASR OFF, leak/stack-use-after-return detection enabled. Real DFNR ran at both producer rates with Kiwi24. Three executed-binary hashes were lost during post-pass harness cleanup; source/build/JUnit evidence remains. |
| Instrumented-Qt TSan | PASS at `011c2bf2`; PCM, compatibility, actual-engine lifetime, client effects and registry: 5/5, no CTest skips or TSan reports (0.95 s). Instrumented Qt 6.8.3/GCC 13.3, thread sanitizer, `QT_NO_GLIB=1`, existing PulseAudio/WDSP suppressions and test-only FFTW planning limit. The Qt 6.11 ownership assertion is compiled out; the full rate matrix is native/ASan coverage. |
| GitHub signature and observed applicable checks, with tested refs | PASS; GitHub Verified and 7/7 current checks successful: [Code Quality: PR #5605](https://github.com/aethersdr/AetherSDR/actions/runs/34685206981), [Static Checks](https://github.com/aethersdr/AetherSDR/actions/runs/34685208663), [CI](https://github.com/aethersdr/AetherSDR/actions/runs/34685208666). Repository CI/static jobs checked out [`fe27edf5`](https://github.com/aethersdr/AetherSDR/commit/fe27edf5374348553349cdef175392a861ead33e), whose tree equals this signed head; dynamic Code Quality checked out the exact head. Superseded auto-cancelled runs are excluded. |

Current Nobara native options: GCC 16.2.1/Qt 6.11.1, RelWithDebInfo `-O2 -g1 -gz=zlib -DNDEBUG`, RTL/RADE/DFNR/MQTT/Specbleach and ASR CPU/Vulkan ON; ASR OFF under sanitizers. Native suite skips are `crdv_quarantined_test`, `app_settings_safety_explicit-profile-path-isolation` (platform-specific on Linux) and `weather_radar_texture_gl_test` (native-GL opt-in). Internal omissions cover MNR on Linux, NVIDIA AFX, physical audio, optional GL and whisper inference fixtures. ASan uses Debug with effective `-g3`, frame pointers, compressed debug and non-recovering undefined behavior instrumentation. System Qt/libraries and prebuilt Rust DFNR are uninstrumented. TSan uses `-O1 -g3 -gz=zlib -DNDEBUG`; existing WDSP ring-slot suppressions can hide a ring overrun. All lanes retain private settings and isolated network/devices. The capacity-guarded native build resumed from a byte-verified relocated task cache; source/options and old caches were preserved.

QBuffer tests share the production timer drain. They cover all six main producer/device combinations, typed/legacy Kiwi24 at every output rate, duration/stereo/high-frequency behavior, malformed/replayed/revoked frames, duplicate feeds, format/reconnect/source/device transitions, concurrent effects and fixed CW/RADE output. Invalid-wrapper constructors exercise failed-preparation withholding through production routes. In-memory output cannot prove native sink reset or audible behavior.

Current-head mutation evidence at integrated A2 `011c2bf2715bca8018053be8bac5d267f29d569b`: removing only the merged DSP-geometry guards from a copied registry translation unit triggered exactly eight intended unsafe-geometry failures. The normal production binary passed 483/483 before and after. Final production compile/link flags and unchanged test objects were used; all 3,189 source blobs and 34 production file hashes/inodes/mtimes remained unchanged. This is a Mac native mutation, not a sanitizer run or standalone A1/NR execution.

## Historical evidence and limits

Earlier head `bab557c5c2d2fea207c1c02927b5325a021e799f` passed the full Mac build and 31 focused tests; the full RTL-enabled Nobara build and unfiltered suite had 410 pass, 3 skip and no failures out of 413; 32 ASan/UBSan tests and five instrumented-Qt TSan tests passed. TSan covered PCM, compatibility, AudioEngine lifetime, client effects and RTL registry. These are earlier-head results, not rebase executions.

Historical mutations caught six AudioEngine, five client-effect and five prerequisite defects; restored runs passed. Their production sources and lifetime test remain byte-identical. The final six Mac AudioEngine mutations used the rev3 rates test; published and replayed sources retain rev4's later MNR platform-availability correction. These older runs are not executions of the new head. Removing the retirement mutex triggered the intended TSan race on attempt 2 (exit 66); attempt 1 did not detect it. An exploratory older TSan matrix timed out at 120 seconds without a race report. The full rate matrix has native/ASan coverage, not a TSan result.

Historical Mac builds used clang 21/Qt 6.11.1, ASR OFF, no librtlsdr/Darwin DFNR, and actual MNR/vDSP. Nobara used GCC 16.2.1/Qt 6.11.1 with RTL/RADE/DFNR/MQTT/Specbleach and native ASR CPU+Vulkan; sanitizers disabled ASR. Native/ASan exercised real DFNR at 24/48 kHz with Kiwi24. Standalone DFNR/NVIDIA wrapper substitutes prove wrapper behavior, not inference. System libraries and prebuilt Rust DFNR were outside ASan/UBSan instrumentation.

The historical TSan lane used instrumented Qt 6.8.3/GCC 13.3, `QT_NO_GLIB=1`, a test-only WDSP planning limit and existing PulseAudio/WDSP suppressions. Qt 6.8.3 omits the Qt 6.11-only `QVector::fromReadOnlyData` ownership assertion at compile time; native/ASan Qt 6.11.1 included it. Zero TSan test-level skips does not cover that assertion.

Historical suite skips were `crdv_quarantined_test`, `app_settings_safety_explicit-profile-path-isolation` and `weather_radar_texture_gl_test`; internal skips covered unavailable NVIDIA AFX, Linux MNR, physical audio, opt-in GL and whisper fixtures. Runs used private state and isolated network/device namespaces. The new-head options, skips and instrumentation limits are recorded above.

No audible/native-device behavior, Windows runtime/native Linux ARM qualification, sustained latency/load, live radio/RF/TX or NVIDIA GPU inference is claimed. Unavailable-platform setter behavior remains documented and unchanged. Native Flex slice-0 before/after qualification requires separate authorization.

The [#5554 §2.6 whole audio-track exit/sign-off](https://github.com/aethersdr/AetherSDR/issues/5554#issuecomment-5642853284) remains outstanding: exactly-one producer with paired direct-route retirement, per-slice/DAX/pre-mute semantics and bounded latest-frame-wins queues across the completed track. A2 supplies milestone evidence. Independent review and applicable CODEOWNERS approval remain required; no merge is requested.

73, Ozy **K6OZY** · GPT-6 Astra-Ultra

---

## Review fixes applied (2026-09-12)

Review feedback on this stack was addressed directly on the branches; the layers
were rebased so the stack stays linear and each layer still carries its original
feature commit with its original author, date and message. The evidence tables
below describe the **pre-review-fix** heads and are retained as history; the
current heads were rebuilt and retested on Arch/GCC 16 as recorded here.

**Blocker — every RX sink open rebuilt the whole NR chain on the GUI thread.**
`setRxDeviceRate()` ran `resetMainPcmState()`, which tore down and reconstructed
NR2, RN2, Specbleach, DFNR and NVIDIA AFX unconditionally, including when the
negotiated rate equalled the current one. Those filters belong to the producer
domain and never see the device rate, so the rebuild bought nothing and cost a
model load — `DeepFilterFilter` construction measures **~455 ms** against the
real library and shipped model, and does not warm up because the cost is the load
itself. `startRxStream()` reaches it on every sink open, including the #1361
zombie-sink and #1411 liveness watchdogs, both of which fire on real hardware, on
the GUI thread, at a moment the user is already hearing a glitch. During TX a
stall that long is a same-length hole in the transmitted waveform.
`resetMainPcmState()` now takes a `rebuildDsp` flag and `setRxDeviceRate()`
passes false, which also keeps the filters' history — the more correct behaviour,
since the producer stream did not change.

**The post-DSP revocation recheck was unpinned.** Removing
`retireInvalidPcmSources()` from before the device write left the entire A2 suite
green, so the guard keeping a revoked epoch's audio off the speaker pinned
nothing. `audio_engine_pcm_lifetime_test` now revokes the producer from inside
`receivePresentationOutputAudioReady`, which the mix emits after assembling the
chunk and before the recheck — the concurrent case, deterministically, on the
production path, with no test hook in the engine.

**Other review fixes.** `m_mainPcmDspReady` is removed (written, never read;
withholding is enforced per call in `processMixedRxAudioData()`). The EQ analyzer
tap and the auxiliary meter mirror now share one predicate,
`mainPcmSourceOwnsDisplay()`. The audio-buffer peak row renders two independent
maxima instead of `"N bytes (M ms)"`, which asserted a relationship that does not
hold across a rate change.

**Disclosure the original body omitted.** `ClientComp::reset()` now also resets
`m_phaseRotator`, and `ClientComp` is the **TX** compressor as well as the RX
one, so this changes TX-chain reset behaviour too. It is correct — a reset should
clear all history — but it was not stated.

**Current-head evidence.** Clean build, `422/422` CTests pass with the documented
three skips. Both new guards are mutation-verified: reverting either the
`rebuildDsp` flag or the pre-write recheck turns
`audio_engine_pcm_lifetime_test` red. The NR-retention check compares processed
output against a primed reference and carries a cold reference asserting the
detector is sensitive, because pointer identity and FFT size alone cannot see a
same-rate rebuild — the allocator commonly returns the freed address.

