### PR TITLE
firmware: confirm before closing Radio Setup mid-upload

### DIFF
--- a/src/core/FirmwareUploader.cpp
+++ b/src/core/FirmwareUploader.cpp
@@ -74,12 +74,28 @@ void FirmwareUploader::upload(const QString& filePath)
     }
 }
 
+FirmwareUploader::Phase FirmwareUploader::phase() const
+{
+    if (!m_uploading) {
+        return Phase::Idle;
+    }
+    if (m_waitingForConfirmation) {
+        return Phase::AwaitingConfirmation;
+    }
+    return m_requiresFreshConnection ? Phase::Transferring : Phase::Preparing;
+}
+
 void FirmwareUploader::cancel()
 {
     if (!m_uploading) {
         return;
     }
-    finishOperation(m_generation, Outcome::Failed, tr("Firmware upload cancelled"));
+    finishOperation(m_generation,
+                    m_waitingForConfirmation ? Outcome::Unconfirmed : Outcome::Failed,
+                    m_waitingForConfirmation
+                        ? tr("Firmware bytes were sent; stopped waiting for radio confirmation. "
+                             "Installation remains unconfirmed. Reconnect to check the firmware version.")
+                        : tr("Firmware upload cancelled before the transfer completed"));
 }
 
 bool FirmwareUploader::beginOperation(const QByteArray& fileData, const QString& fileName)

--- a/src/core/FirmwareUploader.h
+++ b/src/core/FirmwareUploader.h
@@ -34,6 +34,9 @@ public:
 
     bool isUploading() const { return m_uploading; }
 
+    enum class Phase { Idle, Preparing, Transferring, AwaitingConfirmation };
+    Phase phase() const;
+
     // What a finished operation actually established. A drained local socket,
     // `transfer=1.00`, and a command-channel disconnect are all consistent with
     // a successful install and with a silent failure, so none of them may be

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -1136,35 +1136,85 @@ void RadioSetupDialog::updateRadioCapabilityVisibility()
     }
 }
 
-void RadioSetupDialog::closeEvent(QCloseEvent* event)
+bool RadioSetupDialog::confirmFirmwareClose()
 {
-    // A firmware upload does not survive this dialog. The uploader is parented
-    // here and this dialog carries WA_DeleteOnClose, so closing mid-transfer
-    // destroys the uploader and its socket and aborts the image part-written —
-    // silently, with the pre-upload warning having only ever mentioned not
-    // *disconnecting*. The radio is then holding a partial update whose outcome
-    // nobody observed, which is the exact ambiguity #5572's retry barrier
-    // exists to contain. Make the operator say it out loud first.
-    if (m_uploader && m_uploader->isUploading()) {
-        const auto reply = QMessageBox::warning(
-            this, tr("Firmware Update In Progress"),
-            tr("A firmware upload is still in progress.\n\n"
-               "Closing this window aborts it part-way through the image. The "
-               "radio may be left with an incomplete update, and you will need "
-               "to reconnect to it before you can retry.\n\n"
-               "Close anyway?"),
-            QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Cancel);
-        if (reply != QMessageBox::Ok) {
-            event->ignore();
+    // A nested close/reject must not destroy the owner underneath this prompt.
+    if (m_firmwareClosePromptOpen) {
+        return false;
+    }
+    if (!m_uploader || !m_uploader->isUploading()) {
+        return true;
+    }
+    const QPointer<RadioSetupDialog> self(this);
+    const QPointer<FirmwareUploader> uploader(m_uploader);
+    ScopedChildWidget<QMessageBox> boxOwner(
+        QMessageBox::Warning, tr("Firmware Update In Progress"), QString(),
+        QMessageBox::Ok | QMessageBox::Cancel, this);
+    QMessageBox* box = boxOwner.get();
+    box->setDefaultButton(QMessageBox::Cancel);
+    box->setEscapeButton(QMessageBox::Cancel);
+    const auto refreshPrompt = [uploader, box] {
+        if (!uploader) {
             return;
         }
-        // End the attempt explicitly rather than letting destruction do it
-        // silently: cancel() emits one terminal result, and because the radio
-        // never settled the outcome it leaves the retry barrier armed — so the
-        // next attempt still has to go through a fresh command session.
-        m_uploader->cancel();
+        switch (uploader->phase()) {
+        case FirmwareUploader::Phase::Preparing:
+            box->setText(tr("The firmware upload is being prepared. No image bytes have been sent."
+                            "\n\nClose this window and cancel the attempt?"));
+            break;
+        case FirmwareUploader::Phase::Transferring:
+            box->setText(tr("A firmware upload is in progress. Closing this window stops the transfer "
+                            "and may leave the radio with an incomplete image. The update outcome "
+                            "will remain unknown; reconnect before retrying.\n\nClose anyway?"));
+            break;
+        case FirmwareUploader::Phase::AwaitingConfirmation:
+            box->setText(tr("Firmware bytes have left the local write buffer, but the radio has not "
+                            "confirmed installation. Closing this window stops waiting for confirmation; "
+                            "it does not undo the update.\n\nReconnect to check the firmware version "
+                            "before retrying. Close anyway?"));
+            break;
+        case FirmwareUploader::Phase::Idle:
+            box->setText(tr("The firmware upload attempt has ended. Close this window?"));
+            break;
+        }
+    };
+    refreshPrompt();
+    // The upload can advance or finish while exec() runs its nested event loop.
+    connect(uploader, &FirmwareUploader::progressChanged, box, refreshPrompt);
+    connect(uploader, &FirmwareUploader::finished, box, refreshPrompt);
+    m_firmwareClosePromptOpen = true;
+    const int reply = box->exec();
+    if (!self) {
+        return false;
     }
+    m_firmwareClosePromptOpen = false;
+    if (!boxOwner || reply != QMessageBox::Ok) {
+        return false;
+    }
+    if (uploader) {
+        // Classify the CURRENT phase; it may have changed inside the prompt.
+        // cancel() is a no-op if a terminal radio result already arrived.
+        uploader->cancel();
+    }
+    return !self.isNull();
+}
 
+void RadioSetupDialog::done(int result)
+{
+    // QDialog routes Escape, reject() and accept() through done(), bypassing
+    // closeEvent. Keep those paths behind the same confirmation without
+    // redirecting reject() to close() (which recurses during Qt's close path).
+    if (confirmFirmwareClose()) {
+        PersistentDialog::done(result);
+    }
+}
+
+void RadioSetupDialog::closeEvent(QCloseEvent* event)
+{
+    if (!confirmFirmwareClose()) {
+        event->ignore();
+        return;
+    }
     // Persist any uncommitted "user cleared IP" edits in the Peripherals
     // tab before the base class flushes geometry to AppSettings.
     for (const auto& saver : m_peripheralRowSavers)

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -1137,6 +1137,33 @@ void RadioSetupDialog::updateRadioCapabilityVisibility()
 
 void RadioSetupDialog::closeEvent(QCloseEvent* event)
 {
+    // A firmware upload does not survive this dialog. The uploader is parented
+    // here and this dialog carries WA_DeleteOnClose, so closing mid-transfer
+    // destroys the uploader and its socket and aborts the image part-written —
+    // silently, with the pre-upload warning having only ever mentioned not
+    // *disconnecting*. The radio is then holding a partial update whose outcome
+    // nobody observed, which is the exact ambiguity #5572's retry barrier
+    // exists to contain. Make the operator say it out loud first.
+    if (m_uploader && m_uploader->isUploading()) {
+        const auto reply = QMessageBox::warning(
+            this, tr("Firmware Update In Progress"),
+            tr("A firmware upload is still in progress.\n\n"
+               "Closing this window aborts it part-way through the image. The "
+               "radio may be left with an incomplete update, and you will need "
+               "to reconnect to it before you can retry.\n\n"
+               "Close anyway?"),
+            QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Cancel);
+        if (reply != QMessageBox::Ok) {
+            event->ignore();
+            return;
+        }
+        // End the attempt explicitly rather than letting destruction do it
+        // silently: cancel() emits one terminal result, and because the radio
+        // never settled the outcome it leaves the retry barrier armed — so the
+        // next attempt still has to go through a fresh command session.
+        m_uploader->cancel();
+    }
+
     // Persist any uncommitted "user cleared IP" edits in the Peripherals
     // tab before the base class flushes geometry to AppSettings.
     for (const auto& saver : m_peripheralRowSavers)

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -53,6 +53,7 @@ public:
                               LpMeterConnection* lpMeter = nullptr,
                               QWidget* parent = nullptr);
     void selectTab(const QString& tabName);
+    void done(int result) override;
     // Like selectTab("Serial & Controllers"), but also scrolls the page so
     // the FlexControl Tuning Knob group is actually in view instead of just
     // landing at the top of a long, scroll-wrapped page (#4940 follow-up —
@@ -106,6 +107,9 @@ protected:
     void showEvent(QShowEvent* event) override;
 
 private:
+    friend class RadioSetupDialogTestAccess;
+    bool confirmFirmwareClose();
+    bool m_firmwareClosePromptOpen{false};
     bool isFlexOnlyPage(const QTreeWidgetItem* item) const;
     bool isCapabilityPageAvailable(const QTreeWidgetItem* item) const;
     bool isGpsSetupAvailable() const;

--- a/tests/firmware_close_dialog_test.cpp
+++ b/tests/firmware_close_dialog_test.cpp
@@ -1,0 +1,233 @@
+#include "TestSettingsProfile.h"
+#include "core/FirmwareUploader.h"
+#include "gui/RadioSetupDialog.h"
+#include "models/RadioModel.h"
+
+#include <QApplication>
+#include <QMessageBox>
+#include <QPointer>
+#include <QPushButton>
+#include <QSignalSpy>
+#include <QTimer>
+#include <QtTest>
+#include <memory>
+
+namespace AetherSDR {
+// No upload(), port request, socket, peer, firmware file or radio connection.
+// Inject only local write acceptance and delivery into production handlers.
+class FirmwareUploaderTestAccess {
+public:
+    static void start(FirmwareUploader& uploader, int phase)
+    {
+        uploader.beginOperation(QByteArray(8, 'x'), QStringLiteral("test.ssdr"));
+        if (phase > 0) {
+            uploader.markUploadDispatched();
+            uploader.startSending(uploader.m_generation,
+                [](const char*, qint64 size) { return size; });
+        }
+        if (phase > 1) {
+            drain(uploader);
+        }
+    }
+    static void drain(FirmwareUploader& uploader)
+    {
+        uploader.acknowledgeBytes(uploader.m_generation, 8);
+    }
+    static void succeed(FirmwareUploader& uploader)
+    {
+        uploader.onRadioStatus(uploader.m_generation, QStringLiteral("file update"),
+                               {{QStringLiteral("failed"), QStringLiteral("0")}});
+    }
+    static bool blocked(FirmwareUploader& uploader) { return uploader.retryBarrierActive(); }
+};
+class RadioSetupDialogTestAccess {
+public:
+    static void attach(RadioSetupDialog& dialog, FirmwareUploader* uploader)
+    {
+        dialog.m_uploader = uploader;
+    }
+};
+}
+using namespace AetherSDR;
+
+class FirmwareCloseDialogTest : public QObject {
+    Q_OBJECT
+private slots:
+    void closePaths_data()
+    {
+        QTest::addColumn<int>("phase");
+        QTest::addColumn<int>("path");
+        QTest::addColumn<bool>("confirm");
+        for (int phase = 0; phase < 3; ++phase) {
+            for (int path = 0; path < 4; ++path) {
+                for (bool confirm : {false, true}) {
+                    const QByteArray name = QByteArray::number(phase) + "-"
+                        + QByteArray::number(path) + (confirm ? "-confirm" : "-keep");
+                    QTest::newRow(name.constData()) << phase << path << confirm;
+                }
+            }
+        }
+    }
+    void closePaths()
+    {
+        QFETCH(int, phase);
+        QFETCH(int, path);
+        QFETCH(bool, confirm);
+        RadioModel model; // cold, disconnected; never calls connectRadio()
+        RadioSetupDialog dialog(&model);
+        FirmwareUploader uploader(nullptr);
+        RadioSetupDialogTestAccess::attach(dialog, &uploader);
+        FirmwareUploaderTestAccess::start(uploader, phase);
+        QSignalSpy finished(&uploader, &FirmwareUploader::finished);
+        dialog.show();
+        bool prompted = false;
+        bool safeDefault = false;
+        bool reentrantRefused = false;
+        QString prompt;
+        QTimer::singleShot(0, &dialog, [&] {
+            auto* box = qobject_cast<QMessageBox*>(QApplication::activeModalWidget());
+            if (!box) { return; }
+            prompted = true;
+            prompt = box->text();
+            safeDefault = box->defaultButton() == box->button(QMessageBox::Cancel);
+            // A second programmatic dismissal must not bypass the modal guard.
+            dialog.reject();
+            reentrantRefused = dialog.isVisible() && uploader.isUploading();
+            if (!confirm && path == 1) {
+                QTest::keyClick(box, Qt::Key_Escape);
+            } else {
+                box->button(confirm ? QMessageBox::Ok : QMessageBox::Cancel)->click();
+            }
+        });
+        if (path == 0) { dialog.close(); }
+        else if (path == 1) { QTest::keyClick(&dialog, Qt::Key_Escape); }
+        else if (path == 2) { dialog.reject(); }
+        else { dialog.accept(); }
+        QCoreApplication::processEvents();
+        QVERIFY(prompted);
+        QVERIFY(safeDefault);
+        QVERIFY(reentrantRefused);
+        QVERIFY(prompt.contains(phase == 0 ? QStringLiteral("No image bytes")
+                                : phase == 1 ? QStringLiteral("incomplete image")
+                                : QStringLiteral("does not undo")));
+        QCOMPARE(dialog.isVisible(), !confirm);
+        QCOMPARE(uploader.isUploading(), !confirm);
+        QCOMPARE(finished.size(), confirm ? 1 : 0);
+        QCOMPARE(FirmwareUploaderTestAccess::blocked(uploader), phase > 0);
+        if (confirm) {
+            QCOMPARE(qvariant_cast<FirmwareUploader::Outcome>(finished.front().front()),
+                     phase == 2 ? FirmwareUploader::Outcome::Unconfirmed
+                                : FirmwareUploader::Outcome::Failed);
+        }
+        QVERIFY(!model.isConnected());
+    }
+    void advancesInsidePrompt()
+    {
+        RadioModel model;
+        RadioSetupDialog dialog(&model);
+        FirmwareUploader uploader(nullptr);
+        RadioSetupDialogTestAccess::attach(dialog, &uploader);
+        FirmwareUploaderTestAccess::start(uploader, 1);
+        QSignalSpy finished(&uploader, &FirmwareUploader::finished);
+        dialog.show();
+        QTimer::singleShot(0, &dialog, [&] {
+            auto* box = qobject_cast<QMessageBox*>(QApplication::activeModalWidget());
+            QVERIFY(box);
+            FirmwareUploaderTestAccess::drain(uploader);
+            QVERIFY(box->text().contains(QStringLiteral("does not undo")));
+            box->button(QMessageBox::Ok)->click();
+        });
+        dialog.close();
+        QCOMPARE(finished.size(), 1);
+        QCOMPARE(qvariant_cast<FirmwareUploader::Outcome>(finished.front().front()),
+                 FirmwareUploader::Outcome::Unconfirmed);
+    }
+    void terminalInsidePrompt()
+    {
+        RadioModel model;
+        RadioSetupDialog dialog(&model);
+        FirmwareUploader uploader(nullptr);
+        RadioSetupDialogTestAccess::attach(dialog, &uploader);
+        FirmwareUploaderTestAccess::start(uploader, 2);
+        QSignalSpy finished(&uploader, &FirmwareUploader::finished);
+        dialog.show();
+        QTimer::singleShot(0, &dialog, [&] {
+            auto* box = qobject_cast<QMessageBox*>(QApplication::activeModalWidget());
+            QVERIFY(box);
+            FirmwareUploaderTestAccess::succeed(uploader);
+            QVERIFY(box->text().contains(QStringLiteral("has ended")));
+            box->button(QMessageBox::Ok)->click();
+        });
+        dialog.close();
+        QCOMPARE(finished.size(), 1);
+        QCOMPARE(qvariant_cast<FirmwareUploader::Outcome>(finished.front().front()),
+                 FirmwareUploader::Outcome::Succeeded);
+        QVERIFY(!FirmwareUploaderTestAccess::blocked(uploader));
+    }
+    void deleteOnClose()
+    {
+        RadioModel model;
+        auto* dialog = new RadioSetupDialog(&model);
+        dialog->setAttribute(Qt::WA_DeleteOnClose);
+        QPointer<RadioSetupDialog> guard(dialog);
+        auto* uploader = new FirmwareUploader(nullptr, dialog);
+        RadioSetupDialogTestAccess::attach(*dialog, uploader);
+        FirmwareUploaderTestAccess::start(*uploader, 1);
+        dialog->show();
+        QTimer::singleShot(0, dialog, [] {
+            auto* box = qobject_cast<QMessageBox*>(QApplication::activeModalWidget());
+            QVERIFY(box);
+            box->button(QMessageBox::Ok)->click();
+        });
+        QTest::keyClick(dialog, Qt::Key_Escape);
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+        QVERIFY(guard.isNull());
+    }
+    void idleDismissalNeedsNoConfirmation()
+    {
+        RadioModel model;
+        RadioSetupDialog dialog(&model);
+        dialog.show();
+        QTest::keyClick(&dialog, Qt::Key_Escape);
+        QVERIFY(!dialog.isVisible());
+        QVERIFY(!QApplication::activeModalWidget());
+    }
+    void finishedReceiverDeletesOwner()
+    {
+        RadioModel model;
+        auto dialog = std::make_unique<RadioSetupDialog>(&model);
+        auto* uploader = new FirmwareUploader(nullptr, dialog.get());
+        RadioSetupDialogTestAccess::attach(*dialog, uploader);
+        FirmwareUploaderTestAccess::start(*uploader, 2);
+        connect(uploader, &FirmwareUploader::finished, qApp, [&] { dialog.reset(); });
+        dialog->show();
+        QTimer::singleShot(0, dialog.get(), [] {
+            auto* box = qobject_cast<QMessageBox*>(QApplication::activeModalWidget());
+            QVERIFY(box);
+            box->button(QMessageBox::Ok)->click();
+        });
+        dialog->close();
+        QVERIFY(!dialog);
+    }
+    void ownerDeletedInsidePrompt()
+    {
+        RadioModel model;
+        auto dialog = std::make_unique<RadioSetupDialog>(&model);
+        auto* uploader = new FirmwareUploader(nullptr, dialog.get());
+        RadioSetupDialogTestAccess::attach(*dialog, uploader);
+        FirmwareUploaderTestAccess::start(*uploader, 1);
+        dialog->show();
+        QTimer::singleShot(0, qApp, [&] { dialog.reset(); });
+        dialog->close();
+        QVERIFY(!dialog);
+    }
+};
+int main(int argc, char** argv)
+{
+    TestSettingsProfile profile(QStringLiteral("aether-firmware-close-dialog-test"));
+    QApplication app(argc, argv);
+    app.setQuitOnLastWindowClosed(false);
+    FirmwareCloseDialogTest test;
+    return QTest::qExec(&test, argc, argv);
+}
+#include "firmware_close_dialog_test.moc"

--- a/tests/firmware_uploader_test.cpp
+++ b/tests/firmware_uploader_test.cpp
@@ -501,6 +501,26 @@ void checkBarrierReleasedOnlyByRadioSettledOutcomes()
               && !AetherSDR::FirmwareUploaderTestAccess::barrierActive(rejected),
           "a radio-reported rejection is unambiguous and releases the barrier");
 
+    // Closing Radio Setup mid-upload now calls cancel() rather than letting
+    // destruction abort the socket silently. Bytes were already dispatched and
+    // the radio never reported on them, so that path must NOT release the
+    // barrier — the next attempt still needs a fresh command session.
+    AetherSDR::FirmwareUploader cancelled(nullptr);
+    QVector<FinishedEvent> cancelledFinished;
+    QObject::connect(&cancelled, &AetherSDR::FirmwareUploader::finished,
+                     [&cancelledFinished](Outcome outcome, const QString& message) {
+                         cancelledFinished.append({outcome, message});
+                     });
+    AetherSDR::FirmwareUploaderTestAccess::start(
+        cancelled, nonPeriodicBytes(8), [](const char*, qint64 requested) { return requested; });
+    AetherSDR::FirmwareUploaderTestAccess::dispatched(cancelled);
+    cancelled.cancel();
+    check(cancelledFinished.size() == 1 && cancelledFinished.front().outcome == Outcome::Failed
+              && !cancelled.isUploading(),
+          "cancelling a dispatched upload emits exactly one terminal result");
+    check(AetherSDR::FirmwareUploaderTestAccess::barrierActive(cancelled),
+          "cancelling a dispatched upload leaves its outcome unobserved, so the barrier holds");
+
     AetherSDR::FirmwareUploader stalled(nullptr);
     const auto stalledGeneration = AetherSDR::FirmwareUploaderTestAccess::start(
         stalled, nonPeriodicBytes(8), [](const char*, qint64 requested) { return requested; });

--- a/tests/firmware_uploader_test.cpp
+++ b/tests/firmware_uploader_test.cpp
@@ -501,25 +501,32 @@ void checkBarrierReleasedOnlyByRadioSettledOutcomes()
               && !AetherSDR::FirmwareUploaderTestAccess::barrierActive(rejected),
           "a radio-reported rejection is unambiguous and releases the barrier");
 
-    // Closing Radio Setup mid-upload now calls cancel() rather than letting
-    // destruction abort the socket silently. Bytes were already dispatched and
-    // the radio never reported on them, so that path must NOT release the
-    // barrier — the next attempt still needs a fresh command session.
+    // A local drain does not establish installation. Closing the dialog at
+    // this phase must preserve the unknown outcome and refuse same-session retry.
     AetherSDR::FirmwareUploader cancelled(nullptr);
     QVector<FinishedEvent> cancelledFinished;
     QObject::connect(&cancelled, &AetherSDR::FirmwareUploader::finished,
                      [&cancelledFinished](Outcome outcome, const QString& message) {
                          cancelledFinished.append({outcome, message});
                      });
-    AetherSDR::FirmwareUploaderTestAccess::start(
+    const auto cancelledGeneration = AetherSDR::FirmwareUploaderTestAccess::start(
         cancelled, nonPeriodicBytes(8), [](const char*, qint64 requested) { return requested; });
     AetherSDR::FirmwareUploaderTestAccess::dispatched(cancelled);
+    AetherSDR::FirmwareUploaderTestAccess::acknowledge(cancelled, cancelledGeneration, 8);
+    check(cancelled.phase() == AetherSDR::FirmwareUploader::Phase::AwaitingConfirmation,
+          "the cancellation fixture reaches the post-drain confirmation phase");
     cancelled.cancel();
-    check(cancelledFinished.size() == 1 && cancelledFinished.front().outcome == Outcome::Failed
-              && !cancelled.isUploading(),
-          "cancelling a dispatched upload emits exactly one terminal result");
+    cancelled.cancel();
+    AetherSDR::FirmwareUploaderTestAccess::status(
+        cancelled, cancelledGeneration, QStringLiteral("file update"),
+        {{QStringLiteral("failed"), QStringLiteral("0")}});
+    check(cancelledFinished.size() == 1
+              && cancelledFinished.front().outcome == Outcome::Unconfirmed
+              && cancelledFinished.front().message.contains(QStringLiteral("unconfirmed"))
+              && cancelled.phase() == AetherSDR::FirmwareUploader::Phase::Idle,
+          "post-drain cancellation emits one unconfirmed result, even with late callbacks");
     check(AetherSDR::FirmwareUploaderTestAccess::barrierActive(cancelled),
-          "cancelling a dispatched upload leaves its outcome unobserved, so the barrier holds");
+          "post-drain cancellation keeps the retry barrier armed");
 
     AetherSDR::FirmwareUploader stalled(nullptr);
     const auto stalledGeneration = AetherSDR::FirmwareUploaderTestAccess::start(

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1923,6 +1923,26 @@ target_include_directories(firmware_uploader_test PRIVATE src)
 target_link_libraries(firmware_uploader_test PRIVATE aethercore Qt6::Core Qt6::Network)
 add_test(NAME firmware_uploader_test COMMAND firmware_uploader_test)
 
+# Local Qt dialog + injected uploader callbacks; no radio connection or peer.
+add_executable(firmware_close_dialog_test
+    tests/firmware_close_dialog_test.cpp
+    src/gui/DragValuePopup.cpp
+    src/gui/RadioSetupDialog.cpp
+    src/gui/PersistentDialog.cpp
+    src/gui/FramelessResizer.cpp
+    src/gui/FramelessWindowTitleBar.cpp
+    src/gui/SliceColorManager.cpp
+    src/gui/KiwiPublicReceiverPicker.cpp
+    src/gui/GuardedSlider.h
+)
+target_include_directories(firmware_close_dialog_test PRIVATE src tests)
+target_link_libraries(firmware_close_dialog_test PRIVATE
+    aetherdesktop_support Qt6::Widgets Qt6::Test)
+add_test(NAME firmware_close_dialog_test COMMAND firmware_close_dialog_test)
+set_tests_properties(firmware_close_dialog_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen" TIMEOUT 60)
+
+
 add_executable(zip_archive_test
     tests/zip_archive_test.cpp
     src/core/ZipArchive.cpp
@@ -4967,6 +4987,7 @@ target_link_libraries(CAT_Flex_test PRIVATE Qt6::Core Qt6::Network)
 # directly (rather than linking aethercore) needs the vendored SQLite engine.
 # Conditional targets are guarded with if(TARGET ...).
 set(AETHER_SETTINGS_CONSUMERS
+    firmware_close_dialog_test
     atu_seam_gate_test
     backend_capability_revision_test
     tx_operation_integration_test


### PR DESCRIPTION
Closing Radio Setup during a firmware attempt now asks before stopping it. The guard covers the window close button, Escape, `reject()` and `accept()`, and preserves an unknown installation outcome after the image bytes leave the host.

Follow-up to #5597 and the retry/outcome safeguards from #5572. This addresses the client dialog lifecycle; it does not claim to resolve the reporter's physical-radio activation failure.

### Final behavior

- One shared confirmation guards `closeEvent` and `QDialog::done`. Cancel (also the default and Escape response) keeps the window and attempt alive. Nested dismissal cannot bypass the prompt; confirmed closure retains `WA_DeleteOnClose` behavior.
- The prompt distinguishes preparation, an accepted upload/transfer, and waiting for confirmation after local drain. It refreshes if the attempt advances or finishes while the prompt is open.
- `FirmwareUploader::cancel()` reports `Unconfirmed` after local drain, and `Failed` before transfer completion. Cancellation never fabricates a radio-confirmed outcome; the existing retry barrier remains armed after dispatch, and repeated cancellation/late callbacks do not emit a second terminal result.
- `ScopedChildWidget` and guarded pointers preserve the dialog-lifetime fixes from #5596. Owner destruction inside the prompt or a terminal-result callback is covered.

### Scope

`RadioSetupDialog.cpp/.h` contains the dismissal guard and test access. `FirmwareUploader.cpp/.h` exposes the current phase and corrects cancellation classification. `firmware_uploader_test.cpp` covers post-drain cancellation; `firmware_close_dialog_test.cpp` drives the actual production dialog, registered in `tests/tests.cmake`. No protocol commands, retries, reconnect automation, release files, dependencies or CI allow-list entries were added.

### Verification

- Full native macOS ARM64 application build passed. The existing local `iconutil` failure required the established ICNS compatibility generator in generated `build.ninja` only; no tracked packaging change.

- Local macOS: `firmware_uploader_test`, `waveform_upload_state_test`, and the new dialog test pass (3/3 CTests). The dialog test has 30 scenarios plus Qt setup/cleanup: 24 phase/dismissal/decision combinations, progress and terminal delivery inside the prompt, delete-on-close, idle dismissal, and two owner-destruction paths.
- All three tests ran under an OS sandbox denying `network*`. The uploader receives eight dummy bytes through an injected writer, never `upload()`, a firmware file, an upload-port request or a radio connection. The dialog uses a cold disconnected model; its backend may construct unbound Qt socket objects, but it never connects to a radio or starts a peer/listener.
- Mutation checked: restore the old unguarded `done()` and unconditional `Failed` cancellation; the uploader test and 25 dialog cases fail. Restore the fixes; all three CTests pass again. The test exercises production handlers, not a duplicate dialog implementation.
- Accessibility, strict engine-boundary, registration, frozen CI gate, network timeout, colour-delta and whitespace checks pass. Engine-boundary findings are unchanged legacy entries.
- Original contributor commit and both pushed commits are signed and GitHub Verified.

### Evidence limits

No firmware was flashed, no radio was connected or rebooted, and no RF/TX operation was performed. Radio installation, recovery and the original FLEX-6400 report remain unverified. These tests do not establish Windows/Linux GUI behavior or replace platform CI. The full unfiltered local suite was not run.

Whole-application shutdown/force-quit can still destroy the dialog without a dialog dismissal event; protecting application shutdown or moving upload ownership out of the dialog is separate scope. The retry barrier already survived destruction before this PR; explicit cancellation adds a terminal result rather than creating that protection.

Review fixes and verification performed with OpenAI Codex at the operator's request; original contribution by @ten9876 retained.
