### PR TITLE
Fix ProfileTransfer cleanup re-entry crash

### DIFF
--- a/src/core/ProfileTransfer.cpp
+++ b/src/core/ProfileTransfer.cpp
@@ -227,11 +227,7 @@ void ProfileTransfer::cleanup()
     m_overallTimer->stop();
 
     destroySocket(true);
-    if (m_server) {
-        m_server->close();
-        m_server->deleteLater();
-        m_server = nullptr;
-    }
+    destroyServer();
     if (m_saveFile) {
         m_saveFile->cancelWriting();
         m_saveFile->deleteLater();
@@ -265,6 +261,24 @@ void ProfileTransfer::destroySocket(bool abortConnection)
         socket->disconnectFromHost();
     }
     socket->deleteLater();
+}
+
+void ProfileTransfer::destroyServer()
+{
+    if (!m_server) {
+        return;
+    }
+
+    // Same detach-then-act ordering as destroySocket(). close() does not emit
+    // synchronously, but a newConnection already queued before cleanup would
+    // otherwise reach onDownloadConnection() with m_server null; today only the
+    // !m_busy guard stops it dereferencing that. Severing the handler makes the
+    // teardown safe by construction rather than by guard ordering.
+    QTcpServer* server = m_server;
+    m_server = nullptr;
+    QObject::disconnect(server, nullptr, this, nullptr);
+    server->close();
+    server->deleteLater();
 }
 
 ExportSelection ProfileTransfer::expandSelection(ExportSelection selection) const

--- a/src/core/ProfileTransfer.cpp
+++ b/src/core/ProfileTransfer.cpp
@@ -217,15 +217,16 @@ void ProfileTransfer::finish(QString path)
 
 void ProfileTransfer::cleanup()
 {
+    // Enter the terminal state before tearing down QObjects. Their methods can
+    // emit synchronously, and no callback may start a second terminal outcome.
+    m_busy = false;
+    m_cancelled = false;
+
     m_timeout->stop();
     m_idleTimer->stop();
     m_overallTimer->stop();
 
-    if (m_socket) {
-        m_socket->abort();
-        m_socket->deleteLater();
-        m_socket = nullptr;
-    }
+    destroySocket(true);
     if (m_server) {
         m_server->close();
         m_server->deleteLater();
@@ -243,12 +244,27 @@ void ProfileTransfer::cleanup()
     m_bytesQueued = 0;
     m_bytesTotal = 0;
     m_uploadPort = 0;
-    m_busy = false;
-    m_cancelled = false;
     m_usedFallbackPort = false;
     m_downloadFinalized = false;
     m_importCompletionScheduled = false;
     m_phase = Phase::Idle;
+}
+
+void ProfileTransfer::destroySocket(bool abortConnection)
+{
+    if (!m_socket) {
+        return;
+    }
+
+    QTcpSocket* socket = m_socket;
+    m_socket = nullptr;
+    QObject::disconnect(socket, nullptr, this, nullptr);
+    if (abortConnection) {
+        socket->abort();
+    } else {
+        socket->disconnectFromHost();
+    }
+    socket->deleteLater();
 }
 
 ExportSelection ProfileTransfer::expandSelection(ExportSelection selection) const
@@ -398,11 +414,7 @@ void ProfileTransfer::onUploadPortReceived(int code, const QString& body)
 
 void ProfileTransfer::connectUploadSocket(quint16 port)
 {
-    if (m_socket) {
-        m_socket->abort();
-        m_socket->deleteLater();
-        m_socket = nullptr;
-    }
+    destroySocket(true);
 
     m_uploadPort = port;
     m_socket = new QTcpSocket(this);
@@ -500,10 +512,7 @@ void ProfileTransfer::onUploadDisconnected()
         return;
     }
 
-    if (m_socket) {
-        m_socket->deleteLater();
-        m_socket = nullptr;
-    }
+    destroySocket(false);
     m_uploadPayload.clear();
 
     if (m_phase == Phase::UploadMetaSubset) {

--- a/src/core/ProfileTransfer.h
+++ b/src/core/ProfileTransfer.h
@@ -19,6 +19,7 @@ class QTimer;
 namespace AetherSDR {
 
 class RadioModel;
+class ProfileTransferTestAccess;
 
 struct MemoryGroupSelection {
     QString owner;
@@ -195,6 +196,8 @@ inline std::optional<quint16> parseTransferPort(const QString& replyBody)
 class ProfileTransfer : public QObject {
     Q_OBJECT
 
+    friend class ProfileTransferTestAccess;
+
 public:
     enum class Operation {
         ExportDatabase,
@@ -229,6 +232,7 @@ private:
     void fail(const QString& error);
     void finish(QString path);
     void cleanup();
+    void destroySocket(bool abortConnection);
 
     ExportSelection expandSelection(ExportSelection selection) const;
     bool validateCommonPreconditions(Operation operation, QString* error) const;

--- a/src/core/ProfileTransfer.h
+++ b/src/core/ProfileTransfer.h
@@ -233,6 +233,7 @@ private:
     void finish(QString path);
     void cleanup();
     void destroySocket(bool abortConnection);
+    void destroyServer();
 
     ExportSelection expandSelection(ExportSelection selection) const;
     bool validateCommonPreconditions(Operation operation, QString* error) const;

--- a/tests/profile_transfer_cleanup_test.cpp
+++ b/tests/profile_transfer_cleanup_test.cpp
@@ -1,0 +1,143 @@
+#include <QCoreApplication>
+#include <QMetaObject>
+#include <QTcpSocket>
+
+#include "core/ProfileTransfer.h"
+
+#include <iostream>
+
+namespace AetherSDR {
+
+class ProfileTransferTestAccess {
+public:
+    static void prepareIncompleteUpload(ProfileTransfer& transfer, QTcpSocket* socket)
+    {
+        transfer.m_busy = true;
+        transfer.m_phase = ProfileTransfer::Phase::UploadImport;
+        transfer.m_operation = ProfileTransfer::Operation::ImportDatabase;
+        transfer.m_bytesDone = 0;
+        transfer.m_bytesTotal = 1;
+        transfer.m_socket = socket;
+        QObject::connect(socket, &QTcpSocket::disconnected,
+                         &transfer, &ProfileTransfer::onUploadDisconnected);
+    }
+
+    static void fail(ProfileTransfer& transfer, const QString& error)
+    {
+        transfer.fail(error);
+    }
+
+    static void connectUploadSocket(ProfileTransfer& transfer, quint16 port)
+    {
+        transfer.connectUploadSocket(port);
+    }
+
+    static QTcpSocket* socket(const ProfileTransfer& transfer)
+    {
+        return transfer.m_socket;
+    }
+};
+
+} // namespace AetherSDR
+
+namespace {
+
+bool expect(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+    }
+    return condition;
+}
+
+class IncompleteSocket final : public QTcpSocket {
+public:
+    explicit IncompleteSocket(QObject* parent)
+        : QTcpSocket(parent)
+    {
+        setSocketState(QAbstractSocket::ConnectingState);
+    }
+};
+
+IncompleteSocket* prepareIncompleteUpload(AetherSDR::ProfileTransfer& transfer,
+                                          int& abortDisconnects)
+{
+    auto* socket = new IncompleteSocket(&transfer);
+    AetherSDR::ProfileTransferTestAccess::prepareIncompleteUpload(transfer, socket);
+    QObject::connect(socket, &QTcpSocket::stateChanged, socket,
+                     [socket, &abortDisconnects](QAbstractSocket::SocketState state) {
+                         if (state != QAbstractSocket::UnconnectedState) {
+                             return;
+                         }
+                         ++abortDisconnects;
+                         QMetaObject::invokeMethod(socket, "disconnected", Qt::DirectConnection);
+                     });
+    return socket;
+}
+
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv);
+    bool ok = true;
+
+    {
+        AetherSDR::ProfileTransfer transfer(nullptr);
+        int failures = 0;
+        int abortDisconnects = 0;
+        QObject::connect(&transfer, &AetherSDR::ProfileTransfer::failed,
+                         [&failures](AetherSDR::ProfileTransfer::Operation, const QString&) {
+                             ++failures;
+                         });
+
+        IncompleteSocket* socket = prepareIncompleteUpload(transfer, abortDisconnects);
+        QObject::connect(socket, &QTcpSocket::stateChanged, socket,
+                         [&transfer](QAbstractSocket::SocketState state) {
+                             if (state == QAbstractSocket::UnconnectedState) {
+                                 AetherSDR::ProfileTransferTestAccess::fail(
+                                     transfer,
+                                     QStringLiteral("re-entrant cleanup failure"));
+                             }
+                         });
+
+        // No listener, descriptor, or firmware peer is used. This socket starts
+        // in an incomplete state so abort() produces synchronous callbacks.
+        ok &= expect(socket->state() != QAbstractSocket::UnconnectedState,
+                     "socket enters an incomplete connection state before cleanup");
+
+        AetherSDR::ProfileTransferTestAccess::fail(
+            transfer, QStringLiteral("forced cleanup failure"));
+
+        ok &= expect(abortDisconnects == 1,
+                     "failure cleanup synchronously aborts the incomplete socket");
+        ok &= expect(!transfer.isBusy(), "failure cleanup leaves the transfer idle");
+        ok &= expect(AetherSDR::ProfileTransferTestAccess::socket(transfer) == nullptr,
+                     "failure cleanup clears the active socket");
+        ok &= expect(failures == 1, "cleanup cannot emit a re-entrant second failure");
+    }
+
+    {
+        AetherSDR::ProfileTransfer transfer(nullptr);
+        int failures = 0;
+        int abortDisconnects = 0;
+        QObject::connect(&transfer, &AetherSDR::ProfileTransfer::failed,
+                         [&failures](AetherSDR::ProfileTransfer::Operation, const QString&) {
+                             ++failures;
+                         });
+
+        IncompleteSocket* oldSocket = prepareIncompleteUpload(transfer, abortDisconnects);
+        AetherSDR::ProfileTransferTestAccess::connectUploadSocket(transfer, 42607);
+
+        ok &= expect(abortDisconnects == 1,
+                     "socket replacement synchronously aborts the incomplete socket");
+        QTcpSocket* replacementSocket =
+            AetherSDR::ProfileTransferTestAccess::socket(transfer);
+        ok &= expect(replacementSocket != nullptr && replacementSocket != oldSocket,
+                     "socket replacement installs a new upload socket");
+        ok &= expect(transfer.isBusy(), "socket replacement keeps the transfer active");
+        ok &= expect(failures == 0, "socket replacement cannot emit a stale upload failure");
+    }
+
+    return ok ? 0 : 1;
+}

--- a/tests/profile_transfer_cleanup_test.cpp
+++ b/tests/profile_transfer_cleanup_test.cpp
@@ -177,6 +177,9 @@ int main(int argc, char* argv[])
 
         IncompleteSocket* oldSocket =
             prepareIncompleteUpload(transfer, abortDisconnects, detachedFirst);
+        // No event loop is pumped in this file, deliberately: connectUploadSocket()
+        // arms a 200 ms singleShot that would dereference the null m_model and open
+        // a real connection. The timer dies with `transfer` at scope exit.
         AetherSDR::ProfileTransferTestAccess::connectUploadSocket(transfer, 42607);
 
         ok &= expect(abortDisconnects == 1,

--- a/tests/profile_transfer_cleanup_test.cpp
+++ b/tests/profile_transfer_cleanup_test.cpp
@@ -1,5 +1,6 @@
 #include <QCoreApplication>
 #include <QMetaObject>
+#include <QTcpServer>
 #include <QTcpSocket>
 
 #include "core/ProfileTransfer.h"
@@ -22,6 +23,14 @@ public:
                          &transfer, &ProfileTransfer::onUploadDisconnected);
     }
 
+    static void prepareCompleteUpload(ProfileTransfer& transfer, QTcpSocket* socket)
+    {
+        prepareIncompleteUpload(transfer, socket);
+        transfer.m_phase = ProfileTransfer::Phase::UploadMetaSubset;
+        transfer.m_bytesDone = 1;
+        transfer.m_bytesTotal = 1;
+    }
+
     static void fail(ProfileTransfer& transfer, const QString& error)
     {
         transfer.fail(error);
@@ -35,6 +44,21 @@ public:
     static QTcpSocket* socket(const ProfileTransfer& transfer)
     {
         return transfer.m_socket;
+    }
+
+    static void prepareDownloadServer(ProfileTransfer& transfer, QTcpServer* server)
+    {
+        transfer.m_busy = true;
+        transfer.m_phase = ProfileTransfer::Phase::DownloadPackage;
+        transfer.m_operation = ProfileTransfer::Operation::ExportDatabase;
+        transfer.m_server = server;
+        QObject::connect(server, &QTcpServer::newConnection,
+                         &transfer, &ProfileTransfer::onDownloadConnection);
+    }
+
+    static QTcpServer* server(const ProfileTransfer& transfer)
+    {
+        return transfer.m_server;
     }
 };
 
@@ -52,31 +76,51 @@ bool expect(bool condition, const char* message)
 
 class IncompleteSocket final : public QTcpSocket {
 public:
-    explicit IncompleteSocket(QObject* parent)
+    explicit IncompleteSocket(QObject* parent,
+                              QAbstractSocket::SocketState state = QAbstractSocket::ConnectingState)
         : QTcpSocket(parent)
     {
-        setSocketState(QAbstractSocket::ConnectingState);
+        setSocketState(state);
     }
 };
 
-IncompleteSocket* prepareIncompleteUpload(AetherSDR::ProfileTransfer& transfer,
-                                          int& abortDisconnects)
+// Observes the teardown of `socket` from the inside. `abortDisconnects` counts
+// how often the transfer drove the socket to UnconnectedState, and
+// `detachedFirst` records whether the transfer had already released the member
+// at that instant — i.e. whether disposal detaches before it acts. The busy
+// guard hides a missing detach, so the ordering needs its own assertion.
+void observeTeardown(AetherSDR::ProfileTransfer& transfer, IncompleteSocket* socket,
+                     int& abortDisconnects, bool& detachedFirst)
 {
-    auto* socket = new IncompleteSocket(&transfer);
-    AetherSDR::ProfileTransferTestAccess::prepareIncompleteUpload(transfer, socket);
     QObject::connect(socket, &QTcpSocket::stateChanged, socket,
-                     [socket, &abortDisconnects](QAbstractSocket::SocketState state) {
+                     [socket, &transfer, &abortDisconnects,
+                      &detachedFirst](QAbstractSocket::SocketState state) {
                          if (state != QAbstractSocket::UnconnectedState) {
                              return;
                          }
                          ++abortDisconnects;
+                         detachedFirst =
+                             AetherSDR::ProfileTransferTestAccess::socket(transfer) != socket;
                          QMetaObject::invokeMethod(socket, "disconnected", Qt::DirectConnection);
                      });
+}
+
+IncompleteSocket* prepareIncompleteUpload(AetherSDR::ProfileTransfer& transfer,
+                                          int& abortDisconnects, bool& detachedFirst)
+{
+    auto* socket = new IncompleteSocket(&transfer);
+    AetherSDR::ProfileTransferTestAccess::prepareIncompleteUpload(transfer, socket);
+    observeTeardown(transfer, socket, abortDisconnects, detachedFirst);
     return socket;
 }
 
 } // namespace
 
+// This test deliberately runs WITHOUT an event loop. connectUploadSocket()
+// schedules a QTimer::singleShot(200ms) that dereferences m_model, which is
+// null here, so exec()/processEvents()/qWait() would turn that timer into a
+// null dereference. Every path below is driven synchronously on purpose; keep
+// it that way, or give the transfer a RadioModel first.
 int main(int argc, char* argv[])
 {
     QCoreApplication app(argc, argv);
@@ -86,12 +130,14 @@ int main(int argc, char* argv[])
         AetherSDR::ProfileTransfer transfer(nullptr);
         int failures = 0;
         int abortDisconnects = 0;
+        bool detachedFirst = false;
         QObject::connect(&transfer, &AetherSDR::ProfileTransfer::failed,
                          [&failures](AetherSDR::ProfileTransfer::Operation, const QString&) {
                              ++failures;
                          });
 
-        IncompleteSocket* socket = prepareIncompleteUpload(transfer, abortDisconnects);
+        IncompleteSocket* socket =
+            prepareIncompleteUpload(transfer, abortDisconnects, detachedFirst);
         QObject::connect(socket, &QTcpSocket::stateChanged, socket,
                          [&transfer](QAbstractSocket::SocketState state) {
                              if (state == QAbstractSocket::UnconnectedState) {
@@ -111,6 +157,8 @@ int main(int argc, char* argv[])
 
         ok &= expect(abortDisconnects == 1,
                      "failure cleanup synchronously aborts the incomplete socket");
+        ok &= expect(detachedFirst,
+                     "failure cleanup detaches the socket before aborting it");
         ok &= expect(!transfer.isBusy(), "failure cleanup leaves the transfer idle");
         ok &= expect(AetherSDR::ProfileTransferTestAccess::socket(transfer) == nullptr,
                      "failure cleanup clears the active socket");
@@ -121,22 +169,101 @@ int main(int argc, char* argv[])
         AetherSDR::ProfileTransfer transfer(nullptr);
         int failures = 0;
         int abortDisconnects = 0;
+        bool detachedFirst = false;
         QObject::connect(&transfer, &AetherSDR::ProfileTransfer::failed,
                          [&failures](AetherSDR::ProfileTransfer::Operation, const QString&) {
                              ++failures;
                          });
 
-        IncompleteSocket* oldSocket = prepareIncompleteUpload(transfer, abortDisconnects);
+        IncompleteSocket* oldSocket =
+            prepareIncompleteUpload(transfer, abortDisconnects, detachedFirst);
         AetherSDR::ProfileTransferTestAccess::connectUploadSocket(transfer, 42607);
 
         ok &= expect(abortDisconnects == 1,
                      "socket replacement synchronously aborts the incomplete socket");
+        ok &= expect(detachedFirst,
+                     "socket replacement detaches the old socket before aborting it");
         QTcpSocket* replacementSocket =
             AetherSDR::ProfileTransferTestAccess::socket(transfer);
         ok &= expect(replacementSocket != nullptr && replacementSocket != oldSocket,
                      "socket replacement installs a new upload socket");
         ok &= expect(transfer.isBusy(), "socket replacement keeps the transfer active");
         ok &= expect(failures == 0, "socket replacement cannot emit a stale upload failure");
+    }
+
+    {
+        // Successful completion disposes the socket through the same helper,
+        // with abortConnection=false. This is the one disposal site where the
+        // transfer is still busy, so the terminal-state guard cannot stand in
+        // for detaching the handlers -- only the helper does that.
+        AetherSDR::ProfileTransfer transfer(nullptr);
+        int failures = 0;
+        int disconnects = 0;
+        bool detachedFirst = false;
+        int completions = 0;
+        QObject::connect(&transfer, &AetherSDR::ProfileTransfer::failed,
+                         [&failures](AetherSDR::ProfileTransfer::Operation, const QString&) {
+                             ++failures;
+                         });
+        // The completion branch emits exactly this progress message. Counting it
+        // counts how many times the transfer ran that branch, which is the
+        // re-entry question, independent of how many raw disconnected() emissions
+        // Qt produces while the socket winds down.
+        QObject::connect(&transfer, &AetherSDR::ProfileTransfer::progress,
+                         [&completions](const QString& message, qint64, qint64) {
+                             if (message.contains(QStringLiteral("prepare the database"))) {
+                                 ++completions;
+                             }
+                         });
+
+        auto* socket = new IncompleteSocket(&transfer, QAbstractSocket::ConnectedState);
+        AetherSDR::ProfileTransferTestAccess::prepareCompleteUpload(transfer, socket);
+        observeTeardown(transfer, socket, disconnects, detachedFirst);
+        // The radio closing the connection on a complete upload is the entry
+        // point; the handler must then release the socket exactly once.
+        QMetaObject::invokeMethod(socket, "disconnected", Qt::DirectConnection);
+
+        ok &= expect(disconnects == 1,
+                     "completion disposes the socket through the shared helper");
+        ok &= expect(detachedFirst,
+                     "completion detaches the socket before disconnecting it");
+        ok &= expect(AetherSDR::ProfileTransferTestAccess::socket(transfer) == nullptr,
+                     "completion clears the active socket");
+        ok &= expect(completions == 1,
+                     "the synchronous disconnect during teardown cannot re-enter the "
+                     "transfer's completion branch");
+        ok &= expect(failures == 0, "completion emits no failure");
+        ok &= expect(transfer.isBusy(), "completion keeps the transfer active for the next phase");
+    }
+
+    {
+        // The download listener is torn down by the same detach-then-act rule.
+        // This QTcpServer never calls listen(), so it binds no port and owns no
+        // descriptor -- it is an inert QObject standing in for the listener's
+        // signal wiring, which is the only part under test.
+        AetherSDR::ProfileTransfer transfer(nullptr);
+        int handlerCalls = 0;
+        auto* server = new QTcpServer(&transfer);
+        AetherSDR::ProfileTransferTestAccess::prepareDownloadServer(transfer, server);
+
+        // Receiver is the transfer, so this rides the same connection set that
+        // cleanup must sever. If the listener is closed while still attached, a
+        // newConnection already queued before cleanup still reaches the transfer
+        // -- with m_server null underneath it.
+        QObject::connect(server, &QTcpServer::newConnection, &transfer,
+                         [&handlerCalls] { ++handlerCalls; });
+
+        ok &= expect(!server->isListening(), "the download listener test binds no port");
+
+        AetherSDR::ProfileTransferTestAccess::fail(
+            transfer, QStringLiteral("forced download cleanup failure"));
+
+        ok &= expect(AetherSDR::ProfileTransferTestAccess::server(transfer) == nullptr,
+                     "failure cleanup clears the download listener");
+
+        QMetaObject::invokeMethod(server, "newConnection", Qt::DirectConnection);
+        ok &= expect(handlerCalls == 0,
+                     "failure cleanup detaches the listener's handlers before closing it");
     }
 
     return ok ? 0 : 1;

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1906,6 +1906,15 @@ target_include_directories(profile_transfer_test PRIVATE src)
 target_link_libraries(profile_transfer_test PRIVATE Qt6::Core)
 add_test(NAME profile_transfer_test COMMAND profile_transfer_test)
 
+# #5612 — aborting an in-progress upload during cleanup or socket replacement
+# must not let a synchronous disconnect re-enter ProfileTransfer.
+add_executable(profile_transfer_cleanup_test
+    tests/profile_transfer_cleanup_test.cpp
+)
+target_include_directories(profile_transfer_cleanup_test PRIVATE src)
+target_link_libraries(profile_transfer_cleanup_test PRIVATE aethercore Qt6::Core Qt6::Network)
+add_test(NAME profile_transfer_cleanup_test COMMAND profile_transfer_cleanup_test)
+
 add_executable(waveform_upload_state_test
     tests/waveform_upload_state_test.cpp
     src/core/WaveformUploadState.cpp


### PR DESCRIPTION
## Summary

Fixes #5612. A timeout or other failure during an incomplete profile upload could crash because `ProfileTransfer::cleanup()` aborted its active socket while the socket was still stored in `m_socket` and still connected to `onUploadDisconnected()`. The synchronous disconnect re-entered `fail()` and `cleanup()`, cleared the member, and left the outer cleanup dereferencing a null pointer.

This change centralizes socket disposal so the member is cleared and its callbacks are disconnected before aborting or disconnecting. The same helper now covers failure cleanup, fallback socket replacement, and successful upload completion. Cleanup also enters its inactive terminal state before tearing down any QObject, preventing unrelated synchronous callbacks from starting a second terminal outcome.

The regression test uses an inert `QTcpSocket` state-machine object: it opens no listener, descriptor, connection, or simulated firmware peer. It injects an independent synchronous callback during `abort()` and verifies that cleanup emits exactly one terminal failure. A narrow friend accessor reaches the private lifecycle seam without preprocessor access rewriting.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The regression test fails with the original abort-before-detach ordering and passes with the fix restored.

## Test plan

- [x] Native ARM64 configure completed with RADE enabled
- [x] `profile_transfer_test` passes
- [x] `profile_transfer_cleanup_test` passes
- [x] `python3 tools/check_test_registration.py --strict` passes
- [x] Mutation check: restoring abort-before-detach produces the original double failure and segmentation fault
- [x] Guard mutation check: moving terminal-state clearing back after QObject teardown produces two failure emissions and fails the regression test
- [x] Existing CI tests pass on Linux, macOS, and Windows
- [x] Real-radio verification is not applicable to this deterministic QObject/socket lifecycle defect

## Agent automation bridge

The bridge was launched against the built application with isolated settings and transmit disabled; it reported AetherSDR 26.9.2, `txAllowed: false`, and exited cleanly through the bridge. Its 74-verb inventory has no profile-transfer lifecycle or socket-fault injection surface, so it cannot exercise this internal failure path. The operator explicitly approved publication using the production-linked, mutation-checked regression test as the behavioral proof.

## Checklist

- [x] Commit is SSH-signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls
- [x] Code is clean-room
- [x] No meter UI changes
- [x] No user-facing documentation or `CHANGELOG.md` change is needed
- [x] No security-sensitive change or GHSA applies

Generated with OpenAI Codex.


---

## Review follow-up (49b592b3, a1b78897)

Review found that the original regression test proved the terminal-state guard
and the `connectUploadSocket()` detach, but three parts of the fix were
invisible to it — reverting them left the test green. Addressed:

- **`cleanup()`'s detach-before-abort is now asserted directly.** The teardown
  observer records whether the transfer had already released the socket at the
  instant it reached `UnconnectedState`, which is the ordering rule itself
  rather than a symptom of breaking it. Previously the `m_busy` hoist masked a
  missing detach at this site.
- **The successful-completion path (`destroySocket(false)`) now has coverage.**
  A third case drives a complete upload closed by the radio. This is the one
  disposal site where the transfer is still busy, so the terminal-state guard
  cannot stand in for detaching the handlers. Re-entry is pinned by counting
  the completion branch's own `progress` emission, not raw `disconnected()`
  emissions — Qt produces a variable number of those as a socket winds down.
- **The download listener gets the same detach-then-act treatment**, via a new
  `destroyServer()`. `QTcpServer::close()` does not emit synchronously, so this
  is not a live crash; but a `newConnection` queued before cleanup would reach
  `onDownloadConnection()` with `m_server` already null, stopped today only by
  the busy guard. A fourth case pins it with an inert `QTcpServer` that never
  calls `listen()` — it binds no port and owns no descriptor, so the test stays
  socket-free.

### Mutation matrix

Each reverted independently, rebuilt, and run:

| Reverted | Before | After |
|---|---|---|
| `cleanup()` detach before abort | exit 0 — **not caught** | **exit 1** |
| Terminal-state guard placement | exit 1 | exit 1 |
| `connectUploadSocket()` detach | exit 139 (SEGV) | exit 139 (SEGV) |
| Completion path shared helper | exit 0 — **not caught** | **exit 1** |
| `destroyServer()` detach before close | n/a | **exit 1** |

Unmutated: passes. Full app target builds clean;
`check_test_registration.py --strict` passes.

### Disclosed behavior change

Routing successful completion through the shared helper means it now calls
`disconnectFromHost()` where the old code only called `deleteLater()`. This is
behavior-neutral: `onUploadDisconnected()` is reachable only from
`QTcpSocket::disconnected`, so the socket is already `UnconnectedState` and the
call returns immediately. It is kept because it matches the sibling
`FirmwareUploader`/`WaveformInstaller` helpers this fix is a port of.
