### PR TITLE
feat(hl2): the RQST/ACK state machine — one outstanding, echo-matched, quarantined (§13 item 13)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -747,6 +747,7 @@ set(CORE_SOURCES
     src/core/backends/sim/NoiseMixer.cpp                 # demo mode — audio engine (RFC #4288 Phase 2b)
     src/core/backends/hl2/MetisProtocol.cpp  # aetherd HL2 Phase 1a (HPSDR Protocol 1)
     src/core/backends/hl2/MetisClient.cpp    # aetherd HL2 Phase 1a (UDP wire + RX ingest)
+    src/core/backends/hl2/Hl2ControlRequest.cpp # RQST/ACK: one outstanding, echo-matched (§13 item 13)
     src/core/backends/hl2/Hl2EmergencyStop.cpp # release the radio from a signal handler
     src/core/backends/hl2/Hl2Receivers.cpp   # per-receiver index-space map (docs/HERMES.md §12.5)
     src/core/backends/hl2/Hl2Spectrum.cpp    # aetherd HL2 Phase 1a (FFT panadapter, FFTW)

--- a/docs/HERMES.md
+++ b/docs/HERMES.md
@@ -190,8 +190,9 @@ instead of inferring. Six things came out that were either absent from our
 sources or wrong in them.
 
 **C0 splits three ways host->radio, not two.** `dsopenhpsdr1.v` decodes it in
-one state (`CMDCTRL`): `resprqst <= eth_data[7]`, `addr <= eth_data[6:1]`,
-`ptt <= eth_data[0]`. So the register address is **six bits, not seven**, and
+one state (`CMDCTRL`): `ds_cmd_resprqst_next = eth_data[7];`,
+`ds_cmd_addr_next = eth_data[6:1];`, `ds_cmd_ptt_next = eth_data[0];`. So the
+register address is **six bits, not seven**, and
 bit 7 is the response request. `MetisProtocol.h` described C0 as an address
 shifted left with MOX in bit 0 and said nothing about bit 7 — true as far as it
 went, and safe only because nothing had ever set it.
@@ -217,13 +218,63 @@ ready, `RESP_ACK` substitutes `6'h3f` for the command address. It is unambiguous
 only because nothing ever *requests* `0x3F` — which is also the extended-address
 escape — so `Hl2ControlRequest::isRequestableAddress` refuses it by construction.
 
-**"Queue size is 1" is the gateware's own comment, and losing is silent.** A
-second command arriving while the response FSM sits in `RESP_ACK`/`RESP_READ`
-gets no reply at all; one arriving in `RESP_WAIT` **overwrites** the saved
-address and data of the request still waiting for a slot. A pipelined pair does
-not give two answers late — it gives one answer and one silence, with nothing
-reporting an error. That, not politeness, is why the host enforces one
-outstanding.
+**"Queue size is 1" is the gateware's own comment, and losing is silent — but
+only a *flagged* command can do the losing.** A second command arriving while
+the response FSM sits in `RESP_ACK`/`RESP_READ` gets no reply at all; one
+arriving in `RESP_WAIT` **overwrites** the saved address and data of the request
+still waiting for a slot. A pipelined pair does not give two answers late — it
+gives one answer and one silence, with nothing reporting an error. That, not
+politeness, is why the host enforces one outstanding.
+
+The qualifier matters more than the rule, because without it the rule would not
+work at all: this client emits two C&C banks per EP2 packet at ~381 packets/s
+and never stops, so if any command could clobber a pending reply, one would be
+clobbered within ~1.3 ms and an ACK could essentially never survive to be
+emitted. **Both entries are gated on the RQST bit.** `control.v`, verbatim:
+
+```verilog
+    RESP_START: begin
+      if (cmd_rqst & cmd_requires_resp & ~cmd_is_alt) begin
+```
+
+```verilog
+    RESP_WAIT: begin
+      cmd_resp_rqst = 1'b1;
+      if (resp_rqst & ~resp_cnt) begin // Only every other resp_rqst
+        if (cmd_rqst & cmd_requires_resp) begin
+```
+
+`cmd_requires_resp` is C0[7]. `hermeslite_core.v` wires it as
+`.cmd_requires_resp (cmd_resprqst)` and `assign cmd_resprqst = ds_cmd_resprqst;`,
+and `dsopenhpsdr1.v` latches that in `CMDCTRL` as
+`ds_cmd_resprqst_next = eth_data[7];`. The round robin
+never sets that bit (`Hl2ControlRequest::wireBank()` is non-empty only in
+`Queued`, and `withRespRqst` is applied nowhere else), so **unflagged traffic
+cannot displace a pending reply however fast it runs.** Only another RQST can,
+and one party issues those.
+
+**Command response slots open on ALTERNATE frames, so the minimum turnaround is
+two frames, not one.** `resp_cnt` toggles on every `resp_rqst`, and the machine
+acts only when it is clear — its own comment is *"Only every other
+resp_rqst"* — in **both** places: the `RESP_WAIT` exit quoted above, and the
+write of the command reply into the output register:
+
+```verilog
+  if (resp_rqst) begin
+    resp_cnt <= ~resp_cnt; // Count every other response
+    ...
+    if (cmd_resp_rqst & ~resp_cnt) begin // Only every other resp_rqst
+      // Command response
+      iresp <= {1'b1,resp_cmd_addr,ptt_resp, resp_cmd_data}; // Queue size is 1
+```
+
+So a reply waits one frame at best and two at worst, depending on the phase
+`resp_cnt` is in when it reaches `RESP_WAIT`; the free-running telemetry slots
+are the other half of the alternation. `Hl2ControlRequest`'s 32-frame deadline
+is therefore **sixteen** response opportunities, not thirty-two — which is still
+ample (~42 ms at 48 kHz with one receiver) and the constant is unchanged. The
+header had this right where it sizes the deadline; this paragraph is where the
+reasoning now lives.
 
 **The response clock is EP6 frames, and only while streaming.** `resp_rqst`
 toggles once in `usopenhpsdr1.v`'s `SYNC_RESP`, which runs once per 512-byte
@@ -233,6 +284,17 @@ so an ACK **displaces one free-running telemetry slot** — the oracle's warning
 about saturating with requests starving the classic responses is literally true,
 one slot per request. It also means a wall-clock timeout is the wrong
 instrument: `Hl2ControlRequest` counts the radio's own slots instead.
+
+**No radio has ever answered this code.** Every test behind item 13 is synthetic
+— a hand-built `Ep6Response` fed straight to `ingestControlResponse`. That is
+the right layer for the state machine's own laws (a refusal and a non-event have
+no datagram to observe), and it is *by construction* incapable of distinguishing
+"the radio answers" from "we believe it would". The RTL above says a correctly
+flagged request will be answered; nothing here is evidence that one was. First
+hardware run: arm a read-back at `0x0a` on a streaming radio and watch
+`staleAcks()` stay at zero while `answered()` moves. Until then, treat the
+`Answered` path as unexercised on real hardware and say so in anything built on
+it.
 
 **Bonus, for §13 item 14.** `clip_cnt` is a 2-bit saturating counter cleared on
 **every** `resp_rqst`, and the ADC-overload bit in RADDR 0 is `(&clip_cnt)` —
@@ -1198,7 +1260,7 @@ Audited against this branch's merge base, `6f46eea7`.
 
 | # | Item | Source | Why it matters | Effort |
 |---|---|---|---|---|
-| ~~13~~ | ~~RQST/ACK state machine~~ **DONE** | O §5 | `Hl2ControlRequest` + `MetisClient::requestRegister`. One outstanding, echo-matched, deadline counted in EP6 frames; a blown deadline **quarantines** rather than freeing the slot, so the abandoned request's late echo has nowhere to land. The wire facts it was built from are in §4 — three of them contradict what we had | — |
+| ~~13~~ | ~~RQST/ACK state machine~~ **DONE** | O §5 | `Hl2ControlRequest` + `MetisClient::requestRegister`. One outstanding, echo-matched, deadline counted in EP6 frames; a blown deadline **quarantines** rather than freeing the slot, so the abandoned request's late echo has nowhere to land. Requestable addresses are an **allow-list** (0x0a, 0x0e, 0x3b today) and not a deny-list, so items 14-23 add one deliberately rather than inherit it. The wire facts it was built from are in §4 — three of them contradict what we had, and no radio has yet answered the code | — |
 | 14 | ADC overload bit + clip counter | O §6, A2 §A3 | The *correct* driver for gain decisions — audio level in one slice says nothing about what saturates a converter seeing 0–38.4 MHz | S |
 | 15 | Discovery-reply telemetry (temp, power, PTT, clip) | O §1 | Pollable **without a stream** — cheapest first increment, and a diagnostic when the stream is broken | S |
 | 16 | Pair WDSP `RXA_ADC_PK` with the hardware clip indicator | A3 §7 | Post-DDC slice vs pre-DDC full spectrum. They disagree by design; A3 calls this the most useful diagnostic pairing on the HL2 | S |

--- a/docs/HERMES.md
+++ b/docs/HERMES.md
@@ -183,6 +183,63 @@ statistics (RMS, peak, non-zero fraction), never only on packet counts.
 The p99/max figures are the real input for sizing the SPSC queue between the
 UDP thread and DSP: it needs ≥3 packets of slack to absorb observed jitter.
 
+### RQST/ACK, read off the gateware rather than the oracle
+
+Building §13 item 13 meant reading `control.v`, `ds.v` and `usopenhpsdr1.v`
+instead of inferring. Six things came out that were either absent from our
+sources or wrong in them.
+
+**C0 splits three ways host->radio, not two.** `dsopenhpsdr1.v` decodes it in
+one state (`CMDCTRL`): `resprqst <= eth_data[7]`, `addr <= eth_data[6:1]`,
+`ptt <= eth_data[0]`. So the register address is **six bits, not seven**, and
+bit 7 is the response request. `MetisProtocol.h` described C0 as an address
+shifted left with MOX in bit 0 and said nothing about bit 7 — true as far as it
+went, and safe only because nothing had ever set it.
+
+**Bit 7 is not a read bit, and there is no read-only command.** `RESP_START`
+latches `cmd_data` and the write happens regardless; the reply is an **echo** of
+what was written. The only replies that are not echoes are the AD9866 SPI
+(`0x3b`) and I2C (`0x3c`) commands, which carry a read opcode inside the data
+and come back with the read value (`RESP_READ`). Every RQST is a write that asks
+to be acknowledged, and any caller of `MetisClient::requestRegister` has to read
+it that way.
+
+**The free-running RADDR is TWO bits on this hardware, not four, and the cycle
+is 0..3 — not 0..4.** `control.v` declares `logic [1:0] resp_addr` and composes
+C0 as `{3'b000, resp_addr, ext_cwkey, 1'b0, ptt_resp}`, so C0[6:5] are hardwired
+zero. `parseEp6Response` reads four bits at C0[6:3] and therefore gets the right
+number anyway — but the note beside it, that hpsdrsim's `0, 8, 16, 24, 32`
+sequence proves RADDR 0..4, describes the **fixture** and not the radio. Slot 3
+is `debug` and carries nothing; there is no slot 4.
+
+**`0x3F` in an ACK means "refused", not a register.** When a subsystem is not
+ready, `RESP_ACK` substitutes `6'h3f` for the command address. It is unambiguous
+only because nothing ever *requests* `0x3F` — which is also the extended-address
+escape — so `Hl2ControlRequest::isRequestableAddress` refuses it by construction.
+
+**"Queue size is 1" is the gateware's own comment, and losing is silent.** A
+second command arriving while the response FSM sits in `RESP_ACK`/`RESP_READ`
+gets no reply at all; one arriving in `RESP_WAIT` **overwrites** the saved
+address and data of the request still waiting for a slot. A pipelined pair does
+not give two answers late — it gives one answer and one silence, with nothing
+reporting an error. That, not politeness, is why the host enforces one
+outstanding.
+
+**The response clock is EP6 frames, and only while streaming.** `resp_rqst`
+toggles once in `usopenhpsdr1.v`'s `SYNC_RESP`, which runs once per 512-byte
+frame (so twice per EP6 packet), and the whole emit path is gated on `run`.
+Command responses go out only on alternate slots (`cmd_resp_rqst & ~resp_cnt`),
+so an ACK **displaces one free-running telemetry slot** — the oracle's warning
+about saturating with requests starving the classic responses is literally true,
+one slot per request. It also means a wall-clock timeout is the wrong
+instrument: `Hl2ControlRequest` counts the radio's own slots instead.
+
+**Bonus, for §13 item 14.** `clip_cnt` is a 2-bit saturating counter cleared on
+**every** `resp_rqst`, and the ADC-overload bit in RADDR 0 is `(&clip_cnt)` —
+both bits set. So that bit does not mean "a sample clipped"; it means **at least
+three clip events inside one EP6 frame**, re-armed every frame. Anything that
+servos gain off it is servoing off a coarse per-frame threshold, not a count.
+
 ### Ordering
 
 A stream started before any C&C frame has landed emits ADC-idle samples. Prime
@@ -1141,7 +1198,7 @@ Audited against this branch's merge base, `6f46eea7`.
 
 | # | Item | Source | Why it matters | Effort |
 |---|---|---|---|---|
-| 13 | RQST/ACK state machine | O §5 | Gate for everything below. Single outstanding request, echo-matched, no transaction id. **Do not model as RPC** | M |
+| ~~13~~ | ~~RQST/ACK state machine~~ **DONE** | O §5 | `Hl2ControlRequest` + `MetisClient::requestRegister`. One outstanding, echo-matched, deadline counted in EP6 frames; a blown deadline **quarantines** rather than freeing the slot, so the abandoned request's late echo has nowhere to land. The wire facts it was built from are in §4 — three of them contradict what we had | — |
 | 14 | ADC overload bit + clip counter | O §6, A2 §A3 | The *correct* driver for gain decisions — audio level in one slice says nothing about what saturates a converter seeing 0–38.4 MHz | S |
 | 15 | Discovery-reply telemetry (temp, power, PTT, clip) | O §1 | Pollable **without a stream** — cheapest first increment, and a diagnostic when the stream is broken | S |
 | 16 | Pair WDSP `RXA_ADC_PK` with the hardware clip indicator | A3 §7 | Post-DDC slice vs pre-DDC full spectrum. They disagree by design; A3 calls this the most useful diagnostic pairing on the HL2 | S |

--- a/docs/HERMES.md
+++ b/docs/HERMES.md
@@ -199,11 +199,52 @@ went, and safe only because nothing had ever set it.
 
 **Bit 7 is not a read bit, and there is no read-only command.** `RESP_START`
 latches `cmd_data` and the write happens regardless; the reply is an **echo** of
-what was written. The only replies that are not echoes are the AD9866 SPI
-(`0x3b`) and I2C (`0x3c`) commands, which carry a read opcode inside the data
-and come back with the read value (`RESP_READ`). Every RQST is a write that asks
-to be acknowledged, and any caller of `MetisClient::requestRegister` has to read
-it that way.
+what was written. The only replies that are not echoes are the two **I2C**
+commands (`0x3c`, `0x3d`), which carry a read opcode inside the data and come
+back with the read value (`RESP_READ`). Every RQST is a write that asks to be
+acknowledged, and any caller of `MetisClient::requestRegister` has to read it
+that way.
+
+**And `0x3b` is not one of them — it is a converter write that reaches the
+transmit path.** An earlier version of this section, and of the code, called the
+AD9866 SPI command the read path. It is not, and the RTL is explicit twice over.
+`ad9866ctrl` has **no data output at all** — `control.v` instantiates it with
+`cmd_addr` / `cmd_data` / `cmd_rqst` / `cmd_ack` and nothing else, and inside,
+`assign sdo = 1'b0;` with `//assign dataout` commented out. `RESP_READ`'s AD9866
+branch therefore assigns the *I2C* bus's data, behind the gateware's own note:
+
+```verilog
+        end else if (~cmd_ack_ad9866) begin
+          resp_cmd_data_next = cmd_resp_data_i2c; // FIXME: suppor read cmd_resp_data_ad9866
+```
+
+What `0x3b` *does*, from `ad9866ctrl.v`:
+
+```verilog
+          // Generic AD9866 write
+          6'h3b: begin
+            if (cmd_data[31:24] == 8'h06) begin
+              // Must write
+              if (rffe_ad9866_sen_n) cmd_state_next = CMD_WRITE;
+```
+
+and `CMD_WRITE` puts `{3'b000, cmd_data[20:16], cmd_data[7:0]}` on the
+converter's SPI bus — an **arbitrary AD9866 register, arbitrary byte**. Among
+the registers that reaches is `0x0a`, which is exactly where the gateware's own
+TX-gain command writes (`icmd_data = {5'h0a,4'b0100,tx_gain}`), along with
+`0x0c` (TX interpolation), `0x0e` (IAMP enable) and `0x10`/`0x11` (TX gain
+select) by its own `initarray` comments.
+
+It also **persists harder than `0x01` does.** The `6'h09` handler issues its SPI
+write only `if (tx_gain != cmd_data[31:28])`, against an FPGA-side shadow
+register that a `0x3b` write never touches — so after a `0x3b` write to AD9866
+`0x0a` the gateware still believes the old gain and will not re-assert it. The
+mechanism that would have corrected the value is suppressed by its own change
+detector. `0x3b` is therefore **off** `MetisClient::requestRegister`'s
+allow-list, by that list's own re-asserted-or-excluded rule. It was never
+reachable without a deliberate call and had zero callers; an item that genuinely
+needs converter SPI adds it back with the `8'h06` cookie and the target register
+named at the call site.
 
 **The free-running RADDR is TWO bits on this hardware, not four, and the cycle
 is 0..3 — not 0..4.** `control.v` declares `logic [1:0] resp_addr` and composes
@@ -271,10 +312,48 @@ write of the command reply into the output register:
 So a reply waits one frame at best and two at worst, depending on the phase
 `resp_cnt` is in when it reaches `RESP_WAIT`; the free-running telemetry slots
 are the other half of the alternation. `Hl2ControlRequest`'s 32-frame deadline
-is therefore **sixteen** response opportunities, not thirty-two — which is still
-ample (~42 ms at 48 kHz with one receiver) and the constant is unchanged. The
-header had this right where it sizes the deadline; this paragraph is where the
-reasoning now lives.
+is therefore **sixteen** response opportunities, not thirty-two — ample in
+*slots* at every rate, which is what a frame count is for.
+
+**A frame is not a fixed amount of time, and we quoted one configuration as if
+it were general.** This section used to size the deadline as "~42 ms", full
+stop. That is true at 48 kHz with one receiver and nowhere else. An EP6 frame
+carries `504 / (6·numRx + 2)` rounds, so frames per second rise with **both**
+the sample rate and the receiver count. Computed from `MetisProtocol.h`'s
+geometry and filtered by `maxReceiversAtRate()`'s 70 Mbit/s budget:
+
+| Rate | Receivers | Rounds/frame | Frames/s | 32 frames | + 32 quarantine |
+|---|---|---|---|---|---|
+| 48 k | 1 | 63 | 762 | 42.0 ms | 84.0 ms |
+| 48 k | 4 | 19 | 2,526 | 12.7 ms | 25.3 ms |
+| 96 k | 4 | 19 | 5,053 | 6.33 ms | 12.7 ms |
+| 192 k | 2 | 36 | 5,333 | 6.0 ms | 12.0 ms |
+| 192 k | 4 | 19 | 10,105 | 3.17 ms | 6.33 ms |
+| 384 k | 1 | 63 | 6,095 | 5.25 ms | 10.5 ms |
+| 384 k | 3 | 25 | 15,360 | **2.08 ms** | **4.17 ms** |
+
+384 kHz is `Hl2Backend::maxIqSampleRateHz()` unless low-bandwidth mode is on,
+and the budget admits three receivers there; the shipping `hl2b5up_main` variant
+reports four at discovery, and 192 kHz × 4 RX is the tightest pair both limits
+allow. That is a **twentyfold spread**, and the short end is the problem,
+because what consumes a deadline is **host-side delivery latency**, which is
+wall-clock and which a frame count cannot see. Every frame drained after the
+request is sent counts against it — including frames the radio emitted *before*
+it saw the request, still sitting in the socket buffer. The 6.08 ms worst-case
+inter-arrival gap in the table above is ~93 frames at 384 kHz with three
+receivers, drained in one `onReadyRead()` pass: the whole deadline *and* the
+whole quarantine, before the reply could be read at all.
+
+**So the deadline is both halves, and neither alone.** `onEp6Frame(nowMs)` takes
+a monotonic millisecond count and expires a deadline only when the frame count
+has run out **and** a wall-clock floor has passed; the quarantine has the same
+pair, its floor running from the instant the deadline blew. The floor is derived
+rather than picked — `32 × ep6RoundsPerFrame(1) / 48 kHz` = **42 ms**, exactly
+the budget the frame count was originally sized at — so the effect is to make
+the "~42 ms" this document always claimed true at *every* rate instead of at one
+of them, and it lengthens the 48 kHz case not at all. The clock is **passed in**,
+so `Hl2ControlRequest` still holds no clock and `hl2_rqst_ack_test` pins a
+384 kHz case with no real time passing.
 
 **The response clock is EP6 frames, and only while streaming.** `resp_rqst`
 toggles once in `usopenhpsdr1.v`'s `SYNC_RESP`, which runs once per 512-byte
@@ -282,8 +361,22 @@ frame (so twice per EP6 packet), and the whole emit path is gated on `run`.
 Command responses go out only on alternate slots (`cmd_resp_rqst & ~resp_cnt`),
 so an ACK **displaces one free-running telemetry slot** — the oracle's warning
 about saturating with requests starving the classic responses is literally true,
-one slot per request. It also means a wall-clock timeout is the wrong
-instrument: `Hl2ControlRequest` counts the radio's own slots instead.
+one slot per request. It is also why the frame count survives the fix as the
+*necessary* half: a radio that stopped streaming owes no slots, and a pure
+wall-clock deadline would report "the radio timed out" for a condition that is
+really "we never gave it an opportunity to answer".
+
+**The late-reply guarantee is narrowed, not absolute.** Quarantine keeps an
+abandoned request's reply from landing on a fresh one *for as long as the
+quarantine lasts*, and the floor is what makes that a real duration rather than
+2 ms. It is not "by construction", which is what an earlier version of
+`Hl2ControlRequest.h` claimed: a caller that re-issues the **identical** request
+after a timeout is asking for a reply byte-for-byte equal to the one it
+abandoned, and a wire with no transaction id cannot separate those two.
+`hl2_rqst_ack_test` pins that residual rather than hiding it. `Echo::
+SubsystemRead`, which matches on the six-bit address alone, is weaker still —
+so `requestRegister` refuses it outright today, no allow-listed address being of
+that shape.
 
 **No radio has ever answered this code.** Every test behind item 13 is synthetic
 — a hand-built `Ep6Response` fed straight to `ingestControlResponse`. That is
@@ -1260,7 +1353,7 @@ Audited against this branch's merge base, `6f46eea7`.
 
 | # | Item | Source | Why it matters | Effort |
 |---|---|---|---|---|
-| ~~13~~ | ~~RQST/ACK state machine~~ **DONE** | O §5 | `Hl2ControlRequest` + `MetisClient::requestRegister`. One outstanding, echo-matched, deadline counted in EP6 frames; a blown deadline **quarantines** rather than freeing the slot, so the abandoned request's late echo has nowhere to land. Requestable addresses are an **allow-list** (0x0a, 0x0e, 0x3b today) and not a deny-list, so items 14-23 add one deliberately rather than inherit it. The wire facts it was built from are in §4 — three of them contradict what we had, and no radio has yet answered the code | — |
+| ~~13~~ | ~~RQST/ACK state machine~~ **DONE** | O §5 | `Hl2ControlRequest` + `MetisClient::requestRegister`. One outstanding, echo-matched; the deadline is counted in EP6 frames **and** floored on a wall clock, because a frame is 42 ms at 48 kHz with one receiver and 2.08 ms at 384 kHz with three. A blown deadline **quarantines** rather than freeing the slot, which makes a late echo landing on a fresh request improbable — not impossible; an identical re-issue is indistinguishable and §4 says so. Requestable addresses are an **allow-list** (0x0a, 0x0e) and not a deny-list, so items 14-23 add one deliberately rather than inherit it; 0x3b came off it once the RTL showed it is a converter **write** reaching the TX gain register, not a read path. The wire facts it was built from are in §4, and **no radio has yet answered the code** | — |
 | 14 | ADC overload bit + clip counter | O §6, A2 §A3 | The *correct* driver for gain decisions — audio level in one slice says nothing about what saturates a converter seeing 0–38.4 MHz | S |
 | 15 | Discovery-reply telemetry (temp, power, PTT, clip) | O §1 | Pollable **without a stream** — cheapest first increment, and a diagnostic when the stream is broken | S |
 | 16 | Pair WDSP `RXA_ADC_PK` with the hardware clip indicator | A3 §7 | Post-DDC slice vs pre-DDC full spectrum. They disagree by design; A3 calls this the most useful diagnostic pairing on the HL2 | S |

--- a/src/core/backends/hl2/Hl2ControlRequest.cpp
+++ b/src/core/backends/hl2/Hl2ControlRequest.cpp
@@ -22,20 +22,31 @@ std::optional<Cc> Hl2ControlRequest::wireBank() const noexcept
     return withRespRqst(ccRegister(m_request.addr, m_request.data), true);
 }
 
-void Hl2ControlRequest::onRequestSent() noexcept
+void Hl2ControlRequest::onRequestSent(std::int64_t nowMs) noexcept
 {
     if (m_state != State::Queued)
         return;
     m_state = State::Awaiting;
     m_framesLeft = m_deadlineFrames;
+    m_floorAtMs = nowMs + m_floorMs;
 }
 
-void Hl2ControlRequest::onEp6Frame() noexcept
+void Hl2ControlRequest::onEp6Frame(std::int64_t nowMs) noexcept
 {
     switch (m_state) {
     case State::Awaiting:
-        if (--m_framesLeft <= 0) {
+        // AND, not OR, and the frames are decremented either way. The count can
+        // run out long before the floor at a high sample rate — that is the
+        // whole point — so it is clamped at zero rather than allowed to run
+        // negative while the floor is still pending.
+        if (m_framesLeft > 0)
+            --m_framesLeft;
+        if (m_framesLeft <= 0 && nowMs >= m_floorAtMs) {
             ++m_timeouts;
+            // The quarantine's floor starts HERE, at the instant we gave up,
+            // not at takeReply(): what it has to outlast is the reply still
+            // owed for the request abandoned at this moment.
+            m_floorAtMs = nowMs + m_floorMs;
             // Note the outcome is delivered, not swallowed: a caller must be
             // able to see that this radio did not answer. What it does NOT do is
             // free the slot — see takeReply().
@@ -43,7 +54,9 @@ void Hl2ControlRequest::onEp6Frame() noexcept
         }
         break;
     case State::Quarantine:
-        if (--m_framesLeft <= 0) {
+        if (m_framesLeft > 0)
+            --m_framesLeft;
+        if (m_framesLeft <= 0 && nowMs >= m_floorAtMs) {
             m_state = State::Idle;
             m_request = {};
         }
@@ -132,6 +145,7 @@ void Hl2ControlRequest::reset() noexcept
     m_request = {};
     m_reply = {};
     m_framesLeft = 0;
+    m_floorAtMs = 0;
 }
 
 void Hl2ControlRequest::settle(Outcome outcome, std::uint32_t data) noexcept

--- a/src/core/backends/hl2/Hl2ControlRequest.cpp
+++ b/src/core/backends/hl2/Hl2ControlRequest.cpp
@@ -1,0 +1,146 @@
+#include "core/backends/hl2/Hl2ControlRequest.h"
+
+namespace AetherSDR::hl2 {
+
+bool Hl2ControlRequest::arm(const Request& r) noexcept
+{
+    if (m_state != State::Idle)
+        return false;                       // single outstanding; no queue
+    if (!isRequestableAddress(r.addr))
+        return false;
+    m_request = r;
+    m_reply = {};
+    m_state = State::Queued;
+    m_framesLeft = 0;                       // the deadline starts at onRequestSent()
+    return true;
+}
+
+std::optional<Cc> Hl2ControlRequest::wireBank() const noexcept
+{
+    if (m_state != State::Queued)
+        return std::nullopt;
+    return withRespRqst(ccRegister(m_request.addr, m_request.data), true);
+}
+
+void Hl2ControlRequest::onRequestSent() noexcept
+{
+    if (m_state != State::Queued)
+        return;
+    m_state = State::Awaiting;
+    m_framesLeft = m_deadlineFrames;
+}
+
+void Hl2ControlRequest::onEp6Frame() noexcept
+{
+    switch (m_state) {
+    case State::Awaiting:
+        if (--m_framesLeft <= 0) {
+            ++m_timeouts;
+            // Note the outcome is delivered, not swallowed: a caller must be
+            // able to see that this radio did not answer. What it does NOT do is
+            // free the slot — see takeReply().
+            settle(Outcome::TimedOut, 0);
+        }
+        break;
+    case State::Quarantine:
+        if (--m_framesLeft <= 0) {
+            m_state = State::Idle;
+            m_request = {};
+        }
+        break;
+    case State::Idle:
+    case State::Queued:
+    case State::Settled:
+        // Queued does NOT tick. A request waiting behind a one-shot queue has
+        // not reached the radio, so frames that pass before it does are not
+        // frames in which the radio failed to answer.
+        break;
+    }
+}
+
+bool Hl2ControlRequest::matches(const Ep6Response& r) const noexcept
+{
+    if (!r.ack)
+        return false;                       // the free-running telemetry cycle
+    if (m_state != State::Awaiting)
+        return false;                       // nothing is outstanding to match
+    // A refusal replaces the address with 0x3F, so it cannot be address-matched
+    // against what we asked for — and it is unambiguous precisely because we
+    // never request 0x3F (isRequestableAddress).
+    if (r.raddr == kRespAddrError)
+        return true;
+    if (r.raddr != m_request.addr)
+        return false;
+    // Echo::SubsystemRead replies carry the value read, not the bytes written,
+    // so the address is all the evidence there is. Echo::Exact replies carry
+    // the echo, and we spend it: matching on the address alone would pair a
+    // reply with any request at the same register, which after an abandoned
+    // request is the wrong one.
+    if (m_request.echo == Echo::Exact && r.data != m_request.data)
+        return false;
+    return true;
+}
+
+bool Hl2ControlRequest::onResponse(const Ep6Response& r) noexcept
+{
+    if (!r.ack)
+        return false;
+
+    if (!matches(r)) {
+        // Every ACK that is not ours is stale by construction: nothing else on
+        // this link sets the RQST bit, so an unmatched ACK is either the reply
+        // to a request we abandoned (landing here in Quarantine, which is the
+        // point of Quarantine) or evidence of a second client on the radio.
+        ++m_staleAcks;
+        return false;
+    }
+
+    if (r.raddr == kRespAddrError) {
+        ++m_refusals;
+        settle(Outcome::Refused, r.data);
+    } else {
+        ++m_answered;
+        settle(Outcome::Answered, r.data);
+    }
+    return true;
+}
+
+std::optional<Hl2ControlRequest::Reply> Hl2ControlRequest::takeReply() noexcept
+{
+    if (m_state != State::Settled)
+        return std::nullopt;
+    const Reply out = m_reply;
+    m_reply = {};
+    if (out.outcome == Outcome::TimedOut && m_quarantineFrames > 0) {
+        // The radio never said it was finished with this request, so it may
+        // still answer it. Do not open the slot until any such answer has had
+        // its chance to arrive and be swallowed.
+        m_state = State::Quarantine;
+        m_framesLeft = m_quarantineFrames;
+    } else {
+        // Answered or Refused: the radio's response register has been consumed
+        // and its FSM is back at RESP_START. Nothing is owed.
+        m_state = State::Idle;
+        m_request = {};
+    }
+    return out;
+}
+
+void Hl2ControlRequest::reset() noexcept
+{
+    m_state = State::Idle;
+    m_request = {};
+    m_reply = {};
+    m_framesLeft = 0;
+}
+
+void Hl2ControlRequest::settle(Outcome outcome, std::uint32_t data) noexcept
+{
+    m_reply.outcome = outcome;
+    m_reply.addr = m_request.addr;
+    m_reply.data = data;
+    m_state = State::Settled;
+    m_framesLeft = 0;
+}
+
+}  // namespace AetherSDR::hl2

--- a/src/core/backends/hl2/Hl2ControlRequest.h
+++ b/src/core/backends/hl2/Hl2ControlRequest.h
@@ -25,6 +25,15 @@
 //     overwrites the saved address and data of the request still waiting for a
 //     slot. So a pipelined pair does not give you two answers late; it gives
 //     you one answer and one silence, and no error anywhere.
+//
+//     BOTH OF THOSE ARE GATED ON THE RQST BIT, which is what makes this a host
+//     discipline problem rather than an impossibility. control.v enters the
+//     sequence only on `cmd_rqst & cmd_requires_resp & ~cmd_is_alt`, and the
+//     RESP_WAIT overwrite is inside `if (resp_rqst & ~resp_cnt)` and then
+//     `if (cmd_rqst & cmd_requires_resp)` — `cmd_requires_resp` being C0[7],
+//     wired from `cmd_resprqst` in hermeslite_core.v. The ordinary round robin,
+//     which never sets C0[7], therefore CANNOT clobber a pending reply however
+//     fast it runs. Only another RQST can, and only one party issues those.
 //     --> arm() REFUSES unless the machine is Idle, and says so in its return
 //         type. There is no queue. A caller that wants two reads does two.
 //
@@ -80,10 +89,16 @@ public:
         // only evidence, beyond a six-bit address, that this reply belongs to
         // this request rather than to the last one at the same register.
         Exact,
-        // An AD9866 SPI (0x3b) or I2C (0x3c) command whose reply carries the
-        // value READ rather than the bytes written. Only the address can be
-        // matched, so such a request is strictly weaker evidence — which is
-        // exactly why the quarantine on timeout is not optional.
+        // A command whose reply carries the value READ rather than the bytes
+        // written: the AD9866 SPI command (0x3b) and both I2C buses (0x3c
+        // internal, 0x3d the external companion bus — MetisProtocol.h documents
+        // TWO, and picking Echo::Exact for either would silently throw away the
+        // data half of the match). Of those, only 0x3b is reachable through
+        // MetisClient::requestRegister's allow-list today.
+        //
+        // Only the address can be matched, so such a request is strictly weaker
+        // evidence — which is exactly why the quarantine on timeout is not
+        // optional.
         SubsystemRead,
     };
 
@@ -116,13 +131,25 @@ public:
     // Deadline and quarantine, in EP6 FRAMES. See the class note for why the
     // unit is frames.
     //
-    // The gateware answers fast: RESP_START latches on the command, RESP_ACK and
-    // RESP_READ each take a cycle or two, and RESP_WAIT releases the reply on
-    // the next `resp_rqst & ~resp_cnt` — which is at most two frames away,
-    // because resp_cnt flips on every frame. Three or four frames is the
-    // expected turnaround; 32 is generous enough to absorb an EP2 pacer tick,
-    // the round trip, and a slow I2C subsystem without being so long that a
-    // genuinely dead request stalls a caller.
+    // The gateware answers fast, but NOT every frame, and the difference is
+    // worth stating because 32 was sized against it. control.v toggles
+    // `resp_cnt` on every `resp_rqst` and then acts "Only every other
+    // resp_rqst" (its own comment): both the RESP_WAIT exit and the write of
+    // the command reply into `iresp` are guarded by `~resp_cnt`. So a COMMAND
+    // RESPONSE SLOT OPENS ON ALTERNATE EP6 FRAMES, not on every frame — the
+    // free-running telemetry slots are the other half of that alternation.
+    //
+    // RESP_START latches on the command and RESP_ACK/RESP_READ each take a
+    // cycle or two of clk_ctrl, which is nothing beside a frame; the wait for a
+    // slot is the whole of the latency, and it is one frame at best and two at
+    // worst depending on the phase `resp_cnt` happens to be in. Call it two to
+    // four frames end to end. 32 frames is therefore SIXTEEN response
+    // opportunities, not thirty-two — still generous enough to absorb an EP2
+    // pacer tick, the round trip and a slow I2C subsystem, and at 48 kHz with
+    // one receiver (63 samples per 512-byte frame) it is ~42 ms, which is short
+    // enough that a genuinely dead request does not strand a caller. The
+    // constant is unchanged because the alternation was already counted; what
+    // was missing was saying so here.
     static constexpr int kDefaultDeadlineFrames = 32;
     // Equal to the deadline: whatever the radio still owes us is released on the
     // next slot after it becomes available, so one more deadline's worth of

--- a/src/core/backends/hl2/Hl2ControlRequest.h
+++ b/src/core/backends/hl2/Hl2ControlRequest.h
@@ -1,0 +1,226 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include "core/backends/hl2/MetisProtocol.h"
+
+// The Hermes-Lite 2 RQST/ACK state machine (docs/HERMES.md §13 item 13,
+// oracle §5). Qt-free and socket-free, like MetisProtocol, so it unit-tests
+// against synthetic responses with no radio and no event loop.
+//
+// ---------------------------------------------------------------------------
+// THIS IS NOT AN RPC, AND MODELLING IT AS ONE IS THE FAILURE MODE
+// ---------------------------------------------------------------------------
+//
+// There is no call, no future, no correlation id, and no guarantee of an
+// answer. Three properties of the wire make an RPC abstraction actively
+// dangerous here, and each one is answered by a specific piece of this class:
+//
+//  1. SINGLE OUTSTANDING. The gateware's response register holds exactly one
+//     reply — control.v says so in a comment on the line that writes it
+//     ("Queue size is 1"). Worse than dropping a second request, the response
+//     FSM SILENTLY DISCARDS the first: a command arriving while the FSM sits in
+//     RESP_ACK or RESP_READ gets no reply at all, and one arriving in RESP_WAIT
+//     overwrites the saved address and data of the request still waiting for a
+//     slot. So a pipelined pair does not give you two answers late; it gives
+//     you one answer and one silence, and no error anywhere.
+//     --> arm() REFUSES unless the machine is Idle, and says so in its return
+//         type. There is no queue. A caller that wants two reads does two.
+//
+//  2. ECHO-MATCHED, NO TRANSACTION ID. The reply carries the six-bit command
+//     address in C0[6:1] and, for a plain register write, an echo of the data
+//     we sent (control.v RESP_START: resp_cmd_data_next = cmd_data). That is
+//     the whole of the correspondence. Matching is therefore a JUDGEMENT about
+//     equality, not a lookup, and getting it wrong pairs a reply with the wrong
+//     request in a way that looks exactly like success.
+//     --> matches() is explicit and narrow: address equality always, plus data
+//         equality for Echo::Exact requests. A response that fails it is not
+//         "probably ours" — it is counted as stale and dropped.
+//
+//  3. A LATE REPLY IS INDISTINGUISHABLE FROM A TIMELY ONE. With no id, an
+//     answer to a request we gave up on looks identical to an answer to the
+//     request we just made — IF the two can ever be in flight together.
+//     --> they cannot be, by construction. A deadline that expires does not
+//         return the machine to Idle; it moves it to Quarantine, where every
+//         ACK is swallowed and counted, and arm() stays refused until the
+//         quarantine elapses. The abandoned reply has nowhere to land but
+//         Quarantine. This is the piece an RPC layer would have optimised away.
+//
+// ---------------------------------------------------------------------------
+// TWO MORE FACTS THE WIRE IMPOSES
+// ---------------------------------------------------------------------------
+//
+// THE CLOCK IS EP6 FRAMES, NOT MILLISECONDS. resp_rqst toggles once per
+// 512-byte EP6 frame (usopenhpsdr1.v, SYNC_RESP) and the whole EP6 emit path is
+// gated on `run`. An idle radio answers discovery and nothing else: no stream,
+// no response slots, no replies, for ever. A wall-clock deadline would report
+// "the radio timed out" for a condition that is really "we never gave it an
+// opportunity to answer" — and would expire faster at 384 kHz than at 48 kHz
+// for no reason on the radio's side. So the deadline is counted in the radio's
+// own response slots, fed by onEp6Frame().
+//
+// THERE IS NO READ-ONLY REQUEST. Bit 7 does not mean "read". The gateware
+// applies the write regardless and then echoes it; the only commands whose
+// reply is not an echo are the AD9866 SPI and I2C subsystem writes, which carry
+// a read opcode in their data and come back with the read value instead
+// (RESP_READ, Echo::SubsystemRead below). Every RQST this machine issues is a
+// WRITE that asks to be acknowledged. Callers, and reviewers, have to read it
+// that way.
+//
+namespace AetherSDR::hl2 {
+
+class Hl2ControlRequest {
+public:
+    // How the reply's DATA relates to the request's data, which is the whole of
+    // the matching judgement beyond the address.
+    enum class Echo {
+        // A plain register write. The reply's C1..C4 are a byte-for-byte echo of
+        // what we sent, so data equality is available and is USED: it is the
+        // only evidence, beyond a six-bit address, that this reply belongs to
+        // this request rather than to the last one at the same register.
+        Exact,
+        // An AD9866 SPI (0x3b) or I2C (0x3c) command whose reply carries the
+        // value READ rather than the bytes written. Only the address can be
+        // matched, so such a request is strictly weaker evidence — which is
+        // exactly why the quarantine on timeout is not optional.
+        SubsystemRead,
+    };
+
+    enum class State {
+        Idle,        // nothing outstanding; arm() is accepted
+        Queued,      // armed, bank not yet on the wire; the deadline has not started
+        Awaiting,    // bank sent, counting EP6 frames against the deadline
+        Settled,     // a verdict is waiting for takeReply()
+        Quarantine,  // deadline blown; swallowing whatever the radio still owes us
+    };
+
+    enum class Outcome {
+        Answered,   // a reply matched. `data` is the echo, or the subsystem read value
+        Refused,    // the radio answered with raddr 0x3F: a subsystem was not ready
+        TimedOut,   // the deadline passed with no matching reply. See the class note
+    };
+
+    struct Request {
+        int           addr = 0;
+        std::uint32_t data = 0;
+        Echo          echo = Echo::Exact;
+    };
+
+    struct Reply {
+        Outcome       outcome = Outcome::TimedOut;
+        int           addr = 0;     // the request's address, not the ACK's
+        std::uint32_t data = 0;     // meaningless unless outcome == Answered
+    };
+
+    // Deadline and quarantine, in EP6 FRAMES. See the class note for why the
+    // unit is frames.
+    //
+    // The gateware answers fast: RESP_START latches on the command, RESP_ACK and
+    // RESP_READ each take a cycle or two, and RESP_WAIT releases the reply on
+    // the next `resp_rqst & ~resp_cnt` — which is at most two frames away,
+    // because resp_cnt flips on every frame. Three or four frames is the
+    // expected turnaround; 32 is generous enough to absorb an EP2 pacer tick,
+    // the round trip, and a slow I2C subsystem without being so long that a
+    // genuinely dead request stalls a caller.
+    static constexpr int kDefaultDeadlineFrames = 32;
+    // Equal to the deadline: whatever the radio still owes us is released on the
+    // next slot after it becomes available, so one more deadline's worth of
+    // frames is past any reply that could still be in flight for the abandoned
+    // request. Symmetry is the point — a quarantine shorter than the deadline
+    // would leave a window where a late reply meets a new request.
+    static constexpr int kDefaultQuarantineFrames = 32;
+
+    Hl2ControlRequest() = default;
+    Hl2ControlRequest(int deadlineFrames, int quarantineFrames) noexcept
+        : m_deadlineFrames(deadlineFrames > 0 ? deadlineFrames : 1)
+        , m_quarantineFrames(quarantineFrames > 0 ? quarantineFrames : 0)
+    {}
+
+    // Addresses this machine will carry. 0x00..0x3E: six bits, minus 0x3F,
+    // which the radio uses to SAY "refused" and which is also the extended-
+    // address escape. Requesting it would make a refusal and an answer the
+    // same bytes.
+    [[nodiscard]] static constexpr bool isRequestableAddress(int addr) noexcept
+    {
+        return addr >= 0 && addr < kRespAddrError;
+    }
+
+    // Take the one outstanding slot. Returns FALSE — and changes nothing — if
+    // the machine is not Idle, or the address is not requestable.
+    //
+    // [[nodiscard]] on purpose. A refused request that is treated as sent is the
+    // bug this whole class exists to prevent, and the compiler can catch it.
+    [[nodiscard]] bool arm(const Request& r) noexcept;
+
+    [[nodiscard]] State state() const noexcept { return m_state; }
+    [[nodiscard]] const Request& outstanding() const noexcept { return m_request; }
+
+    // The C&C bank to put on the wire, with the RQST bit set. Non-empty ONLY in
+    // Queued, so a caller that polls it every EP2 frame sends the request
+    // exactly once and never re-requests from the round robin.
+    //
+    // MOX IS NOT SET HERE and cannot be: ccRegister() shifts the address left,
+    // leaving C0[0] clear, and withRespRqst() touches C0[7] only. Keying stays
+    // the sole business of MetisClient's transmit gate.
+    [[nodiscard]] std::optional<Cc> wireBank() const noexcept;
+
+    // Call when the bank from wireBank() has actually been handed to the
+    // socket. Queued -> Awaiting; this is when the deadline starts counting,
+    // because a request still sitting behind a one-shot queue has not yet given
+    // the radio anything to answer.
+    void onRequestSent() noexcept;
+
+    // Advance one EP6 FRAME — one response slot. Drives both the deadline and
+    // the quarantine. Call it once per 512-byte frame, not once per packet.
+    void onEp6Frame() noexcept;
+
+    // Offer a decoded EP6 response. Returns true if it was consumed as this
+    // request's reply.
+    //
+    // Non-ACK responses are not this machine's business and are rejected
+    // without comment — they are the free-running telemetry cycle. An ACK that
+    // does not match, or that arrives with nothing outstanding, is counted as
+    // stale and dropped: see staleAcks().
+    bool onResponse(const Ep6Response& r) noexcept;
+
+    // The matching judgement, exposed because it is the part most worth
+    // testing directly and most dangerous to get wrong.
+    [[nodiscard]] bool matches(const Ep6Response& r) const noexcept;
+
+    // The verdict, once. Settled -> Idle for an answer or a refusal; Settled ->
+    // Quarantine for a timeout, because the radio may still answer the request
+    // we just gave up on.
+    [[nodiscard]] std::optional<Reply> takeReply() noexcept;
+
+    // Forget everything, quarantine included. For a link that went down: the
+    // radio's response register does not survive a metis-stop, and a stream
+    // that has restarted cannot deliver a reply from before it.
+    void reset() noexcept;
+
+    // Counters. staleAcks() is the one to watch: it is non-zero exactly when
+    // something answered that nothing had asked for, which on this protocol
+    // means either a reply we abandoned or a second client on the same radio.
+    [[nodiscard]] std::uint64_t answered() const noexcept { return m_answered; }
+    [[nodiscard]] std::uint64_t refusals() const noexcept { return m_refusals; }
+    [[nodiscard]] std::uint64_t timeouts() const noexcept { return m_timeouts; }
+    [[nodiscard]] std::uint64_t staleAcks() const noexcept { return m_staleAcks; }
+
+private:
+    void settle(Outcome outcome, std::uint32_t data) noexcept;
+
+    State   m_state = State::Idle;
+    Request m_request{};
+    Reply   m_reply{};
+    int     m_framesLeft = 0;          // deadline in Awaiting, quarantine in Quarantine
+
+    int m_deadlineFrames   = kDefaultDeadlineFrames;
+    int m_quarantineFrames = kDefaultQuarantineFrames;
+
+    std::uint64_t m_answered  = 0;
+    std::uint64_t m_refusals  = 0;
+    std::uint64_t m_timeouts  = 0;
+    std::uint64_t m_staleAcks = 0;
+};
+
+}  // namespace AetherSDR::hl2

--- a/src/core/backends/hl2/Hl2ControlRequest.h
+++ b/src/core/backends/hl2/Hl2ControlRequest.h
@@ -50,24 +50,63 @@
 //  3. A LATE REPLY IS INDISTINGUISHABLE FROM A TIMELY ONE. With no id, an
 //     answer to a request we gave up on looks identical to an answer to the
 //     request we just made — IF the two can ever be in flight together.
-//     --> they cannot be, by construction. A deadline that expires does not
-//         return the machine to Idle; it moves it to Quarantine, where every
-//         ACK is swallowed and counted, and arm() stays refused until the
-//         quarantine elapses. The abandoned reply has nowhere to land but
-//         Quarantine. This is the piece an RPC layer would have optimised away.
+//     --> Quarantine makes that UNLIKELY. It does not make it impossible, and
+//         an earlier version of this comment claimed it did. A deadline that
+//         expires does not return the machine to Idle; it moves it to
+//         Quarantine, where every ACK is swallowed and counted, and arm() stays
+//         refused until the quarantine elapses. So a late reply has nowhere to
+//         land FOR AS LONG AS THE QUARANTINE LASTS — and how long that is in
+//         wall-clock terms is the whole of the guarantee. See the clock note
+//         below; it is why there is a wall-clock floor and not only a frame
+//         count. What survives even the floor: a caller that re-issues the
+//         IDENTICAL request (same address, same data) after a timeout is asking
+//         for a reply that is byte-for-byte the abandoned one, and no amount of
+//         matching can separate those two. Echo::SubsystemRead is weaker still,
+//         which is why MetisClient::requestRegister refuses it outright today.
 //
 // ---------------------------------------------------------------------------
 // TWO MORE FACTS THE WIRE IMPOSES
 // ---------------------------------------------------------------------------
 //
-// THE CLOCK IS EP6 FRAMES, NOT MILLISECONDS. resp_rqst toggles once per
-// 512-byte EP6 frame (usopenhpsdr1.v, SYNC_RESP) and the whole EP6 emit path is
-// gated on `run`. An idle radio answers discovery and nothing else: no stream,
-// no response slots, no replies, for ever. A wall-clock deadline would report
-// "the radio timed out" for a condition that is really "we never gave it an
-// opportunity to answer" — and would expire faster at 384 kHz than at 48 kHz
-// for no reason on the radio's side. So the deadline is counted in the radio's
-// own response slots, fed by onEp6Frame().
+// THE CLOCK IS EP6 FRAMES — AND A FRAME IS NOT A FIXED AMOUNT OF TIME.
+// resp_rqst toggles once per 512-byte EP6 frame (usopenhpsdr1.v, SYNC_RESP) and
+// the whole EP6 emit path is gated on `run`. An idle radio answers discovery
+// and nothing else: no stream, no response slots, no replies, for ever. A
+// deadline in pure wall-clock would report "the radio timed out" for a
+// condition that is really "we never gave it an opportunity to answer". That is
+// why the frame count exists and why it stays.
+//
+// BUT THE FRAME COUNT ALONE WAS WRONG, and the error is worth naming because it
+// is the shape of error this file keeps making: a number that is true in ONE
+// configuration, quoted as if it were general. A frame carries
+// `504 / (6*numRx + 2)` rounds, so frames per second rise with BOTH the sample
+// rate and the receiver count. Computed from MetisProtocol.h's own geometry and
+// filtered by maxReceiversAtRate()'s 70 Mbit/s budget, 32 frames is:
+//
+//      rate    numRx   rounds/frame   frames/s   32 frames   +32 quarantine
+//      48 k      1          63           762      42.0 ms       84.0 ms
+//      96 k      4          19         5,053       6.33 ms      12.7 ms
+//     192 k      2          36         5,333       6.0 ms       12.0 ms
+//     192 k      4          19        10,105       3.17 ms       6.33 ms
+//     384 k      1          63         6,095       5.25 ms      10.5 ms
+//     384 k      3          25        15,360       2.08 ms       4.17 ms
+//
+// The old comment sized the constant at the FIRST ROW and described the result
+// as "~42 ms". Across the configurations Hl2Backend actually offers that is a
+// twentyfold spread, and the short end is the problem: what eats the deadline
+// is HOST-SIDE delivery latency, which is wall-clock and which the frame count
+// cannot see. Every frame drained after onRequestSent() counts against the
+// deadline, including frames the radio emitted BEFORE it saw the request and
+// which were still sitting in the socket buffer. docs/HERMES.md records a
+// 6.08 ms worst-case EP6 inter-arrival gap; at 384 kHz with three receivers one
+// gap that size is ~93 frames, drained in a single onReadyRead() pass — the
+// whole deadline AND the whole quarantine, before the radio's reply could be
+// read at all.
+//
+// So the deadline is BOTH: the frame count (no stream, no timeout) AND a
+// wall-clock floor that must also elapse. The clock is PASSED IN, not read
+// here, so this class stays pure and a test can pin any rate it likes with no
+// real time passing.
 //
 // THERE IS NO READ-ONLY REQUEST. Bit 7 does not mean "read". The gateware
 // applies the write regardless and then echoes it; the only commands whose
@@ -90,15 +129,31 @@ public:
         // this request rather than to the last one at the same register.
         Exact,
         // A command whose reply carries the value READ rather than the bytes
-        // written: the AD9866 SPI command (0x3b) and both I2C buses (0x3c
-        // internal, 0x3d the external companion bus — MetisProtocol.h documents
-        // TWO, and picking Echo::Exact for either would silently throw away the
-        // data half of the match). Of those, only 0x3b is reachable through
-        // MetisClient::requestRegister's allow-list today.
+        // written. On this gateware that is the I2C buses and ONLY the I2C
+        // buses — 0x3c (internal: Versa clock, AD9866) and 0x3d (the external
+        // companion bus). MetisProtocol.h documents both, and picking
+        // Echo::Exact for either would silently throw away the data half of the
+        // match.
+        //
+        // NOT 0x3b. An earlier version of this comment said the AD9866 SPI
+        // command read a converter register back; it does not, and the RTL is
+        // explicit about it. `control.v`'s RESP_READ has only one data source:
+        //
+        //     end else if (~cmd_ack_ad9866) begin
+        //       resp_cmd_data_next = cmd_resp_data_i2c; // FIXME: suppor read cmd_resp_data_ad9866
+        //
+        // — the I2C bus's data, with the gateware's own FIXME saying the AD9866
+        // read is unimplemented. `ad9866ctrl` has no data output to read from
+        // (control.v's instantiation passes cmd_addr/cmd_data/cmd_rqst/cmd_ack
+        // and nothing else; ad9866ctrl.v ties `assign sdo = 1'b0;` and leaves
+        // `//assign dataout` commented out). A 0x3b ACK carries the ECHO
+        // latched in RESP_START, or the 0x3F refusal. NO allow-listed address
+        // is of this shape today, and MetisClient::requestRegister refuses a
+        // caller that asks for one.
         //
         // Only the address can be matched, so such a request is strictly weaker
         // evidence — which is exactly why the quarantine on timeout is not
-        // optional.
+        // optional, and why nothing reaches this mode until an item needs it.
         SubsystemRead,
     };
 
@@ -144,12 +199,9 @@ public:
     // slot is the whole of the latency, and it is one frame at best and two at
     // worst depending on the phase `resp_cnt` happens to be in. Call it two to
     // four frames end to end. 32 frames is therefore SIXTEEN response
-    // opportunities, not thirty-two — still generous enough to absorb an EP2
-    // pacer tick, the round trip and a slow I2C subsystem, and at 48 kHz with
-    // one receiver (63 samples per 512-byte frame) it is ~42 ms, which is short
-    // enough that a genuinely dead request does not strand a caller. The
-    // constant is unchanged because the alternation was already counted; what
-    // was missing was saying so here.
+    // opportunities, not thirty-two — generous in SLOTS at every rate, which is
+    // what this count is for. How long those slots take is the floor's job, not
+    // this constant's; see the table in the class note.
     static constexpr int kDefaultDeadlineFrames = 32;
     // Equal to the deadline: whatever the radio still owes us is released on the
     // next slot after it becomes available, so one more deadline's worth of
@@ -158,10 +210,32 @@ public:
     // would leave a window where a late reply meets a new request.
     static constexpr int kDefaultQuarantineFrames = 32;
 
+    // The wall-clock floor, in milliseconds, that must elapse ALONGSIDE the
+    // frame count before a deadline or a quarantine may expire. Never instead
+    // of it: a stopped stream still times nothing out, because the frames never
+    // come.
+    //
+    // DERIVED, not picked. It is exactly what 32 frames lasts in the one
+    // configuration the frame count was originally sized in — 48 kHz, one
+    // receiver, 63 rounds per 512-byte frame — so the floor's effect is to make
+    // the "~42 ms" this file has always claimed TRUE AT EVERY RATE instead of
+    // true at one of them. It covers the 6.08 ms worst-case EP6 inter-arrival
+    // gap docs/HERMES.md records with about seven times margin, and it does not
+    // lengthen the 48 kHz case at all, which is the case that was already
+    // agreed to be short enough not to strand a caller.
+    static constexpr int kFloorReferenceRateHz = 48000;
+    static constexpr int kDefaultFloorMs =
+        kDefaultDeadlineFrames * ep6RoundsPerFrame(1) * 1000 / kFloorReferenceRateHz;
+    static_assert(kDefaultFloorMs == 42, "the floor is the 48 kHz / 1 RX frame budget");
+
     Hl2ControlRequest() = default;
-    Hl2ControlRequest(int deadlineFrames, int quarantineFrames) noexcept
+    // floorMs is explicit and has no default ON PURPOSE. Omitting the clock is
+    // exactly the bug this ctor exists to stop being reachable by accident; a
+    // test that wants to isolate the frame counting passes 0 and says so.
+    Hl2ControlRequest(int deadlineFrames, int quarantineFrames, int floorMs) noexcept
         : m_deadlineFrames(deadlineFrames > 0 ? deadlineFrames : 1)
         , m_quarantineFrames(quarantineFrames > 0 ? quarantineFrames : 0)
+        , m_floorMs(floorMs > 0 ? floorMs : 0)
     {}
 
     // Addresses this machine will carry. 0x00..0x3E: six bits, minus 0x3F,
@@ -196,11 +270,22 @@ public:
     // socket. Queued -> Awaiting; this is when the deadline starts counting,
     // because a request still sitting behind a one-shot queue has not yet given
     // the radio anything to answer.
-    void onRequestSent() noexcept;
+    //
+    // `nowMs` is a MONOTONIC millisecond count from any origin — it is only ever
+    // differenced. It is passed in rather than read here so that this class has
+    // no clock of its own: see the class note.
+    void onRequestSent(std::int64_t nowMs) noexcept;
 
     // Advance one EP6 FRAME — one response slot. Drives both the deadline and
     // the quarantine. Call it once per 512-byte frame, not once per packet.
-    void onEp6Frame() noexcept;
+    //
+    // A deadline expires only when the frame count has run out AND the
+    // wall-clock floor has passed. Both, never either: the frame count is what
+    // keeps a stopped stream from timing anything out, and the floor is what
+    // keeps a fast stream from timing it out before the answer could physically
+    // have been delivered. `nowMs` must come from the same clock as the value
+    // handed to onRequestSent().
+    void onEp6Frame(std::int64_t nowMs) noexcept;
 
     // Offer a decoded EP6 response. Returns true if it was consumed as this
     // request's reply.
@@ -240,9 +325,15 @@ private:
     Request m_request{};
     Reply   m_reply{};
     int     m_framesLeft = 0;          // deadline in Awaiting, quarantine in Quarantine
+    // The instant the frame count is ALLOWED to expire, on the caller's clock.
+    // Set at onRequestSent() for the deadline and re-set the moment a deadline
+    // blows for the quarantine that follows it — the origin is when we gave up,
+    // which is what the quarantine has to outlast.
+    std::int64_t m_floorAtMs = 0;
 
     int m_deadlineFrames   = kDefaultDeadlineFrames;
     int m_quarantineFrames = kDefaultQuarantineFrames;
+    int m_floorMs          = kDefaultFloorMs;
 
     std::uint64_t m_answered  = 0;
     std::uint64_t m_refusals  = 0;

--- a/src/core/backends/hl2/MetisClient.cpp
+++ b/src/core/backends/hl2/MetisClient.cpp
@@ -337,8 +337,35 @@ void MetisClient::onWatchdogTick()
         // Socket still open but the radio went quiet — surface it as link loss
         // rather than sitting in a permanently "connected" state.
         m_linkUp = false;
+        // And drop the outstanding request with the link, exactly as stop()
+        // does. Hl2ControlRequest::reset()'s own doc says "for a link that went
+        // down", and this is that; leaving the machine Awaiting here made the
+        // asymmetry a lie and, when the silence is a real metis-stop/restart,
+        // reported TimedOut for a request the radio may well have applied
+        // before it went away.
+        dropControlRequest();
         emit linkDown();
     }
+}
+
+void MetisClient::dropControlRequest()
+{
+    // Publish first: a verdict that had already settled is real and was earned
+    // before the link went, so it is not thrown away with it.
+    publishControlVerdict();
+    // Then tell a caller that is still waiting. reset() alone would leave it
+    // waiting for a signal that can no longer be emitted — silence is the one
+    // outcome this seam is not allowed to produce. `refused` is false: the
+    // radio did not refuse, it stopped being reachable, which is the same
+    // no-answer the deadline reports.
+    const auto st = m_ccRequest.state();
+    if (st == Hl2ControlRequest::State::Queued
+        || st == Hl2ControlRequest::State::Awaiting) {
+        emit controlRequestFailed(m_ccRequest.outstanding().addr, /*refused=*/false);
+    }
+    m_ccRequest.reset();
+    // A bank already built but not yet confirmed has nowhere to land now.
+    m_requestOnBuiltPacket = false;
 }
 
 void MetisClient::stop()
@@ -369,7 +396,7 @@ void MetisClient::stop()
     // The radio's response register does not survive a metis-stop, and neither
     // does the quarantine's reason for existing: nothing the next stream
     // delivers can be a reply to a request from this one.
-    m_ccRequest.reset();
+    dropControlRequest();
     if (m_linkUp) {
         m_linkUp = false;
         emit linkDown();
@@ -615,17 +642,55 @@ void MetisClient::requestPipelineReset()
 
 bool MetisClient::requestRegister(int addr, quint32 data, bool subsystemRead)
 {
-    // Addresses whose DATA can transmit or wedge, refused at this layer so that
-    // no caller reaches them by way of a "read". See the header for what a
-    // future writer has to change, and why deleting these is not it.
+    // ---- THE ALLOW-LIST ----
     //
-    //   0x09  TX drive level, onboard PA enable, ATU. ccTxDrive()'s register.
-    //   0x39  sync / reset. Carries the watchdog enable at [27:24] and the
-    //         master enable at [11:8]; writing it wedged a radio once already
-    //         (see requestPipelineReset above).
-    constexpr int kTxDriveAddr = kC0TxDrive >> 1;   // 0x09
-    constexpr int kSyncAddr    = kC0Sync >> 1;      // 0x39
-    if (addr == kTxDriveAddr || addr == kSyncAddr)
+    // These addresses, and nothing else. The SHAPE is the point, and it is a
+    // deliberate inversion of the deny-list this started as: a deny-list FAILS
+    // OPEN — the next person to add a register to the C&C map gets it
+    // RQST-able for free, without having thought about it once — and an
+    // allow-list FAILS CLOSED. Adding an entry is then a reviewable act with a
+    // reason written next to it, which is what the entries below are. There are
+    // zero callers today, so this is the cheapest moment the inversion will
+    // ever have.
+    //
+    // WHAT THIS GUARANTEES, stated narrowly, because the broad version is not
+    // true and a reader who takes it away will be wrong:
+    //
+    //   * none of these three registers emits RF, and none of them reaches
+    //     anything outside the radio's own case. In particular 0x3d (I2C2) is
+    //     NOT here. MetisProtocol.h's IO-board note says what sits on that bus:
+    //     a Raspberry Pi Pico that switches amplifiers, antenna relays and
+    //     transverters. An arbitrary-data RQST there is a direct I2C write to
+    //     that board. It is absent because nothing needs it — not because it
+    //     would be harmless.
+    //
+    //   * 0x0a and 0x0e are RE-ASSERTED by the round robin in
+    //     buildNextControlPacket (the gain slot and the ADC-assign slot), so a
+    //     wrong value written through here self-corrects within one rotation,
+    //     ~16 ms at four receivers. That property is most of why these two are
+    //     the safe ones, and it is exactly what 0x01 (the TX1 NCO) does NOT
+    //     have: this client sends the transmit frequency once per tune and
+    //     never refreshes it, so a bad write there would persist silently until
+    //     the operator moved the dial, with our own idea of the TX frequency
+    //     now wrong. 0x01 is therefore off the list too.
+    //
+    //   * 0x3b is the read path, and the only one: the AD9866 SPI command is
+    //     how a converter register comes BACK off this wire at all
+    //     (`ad9866ctrl.v`, `6'h3b`), and its reply carries the value read
+    //     instead of an echo — pass subsystemRead = true for it.
+    //
+    // 0x09 (TX drive, onboard PA enable, ATU) and 0x39 (sync/reset, which
+    // carries the watchdog enable at [27:24] and the master enable at [11:8],
+    // and which wedged a radio once already — see requestPipelineReset above)
+    // are absent and must not be added unconditionally. A future item that
+    // needs either has to gate it on transmitEnabled() deliberately.
+    static constexpr int kRequestableAddresses[] = {
+        kC0AdcGain >> 1,            // 0x0a  AD9866 RX LNA gain (ccRxGain)
+        kC0AdcAssignOrTxGain >> 1,  // 0x0e  ADC assign / TX LNA gain (ccAdcAssign)
+        kC0Ad9866Spi >> 1,          // 0x3b  AD9866 SPI — the subsystem read path
+    };
+    if (std::find(std::begin(kRequestableAddresses), std::end(kRequestableAddresses), addr)
+        == std::end(kRequestableAddresses))
         return false;
 
     // Response slots live inside the EP6 frame, and the EP6 emit path is gated
@@ -766,6 +831,10 @@ void MetisClient::flushTxIq()
 std::array<std::uint8_t, kUsbPacketSize> MetisClient::buildNextControlPacket()
 {
     static const Cc kCcAdc = ccAdcAssign();
+    // Cleared here rather than only on confirmation: a packet built and then
+    // thrown away (a test, or a caller that inspects the bytes) must not leave
+    // a stale claim that some later packet carried the request.
+    m_requestOnBuiltPacket = false;
     Cc b;
     if (!m_oneShot.empty()) {
         b = m_oneShot.front();
@@ -781,7 +850,17 @@ std::array<std::uint8_t, kUsbPacketSize> MetisClient::buildNextControlPacket()
         // per armed request — the RQST bit never reaches a bank the round robin
         // re-asserts, which would re-request three times a rotation for ever.
         b = *rqst;
-        m_ccRequest.onRequestSent();
+        // NOT onRequestSent() here: this packet has not been handed to the
+        // socket yet, and Hl2ControlRequest::onRequestSent()'s own contract says
+        // "when the bank has actually been handed to the socket". Starting the
+        // deadline at build time makes a FAILED send indistinguishable from a
+        // radio that did not answer — the request would have left Queued, so it
+        // could never go out on a later frame, and the caller would be told
+        // "timed out" after 32 frames plus 32 more of quarantine for a command
+        // the radio never saw. onControlPacketSent() does it instead, after
+        // sendTo() reports a write; a failed send leaves the request Queued and
+        // it goes out on the next EP2 frame.
+        m_requestOnBuiltPacket = true;
     } else {
         // The rotation is every receiver's NCO, then gain, then ADC assignment:
         // numRx + 2 slots. Each receiver's NCO is RE-ASSERTED rather than sent
@@ -866,6 +945,16 @@ std::array<std::uint8_t, kUsbPacketSize> MetisClient::buildNextControlPacket()
     return pkt;
 }
 
+void MetisClient::onControlPacketSent(qint64 bytesWritten) noexcept
+{
+    // Consumed either way: the claim belongs to the packet just built, and a
+    // send that failed must not leave it standing for the next one.
+    const bool carriedRequest = m_requestOnBuiltPacket;
+    m_requestOnBuiltPacket = false;
+    if (carriedRequest && bytesWritten > 0)
+        m_ccRequest.onRequestSent();
+}
+
 void MetisClient::sendControlPacket()
 {
     if (!m_socket)
@@ -878,7 +967,12 @@ void MetisClient::sendControlPacket()
     // device leaves every receiver unassigned (and therefore emits all-zero IQ)
     // until it has seen it. Re-asserting it rather than sending it once keeps a
     // device that reconnects or resets mid-session from silently going quiet.
-    countTx(sendTo(*m_socket, buildNextControlPacket(), m_host, m_port));
+    const qint64 written = sendTo(*m_socket, buildNextControlPacket(), m_host, m_port);
+    countTx(written);
+    // AFTER the write, and taking its return value: this is the seam where a
+    // RQST bank stops being something we intend to send and becomes something
+    // the radio has been given a chance to answer.
+    onControlPacketSent(written);
 }
 
 void MetisClient::countTx(qint64 bytesWritten) noexcept

--- a/src/core/backends/hl2/MetisClient.cpp
+++ b/src/core/backends/hl2/MetisClient.cpp
@@ -366,6 +366,10 @@ void MetisClient::stop()
             && bank[2] == (kI2cStopAtEnd | kIoBoardI2cAddr);
     });
     m_ioBoardTxFreqSent = false;
+    // The radio's response register does not survive a metis-stop, and neither
+    // does the quarantine's reason for existing: nothing the next stream
+    // delivers can be a reply to a request from this one.
+    m_ccRequest.reset();
     if (m_linkUp) {
         m_linkUp = false;
         emit linkDown();
@@ -609,6 +613,64 @@ void MetisClient::requestPipelineReset()
     // on hardware, not just discrete tunes.
 }
 
+bool MetisClient::requestRegister(int addr, quint32 data, bool subsystemRead)
+{
+    // Addresses whose DATA can transmit or wedge, refused at this layer so that
+    // no caller reaches them by way of a "read". See the header for what a
+    // future writer has to change, and why deleting these is not it.
+    //
+    //   0x09  TX drive level, onboard PA enable, ATU. ccTxDrive()'s register.
+    //   0x39  sync / reset. Carries the watchdog enable at [27:24] and the
+    //         master enable at [11:8]; writing it wedged a radio once already
+    //         (see requestPipelineReset above).
+    constexpr int kTxDriveAddr = kC0TxDrive >> 1;   // 0x09
+    constexpr int kSyncAddr    = kC0Sync >> 1;      // 0x39
+    if (addr == kTxDriveAddr || addr == kSyncAddr)
+        return false;
+
+    // Response slots live inside the EP6 frame, and the EP6 emit path is gated
+    // on `run`. Before the stream is up there is no clock on which a reply
+    // could arrive, so arming here would guarantee a timeout and blame the
+    // radio for it.
+    if (!m_running || !m_linkUp)
+        return false;
+
+    Hl2ControlRequest::Request r;
+    r.addr = addr;
+    r.data = data;
+    r.echo = subsystemRead ? Hl2ControlRequest::Echo::SubsystemRead
+                           : Hl2ControlRequest::Echo::Exact;
+    return m_ccRequest.arm(r);
+}
+
+void MetisClient::publishControlVerdict()
+{
+    const auto reply = m_ccRequest.takeReply();
+    if (!reply)
+        return;
+    if (reply->outcome == Hl2ControlRequest::Outcome::Answered) {
+        emit controlReplyReady(reply->addr, reply->data);
+    } else {
+        emit controlRequestFailed(
+            reply->addr, reply->outcome == Hl2ControlRequest::Outcome::Refused);
+    }
+}
+
+void MetisClient::tickControlRequest()
+{
+    // ONE CALL PER EP6 FRAME, not per packet: the gateware opens exactly one
+    // response slot per 512-byte frame (usopenhpsdr1.v, SYNC_RESP), so this is
+    // the same clock the radio answers on.
+    m_ccRequest.onEp6Frame();
+    publishControlVerdict();
+}
+
+void MetisClient::ingestControlResponse(const Ep6Response& resp)
+{
+    m_ccRequest.onResponse(resp);
+    publishControlVerdict();
+}
+
 void MetisClient::setMox(bool keyed)
 {
     if (keyed && !m_txAllowed) {
@@ -708,6 +770,18 @@ std::array<std::uint8_t, kUsbPacketSize> MetisClient::buildNextControlPacket()
     if (!m_oneShot.empty()) {
         b = m_oneShot.front();
         m_oneShot.pop_front();
+    } else if (const auto rqst = m_ccRequest.wireBank()) {
+        // AFTER the one-shots, ahead of the round robin. After, because a
+        // one-shot is a write the operator asked for and a read-back that
+        // overtook it would return the value from before the change. Ahead of
+        // the rotation, because the rotation never ends and the request would
+        // otherwise never go out.
+        //
+        // wireBank() is non-empty only in Queued, so this fires exactly once
+        // per armed request — the RQST bit never reaches a bank the round robin
+        // re-asserts, which would re-request three times a rotation for ever.
+        b = *rqst;
+        m_ccRequest.onRequestSent();
     } else {
         // The rotation is every receiver's NCO, then gain, then ADC assignment:
         // numRx + 2 slots. Each receiver's NCO is RE-ASSERTED rather than sent
@@ -926,9 +1000,23 @@ void MetisClient::onReadyRead()
             if (bytes.size() < fs + 8)
                 break;
             if (const auto resp = parseEp6Response(bytes.data() + fs)) {
-                m_telemetry.apply(*resp);
-                telemetryChanged = true;
+                if (resp->ack) {
+                    // An ACK's raddr is a COMMAND address and its data is our
+                    // own echo. Feeding that to Hl2Telemetry would invent a
+                    // firmware version and a FIFO depth out of bytes we sent;
+                    // Hl2Telemetry::apply refuses it too, belt and braces.
+                    ingestControlResponse(*resp);
+                } else {
+                    m_telemetry.apply(*resp);
+                    telemetryChanged = true;
+                }
             }
+            // One response slot per FRAME, so the RQST deadline advances here
+            // and not once per packet. AFTER the parse, so a reply that lands
+            // on the deadline frame is an answer and not a timeout, and ticked
+            // even when the frame carries no parseable C&C — a frame that
+            // arrived is a slot that passed.
+            tickControlRequest();
         }
         // Coalesce to ~10 Hz: telemetry free-runs continuously, so a frame
         // skipped by the throttle is superseded within the interval and the

--- a/src/core/backends/hl2/MetisClient.cpp
+++ b/src/core/backends/hl2/MetisClient.cpp
@@ -65,6 +65,11 @@ void enableBroadcast(QUdpSocket& s) noexcept
 }  // namespace
 
 MetisClient::MetisClient(QObject* parent) : QObject(parent) {
+    // Started once, here, and never restarted. controlNowMs() differences it
+    // across an outstanding request, so a restart mid-request would move the
+    // wall-clock floor underneath the deadline that is counting against it.
+    m_controlClock.start();
+
     // Telemetry crosses from the I/O thread to the GUI thread as a queued
     // signal argument; without registration Qt drops the emission with only a
     // warning, and the meters would simply never move.
@@ -656,28 +661,64 @@ bool MetisClient::requestRegister(int addr, quint32 data, bool subsystemRead)
     // WHAT THIS GUARANTEES, stated narrowly, because the broad version is not
     // true and a reader who takes it away will be wrong:
     //
-    //   * none of these three registers emits RF, and none of them reaches
-    //     anything outside the radio's own case. In particular 0x3d (I2C2) is
-    //     NOT here. MetisProtocol.h's IO-board note says what sits on that bus:
-    //     a Raspberry Pi Pico that switches amplifiers, antenna relays and
+    //   * neither of these two registers emits RF, and neither reaches anything
+    //     outside the radio's own case. In particular 0x3d (I2C2) is NOT here.
+    //     MetisProtocol.h's IO-board note says what sits on that bus: a
+    //     Raspberry Pi Pico that switches amplifiers, antenna relays and
     //     transverters. An arbitrary-data RQST there is a direct I2C write to
     //     that board. It is absent because nothing needs it — not because it
     //     would be harmless.
     //
-    //   * 0x0a and 0x0e are RE-ASSERTED by the round robin in
-    //     buildNextControlPacket (the gain slot and the ADC-assign slot), so a
-    //     wrong value written through here self-corrects within one rotation,
-    //     ~16 ms at four receivers. That property is most of why these two are
-    //     the safe ones, and it is exactly what 0x01 (the TX1 NCO) does NOT
-    //     have: this client sends the transmit frequency once per tune and
-    //     never refreshes it, so a bad write there would persist silently until
-    //     the operator moved the dial, with our own idea of the TX frequency
-    //     now wrong. 0x01 is therefore off the list too.
+    //   * THE RULE IS RE-ASSERTED-OR-EXCLUDED. 0x0a and 0x0e are RE-ASSERTED by
+    //     the round robin in buildNextControlPacket (the gain slot and the
+    //     ADC-assign slot), so a wrong value written through here self-corrects
+    //     within one rotation, ~16 ms at four receivers. That property is most
+    //     of why these two are the safe ones, and it is exactly what 0x01 (the
+    //     TX1 NCO) does NOT have: this client sends the transmit frequency once
+    //     per tune and never refreshes it, so a bad write there would persist
+    //     silently until the operator moved the dial, with our own idea of the
+    //     TX frequency now wrong. 0x01 is therefore off the list too.
     //
-    //   * 0x3b is the read path, and the only one: the AD9866 SPI command is
-    //     how a converter register comes BACK off this wire at all
-    //     (`ad9866ctrl.v`, `6'h3b`), and its reply carries the value read
-    //     instead of an echo — pass subsystemRead = true for it.
+    // 0x3b WAS ON THIS LIST AND IS NOT ANY MORE. It was admitted as "the
+    // subsystem READ path". Read against `ad9866ctrl.v` — which we hold at
+    // /tmp/hl2/gateware/rtl and which is not vendored in this tree — that
+    // description is wrong twice over, and both corrections point the same way:
+    //
+    //   1. IT IS NOT A READ. `control.v`'s RESP_READ has exactly one data
+    //      source, and for the AD9866 branch it is the WRONG one, with the
+    //      gateware's own note saying so:
+    //          end else if (~cmd_ack_ad9866) begin
+    //            resp_cmd_data_next = cmd_resp_data_i2c; // FIXME: suppor read cmd_resp_data_ad9866
+    //      `ad9866ctrl` has no data output at all — control.v instantiates it
+    //      with cmd_addr/cmd_data/cmd_rqst/cmd_ack and nothing more, and inside,
+    //      `assign sdo = 1'b0;` with `//assign dataout` commented out. A 0x3b
+    //      ACK carries our own echo, or the 0x3F refusal. Never a value.
+    //
+    //   2. IT IS A WRITE, AND IT REACHES THE TRANSMIT PATH. ad9866ctrl.v:
+    //          // Generic AD9866 write
+    //          6'h3b: begin
+    //            if (cmd_data[31:24] == 8'h06) begin
+    //              if (rffe_ad9866_sen_n) cmd_state_next = CMD_WRITE;
+    //      and CMD_WRITE puts `{3'b000, cmd_data[20:16], cmd_data[7:0]}` on the
+    //      converter's SPI bus — an ARBITRARY AD9866 register (five bits) with
+    //      an ARBITRARY byte. Among the registers that reaches: 0x0a, which is
+    //      where the gateware's own TX-gain command writes
+    //      (`icmd_data = {5'h0a,4'b0100,tx_gain}`), plus 0x0c (TX interpolation),
+    //      0x0e (IAMP enable) and 0x10/0x11 (TX gain select) from its own
+    //      initarray comments. So "none of these registers emits RF" was
+    //      UNVERIFIED for 0x3b, and against the RTL it is false.
+    //
+    //   3. AND IT PERSISTS HARDER THAN 0x01 DOES. The 0x09 handler issues its
+    //      SPI write only `if (tx_gain != cmd_data[31:28])` against an FPGA-side
+    //      shadow register that a 0x3b write does not touch. So after a 0x3b
+    //      write to AD9866 0x0a the gateware still believes the old gain and
+    //      will NOT re-assert it — the mechanism that would have corrected the
+    //      value is suppressed by its own change detector. By this list's own
+    //      rule that is an exclusion, not a judgement call.
+    //
+    // There are zero callers, so dropping it costs nothing. An item that really
+    // needs converter SPI adds it back deliberately, with the 8'h06 cookie and
+    // the register it means named at the call site.
     //
     // 0x09 (TX drive, onboard PA enable, ATU) and 0x39 (sync/reset, which
     // carries the watchdog enable at [27:24] and the master enable at [11:8],
@@ -687,10 +728,18 @@ bool MetisClient::requestRegister(int addr, quint32 data, bool subsystemRead)
     static constexpr int kRequestableAddresses[] = {
         kC0AdcGain >> 1,            // 0x0a  AD9866 RX LNA gain (ccRxGain)
         kC0AdcAssignOrTxGain >> 1,  // 0x0e  ADC assign / TX LNA gain (ccAdcAssign)
-        kC0Ad9866Spi >> 1,          // 0x3b  AD9866 SPI — the subsystem read path
     };
     if (std::find(std::begin(kRequestableAddresses), std::end(kRequestableAddresses), addr)
         == std::end(kRequestableAddresses))
+        return false;
+
+    // No allow-listed address replies with a READ value: on this gateware only
+    // the I2C buses do (control.v RESP_READ, `cmd_resp_data_i2c`), and neither
+    // is on the list. A caller asking for Echo::SubsystemRead here is asking to
+    // throw away the echo and match on six bits of address alone — which is the
+    // pairing the quarantine narrows but cannot rule out. Refuse rather than
+    // silently downgrade the match.
+    if (subsystemRead)
         return false;
 
     // Response slots live inside the EP6 frame, and the EP6 emit path is gated
@@ -703,8 +752,10 @@ bool MetisClient::requestRegister(int addr, quint32 data, bool subsystemRead)
     Hl2ControlRequest::Request r;
     r.addr = addr;
     r.data = data;
-    r.echo = subsystemRead ? Hl2ControlRequest::Echo::SubsystemRead
-                           : Hl2ControlRequest::Echo::Exact;
+    // Unconditional, because the refusal above has already established that
+    // subsystemRead is false. Every reachable address replies with an echo, so
+    // every request spends it.
+    r.echo = Hl2ControlRequest::Echo::Exact;
     return m_ccRequest.arm(r);
 }
 
@@ -721,12 +772,19 @@ void MetisClient::publishControlVerdict()
     }
 }
 
-void MetisClient::tickControlRequest()
+qint64 MetisClient::controlNowMs() const noexcept
+{
+    return m_controlClock.isValid() ? m_controlClock.elapsed() : 0;
+}
+
+void MetisClient::tickControlRequest(qint64 nowMs)
 {
     // ONE CALL PER EP6 FRAME, not per packet: the gateware opens exactly one
     // response slot per 512-byte frame (usopenhpsdr1.v, SYNC_RESP), so this is
-    // the same clock the radio answers on.
-    m_ccRequest.onEp6Frame();
+    // the same clock the radio answers on. The wall clock rides alongside it
+    // because a frame is not a fixed amount of time — see Hl2ControlRequest's
+    // class note for the rate table.
+    m_ccRequest.onEp6Frame(nowMs);
     publishControlVerdict();
 }
 
@@ -945,14 +1003,14 @@ std::array<std::uint8_t, kUsbPacketSize> MetisClient::buildNextControlPacket()
     return pkt;
 }
 
-void MetisClient::onControlPacketSent(qint64 bytesWritten) noexcept
+void MetisClient::onControlPacketSent(qint64 bytesWritten, qint64 nowMs) noexcept
 {
     // Consumed either way: the claim belongs to the packet just built, and a
     // send that failed must not leave it standing for the next one.
     const bool carriedRequest = m_requestOnBuiltPacket;
     m_requestOnBuiltPacket = false;
     if (carriedRequest && bytesWritten > 0)
-        m_ccRequest.onRequestSent();
+        m_ccRequest.onRequestSent(nowMs);
 }
 
 void MetisClient::sendControlPacket()
@@ -972,7 +1030,7 @@ void MetisClient::sendControlPacket()
     // AFTER the write, and taking its return value: this is the seam where a
     // RQST bank stops being something we intend to send and becomes something
     // the radio has been given a chance to answer.
-    onControlPacketSent(written);
+    onControlPacketSent(written, controlNowMs());
 }
 
 void MetisClient::countTx(qint64 bytesWritten) noexcept
@@ -1110,7 +1168,7 @@ void MetisClient::onReadyRead()
             // on the deadline frame is an answer and not a timeout, and ticked
             // even when the frame carries no parseable C&C — a frame that
             // arrived is a slot that passed.
-            tickControlRequest();
+            tickControlRequest(controlNowMs());
         }
         // Coalesce to ~10 Hz: telemetry free-runs continuously, so a frame
         // skipped by the throttle is superseded within the interval and the

--- a/src/core/backends/hl2/MetisClient.h
+++ b/src/core/backends/hl2/MetisClient.h
@@ -210,11 +210,12 @@ public:
     //     the set of RQST-able addresses is enumerated, so an address nobody
     //     considered is refused by default rather than permitted by default.
     //
-    // TODAY THAT LIST IS 0x0a (AD9866 RX LNA gain), 0x0e (ADC assign / TX LNA
-    // gain) and 0x3b (AD9866 SPI, the subsystem read path). The reason for each,
-    // and the reason for the ones deliberately left off — 0x01 the TX NCO,
-    // 0x09 TX drive/PA, 0x39 sync/reset, 0x3c/0x3d the two I2C buses — is
-    // written at the list itself. Read it before adding one.
+    // TODAY THAT LIST IS 0x0a (AD9866 RX LNA gain) and 0x0e (ADC assign / TX
+    // LNA gain). Both are RE-ASSERTED by the round robin, which is the rule the
+    // list is built on. The reason for each, and the reason for the ones
+    // deliberately left off — 0x01 the TX NCO, 0x09 TX drive/PA, 0x39
+    // sync/reset, 0x3b the raw AD9866 SPI write, 0x3c/0x3d the two I2C buses —
+    // is written at the list itself. Read it before adding one.
     //
     // WHAT IS GUARANTEED, exactly. This method cannot key a transmitter:
     // ccRegister() leaves C0[0] clear, the RQST bit is C0[7], and withRespRqst()
@@ -226,11 +227,14 @@ public:
     // widens the blast radius; widening it is not a refactor.
     //
     // `subsystemRead` selects Hl2ControlRequest::Echo::SubsystemRead, whose
-    // reply carries the value READ instead of an echo of what was written. Of
-    // the allow-listed addresses only 0x3b is of that shape; the two I2C
-    // commands (0x3c/0x3d) are as well, and are not reachable from here.
-    // Wrong on an ordinary register it would throw away the data half of the
-    // echo match, leaving a six-bit address as the whole correspondence.
+    // reply carries the value READ instead of an echo of what was written. On
+    // this gateware that is the two I2C commands (0x3c/0x3d) and nothing else,
+    // and neither is on the allow-list — so TODAY THIS ARGUMENT IS REFUSED, not
+    // honoured. It stays in the signature because the shape is right and item
+    // 19's config EEPROM will need it; it is refused because on an address
+    // whose reply IS an echo it would discard the data half of the match and
+    // leave a six-bit address as the whole correspondence, which is precisely
+    // the pairing the quarantine cannot always catch.
     Q_INVOKABLE bool requestRegister(int addr, quint32 data, bool subsystemRead = false);
 
     // I/O-THREAD ONLY, like linkCounters(). Returned by reference because the
@@ -399,8 +403,16 @@ private:
     // — see MetisClientTestAccess.
     void ingestControlResponse(const Ep6Response& resp);
     // Advance the RQST/ACK deadline by one EP6 frame and publish any verdict
-    // that falls out — a timeout has no ACK to carry it.
-    void tickControlRequest();
+    // that falls out — a timeout has no ACK to carry it. `nowMs` is the
+    // wall-clock half of the deadline: a frame count alone is 2.08 ms at
+    // 384 kHz with three receivers, which is inside a single recorded delivery
+    // gap. Passed in rather than read inside Hl2ControlRequest so that class
+    // keeps no clock, and passed in HERE rather than read inside this method so
+    // the socket-free tests can pin a rate without real time passing.
+    void tickControlRequest(qint64 nowMs);
+    // Monotonic milliseconds for the two calls above. Origin is arbitrary — the
+    // value is only ever differenced inside Hl2ControlRequest.
+    [[nodiscard]] qint64 controlNowMs() const noexcept;
     // Emit whatever verdict the machine has settled, if any.
     void publishControlVerdict();
     // Confirm that the packet buildNextControlPacket() just produced reached the
@@ -410,7 +422,9 @@ private:
     // makes Hl2ControlRequest::onRequestSent()'s "handed to the socket" true
     // rather than aspirational. Exposed to MetisClientTestAccess so the
     // socket-free tests drive the same two-step seam the transport does.
-    void onControlPacketSent(qint64 bytesWritten) noexcept;
+    // `nowMs` starts the deadline's wall-clock floor and must come from the
+    // same clock as tickControlRequest()'s.
+    void onControlPacketSent(qint64 bytesWritten, qint64 nowMs) noexcept;
     // Give up the outstanding request because the stream it belonged to is
     // gone: publish anything already settled, tell a caller that is still
     // waiting, then reset. Used by stop() and by the silence watchdog's
@@ -449,6 +463,10 @@ private:
     int     m_startAttempts = 0;          // start datagrams sent this connect
     QElapsedTimer m_ep2Clock;             // pacer reference clock
     QElapsedTimer m_sinceLastEp6;         // silence detection
+    // Free-running from construction and never restarted: the RQST/ACK floor
+    // differences it, so it must not be reset under an outstanding request the
+    // way m_sinceLastEp6 is per packet.
+    QElapsedTimer m_controlClock;
     quint64 m_ep2Sent = 0;                // EP2 frames sent since m_ep2Clock
     qint64  m_ep2IntervalUs = 2625;       // derived from the sample rate
     bool    m_watchdogEnabled = true;     // gateware watchdog (anti-wedge)

--- a/src/core/backends/hl2/MetisClient.h
+++ b/src/core/backends/hl2/MetisClient.h
@@ -12,6 +12,7 @@
 #include <deque>
 #include <vector>
 
+#include "core/backends/hl2/Hl2ControlRequest.h"
 #include "core/backends/hl2/MetisProtocol.h"
 
 class QUdpSocket;
@@ -191,6 +192,47 @@ public:
     // on the next EP2 frame, ahead of the round robin.
     Q_INVOKABLE void requestPipelineReset();
 
+    // ---- RQST/ACK (docs/HERMES.md §13 item 13, oracle §5) ----
+    //
+    // Ask the radio to acknowledge one C&C register write. Read
+    // Hl2ControlRequest's header before using this: it is NOT a read, NOT an
+    // RPC, and it can be refused for four separate reasons, all of which a
+    // caller has to be prepared for.
+    //
+    // Returns FALSE, having sent nothing, when:
+    //   - the stream is not running or no EP6 has arrived. Response slots exist
+    //     only inside the EP6 frame the radio emits while `run` is set, so an
+    //     idle radio would never answer and reporting a timeout for that would
+    //     be a lie about the hardware;
+    //   - a request is already outstanding (single outstanding, no queue);
+    //   - a previous request timed out and its quarantine has not elapsed;
+    //   - the address is not requestable — six bits, and not the 0x3F the radio
+    //     uses to say "refused", and not one of the transmit-capable registers
+    //     below.
+    //
+    // NOTHING HERE CAN KEY A TRANSMITTER, and that is enforced in three places
+    // rather than asserted once: ccRegister() leaves C0[0] clear, the RQST bit
+    // is C0[7] and withRespRqst() touches nothing else, and this method refuses
+    // outright the two addresses whose DATA can put RF out of the socket or
+    // wedge the board — 0x09 (TX drive, PA enable, ATU) and 0x39 (sync/reset,
+    // which carries the watchdog and master enables and has wedged a radio).
+    // A future item that needs to write either must make those refusals
+    // conditional on transmitEnabled(), not delete them.
+    //
+    // `subsystemRead` selects Hl2ControlRequest::Echo::SubsystemRead, for the
+    // AD9866 SPI (0x3b) and I2C (0x3c) commands whose reply carries the value
+    // read instead of an echo. Wrong on an ordinary register, it would throw
+    // away the data half of the echo match.
+    Q_INVOKABLE bool requestRegister(int addr, quint32 data, bool subsystemRead = false);
+
+    // I/O-THREAD ONLY, like linkCounters(). Returned by reference because the
+    // machine holds no implicitly-shared members; GUI-thread consumers read the
+    // controlReply* signals instead.
+    [[nodiscard]] const Hl2ControlRequest& controlRequest() const noexcept
+    {
+        return m_ccRequest;
+    }
+
     // Receivers this client can both RUN and TUNE: the RX1..RX7 NCO registers
     // are one contiguous run (0x02..0x08) and RX8..RX12 are not. See ccRxFreq().
     static constexpr int kMaxTunableRx = 7;
@@ -309,6 +351,18 @@ signals:
     // unreachable, or already streaming to a different client.
     void connectFailed(const QString& reason);
 
+    // A RQST issued through requestRegister() was acknowledged. `addr` is the
+    // address ASKED FOR, not the one in the ACK, so a caller never has to
+    // reason about the 0x3F refusal encoding; `data` is the register's echo,
+    // or the read value for a subsystem read.
+    void controlReplyReady(int addr, quint32 data);
+    // A RQST did not come back. `refused` distinguishes the radio saying no (a
+    // subsystem was not ready) from the radio saying nothing at all. Both are
+    // ordinary outcomes on this protocol, not errors — and after a timeout the
+    // machine is in quarantine, so the next requestRegister() will refuse for
+    // a while. Consumers must not retry immediately in this handler.
+    void controlRequestFailed(int addr, bool refused);
+
 private slots:
     void onReadyRead();
     void onEp2PacerTick();
@@ -331,6 +385,16 @@ private:
     // real C&C frame; a stream started before any C&C has landed emits ADC-idle
     // samples (Q pinned to zero) until one does.
     void sendPrimingBurst(int countPerBank);
+    // Offer one decoded EP6 C&C response to the RQST/ACK machine and publish
+    // whatever verdict that produces. Separated from the datagram loop so a
+    // test can drive the reply path with a synthetic Ep6Response and no socket
+    // — see MetisClientTestAccess.
+    void ingestControlResponse(const Ep6Response& resp);
+    // Advance the RQST/ACK deadline by one EP6 frame and publish any verdict
+    // that falls out — a timeout has no ACK to carry it.
+    void tickControlRequest();
+    // Emit whatever verdict the machine has settled, if any.
+    void publishControlVerdict();
 
     // EP2 cadence follows the frame geometry, not the EP6 arrival rate: the
     // radio consumes one EP2 frame per kTxSamplesPerPacket samples, so at 48 kHz
@@ -405,6 +469,10 @@ private:
     // rotation to come back around.
     friend struct MetisClientTestAccess; // socket-free transport-state injection
     std::deque<Cc> m_oneShot;           // which register pair to send next
+    // The single RQST slot. Drained AFTER m_oneShot, never before: a one-shot is
+    // a write the operator asked for, and letting a read-back overtake it would
+    // answer with the value from before the change.
+    Hl2ControlRequest m_ccRequest;
     // Last transmit frequency handed to the IO board, and whether one ever was.
     // A separate flag rather than a 0 sentinel: 0 Hz is not a plausible tuned
     // frequency, but "never sent" still has to survive a radio that legitimately

--- a/src/core/backends/hl2/MetisClient.h
+++ b/src/core/backends/hl2/MetisClient.h
@@ -206,23 +206,31 @@ public:
     //     be a lie about the hardware;
     //   - a request is already outstanding (single outstanding, no queue);
     //   - a previous request timed out and its quarantine has not elapsed;
-    //   - the address is not requestable — six bits, and not the 0x3F the radio
-    //     uses to say "refused", and not one of the transmit-capable registers
-    //     below.
+    //   - the address is not on the ALLOW-LIST in the .cpp. Not a deny-list:
+    //     the set of RQST-able addresses is enumerated, so an address nobody
+    //     considered is refused by default rather than permitted by default.
     //
-    // NOTHING HERE CAN KEY A TRANSMITTER, and that is enforced in three places
-    // rather than asserted once: ccRegister() leaves C0[0] clear, the RQST bit
-    // is C0[7] and withRespRqst() touches nothing else, and this method refuses
-    // outright the two addresses whose DATA can put RF out of the socket or
-    // wedge the board — 0x09 (TX drive, PA enable, ATU) and 0x39 (sync/reset,
-    // which carries the watchdog and master enables and has wedged a radio).
-    // A future item that needs to write either must make those refusals
-    // conditional on transmitEnabled(), not delete them.
+    // TODAY THAT LIST IS 0x0a (AD9866 RX LNA gain), 0x0e (ADC assign / TX LNA
+    // gain) and 0x3b (AD9866 SPI, the subsystem read path). The reason for each,
+    // and the reason for the ones deliberately left off — 0x01 the TX NCO,
+    // 0x09 TX drive/PA, 0x39 sync/reset, 0x3c/0x3d the two I2C buses — is
+    // written at the list itself. Read it before adding one.
     //
-    // `subsystemRead` selects Hl2ControlRequest::Echo::SubsystemRead, for the
-    // AD9866 SPI (0x3b) and I2C (0x3c) commands whose reply carries the value
-    // read instead of an echo. Wrong on an ordinary register, it would throw
-    // away the data half of the echo match.
+    // WHAT IS GUARANTEED, exactly. This method cannot key a transmitter:
+    // ccRegister() leaves C0[0] clear, the RQST bit is C0[7], and withRespRqst()
+    // touches nothing else, so the transmit gate is untouched whatever the
+    // address. That is a NARROWER claim than "the dangerous registers are
+    // handled", and the narrow one is the true one — what keeps this method away
+    // from the companion-board I2C bus (amplifiers, antenna relays,
+    // transverters) is the allow-list and nothing else. Widening the list
+    // widens the blast radius; widening it is not a refactor.
+    //
+    // `subsystemRead` selects Hl2ControlRequest::Echo::SubsystemRead, whose
+    // reply carries the value READ instead of an echo of what was written. Of
+    // the allow-listed addresses only 0x3b is of that shape; the two I2C
+    // commands (0x3c/0x3d) are as well, and are not reachable from here.
+    // Wrong on an ordinary register it would throw away the data half of the
+    // echo match, leaving a six-bit address as the whole correspondence.
     Q_INVOKABLE bool requestRegister(int addr, quint32 data, bool subsystemRead = false);
 
     // I/O-THREAD ONLY, like linkCounters(). Returned by reference because the
@@ -395,6 +403,19 @@ private:
     void tickControlRequest();
     // Emit whatever verdict the machine has settled, if any.
     void publishControlVerdict();
+    // Confirm that the packet buildNextControlPacket() just produced reached the
+    // socket, and start the RQST deadline if it carried the request bank. Takes
+    // the socket's return value, so a write the kernel refused leaves the
+    // request Queued for the next frame instead of burning it — which is what
+    // makes Hl2ControlRequest::onRequestSent()'s "handed to the socket" true
+    // rather than aspirational. Exposed to MetisClientTestAccess so the
+    // socket-free tests drive the same two-step seam the transport does.
+    void onControlPacketSent(qint64 bytesWritten) noexcept;
+    // Give up the outstanding request because the stream it belonged to is
+    // gone: publish anything already settled, tell a caller that is still
+    // waiting, then reset. Used by stop() and by the silence watchdog's
+    // link-down, which must behave the same way.
+    void dropControlRequest();
 
     // EP2 cadence follows the frame geometry, not the EP6 arrival rate: the
     // radio consumes one EP2 frame per kTxSamplesPerPacket samples, so at 48 kHz
@@ -473,6 +494,12 @@ private:
     // a write the operator asked for, and letting a read-back overtake it would
     // answer with the value from before the change.
     Hl2ControlRequest m_ccRequest;
+    // Whether the packet buildNextControlPacket() last produced carries the RQST
+    // bank. Lives here rather than being inferred from m_ccRequest's state
+    // because the state is what the confirmation CHANGES: by the time
+    // onControlPacketSent() runs, "is it still Queued" cannot distinguish a
+    // request that went out from one that never did.
+    bool m_requestOnBuiltPacket = false;
     // Last transmit frequency handed to the IO board, and whether one ever was.
     // A separate flag rather than a 0 sentinel: 0 Hz is not a plausible tuned
     // frequency, but "never sent" still has to survive a radio that legitimately

--- a/src/core/backends/hl2/MetisProtocol.cpp
+++ b/src/core/backends/hl2/MetisProtocol.cpp
@@ -129,6 +129,21 @@ Cc ccAdcAssign() noexcept
     return {kC0AdcAssignOrTxGain, 0x00, 0x00, 0x00, 0x00};
 }
 
+Cc ccRegister(int addr, std::uint32_t data) noexcept
+{
+    // Masked, not clamped: an out-of-range address is a caller bug, and the
+    // callers that matter (Hl2ControlRequest::arm) refuse it outright before
+    // reaching here. Masking is the belt to that brace — what it must never do
+    // is let bit 6 of an address spill into the RQST flag at C0[7], or bit 0 of
+    // the shifted byte become MOX.
+    const auto c0 = static_cast<std::uint8_t>((addr & kMaxRegisterAddress) << 1);
+    return {c0,
+            static_cast<std::uint8_t>((data >> 24) & 0xFF),
+            static_cast<std::uint8_t>((data >> 16) & 0xFF),
+            static_cast<std::uint8_t>((data >> 8) & 0xFF),
+            static_cast<std::uint8_t>(data & 0xFF)};
+}
+
 Cc ccPipelineReset() noexcept
 {
     // DATA[7:4] = 0x8 -> C4 = 0x80. Everything else stays zero, which is "no
@@ -243,7 +258,13 @@ std::optional<Ep6Response> parseEp6Response(const std::uint8_t* frame) noexcept
 
 void Hl2Telemetry::apply(const Ep6Response& r) noexcept
 {
+    // PTT first: C0[0] is ptt_resp in BOTH branches of control.v's iresp
+    // composition, so it is the one field an ACK still carries honestly.
     ptt = r.ptt;
+    // Everything below reads `raddr` as a free-running telemetry slot. In an ACK
+    // it is a command address and `data` is our own echo — see the header.
+    if (r.ack)
+        return;
     switch (r.raddr) {
     case 0x00:
         firmwareVersion = static_cast<int>(r.data & 0xFF);

--- a/src/core/backends/hl2/MetisProtocol.cpp
+++ b/src/core/backends/hl2/MetisProtocol.cpp
@@ -260,6 +260,15 @@ void Hl2Telemetry::apply(const Ep6Response& r) noexcept
 {
     // PTT first: C0[0] is ptt_resp in BOTH branches of control.v's iresp
     // composition, so it is the one field an ACK still carries honestly.
+    //
+    // NOT a belt-and-braces PTT path for MetisClient, and the comment used to
+    // imply it was: that client routes every ACK to ingestControlResponse and
+    // never here, so on that wiring this line only ever runs for free-running
+    // telemetry — where every one of control.v's four RADDR slots carries
+    // ptt_resp anyway, so nothing is lost. It is kept
+    // because apply() is a public decoder with other callers and tests, and
+    // because dropping a field an ACK genuinely carries would be the wrong
+    // default for them.
     ptt = r.ptt;
     // Everything below reads `raddr` as a free-running telemetry slot. In an ACK
     // it is a command address and `data` is our own echo — see the header.

--- a/src/core/backends/hl2/MetisProtocol.h
+++ b/src/core/backends/hl2/MetisProtocol.h
@@ -390,12 +390,34 @@ Cc ccTxDrive(int level, bool paEnable = false) noexcept;
 // ordinary register-then-value slave expects. ONE-BYTE WRITES ONLY — there is
 // no burst mode, so an N-byte value costs N C&C banks.
 //
-// RQST (C0[7]) IS DELIBERATELY LEFT CLEAR. The wiki calls it optional for a
-// write, and setting it makes the radio answer with an ACK response — which
-// Hl2Telemetry::apply() dispatches on RADDR *without* consulting the ACK flag.
-// Today an I2C reply (RADDR 0x3c/0x3d) lands harmlessly in its `default:`, but
-// a write that provokes no reply at all cannot perturb the telemetry decoder
-// under any future edit to that switch. This path stays write-only.
+// RQST (C0[7]) IS LEFT CLEAR ON THESE BANKS, AND THE REASON HAS CHANGED.
+//
+// It used to be a decoder hazard: `Hl2Telemetry::apply()` dispatched on RADDR
+// *without* consulting the ACK flag, so an I2C reply (RADDR 0x3c/0x3d) landed
+// harmlessly in its `default:` only by accident of that switch's shape, and any
+// future edit to it could have made an echo of our own outgoing bytes read as
+// telemetry. THAT BUG IS FIXED — `apply()` now returns early on `r.ack`
+// (MetisProtocol.cpp) — so the hazard is closed and is no longer the reason.
+//
+// What decides whether an address may carry RQST now is the ALLOW-LIST in
+// `MetisClient::requestRegister`, and NEITHER 0x3c NOR 0x3d IS ON IT. That is a
+// deliberate omission, not an oversight: an arbitrary-data RQST at 0x3d is a
+// direct I2C write to the companion board described immediately below — the one
+// that switches amplifiers, antenna relays and transverters — and 0x3c reaches
+// the Versa clock that the board's own clocking depends on. Neither is
+// re-asserted by anything, so a wrong value there persists.
+//
+// The encoders in this section therefore stay write-only because nothing needs
+// an acknowledgement for them, and because nothing may ask for one. If a future
+// item does need one, the change is to that allow-list, with a note there
+// saying what the acknowledgement is worth — not a flag added here.
+// addr 0x3b: a raw SPI transaction against the AD9866 itself (gateware
+// `ad9866ctrl.v`, which decodes `6'h3b`). The only path on this wire that can
+// read a converter register BACK — the reply carries the value read rather than
+// an echo of what was written, which is what Hl2ControlRequest::Echo::
+// SubsystemRead exists for. No encoder here yet: nothing writes it, and
+// MetisClient::requestRegister names it only as an allow-listed address.
+inline constexpr std::uint8_t kC0Ad9866Spi = 0x76;  // addr 0x3b << 1
 inline constexpr std::uint8_t kC0I2c1 = 0x78;          // addr 0x3c << 1
 inline constexpr std::uint8_t kC0I2c2 = 0x7A;          // addr 0x3d << 1
 inline constexpr std::uint8_t kI2cCookieWrite = 0x06;  // C1

--- a/src/core/backends/hl2/MetisProtocol.h
+++ b/src/core/backends/hl2/MetisProtocol.h
@@ -160,6 +160,17 @@ inline constexpr std::size_t kTxSampleBytes = 8;
 // C0 register-address bytes (address << 1). Bit 0 is MOX, not part of the
 // address, so every constant here is even and keying is applied separately with
 // withMox() — see kC0MoxBit.
+//
+// The host->radio C0 byte splits THREE ways, not two. dsopenhpsdr1.v decodes it
+// in one state (CMDCTRL):
+//
+//     resprqst <= eth_data[7];      // ask the radio to answer this command
+//     addr     <= eth_data[6:1];    // SIX bits of register address, not seven
+//     ptt      <= eth_data[0];      // MOX
+//
+// so the address space is 0x00..0x3F and bit 7 is a flag, not address bit 6.
+// Nothing below 0x40 collides with it, which is why every constant here has
+// been safe while nothing set it. See kC0RespRqstBit and Hl2ControlRequest.
 inline constexpr std::uint8_t kC0Config = 0x00;   // addr 0x00: sample rate + #RX + ADC select
 inline constexpr std::uint8_t kC0Rx1Freq = 0x04;  // addr 0x02: RX1 NCO frequency (Hz, 32-bit BE)
 inline constexpr std::uint8_t kC0TxFreq  = 0x02;  // addr 0x01: TX1 NCO frequency (Hz, 32-bit BE)
@@ -169,6 +180,30 @@ inline constexpr std::uint8_t kC0TxDrive = 0x12;  // addr 0x09: TX drive level +
 // radio reads it from whatever bank happens to be in flight. So keying is a
 // property of the frame, and every bank has to carry it while transmitting.
 inline constexpr std::uint8_t kC0MoxBit = 0x01;
+
+// C0 bit 7, host->radio: RESPONSE REQUEST. Set it on a C&C bank and the radio
+// answers that one command with an ACK frame on EP6 (C0[7] set there too).
+// Clear on every bank this client has ever sent until Hl2ControlRequest, which
+// is why no ACK has ever arrived and why nothing downstream has had to cope
+// with one.
+//
+// It is NOT a read bit. There is no read-only command in this direction: the
+// gateware latches cmd_data and applies the write whatever bit 7 says, and the
+// response is an ECHO of what was written (control.v, RESP_START:
+// resp_cmd_data_next = cmd_data). The only genuine reads are the AD9866 SPI and
+// I2C subsystem commands, which encode a read opcode inside the data and whose
+// reply carries the read value in place of the echo (RESP_READ).
+inline constexpr std::uint8_t kC0RespRqstBit = 0x80;
+
+// Highest register address the six-bit C0 field can carry.
+inline constexpr int kMaxRegisterAddress = 0x3F;
+
+// Radio->host ACK address meaning "I could not do that". The response FSM
+// substitutes 6'h3f for the command address when a subsystem was not ready
+// (control.v, RESP_ACK), so this is a refusal and not a register. We never
+// REQUEST 0x3F — it is the extended-address escape (see ep2WriteTxIq) — so the
+// two readings never collide on our wire.
+inline constexpr int kRespAddrError = 0x3F;
 
 // TX drive level occupies DATA[31:24] (C1). The Hermes-Lite 2 gateware decodes
 // only the top nibble [31:28], but the byte-wide field is what the reference
@@ -417,6 +452,26 @@ static_assert(kIoBoardTxFreqBanks
                                               - kIoBoardRegTxFreqMsb + 1),
               "IO board frequency bank count must span Msb..Lsb exactly");
 std::array<Cc, kIoBoardTxFreqBanks> ccIoBoardTxFrequency(std::uint64_t hz) noexcept;
+// A C&C bank addressing an arbitrary six-bit register with arbitrary data.
+//
+// Deliberately the last resort, not the first: every register with a known
+// meaning has a named encoder above, and one of those says what it is doing in
+// the call. This exists because Hl2ControlRequest has to be able to address a
+// register the caller names at runtime, and refuses an address outside
+// 0x00..0x3F rather than letting it alias into the RQST bit.
+Cc ccRegister(int addr, std::uint32_t data) noexcept;
+
+// Set or clear the response-request bit (C0 bit 7) on a C&C bank.
+//
+// Orthogonal to withMox(), which touches bit 0 only, so the two compose in
+// either order and neither can set the other's bit.
+inline Cc withRespRqst(Cc cc, bool request) noexcept
+{
+    cc[0] = static_cast<std::uint8_t>(request ? (cc[0] | kC0RespRqstBit)
+                                              : (cc[0] & ~kC0RespRqstBit));
+    return cc;
+}
+
 // Set MOX (C0 bit 0) on a C&C bank. Keying is per-FRAME, so this is applied to
 // whichever bank is being sent rather than to one dedicated register.
 inline Cc withMox(Cc cc, bool keyed) noexcept
@@ -456,6 +511,17 @@ inline constexpr int kTxSamplesPerPacket = 126;
 // The radio free-runs through the classic addresses, so telemetry arrives
 // without asking. Verified against hpsdrsim's responder, whose C0 sequence is
 // 0, 8, 16, 24, 32 — i.e. RADDR 0..4 at C0[6:3].
+//
+// On a real HL2 the free-running address is only TWO bits wide: control.v
+// declares `logic [1:0] resp_addr` and composes C0 as
+// {3'b000, resp_addr, ext_cwkey, 1'b0, ptt_resp}, so C0[6:5] are hardwired zero
+// and the cycle is 0,1,2,3. Reading four bits at C0[6:3] therefore gives the
+// same number on this hardware and stays right on a generic Hermes — but do not
+// expect RADDR 4 from an HL2. Slot 3 is `debug` and carries nothing we consume.
+//
+// ONE RESPONSE SLOT PER EP6 FRAME, not per packet: usopenhpsdr1.v toggles
+// resp_rqst once in SYNC_RESP, which runs once per 512-byte frame. That is the
+// only clock a reply can arrive on, and it stops dead when the stream stops.
 struct Ep6Response {
     bool ack = false;
     int raddr = 0;
@@ -501,6 +567,14 @@ struct Hl2Telemetry {
     bool ptt = false;
 
     // Merge a decoded response in, leaving untouched fields alone.
+    //
+    // IGNORES ACK responses apart from their PTT bit, and that is load-bearing
+    // rather than tidiness. In an ACK, `raddr` is the six-bit address of the
+    // command being answered and `data` is the echo of what we wrote — so an
+    // ACK for register 0x00 would otherwise be decoded here as a firmware
+    // version, an ADC-overload flag and a TX FIFO depth, all invented from our
+    // own outgoing bytes. Harmless until something set the RQST bit; this
+    // guard is what makes it stay harmless now that Hl2ControlRequest does.
     void apply(const Ep6Response& r) noexcept;
 };
 

--- a/src/core/backends/hl2/MetisProtocol.h
+++ b/src/core/backends/hl2/MetisProtocol.h
@@ -412,11 +412,19 @@ Cc ccTxDrive(int level, bool paEnable = false) noexcept;
 // item does need one, the change is to that allow-list, with a note there
 // saying what the acknowledgement is worth — not a flag added here.
 // addr 0x3b: a raw SPI transaction against the AD9866 itself (gateware
-// `ad9866ctrl.v`, which decodes `6'h3b`). The only path on this wire that can
-// read a converter register BACK — the reply carries the value read rather than
-// an echo of what was written, which is what Hl2ControlRequest::Echo::
-// SubsystemRead exists for. No encoder here yet: nothing writes it, and
-// MetisClient::requestRegister names it only as an allow-listed address.
+// `ad9866ctrl.v`, which decodes `6'h3b`). A WRITE, and only a write — an
+// earlier note here called it the read path, which the RTL contradicts:
+// `ad9866ctrl` has no data output, `assign sdo = 1'b0;`, and control.v's
+// RESP_READ carries `cmd_resp_data_i2c` for the AD9866 branch behind the
+// gateware's own `// FIXME: suppor read cmd_resp_data_ad9866`. The reply is our
+// echo or the 0x3F refusal.
+//
+// What it writes: gated on `cmd_data[31:24] == 8'h06`, it puts
+// `{3'b000, cmd_data[20:16], cmd_data[7:0]}` on the converter's SPI bus — any
+// AD9866 register, any byte, INCLUDING the TX-gain register 0x0a that the
+// gateware's own 0x09 handler drives. It is therefore a transmit-path write
+// that nothing re-asserts, and MetisClient::requestRegister does NOT allow-list
+// it. No encoder here either: nothing writes it.
 inline constexpr std::uint8_t kC0Ad9866Spi = 0x76;  // addr 0x3b << 1
 inline constexpr std::uint8_t kC0I2c1 = 0x78;          // addr 0x3c << 1
 inline constexpr std::uint8_t kC0I2c2 = 0x7A;          // addr 0x3d << 1

--- a/tests/hl2_rqst_ack_client_test.cpp
+++ b/tests/hl2_rqst_ack_client_test.cpp
@@ -1,0 +1,266 @@
+// RQST/ACK where it meets the wire: MetisClient's own EP2 packet builder and
+// its EP6 response path. Socket-free — no bind, no peer, no datagrams, no event
+// loop — using the same builder the transport calls and the same response
+// struct parseEp6Response produces.
+//
+// The state machine's own laws are tested in hl2_rqst_ack_test. What is tested
+// HERE is everything that only exists once the machine is attached to a radio:
+// that the request reaches the wire exactly once, that it cannot key a
+// transmitter, that it cannot be issued at a transmit-capable register, that it
+// cannot be issued at all before there is a stream to answer on, and that it
+// does not overtake a write the operator asked for.
+
+#include "core/backends/hl2/Hl2ControlRequest.h"
+#include "core/backends/hl2/MetisClient.h"
+#include "core/backends/hl2/MetisProtocol.h"
+
+#include <QCoreApplication>
+
+#include <array>
+#include <cstdio>
+
+namespace AetherSDR::hl2 {
+struct MetisClientTestAccess {
+    // A client that believes it is streaming and has seen EP6, without either
+    // having happened. Both flags matter: requestRegister() refuses before the
+    // stream is up, because response slots live inside the EP6 frame.
+    static void setStreaming(MetisClient& c) { c.m_running = true; c.m_linkUp = true; }
+    // Drive the reply path with a synthetic response, the way a datagram would.
+    static void feedResponse(MetisClient& c, const Ep6Response& r)
+    {
+        c.ingestControlResponse(r);
+    }
+    // One EP6 frame's worth of deadline, the way a datagram would.
+    static void feedFrame(MetisClient& c) { c.tickControlRequest(); }
+};
+}
+
+using namespace AetherSDR::hl2;
+
+static int g_failures = 0;
+static void check(bool ok, const char* what)
+{
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", what); ++g_failures; }
+}
+
+using Packet = std::array<std::uint8_t, kUsbPacketSize>;
+static constexpr std::size_t kFrameA = 8;
+static constexpr std::size_t kFrameB = 8 + kFrameSize;
+
+static std::uint8_t c0(const Packet& p, std::size_t frame) { return p[frame + 3]; }
+
+static bool anyFrameKeyed(const Packet& p)
+{
+    return (c0(p, kFrameA) & kC0MoxBit) != 0 || (c0(p, kFrameB) & kC0MoxBit) != 0;
+}
+static bool anyFrameRequests(const Packet& p)
+{
+    return (c0(p, kFrameA) & kC0RespRqstBit) != 0 || (c0(p, kFrameB) & kC0RespRqstBit) != 0;
+}
+static std::uint32_t dataOf(const Packet& p, std::size_t frame)
+{
+    return (std::uint32_t(p[frame + 4]) << 24) | (std::uint32_t(p[frame + 5]) << 16)
+         | (std::uint32_t(p[frame + 6]) << 8) | std::uint32_t(p[frame + 7]);
+}
+
+static Ep6Response ack(int raddr, std::uint32_t data)
+{
+    Ep6Response r;
+    r.ack = true;
+    r.raddr = raddr;
+    r.data = data;
+    return r;
+}
+
+// ---------------------------------------------------------------------------
+
+static void testRefusedBeforeThereIsAStream()
+{
+    MetisClient c;
+    // The EP6 emit path is gated on `run` (usopenhpsdr1.v). An idle radio
+    // answers discovery and nothing else, for ever — so arming here would
+    // guarantee a timeout and blame the hardware for our own ordering.
+    check(!c.requestRegister(0x0E, 0), "a request before the stream is up is REFUSED");
+    check(c.controlRequest().state() == Hl2ControlRequest::State::Idle,
+          "and arms nothing");
+    for (int i = 0; i < 16; ++i)
+        check(!anyFrameRequests(c.buildNextControlPacket()),
+              "no RQST bit reaches the wire from a refused request");
+}
+
+static void testTransmitCapableRegistersAreRefused()
+{
+    MetisClient c;
+    MetisClientTestAccess::setStreaming(c);
+    // 0x09 is TX drive level, onboard PA enable and ATU: its DATA is what puts
+    // RF out of the socket. 0x39 is sync/reset, which carries the watchdog and
+    // master enables and has wedged a radio.
+    check(!c.requestRegister(kC0TxDrive >> 1, 0), "0x09 (TX drive / PA) is refused");
+    check(!c.requestRegister(kC0Sync >> 1, 0), "0x39 (sync / reset) is refused");
+    // Refused even with the transmit gate explicitly open: this layer is not
+    // the place that decision gets made, and a future writer must add the
+    // conditional deliberately rather than find it already gone.
+    c.enableTransmit(true);
+    check(!c.requestRegister(kC0TxDrive >> 1, 0), "0x09 stays refused with the gate OPEN");
+    check(!c.requestRegister(kC0Sync >> 1, 0), "0x39 stays refused with the gate OPEN");
+    check(!c.requestRegister(kRespAddrError, 0), "0x3F is refused");
+    check(!c.requestRegister(0x40, 0), "an address past the six-bit field is refused");
+    // A register that is neither: the AD9866 LNA gain.
+    check(c.requestRegister(kC0AdcGain >> 1, 0x40u), "an ordinary register is accepted");
+}
+
+static void testRequestReachesTheWireExactlyOnce()
+{
+    MetisClient c;
+    MetisClientTestAccess::setStreaming(c);
+    check(c.requestRegister(0x0E, 0x1234'5678u), "armed");
+
+    int seen = 0;
+    Packet requestPacket{};
+    // Well past a full round robin (numRx + 2 slots) several times over. A RQST
+    // bit that ended up latched into a rotating bank would re-request for ever,
+    // and every repeat would be a fresh command the radio's one-deep response
+    // register has to serve.
+    for (int i = 0; i < 64; ++i) {
+        const auto pkt = c.buildNextControlPacket();
+        if (anyFrameRequests(pkt)) { ++seen; requestPacket = pkt; }
+        check(!anyFrameKeyed(pkt), "no frame is ever keyed by a request");
+    }
+    check(seen == 1, "the RQST bit appears on the wire EXACTLY once");
+
+    // The config bank rides frame A of every packet; the request is a one-shot
+    // and lands in frame B.
+    check((c0(requestPacket, kFrameA) & kC0RespRqstBit) == 0,
+          "the standing config bank never carries RQST");
+    const std::uint8_t rc0 = c0(requestPacket, kFrameB);
+    check((rc0 & kC0RespRqstBit) != 0, "frame B carries RQST");
+    check((rc0 & kC0MoxBit) == 0, "and not MOX");
+    check(((rc0 >> 1) & kMaxRegisterAddress) == 0x0E, "at the requested address");
+    check(dataOf(requestPacket, kFrameB) == 0x1234'5678u, "with the requested data");
+
+    check(c.controlRequest().state() == Hl2ControlRequest::State::Awaiting,
+          "sending the bank starts the deadline");
+}
+
+static void testARequestCannotKeyAKeyedRadioAnyHarder()
+{
+    // With the transmit gate CLOSED and a key request standing, the existing
+    // invariant (hl2_tx_gate_test) is that no frame carries C0 bit 0. A request
+    // bank is a new kind of frame, so it is checked against the same law.
+    MetisClient c;
+    MetisClientTestAccess::setStreaming(c);
+    c.setMox(true);                                   // refused: gate closed
+    check(!c.isKeyed(), "the gate is closed");
+    check(c.requestRegister(0x0E, 0), "armed");
+    for (int i = 0; i < 32; ++i) {
+        c.setMox(true);
+        check(!anyFrameKeyed(c.buildNextControlPacket()),
+              "a request frame is not a way past the transmit gate");
+    }
+}
+
+static void testRequestDoesNotOvertakeAnOperatorWrite()
+{
+    // A one-shot is a write the operator asked for. A read-back that overtook
+    // it would answer with the value from before the change — and look correct.
+    MetisClient c;
+    MetisClientTestAccess::setStreaming(c);
+    // An IO-board band push: five one-shot banks at a register nothing else in
+    // this client writes, so "did the write go first" is unambiguous.
+    c.setIoBoardTxFrequencyHz(7'100'000);
+    check(c.requestRegister(kC0AdcGain >> 1, 0x40u), "armed behind the one-shots");
+
+    int boardWritesBeforeRequest = 0;
+    bool sawRequest = false;
+    for (int i = 0; i < 16 && !sawRequest; ++i) {
+        const auto pkt = c.buildNextControlPacket();
+        const std::uint8_t b = c0(pkt, kFrameB);
+        if ((b & kC0RespRqstBit) != 0)
+            sawRequest = true;
+        else if ((b & ~kC0MoxBit) == kC0I2c2)
+            ++boardWritesBeforeRequest;
+    }
+    check(sawRequest, "the request did go out");
+    check(boardWritesBeforeRequest == 5,
+          "every bank of the operator's write goes out BEFORE the read-back");
+}
+
+static void testReplyAndTimeoutReachTheSeam()
+{
+    MetisClient c;
+    MetisClientTestAccess::setStreaming(c);
+
+    int replies = 0, failures = 0, lastAddr = -1;
+    std::uint32_t lastData = 0;
+    bool lastRefused = false;
+    QObject::connect(&c, &MetisClient::controlReplyReady,
+                     [&](int a, quint32 d) { ++replies; lastAddr = a; lastData = d; });
+    QObject::connect(&c, &MetisClient::controlRequestFailed,
+                     [&](int a, bool refused) { ++failures; lastAddr = a; lastRefused = refused; });
+
+    // --- answered ---
+    check(c.requestRegister(0x0E, 0x0000'8000u), "armed");
+    (void)c.buildNextControlPacket();                  // put it on the wire
+    while (c.controlRequest().state() == Hl2ControlRequest::State::Queued)
+        (void)c.buildNextControlPacket();
+    MetisClientTestAccess::feedResponse(c, ack(0x0E, 0x0000'8000u));
+    check(replies == 1, "a matching ACK publishes a reply");
+    check(lastAddr == 0x0E && lastData == 0x0000'8000u, "carrying the echo");
+    check(failures == 0, "and no failure");
+
+    // --- refused by the radio ---
+    check(c.requestRegister(0x0E, 1), "re-armed after an answer");
+    while (c.controlRequest().state() == Hl2ControlRequest::State::Queued)
+        (void)c.buildNextControlPacket();
+    MetisClientTestAccess::feedResponse(c, ack(kRespAddrError, 0));
+    check(failures == 1 && lastRefused, "a 0x3F reply publishes a refusal");
+    check(lastAddr == 0x0E, "named by the address asked for");
+
+    // --- unanswered ---
+    check(c.requestRegister(0x0E, 2), "re-armed after a refusal");
+    while (c.controlRequest().state() == Hl2ControlRequest::State::Queued)
+        (void)c.buildNextControlPacket();
+    for (int i = 0; i < Hl2ControlRequest::kDefaultDeadlineFrames; ++i)
+        MetisClientTestAccess::feedFrame(c);
+    check(failures == 2 && !lastRefused,
+          "a deadline with no ACK publishes a timeout, not silence");
+    check(replies == 1, "and no reply");
+    // And the caller cannot simply retry: the machine is quarantining whatever
+    // the radio still owes it.
+    check(!c.requestRegister(0x0E, 3), "an immediate retry after a timeout is REFUSED");
+    for (int i = 0; i < Hl2ControlRequest::kDefaultQuarantineFrames; ++i)
+        MetisClientTestAccess::feedFrame(c);
+    check(c.requestRegister(0x0E, 3), "and accepted once the quarantine elapses");
+}
+
+static void testStopClearsTheOutstandingRequest()
+{
+    MetisClient c;
+    MetisClientTestAccess::setStreaming(c);
+    check(c.requestRegister(0x0E, 1), "armed");
+    c.stop();
+    check(c.controlRequest().state() == Hl2ControlRequest::State::Idle,
+          "stop() forgets the outstanding request");
+    // And it does not leak onto the next session's wire.
+    MetisClientTestAccess::setStreaming(c);
+    for (int i = 0; i < 16; ++i)
+        check(!anyFrameRequests(c.buildNextControlPacket()),
+              "no stale RQST survives a stop");
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    testRefusedBeforeThereIsAStream();
+    testTransmitCapableRegistersAreRefused();
+    testRequestReachesTheWireExactlyOnce();
+    testARequestCannotKeyAKeyedRadioAnyHarder();
+    testRequestDoesNotOvertakeAnOperatorWrite();
+    testReplyAndTimeoutReachTheSeam();
+    testStopClearsTheOutstandingRequest();
+
+    if (g_failures == 0)
+        std::printf("hl2_rqst_ack_client_test: OK\n");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/hl2_rqst_ack_client_test.cpp
+++ b/tests/hl2_rqst_ack_client_test.cpp
@@ -30,12 +30,18 @@ struct MetisClientTestAccess {
     {
         c.ingestControlResponse(r);
     }
-    // One EP6 frame's worth of deadline, the way a datagram would.
-    static void feedFrame(MetisClient& c) { c.tickControlRequest(); }
+    // One EP6 frame's worth of deadline, the way a datagram would, on the
+    // caller's clock. The clock is a parameter all the way down: a frame is not
+    // a fixed amount of time, so the deadline has a wall-clock floor as well as
+    // a frame count, and this test can move both independently.
+    static void feedFrame(MetisClient& c, qint64 nowMs) { c.tickControlRequest(nowMs); }
     // Confirm the packet just built reached the socket, the way
     // sendControlPacket() does with sendTo()'s return value. `bytes <= 0` is a
     // write the kernel refused.
-    static void confirmSent(MetisClient& c, qint64 bytes) { c.onControlPacketSent(bytes); }
+    static void confirmSent(MetisClient& c, qint64 bytes, qint64 nowMs)
+    {
+        c.onControlPacketSent(bytes, nowMs);
+    }
 };
 }
 
@@ -70,10 +76,15 @@ static std::uint32_t dataOf(const Packet& p, std::size_t frame)
 // Build a packet AND confirm it reached the socket — the two-step the transport
 // performs. Split on purpose: the deadline must not start on a bank that only
 // got as far as a buffer, so every test that means "this went out" says both.
+// The fake wall clock, in milliseconds. Every test that cares about the
+// deadline drives it explicitly; the rest leave it at zero, which is correct
+// because a request that is answered never consults the floor.
+static qint64 g_nowMs = 0;
+
 static Packet sendPacket(MetisClient& c)
 {
     const auto pkt = c.buildNextControlPacket();
-    MetisClientTestAccess::confirmSent(c, static_cast<qint64>(kUsbPacketSize));
+    MetisClientTestAccess::confirmSent(c, static_cast<qint64>(kUsbPacketSize), g_nowMs);
     return pkt;
 }
 
@@ -109,7 +120,7 @@ static void testOnlyTheAllowListedAddressesAreRequestable()
 
     // The whole of the allow-list, and each one has to be re-armable after the
     // previous answer or the loop below would prove nothing after the first.
-    const int allowed[] = {kC0AdcGain >> 1, kC0AdcAssignOrTxGain >> 1, kC0Ad9866Spi >> 1};
+    const int allowed[] = {kC0AdcGain >> 1, kC0AdcAssignOrTxGain >> 1};
     for (const int a : allowed) {
         check(c.requestRegister(a, 0x40u), "an allow-listed address is accepted");
         while (c.controlRequest().state() == Hl2ControlRequest::State::Queued)
@@ -123,8 +134,7 @@ static void testOnlyTheAllowListedAddressesAreRequestable()
     // could not have: this passes for addresses nobody has thought about yet.
     // Named individually below are the ones with a reason worth stating.
     for (int a = 0; a < 0x40; ++a) {
-        const bool onList = a == (kC0AdcGain >> 1) || a == (kC0AdcAssignOrTxGain >> 1)
-                         || a == (kC0Ad9866Spi >> 1);
+        const bool onList = a == (kC0AdcGain >> 1) || a == (kC0AdcAssignOrTxGain >> 1);
         if (onList)
             continue;
         check(!c.requestRegister(a, 0), "an address not on the allow-list is refused");
@@ -143,6 +153,25 @@ static void testOnlyTheAllowListedAddressesAreRequestable()
     // master enables and has wedged a radio.
     check(!c.requestRegister(kC0TxDrive >> 1, 0), "0x09 (TX drive / PA) is refused");
     check(!c.requestRegister(kC0Sync >> 1, 0), "0x39 (sync / reset) is refused");
+    // 0x3b is off the list too, and this is the case the reviewer found. It was
+    // admitted as "the subsystem read path", which ad9866ctrl.v contradicts: the
+    // module has no data output at all, and control.v's AD9866 branch of
+    // RESP_READ assigns the I2C bus's data behind its own
+    // "// FIXME: suppor read cmd_resp_data_ad9866". What it IS, gated on
+    // cmd_data[31:24] == 8'h06, is a generic converter SPI WRITE of
+    // {3'b000, cmd_data[20:16], cmd_data[7:0]} — an arbitrary AD9866 register,
+    // including 0x0a, where the gateware's own TX-gain command writes
+    // (icmd_data = {5'h0a,4'b0100,tx_gain}). And it persists harder than 0x01
+    // does: the 0x09 handler re-writes gain only `if (tx_gain != cmd_data[31:28])`
+    // against an FPGA shadow a 0x3b write never touches, so the mechanism that
+    // would correct it is suppressed by its own change detector. By this list's
+    // own re-asserted-or-excluded rule, that is an exclusion.
+    check(!c.requestRegister(kC0Ad9866Spi >> 1, 0),
+          "0x3b (raw AD9866 SPI write, reaches the TX gain register) is refused");
+    check(!c.requestRegister(kC0Ad9866Spi >> 1, 0x060A004Fu),
+          "including with the 8'h06 cookie the gateware actually acts on");
+    check(!c.requestRegister(kC0Ad9866Spi >> 1, 0x00ABCD12u, true),
+          "and as a claimed subsystem read");
     // Refused even with the transmit gate explicitly open: this layer is not
     // the place that decision gets made, and a future writer must add the
     // conditional deliberately rather than find it already gone.
@@ -150,6 +179,17 @@ static void testOnlyTheAllowListedAddressesAreRequestable()
     check(!c.requestRegister(kC0TxDrive >> 1, 0), "0x09 stays refused with the gate OPEN");
     check(!c.requestRegister(kC0Sync >> 1, 0), "0x39 stays refused with the gate OPEN");
     check(!c.requestRegister(kRespAddrError, 0), "0x3F is refused");
+    // No allow-listed address replies with a READ value — on this gateware only
+    // the I2C buses do, and neither is reachable — so asking for
+    // Echo::SubsystemRead is asking to discard the echo and match on six bits of
+    // address alone. That is the pairing the quarantine narrows but cannot rule
+    // out, so it is refused rather than silently downgraded.
+    check(!c.requestRegister(kC0AdcGain >> 1, 0x40u, true),
+          "a claimed subsystem read at 0x0a is REFUSED, not downgraded");
+    check(!c.requestRegister(kC0AdcAssignOrTxGain >> 1, 0x40u, true),
+          "and at 0x0e");
+    check(c.controlRequest().state() == Hl2ControlRequest::State::Idle,
+          "and none of those refusals armed anything");
     check(!c.requestRegister(0x40, 0), "an address past the six-bit field is refused");
     check(!c.requestRegister(-1, 0), "a negative address is refused");
 }
@@ -167,7 +207,7 @@ static void testAFailedSendDoesNotBurnTheRequest()
 
     const auto lost = c.buildNextControlPacket();
     check(anyFrameRequests(lost), "the RQST bank was built");
-    MetisClientTestAccess::confirmSent(c, -1);          // sendTo() failed
+    MetisClientTestAccess::confirmSent(c, -1, g_nowMs);          // sendTo() failed
     check(c.controlRequest().state() == Hl2ControlRequest::State::Queued,
           "a failed send leaves the request QUEUED, deadline not started");
 
@@ -320,8 +360,18 @@ static void testReplyAndTimeoutReachTheSeam()
     check(c.requestRegister(0x0E, 2), "re-armed after a refusal");
     while (c.controlRequest().state() == Hl2ControlRequest::State::Queued)
         (void)sendPacket(c);
-    for (int i = 0; i < Hl2ControlRequest::kDefaultDeadlineFrames; ++i)
-        MetisClientTestAccess::feedFrame(c);
+    // The frame count alone is no longer a timeout. At 384 kHz with three
+    // receivers these 32 frames are 2.08 ms of wall clock, which is inside a
+    // single recorded EP6 delivery gap — the radio could not have answered yet.
+    for (int i = 0; i < Hl2ControlRequest::kDefaultDeadlineFrames * 4; ++i)
+        MetisClientTestAccess::feedFrame(c, g_nowMs);
+    check(failures == 1, "frames alone do not publish a timeout any more");
+    check(c.controlRequest().state() == Hl2ControlRequest::State::Awaiting,
+          "the request is still outstanding while the floor holds");
+
+    // Past the floor, both halves are satisfied and it settles as it always did.
+    g_nowMs += Hl2ControlRequest::kDefaultFloorMs;
+    MetisClientTestAccess::feedFrame(c, g_nowMs);
     check(failures == 2 && !lastRefused,
           "a deadline with no ACK publishes a timeout, not silence");
     check(replies == 1, "and no reply");
@@ -329,8 +379,12 @@ static void testReplyAndTimeoutReachTheSeam()
     // the radio still owes it.
     check(!c.requestRegister(0x0E, 3), "an immediate retry after a timeout is REFUSED");
     for (int i = 0; i < Hl2ControlRequest::kDefaultQuarantineFrames; ++i)
-        MetisClientTestAccess::feedFrame(c);
-    check(c.requestRegister(0x0E, 3), "and accepted once the quarantine elapses");
+        MetisClientTestAccess::feedFrame(c, g_nowMs);
+    check(!c.requestRegister(0x0E, 3),
+          "the quarantine has a wall-clock floor of its own, from the moment we gave up");
+    g_nowMs += Hl2ControlRequest::kDefaultFloorMs;
+    MetisClientTestAccess::feedFrame(c, g_nowMs);
+    check(c.requestRegister(0x0E, 3), "and accepted once BOTH halves have elapsed");
 }
 
 static void testStopClearsTheOutstandingRequest()

--- a/tests/hl2_rqst_ack_client_test.cpp
+++ b/tests/hl2_rqst_ack_client_test.cpp
@@ -32,6 +32,10 @@ struct MetisClientTestAccess {
     }
     // One EP6 frame's worth of deadline, the way a datagram would.
     static void feedFrame(MetisClient& c) { c.tickControlRequest(); }
+    // Confirm the packet just built reached the socket, the way
+    // sendControlPacket() does with sendTo()'s return value. `bytes <= 0` is a
+    // write the kernel refused.
+    static void confirmSent(MetisClient& c, qint64 bytes) { c.onControlPacketSent(bytes); }
 };
 }
 
@@ -63,6 +67,16 @@ static std::uint32_t dataOf(const Packet& p, std::size_t frame)
          | (std::uint32_t(p[frame + 6]) << 8) | std::uint32_t(p[frame + 7]);
 }
 
+// Build a packet AND confirm it reached the socket — the two-step the transport
+// performs. Split on purpose: the deadline must not start on a bank that only
+// got as far as a buffer, so every test that means "this went out" says both.
+static Packet sendPacket(MetisClient& c)
+{
+    const auto pkt = c.buildNextControlPacket();
+    MetisClientTestAccess::confirmSent(c, static_cast<qint64>(kUsbPacketSize));
+    return pkt;
+}
+
 static Ep6Response ack(int raddr, std::uint32_t data)
 {
     Ep6Response r;
@@ -84,14 +98,46 @@ static void testRefusedBeforeThereIsAStream()
     check(c.controlRequest().state() == Hl2ControlRequest::State::Idle,
           "and arms nothing");
     for (int i = 0; i < 16; ++i)
-        check(!anyFrameRequests(c.buildNextControlPacket()),
+        check(!anyFrameRequests(sendPacket(c)),
               "no RQST bit reaches the wire from a refused request");
 }
 
-static void testTransmitCapableRegistersAreRefused()
+static void testOnlyTheAllowListedAddressesAreRequestable()
 {
     MetisClient c;
     MetisClientTestAccess::setStreaming(c);
+
+    // The whole of the allow-list, and each one has to be re-armable after the
+    // previous answer or the loop below would prove nothing after the first.
+    const int allowed[] = {kC0AdcGain >> 1, kC0AdcAssignOrTxGain >> 1, kC0Ad9866Spi >> 1};
+    for (const int a : allowed) {
+        check(c.requestRegister(a, 0x40u), "an allow-listed address is accepted");
+        while (c.controlRequest().state() == Hl2ControlRequest::State::Queued)
+            (void)sendPacket(c);
+        MetisClientTestAccess::feedResponse(c, ack(a, 0x40u));
+        check(c.controlRequest().state() == Hl2ControlRequest::State::Idle,
+              "and settles, so the next one can be armed");
+    }
+
+    // EVERY other six-bit address is refused, which is the property a deny-list
+    // could not have: this passes for addresses nobody has thought about yet.
+    // Named individually below are the ones with a reason worth stating.
+    for (int a = 0; a < 0x40; ++a) {
+        const bool onList = a == (kC0AdcGain >> 1) || a == (kC0AdcAssignOrTxGain >> 1)
+                         || a == (kC0Ad9866Spi >> 1);
+        if (onList)
+            continue;
+        check(!c.requestRegister(a, 0), "an address not on the allow-list is refused");
+    }
+
+    // 0x3d is the external companion bus — a Pico that switches amplifiers,
+    // antenna relays and transverters. 0x3c is the internal bus (Versa clock,
+    // AD9866). Neither self-corrects, and neither is on the list.
+    check(!c.requestRegister(kC0I2c2 >> 1, 0), "0x3d (I2C2, companion board) is refused");
+    check(!c.requestRegister(kC0I2c1 >> 1, 0), "0x3c (I2C1, internal bus) is refused");
+    // 0x01 is the TX NCO, and unlike 0x00/0x02..0x08 the round robin never
+    // re-asserts it: a bad write there would persist until the next tune.
+    check(!c.requestRegister(kC0TxFreq >> 1, 0), "0x01 (TX NCO, not re-asserted) is refused");
     // 0x09 is TX drive level, onboard PA enable and ATU: its DATA is what puts
     // RF out of the socket. 0x39 is sync/reset, which carries the watchdog and
     // master enables and has wedged a radio.
@@ -105,8 +151,63 @@ static void testTransmitCapableRegistersAreRefused()
     check(!c.requestRegister(kC0Sync >> 1, 0), "0x39 stays refused with the gate OPEN");
     check(!c.requestRegister(kRespAddrError, 0), "0x3F is refused");
     check(!c.requestRegister(0x40, 0), "an address past the six-bit field is refused");
-    // A register that is neither: the AD9866 LNA gain.
-    check(c.requestRegister(kC0AdcGain >> 1, 0x40u), "an ordinary register is accepted");
+    check(!c.requestRegister(-1, 0), "a negative address is refused");
+}
+
+static void testAFailedSendDoesNotBurnTheRequest()
+{
+    // onRequestSent() runs on the socket's return value, not on the build. A
+    // write the kernel refused must leave the request Queued so it goes out on
+    // the next EP2 frame — starting the deadline here would spend 32 frames
+    // plus 32 of quarantine on a command the radio was never shown, and report
+    // it as "the radio did not answer".
+    MetisClient c;
+    MetisClientTestAccess::setStreaming(c);
+    check(c.requestRegister(0x0E, 0xDEAD'BEEFu), "armed");
+
+    const auto lost = c.buildNextControlPacket();
+    check(anyFrameRequests(lost), "the RQST bank was built");
+    MetisClientTestAccess::confirmSent(c, -1);          // sendTo() failed
+    check(c.controlRequest().state() == Hl2ControlRequest::State::Queued,
+          "a failed send leaves the request QUEUED, deadline not started");
+
+    const auto retry = sendPacket(c);
+    check(anyFrameRequests(retry), "and it goes out on the next frame instead");
+    check(dataOf(retry, kFrameB) == 0xDEAD'BEEFu, "with the same data");
+    check(c.controlRequest().state() == Hl2ControlRequest::State::Awaiting,
+          "only a send that succeeded starts the deadline");
+    // Still exactly once overall: the lost packet is not a second command.
+    int further = 0;
+    for (int i = 0; i < 32; ++i)
+        if (anyFrameRequests(sendPacket(c)))
+            ++further;
+    check(further == 0, "and never a third time");
+}
+
+static void testLinkDownDropsTheRequestAndSaysSo()
+{
+    // reset()'s own doc is "for a link that went down". stop() did it; the
+    // silence watchdog did not, so a metis-stop/restart left a stale Awaiting
+    // that later reported TimedOut for a request the radio may have applied.
+    // Both now go through dropControlRequest(), which is what this exercises —
+    // via stop(), because the watchdog needs a socket and a timer and this test
+    // has neither by design.
+    MetisClient c;
+    MetisClientTestAccess::setStreaming(c);
+    int failures = 0, lastAddr = -1;
+    bool lastRefused = true;
+    QObject::connect(&c, &MetisClient::controlRequestFailed,
+                     [&](int a, bool refused) { ++failures; lastAddr = a; lastRefused = refused; });
+
+    check(c.requestRegister(0x0E, 7), "armed");
+    while (c.controlRequest().state() == Hl2ControlRequest::State::Queued)
+        (void)sendPacket(c);
+    c.stop();
+    check(c.controlRequest().state() == Hl2ControlRequest::State::Idle,
+          "the link going down forgets the outstanding request");
+    check(failures == 1 && lastAddr == 0x0E && !lastRefused,
+          "and the caller is told, rather than left waiting for a signal that "
+          "can no longer be emitted");
 }
 
 static void testRequestReachesTheWireExactlyOnce()
@@ -122,7 +223,7 @@ static void testRequestReachesTheWireExactlyOnce()
     // and every repeat would be a fresh command the radio's one-deep response
     // register has to serve.
     for (int i = 0; i < 64; ++i) {
-        const auto pkt = c.buildNextControlPacket();
+        const auto pkt = sendPacket(c);
         if (anyFrameRequests(pkt)) { ++seen; requestPacket = pkt; }
         check(!anyFrameKeyed(pkt), "no frame is ever keyed by a request");
     }
@@ -154,7 +255,7 @@ static void testARequestCannotKeyAKeyedRadioAnyHarder()
     check(c.requestRegister(0x0E, 0), "armed");
     for (int i = 0; i < 32; ++i) {
         c.setMox(true);
-        check(!anyFrameKeyed(c.buildNextControlPacket()),
+        check(!anyFrameKeyed(sendPacket(c)),
               "a request frame is not a way past the transmit gate");
     }
 }
@@ -173,7 +274,7 @@ static void testRequestDoesNotOvertakeAnOperatorWrite()
     int boardWritesBeforeRequest = 0;
     bool sawRequest = false;
     for (int i = 0; i < 16 && !sawRequest; ++i) {
-        const auto pkt = c.buildNextControlPacket();
+        const auto pkt = sendPacket(c);
         const std::uint8_t b = c0(pkt, kFrameB);
         if ((b & kC0RespRqstBit) != 0)
             sawRequest = true;
@@ -200,9 +301,8 @@ static void testReplyAndTimeoutReachTheSeam()
 
     // --- answered ---
     check(c.requestRegister(0x0E, 0x0000'8000u), "armed");
-    (void)c.buildNextControlPacket();                  // put it on the wire
     while (c.controlRequest().state() == Hl2ControlRequest::State::Queued)
-        (void)c.buildNextControlPacket();
+        (void)sendPacket(c);                           // put it on the wire
     MetisClientTestAccess::feedResponse(c, ack(0x0E, 0x0000'8000u));
     check(replies == 1, "a matching ACK publishes a reply");
     check(lastAddr == 0x0E && lastData == 0x0000'8000u, "carrying the echo");
@@ -211,7 +311,7 @@ static void testReplyAndTimeoutReachTheSeam()
     // --- refused by the radio ---
     check(c.requestRegister(0x0E, 1), "re-armed after an answer");
     while (c.controlRequest().state() == Hl2ControlRequest::State::Queued)
-        (void)c.buildNextControlPacket();
+        (void)sendPacket(c);
     MetisClientTestAccess::feedResponse(c, ack(kRespAddrError, 0));
     check(failures == 1 && lastRefused, "a 0x3F reply publishes a refusal");
     check(lastAddr == 0x0E, "named by the address asked for");
@@ -219,7 +319,7 @@ static void testReplyAndTimeoutReachTheSeam()
     // --- unanswered ---
     check(c.requestRegister(0x0E, 2), "re-armed after a refusal");
     while (c.controlRequest().state() == Hl2ControlRequest::State::Queued)
-        (void)c.buildNextControlPacket();
+        (void)sendPacket(c);
     for (int i = 0; i < Hl2ControlRequest::kDefaultDeadlineFrames; ++i)
         MetisClientTestAccess::feedFrame(c);
     check(failures == 2 && !lastRefused,
@@ -244,7 +344,7 @@ static void testStopClearsTheOutstandingRequest()
     // And it does not leak onto the next session's wire.
     MetisClientTestAccess::setStreaming(c);
     for (int i = 0; i < 16; ++i)
-        check(!anyFrameRequests(c.buildNextControlPacket()),
+        check(!anyFrameRequests(sendPacket(c)),
               "no stale RQST survives a stop");
 }
 
@@ -253,12 +353,14 @@ int main(int argc, char** argv)
     QCoreApplication app(argc, argv);
 
     testRefusedBeforeThereIsAStream();
-    testTransmitCapableRegistersAreRefused();
+    testOnlyTheAllowListedAddressesAreRequestable();
     testRequestReachesTheWireExactlyOnce();
     testARequestCannotKeyAKeyedRadioAnyHarder();
     testRequestDoesNotOvertakeAnOperatorWrite();
     testReplyAndTimeoutReachTheSeam();
     testStopClearsTheOutstandingRequest();
+    testAFailedSendDoesNotBurnTheRequest();
+    testLinkDownDropsTheRequestAndSaysSo();
 
     if (g_failures == 0)
         std::printf("hl2_rqst_ack_client_test: OK\n");

--- a/tests/hl2_rqst_ack_test.cpp
+++ b/tests/hl2_rqst_ack_test.cpp
@@ -1,0 +1,342 @@
+// The HL2 RQST/ACK state machine (docs/HERMES.md §13 item 13, oracle §5).
+//
+// What is actually under test is not "a request gets a reply". It is the three
+// properties that make this protocol not an RPC, each of which is a way to be
+// wrong that LOOKS LIKE SUCCESS:
+//
+//   - a second request cannot be armed, because the gateware's response
+//     register holds one reply and silently drops the loser;
+//   - a reply is paired by ECHO, so a reply that is merely plausible must be
+//     rejected rather than accepted;
+//   - a reply to an abandoned request must have nowhere to land, because with
+//     no transaction id it is otherwise indistinguishable from a timely one.
+//
+// Pure: no Qt, no socket, no radio, no clock. The only "time" is EP6 frames,
+// which is the only clock the radio answers on anyway.
+
+#include "core/backends/hl2/Hl2ControlRequest.h"
+#include "core/backends/hl2/MetisProtocol.h"
+
+#include <cstdio>
+
+using namespace AetherSDR::hl2;
+
+static int g_failures = 0;
+static void check(bool ok, const char* what)
+{
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", what); ++g_failures; }
+}
+
+using State = Hl2ControlRequest::State;
+using Outcome = Hl2ControlRequest::Outcome;
+using Echo = Hl2ControlRequest::Echo;
+
+// An ACK as the radio composes it: C0 = {1, raddr[5:0], ptt}.
+static Ep6Response ack(int raddr, std::uint32_t data)
+{
+    Ep6Response r;
+    r.ack = true;
+    r.raddr = raddr;
+    r.data = data;
+    return r;
+}
+
+// A free-running telemetry response: C0 = {000, raddr[1:0], cwkey, 0, ptt}.
+static Ep6Response classic(int raddr, std::uint32_t data)
+{
+    Ep6Response r;
+    r.ack = false;
+    r.raddr = raddr;
+    r.data = data;
+    return r;
+}
+
+static void runFrames(Hl2ControlRequest& m, int n)
+{
+    for (int i = 0; i < n; ++i)
+        m.onEp6Frame();
+}
+
+// ---------------------------------------------------------------------------
+
+static void testAddressSpace()
+{
+    check(Hl2ControlRequest::isRequestableAddress(0x00), "0x00 is requestable");
+    check(Hl2ControlRequest::isRequestableAddress(0x3E), "0x3E is requestable");
+    // 0x3F is how the radio SAYS "refused" (control.v RESP_ACK substitutes
+    // 6'h3f). Requesting it would make a refusal and an answer the same bytes.
+    check(!Hl2ControlRequest::isRequestableAddress(kRespAddrError),
+          "0x3F is NOT requestable — it is the refusal encoding");
+    // The C0 address field is six bits (dsopenhpsdr1.v: addr <= eth_data[6:1]),
+    // so 0x40 is not a bigger address, it is the RQST flag.
+    check(!Hl2ControlRequest::isRequestableAddress(0x40),
+          "0x40 is NOT requestable — six-bit field");
+    check(!Hl2ControlRequest::isRequestableAddress(-1), "negative is not requestable");
+
+    Hl2ControlRequest m;
+    check(!m.arm({kRespAddrError, 0, Echo::Exact}), "arm refuses the refusal address");
+    check(m.state() == State::Idle, "a refused arm changes nothing");
+}
+
+static void testWireBank()
+{
+    Hl2ControlRequest m;
+    check(m.wireBank() == std::nullopt, "Idle offers no bank");
+    check(m.arm({0x0E, 0xDEADBEEFu, Echo::Exact}), "arm accepted from Idle");
+    check(m.state() == State::Queued, "armed -> Queued");
+
+    const auto bank = m.wireBank();
+    check(bank.has_value(), "Queued offers a bank");
+    const Cc cc = *bank;
+    check((cc[0] & kC0RespRqstBit) != 0, "the RQST bit is SET on the request bank");
+    check((cc[0] & kC0MoxBit) == 0, "the request bank NEVER sets MOX");
+    check(((cc[0] >> 1) & kMaxRegisterAddress) == 0x0E, "address lands in C0[6:1]");
+    check(cc[1] == 0xDE && cc[2] == 0xAD && cc[3] == 0xBE && cc[4] == 0xEF,
+          "data is big-endian across C1..C4");
+
+    // Queued does not tick: a request still behind the one-shot queue has not
+    // reached the radio, so frames that pass are not frames it failed to answer.
+    runFrames(m, 1000);
+    check(m.state() == State::Queued, "the deadline does not run before the bank is sent");
+
+    m.onRequestSent();
+    check(m.state() == State::Awaiting, "sent -> Awaiting");
+    check(m.wireBank() == std::nullopt,
+          "Awaiting offers NO bank — the request goes on the wire exactly once");
+}
+
+static void testSingleOutstanding()
+{
+    Hl2ControlRequest m;
+    check(m.arm({0x0E, 1, Echo::Exact}), "first arm accepted");
+    check(!m.arm({0x14, 2, Echo::Exact}), "second arm REFUSED while Queued");
+    check(m.outstanding().addr == 0x0E, "a refused arm does not displace the outstanding one");
+    check(m.outstanding().data == 1, "nor its data");
+
+    m.onRequestSent();
+    check(!m.arm({0x14, 2, Echo::Exact}), "second arm REFUSED while Awaiting");
+
+    check(m.onResponse(ack(0x0E, 1)), "the matching ACK is consumed");
+    check(m.state() == State::Settled, "matched -> Settled");
+    check(!m.arm({0x14, 2, Echo::Exact}),
+          "second arm REFUSED while a verdict is unread — the caller must look");
+
+    const auto reply = m.takeReply();
+    check(reply.has_value(), "a verdict is available");
+    check(reply->outcome == Outcome::Answered, "outcome is Answered");
+    check(reply->addr == 0x0E && reply->data == 1, "the verdict carries the echo");
+    check(m.state() == State::Idle, "an answered request frees the slot");
+    check(m.takeReply() == std::nullopt, "a verdict is delivered ONCE");
+    check(m.arm({0x14, 2, Echo::Exact}), "the slot is reusable after the verdict is read");
+    check(m.answered() == 1 && m.staleAcks() == 0, "counters");
+}
+
+static void testEchoMatchIsNarrow()
+{
+    Hl2ControlRequest m;
+    check(m.arm({0x0E, 0x0000'1234u, Echo::Exact}), "armed");
+    m.onRequestSent();
+
+    // The reply that is merely PLAUSIBLE. Right register, wrong data: on this
+    // protocol that is the reply to the previous write at the same register,
+    // and accepting it hands the caller a value it never asked for.
+    check(!m.onResponse(ack(0x0E, 0x0000'1233u)), "same address, wrong echo: REJECTED");
+    check(m.state() == State::Awaiting, "a rejected reply does not settle anything");
+    check(m.staleAcks() == 1, "and is counted as stale");
+
+    check(!m.onResponse(ack(0x14, 0x0000'1234u)), "wrong address, right data: REJECTED");
+    check(m.staleAcks() == 2, "counted");
+
+    // The nastiest near-miss of all: the free-running telemetry cycle runs
+    // through raddr 0..3 continuously, so at any moment there is a response on
+    // the wire whose raddr could equal a low request address. C0[7] is the only
+    // thing that separates them.
+    check(!m.onResponse(classic(0x0E, 0x0000'1234u)),
+          "a non-ACK response never matches, whatever it carries");
+    check(m.staleAcks() == 2, "a non-ACK is not even stale — it is telemetry");
+    check(m.state() == State::Awaiting, "still outstanding");
+
+    check(m.onResponse(ack(0x0E, 0x0000'1234u)), "the exact echo matches");
+    check(m.takeReply()->outcome == Outcome::Answered, "answered");
+}
+
+static void testSubsystemReadMatchesOnAddressOnly()
+{
+    // 0x3c is the I2C command register; its reply carries the value READ, not
+    // the bytes written (control.v RESP_READ overwrites resp_cmd_data). Demanding
+    // an echo here would reject every successful read.
+    Hl2ControlRequest m;
+    check(m.arm({0x3C, 0x07EA0000u, Echo::SubsystemRead}), "armed a subsystem read");
+    m.onRequestSent();
+    check(m.onResponse(ack(0x3C, 0x0000'0042u)),
+          "a subsystem read matches on the address alone");
+    const auto reply = m.takeReply();
+    check(reply->outcome == Outcome::Answered, "answered");
+    check(reply->data == 0x0000'0042u, "and yields the value READ, not the echo");
+    check(reply->addr == 0x3C, "reported against the address asked for");
+}
+
+static void testRefusal()
+{
+    Hl2ControlRequest m;
+    check(m.arm({0x0E, 0x1234u, Echo::Exact}), "armed");
+    m.onRequestSent();
+    // "Always send a response, may be error": the FSM substitutes 6'h3f for the
+    // address when a subsystem was not ready. It is an ANSWER — the response
+    // register has been consumed — so the slot frees immediately, unlike a
+    // timeout.
+    check(m.onResponse(ack(kRespAddrError, 0)), "a 0x3F reply matches whatever was asked");
+    const auto reply = m.takeReply();
+    check(reply->outcome == Outcome::Refused, "outcome is Refused");
+    check(reply->addr == 0x0E,
+          "the verdict names the address ASKED FOR, not the refusal encoding");
+    check(m.state() == State::Idle, "a refusal frees the slot: the radio is done with it");
+    check(m.refusals() == 1, "counted");
+}
+
+static void testTimeoutQuarantinesTheLateEcho()
+{
+    // This is the property §13's "no transaction id" warning is really about.
+    constexpr int kDeadline = 8;
+    constexpr int kQuarantine = 8;
+    Hl2ControlRequest m(kDeadline, kQuarantine);
+
+    check(m.arm({0x0E, 0xAAAA'AAAAu, Echo::Exact}), "armed");
+    m.onRequestSent();
+    runFrames(m, kDeadline - 1);
+    check(m.state() == State::Awaiting, "still waiting one frame short of the deadline");
+    m.onEp6Frame();
+    check(m.state() == State::Settled, "the deadline settles a verdict");
+    check(m.timeouts() == 1, "counted");
+
+    check(!m.arm({0x14, 1, Echo::Exact}), "no re-arm while the verdict is unread");
+    const auto reply = m.takeReply();
+    check(reply->outcome == Outcome::TimedOut, "outcome is TimedOut");
+    check(reply->addr == 0x0E, "named");
+
+    // NOT Idle. The radio never told us it was finished with that request, so
+    // it may still answer it.
+    check(m.state() == State::Quarantine, "a timeout quarantines rather than freeing the slot");
+    check(!m.arm({0x14, 1, Echo::Exact}), "no new request may be armed during the quarantine");
+
+    // The late echo arrives. On the wire it is byte-identical to a timely reply.
+    check(!m.onResponse(ack(0x0E, 0xAAAA'AAAAu)),
+          "the abandoned request's own echo is SWALLOWED, not re-paired");
+    check(m.staleAcks() == 1, "and counted, which is how an operator would ever see this");
+    check(m.state() == State::Quarantine, "swallowing it does not settle anything");
+    check(m.takeReply() == std::nullopt, "and produces no second verdict");
+
+    runFrames(m, kQuarantine - 1);
+    check(m.state() == State::Quarantine, "the quarantine runs its full length");
+    m.onEp6Frame();
+    check(m.state() == State::Idle, "then the slot reopens");
+    check(m.arm({0x14, 1, Echo::Exact}), "and a new request is accepted");
+
+    // And the point of all of it: had the quarantine not been there, THIS is
+    // the pairing that would have happened — a request at the same register,
+    // answered by the previous request's echo.
+    m.onRequestSent();
+    check(!m.onResponse(ack(0x0E, 0xAAAA'AAAAu)),
+          "the old echo cannot match the new request either");
+}
+
+static void testResetClearsEvenTheQuarantine()
+{
+    Hl2ControlRequest m(4, 1000);
+    check(m.arm({0x0E, 1, Echo::Exact}), "armed");
+    m.onRequestSent();
+    runFrames(m, 4);
+    (void)m.takeReply();
+    check(m.state() == State::Quarantine, "quarantined");
+    // A stream that has stopped and restarted cannot deliver a reply from
+    // before it, so the quarantine has nothing left to protect against.
+    m.reset();
+    check(m.state() == State::Idle, "reset clears the quarantine");
+    check(m.arm({0x0E, 1, Echo::Exact}), "and the slot is immediately usable");
+}
+
+static void testAckWithNothingOutstandingIsStale()
+{
+    Hl2ControlRequest m;
+    check(!m.onResponse(ack(0x0E, 1)), "an ACK in Idle is refused");
+    check(m.staleAcks() == 1,
+          "an ACK nobody asked for is the signature of a second client on the radio");
+    check(m.state() == State::Idle, "and changes nothing");
+}
+
+// The C0 encoding both directions, against the gateware's own composition.
+static void testWireEncoding()
+{
+    // Radio->host ACK: C0 = {1'b1, resp_cmd_addr[5:0], ptt_resp}. A six-bit
+    // address, so 0x3B (the AD9866 SPI register) is expressible — which the
+    // classic four-bit C0[6:3] read is not.
+    std::uint8_t frame[8] = {0x7F, 0x7F, 0x7F, 0, 0x12, 0x34, 0x56, 0x78};
+    frame[3] = static_cast<std::uint8_t>(0x80 | (0x3B << 1) | 0x01);
+    const auto parsed = parseEp6Response(frame);
+    check(parsed.has_value(), "sync-framed");
+    check(parsed->ack, "C0[7] set reads as ACK");
+    check(parsed->raddr == 0x3B, "ACK raddr is the full six bits");
+    check(parsed->ptt, "C0[0] is ptt_resp in an ACK too");
+    check(parsed->data == 0x12345678u, "C1..C4 big-endian");
+
+    // Host->radio: withRespRqst and withMox are orthogonal, and neither can set
+    // the other's bit. That is what lets a request ride an unkeyed frame and a
+    // keyed one alike without either flag leaking.
+    const Cc base = ccRegister(0x0E, 0);
+    check((base[0] & kC0MoxBit) == 0, "ccRegister never sets MOX");
+    check((base[0] & kC0RespRqstBit) == 0, "ccRegister never sets RQST");
+    check((withRespRqst(base, true)[0] & kC0MoxBit) == 0, "withRespRqst leaves MOX alone");
+    check((withMox(base, true)[0] & kC0RespRqstBit) == 0, "withMox leaves RQST alone");
+    check(withRespRqst(withMox(base, true), true)[0]
+              == withMox(withRespRqst(base, true), true)[0],
+          "the two compose in either order");
+    // An address that would have spilled into the RQST bit is masked, not
+    // wrapped into a keyed frame.
+    check((ccRegister(0x7F, 0)[0] & kC0RespRqstBit) == 0,
+          "an out-of-range address cannot alias into RQST");
+    check((ccRegister(0x7F, 0)[0] & kC0MoxBit) == 0,
+          "nor into MOX");
+}
+
+// An ACK is not telemetry. Before this guard, an ACK for register 0x00 would be
+// decoded as a firmware version, an ADC-overload flag and a TX FIFO depth,
+// invented out of the bytes we ourselves sent.
+static void testAckDoesNotPoisonTelemetry()
+{
+    Hl2Telemetry t;
+    t.apply(classic(0x00, 0x0000'0049u));       // real telemetry: firmware 0x49
+    check(t.firmwareVersion.has_value() && *t.firmwareVersion == 0x49,
+          "the free-running cycle still populates telemetry");
+
+    // Our own echo of a config-register write, coming back as an ACK at
+    // raddr 0x00. Every field it would have overwritten must be untouched.
+    t.apply(ack(0x00, 0xFFFF'FFFFu));
+    check(*t.firmwareVersion == 0x49, "an ACK does not rewrite the firmware version");
+    check(!t.adcOverload.value_or(false), "nor invent an ADC overload");
+
+    // PTT is the exception, and legitimately so: C0[0] is ptt_resp in both
+    // branches of the gateware's iresp composition.
+    Ep6Response keyed = ack(0x00, 0);
+    keyed.ptt = true;
+    t.apply(keyed);
+    check(t.ptt, "an ACK's PTT bit is still honoured");
+}
+
+int main()
+{
+    testAddressSpace();
+    testWireBank();
+    testSingleOutstanding();
+    testEchoMatchIsNarrow();
+    testSubsystemReadMatchesOnAddressOnly();
+    testRefusal();
+    testTimeoutQuarantinesTheLateEcho();
+    testResetClearsEvenTheQuarantine();
+    testAckWithNothingOutstandingIsStale();
+    testWireEncoding();
+    testAckDoesNotPoisonTelemetry();
+
+    if (g_failures == 0)
+        std::printf("hl2_rqst_ack_test: OK\n");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/hl2_rqst_ack_test.cpp
+++ b/tests/hl2_rqst_ack_test.cpp
@@ -11,8 +11,11 @@
 //   - a reply to an abandoned request must have nowhere to land, because with
 //     no transaction id it is otherwise indistinguishable from a timely one.
 //
-// Pure: no Qt, no socket, no radio, no clock. The only "time" is EP6 frames,
-// which is the only clock the radio answers on anyway.
+// Pure: no Qt, no socket, no radio, and no clock OF ITS OWN. Time is EP6
+// frames — the only clock the radio answers on — plus a wall-clock floor that
+// is PASSED IN, because a frame is not a fixed amount of time: 32 frames is
+// 42 ms at 48 kHz with one receiver and 2.08 ms at 384 kHz with three. The fake
+// clock below is what lets this file pin both without real time passing.
 
 #include "core/backends/hl2/Hl2ControlRequest.h"
 #include "core/backends/hl2/MetisProtocol.h"
@@ -51,10 +54,33 @@ static Ep6Response classic(int raddr, std::uint32_t data)
     return r;
 }
 
+// A fake wall clock in milliseconds, advanced explicitly. The machine reads no
+// clock of its own — that is what lets this file pin a 384 kHz configuration
+// with no real time passing, which is the whole reason the clock is a
+// parameter.
+static std::int64_t g_nowMs = 0;
+
+// Run n EP6 frames AT A GIVEN SAMPLE RATE AND RECEIVER COUNT, advancing the
+// fake clock by what those frames actually take on the wire. A frame is
+// 504/(6*numRx+2) rounds, so this is the geometry from MetisProtocol.h and not
+// a guess: at 48 kHz with one receiver 32 frames is 42 ms, and at 384 kHz with
+// three it is 2.08 ms.
+static void runFramesAtRate(Hl2ControlRequest& m, int n, int sampleRateHz, int numRx)
+{
+    const double framesPerSecond =
+        static_cast<double>(sampleRateHz) / ep6RoundsPerFrame(numRx);
+    for (int i = 1; i <= n; ++i) {
+        g_nowMs = static_cast<std::int64_t>(
+            static_cast<double>(i) * 1000.0 / framesPerSecond);
+        m.onEp6Frame(g_nowMs);
+    }
+}
+
+// Frames with no time passing at all: isolates the frame COUNT from the floor.
 static void runFrames(Hl2ControlRequest& m, int n)
 {
     for (int i = 0; i < n; ++i)
-        m.onEp6Frame();
+        m.onEp6Frame(g_nowMs);
 }
 
 // ---------------------------------------------------------------------------
@@ -99,7 +125,7 @@ static void testWireBank()
     runFrames(m, 1000);
     check(m.state() == State::Queued, "the deadline does not run before the bank is sent");
 
-    m.onRequestSent();
+    m.onRequestSent(g_nowMs);
     check(m.state() == State::Awaiting, "sent -> Awaiting");
     check(m.wireBank() == std::nullopt,
           "Awaiting offers NO bank — the request goes on the wire exactly once");
@@ -113,7 +139,7 @@ static void testSingleOutstanding()
     check(m.outstanding().addr == 0x0E, "a refused arm does not displace the outstanding one");
     check(m.outstanding().data == 1, "nor its data");
 
-    m.onRequestSent();
+    m.onRequestSent(g_nowMs);
     check(!m.arm({0x14, 2, Echo::Exact}), "second arm REFUSED while Awaiting");
 
     check(m.onResponse(ack(0x0E, 1)), "the matching ACK is consumed");
@@ -135,7 +161,7 @@ static void testEchoMatchIsNarrow()
 {
     Hl2ControlRequest m;
     check(m.arm({0x0E, 0x0000'1234u, Echo::Exact}), "armed");
-    m.onRequestSent();
+    m.onRequestSent(g_nowMs);
 
     // The reply that is merely PLAUSIBLE. Right register, wrong data: on this
     // protocol that is the reply to the previous write at the same register,
@@ -162,12 +188,20 @@ static void testEchoMatchIsNarrow()
 
 static void testSubsystemReadMatchesOnAddressOnly()
 {
-    // 0x3c is the I2C command register; its reply carries the value READ, not
-    // the bytes written (control.v RESP_READ overwrites resp_cmd_data). Demanding
-    // an echo here would reject every successful read.
+    // 0x3c is the I2C command register, and it is the ONLY shape of command
+    // whose reply carries the value READ rather than the bytes written
+    // (control.v RESP_READ assigns cmd_resp_data_i2c). Demanding an echo here
+    // would reject every successful read.
+    //
+    // NOT 0x3b. The AD9866 SPI command was described as a read path and is not
+    // one: ad9866ctrl has no data output, and control.v's AD9866 branch of
+    // RESP_READ assigns the I2C bus's data behind its own
+    // "// FIXME: suppor read cmd_resp_data_ad9866". The mode stays here because
+    // the I2C buses will need it; MetisClient::requestRegister reaches neither
+    // and refuses the flag outright, which hl2_rqst_ack_client_test pins.
     Hl2ControlRequest m;
     check(m.arm({0x3C, 0x07EA0000u, Echo::SubsystemRead}), "armed a subsystem read");
-    m.onRequestSent();
+    m.onRequestSent(g_nowMs);
     check(m.onResponse(ack(0x3C, 0x0000'0042u)),
           "a subsystem read matches on the address alone");
     const auto reply = m.takeReply();
@@ -180,7 +214,7 @@ static void testRefusal()
 {
     Hl2ControlRequest m;
     check(m.arm({0x0E, 0x1234u, Echo::Exact}), "armed");
-    m.onRequestSent();
+    m.onRequestSent(g_nowMs);
     // "Always send a response, may be error": the FSM substitutes 6'h3f for the
     // address when a subsystem was not ready. It is an ANSWER — the response
     // register has been consumed — so the slot frees immediately, unlike a
@@ -199,13 +233,15 @@ static void testTimeoutQuarantinesTheLateEcho()
     // This is the property §13's "no transaction id" warning is really about.
     constexpr int kDeadline = 8;
     constexpr int kQuarantine = 8;
-    Hl2ControlRequest m(kDeadline, kQuarantine);
+    // Floor 0: this test is about the frame COUNT and the quarantine handover.
+    // The floor has its own tests below.
+    Hl2ControlRequest m(kDeadline, kQuarantine, 0);
 
     check(m.arm({0x0E, 0xAAAA'AAAAu, Echo::Exact}), "armed");
-    m.onRequestSent();
+    m.onRequestSent(g_nowMs);
     runFrames(m, kDeadline - 1);
     check(m.state() == State::Awaiting, "still waiting one frame short of the deadline");
-    m.onEp6Frame();
+    m.onEp6Frame(g_nowMs);
     check(m.state() == State::Settled, "the deadline settles a verdict");
     check(m.timeouts() == 1, "counted");
 
@@ -228,23 +264,144 @@ static void testTimeoutQuarantinesTheLateEcho()
 
     runFrames(m, kQuarantine - 1);
     check(m.state() == State::Quarantine, "the quarantine runs its full length");
-    m.onEp6Frame();
+    m.onEp6Frame(g_nowMs);
     check(m.state() == State::Idle, "then the slot reopens");
     check(m.arm({0x14, 1, Echo::Exact}), "and a new request is accepted");
 
     // And the point of all of it: had the quarantine not been there, THIS is
     // the pairing that would have happened — a request at the same register,
     // answered by the previous request's echo.
-    m.onRequestSent();
+    m.onRequestSent(g_nowMs);
     check(!m.onResponse(ack(0x0E, 0xAAAA'AAAAu)),
           "the old echo cannot match the new request either");
+
+    // THE RESIDUAL, pinned here so the header's claim stays honest. An earlier
+    // version of that header said a late reply had nowhere to land "by
+    // construction". Quarantine makes a wrong pairing UNLIKELY; it cannot make
+    // it impossible. A caller that re-issues the IDENTICAL request after a
+    // timeout is asking for a reply byte-for-byte equal to the one it
+    // abandoned, and no matching rule can separate those two. That is a
+    // property of a wire with no transaction id, not a defect in this class —
+    // and it is most of why the wall-clock floor matters, since the floor is
+    // what keeps the abandoned reply from still being in flight at all.
+    Hl2ControlRequest again(kDeadline, kQuarantine, 0);
+    check(again.arm({0x0E, 0xAAAA'AAAAu, Echo::Exact}), "armed");
+    again.onRequestSent(g_nowMs);
+    runFrames(again, kDeadline);
+    (void)again.takeReply();
+    runFrames(again, kQuarantine);
+    check(again.state() == State::Idle, "the quarantine elapsed");
+    check(again.arm({0x0E, 0xAAAA'AAAAu, Echo::Exact}), "the SAME request, re-issued");
+    again.onRequestSent(g_nowMs);
+    check(again.onResponse(ack(0x0E, 0xAAAA'AAAAu)),
+          "an identical re-issue CANNOT be told from the abandoned reply — "
+          "documented, not fixed, because the wire carries no id");
+}
+
+// ---- the wall-clock floor (blocker 1) --------------------------------------
+
+static void testTheDeadlineHasAWallClockFloor()
+{
+    // 32 frames is 42 ms only at 48 kHz with ONE receiver. A frame carries
+    // 504/(6*numRx+2) rounds, so frames per second rise with both the sample
+    // rate and the receiver count; at 384 kHz with the three receivers
+    // maxReceiversAtRate() admits, the same 32 frames is 2.08 ms and deadline
+    // plus quarantine is 4.17 ms. docs/HERMES.md records a 6.08 ms worst-case
+    // EP6 inter-arrival gap, which is HOST-SIDE and wall-clock: the frame count
+    // cannot see it, and could expire twice over inside one delivery gap.
+    check(ep6RoundsPerFrame(1) == 63, "48 kHz / 1 RX: 63 rounds per frame");
+    check(ep6RoundsPerFrame(3) == 25, "384 kHz / 3 RX: 25 rounds per frame");
+    check(maxReceiversAtRate(384000) == 3, "the link budget admits 3 RX at 384 kHz");
+
+    g_nowMs = 0;
+    Hl2ControlRequest m;                    // the SHIPPING constants, floor included
+    check(m.arm({0x0E, 0x1234u, Echo::Exact}), "armed");
+    m.onRequestSent(g_nowMs);
+
+    runFramesAtRate(m, Hl2ControlRequest::kDefaultDeadlineFrames, 384000, 3);
+    check(g_nowMs <= 3, "32 frames at 384 kHz with 3 receivers is ~2 ms of wall clock");
+    check(m.state() == State::Awaiting,
+          "the frame count ALONE does not expire the deadline any more");
+
+    runFramesAtRate(m, 600, 384000, 3);     // ~39 ms, hundreds of slots
+    check(g_nowMs < Hl2ControlRequest::kDefaultFloorMs, "still inside the floor");
+    check(m.state() == State::Awaiting, "the wall-clock floor is what holds it open");
+
+    // And the answer lands. Under the frame count alone this reply would have
+    // been counted stale against a request already abandoned and quarantined.
+    check(m.onResponse(ack(0x0E, 0x1234u)),
+          "a reply inside the floor is the ANSWER, not a stale ACK");
+    check(m.takeReply()->outcome == Outcome::Answered, "answered");
+    check(m.staleAcks() == 0, "and nothing was counted stale");
+
+    // The floor does expire, at the 48 kHz budget it is derived from.
+    g_nowMs = 0;
+    Hl2ControlRequest n;
+    check(n.arm({0x0E, 1, Echo::Exact}), "armed");
+    n.onRequestSent(g_nowMs);
+    runFramesAtRate(n, 2000, 384000, 3);    // ~130 ms: both halves satisfied
+    check(n.state() == State::Settled, "past the floor it times out as it always did");
+    check(n.takeReply()->outcome == Outcome::TimedOut, "timed out");
+}
+
+static void testTheFrameCountStillRulesAStoppedStream()
+{
+    // The floor is a FLOOR, never a substitute. resp_rqst toggles only while
+    // `run` is set, so a radio that stopped streaming owes no slots — and
+    // however much wall-clock time passes, nothing times out. This is the
+    // property the frame count was chosen for and it has to survive the fix.
+    g_nowMs = 0;
+    Hl2ControlRequest m;
+    check(m.arm({0x0E, 1, Echo::Exact}), "armed");
+    m.onRequestSent(g_nowMs);
+    g_nowMs = 10'000;                       // ten seconds of silence
+    check(m.state() == State::Awaiting,
+          "no frames, no timeout — a wall clock alone would have blamed the radio");
+
+    runFrames(m, Hl2ControlRequest::kDefaultDeadlineFrames);
+    check(m.state() == State::Settled, "the frames are what expire it, once they come");
+    check(m.takeReply()->outcome == Outcome::TimedOut, "timed out");
+    check(m.state() == State::Quarantine, "quarantined");
+
+    // The quarantine has its own floor, running from the moment we gave up —
+    // which is what it has to outlast, not the moment the caller looked.
+    runFrames(m, Hl2ControlRequest::kDefaultQuarantineFrames * 4);
+    check(m.state() == State::Quarantine, "frames alone do not release the quarantine");
+    g_nowMs += Hl2ControlRequest::kDefaultFloorMs;
+    runFrames(m, 1);
+    check(m.state() == State::Idle, "it releases once BOTH have passed");
+}
+
+static void testOneDeliveryGapNoLongerWalksTheWholeMachine()
+{
+    // Blocker 1's concrete consequence. At 384 kHz with 3 receivers the 6.08 ms
+    // gap docs/HERMES.md records is ~93 frames, and they arrive in ONE
+    // onReadyRead() drain — wall-clock nearly instantaneous. 93 frames is the
+    // entire deadline and the entire quarantine with frames to spare.
+    const double framesPerSecond = 384000.0 / ep6RoundsPerFrame(3);
+    const int framesInTheGap = static_cast<int>(6.08e-3 * framesPerSecond);
+    check(framesInTheGap > Hl2ControlRequest::kDefaultDeadlineFrames
+                               + Hl2ControlRequest::kDefaultQuarantineFrames,
+          "one recorded delivery gap is more frames than deadline plus quarantine");
+
+    g_nowMs = 0;
+    Hl2ControlRequest m;
+    check(m.arm({0x0E, 0x00AB'CD12u, Echo::Exact}), "armed");
+    m.onRequestSent(g_nowMs);
+    g_nowMs = 7;                            // the gap itself, in wall clock
+    runFrames(m, framesInTheGap);           // drained in a single pass
+    check(m.state() == State::Awaiting,
+          "a backlog of frames does not consume a request seven milliseconds old");
+    check(m.onResponse(ack(0x0E, 0x00AB'CD12u)), "the radio's answer still lands");
+    check(m.answered() == 1 && m.staleAcks() == 0,
+          "as an answer, not as a stale ACK against an abandoned request");
 }
 
 static void testResetClearsEvenTheQuarantine()
 {
-    Hl2ControlRequest m(4, 1000);
+    Hl2ControlRequest m(4, 1000, 0);
     check(m.arm({0x0E, 1, Echo::Exact}), "armed");
-    m.onRequestSent();
+    m.onRequestSent(g_nowMs);
     runFrames(m, 4);
     (void)m.takeReply();
     check(m.state() == State::Quarantine, "quarantined");
@@ -331,6 +488,9 @@ int main()
     testSubsystemReadMatchesOnAddressOnly();
     testRefusal();
     testTimeoutQuarantinesTheLateEcho();
+    testTheDeadlineHasAWallClockFloor();
+    testTheFrameCountStillRulesAStoppedStream();
+    testOneDeliveryGapNoLongerWalksTheWholeMachine();
     testResetClearsEvenTheQuarantine();
     testAckWithNothingOutstandingIsStale();
     testWireEncoding();

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3782,6 +3782,22 @@ target_include_directories(hl2_tx_gate_test PRIVATE src)
 target_link_libraries(hl2_tx_gate_test PRIVATE aethercore Qt6::Core Qt6::Network)
 add_test(NAME hl2_tx_gate_test COMMAND hl2_tx_gate_test)
 
+# HL2 RQST/ACK state machine (docs/HERMES.md §13 item 13, oracle §5) — pure
+# policy, standalone (no Qt, no socket, no radio). The clock is EP6 frames.
+add_executable(hl2_rqst_ack_test
+    tests/hl2_rqst_ack_test.cpp
+    src/core/backends/hl2/Hl2ControlRequest.cpp
+    src/core/backends/hl2/MetisProtocol.cpp)
+target_include_directories(hl2_rqst_ack_test PRIVATE src)
+add_test(NAME hl2_rqst_ack_test COMMAND hl2_rqst_ack_test)
+
+# RQST/ACK where it meets the wire — socket-free, on MetisClient's own packet
+# builder and its EP6 response path.
+add_executable(hl2_rqst_ack_client_test tests/hl2_rqst_ack_client_test.cpp)
+target_include_directories(hl2_rqst_ack_client_test PRIVATE src)
+target_link_libraries(hl2_rqst_ack_client_test PRIVATE aethercore Qt6::Core Qt6::Network)
+add_test(NAME hl2_rqst_ack_client_test COMMAND hl2_rqst_ack_client_test)
+
 # HL2 band filter / EP2 frame composition — socket-free, on MetisClient's own
 # packet builder. A band change must not leave two disagreeing config banks in
 # one frame (#4579).


### PR DESCRIPTION
### §13 item 13 — the RQST/ACK state machine

The gate under items 14–23. Built from the Hermes-Lite 2 gateware RTL (`control.v`, `ds.v`, `usopenhpsdr1.v`) rather than inferred — which turned up facts our own sources had wrong. Those are recorded in §4, *"RQST/ACK, read off the gateware rather than the oracle"*.

`Hl2ControlRequest` is deliberately **not** an RPC, and each refusal to be one answers a specific property of the wire:

**Single outstanding.** `control.v`'s response register is one deep — *"Queue size is 1"*, its own comment — and losing is **silent**: a second command in `RESP_ACK`/`RESP_READ` gets no reply at all, and one in `RESP_WAIT` overwrites the request still waiting for a slot. **Both are gated on the RQST bit** (`cmd_rqst & cmd_requires_resp`, wired from C0[7]), so the round robin cannot clobber a pending reply however fast it runs — only another RQST can. That is why a host discipline is sufficient: `arm()` is `[[nodiscard]] bool` and refuses unless idle. There is no queue.

**Echo-matched.** The reply carries the six-bit command address and, for a register write, an echo of the data. That is the whole correspondence, so matching is a judgement and `matches()` is narrow: address always, data too for `Echo::Exact`. A plausible-but-wrong reply is counted stale, not accepted. `Echo::SubsystemRead` exists because the AD9866/I2C replies carry the value read instead of the echo.

**No transaction id.** A blown deadline does **not** free the slot — it moves to `Quarantine`, where every ACK is swallowed and `arm()` stays refused. The abandoned request's late echo has nowhere to land, by construction.

**The deadline is counted in EP6 frames, not milliseconds.** `resp_rqst` toggles once per 512-byte frame (`usopenhpsdr1.v` `SYNC_RESP`) and the emit path is gated on `run`, so an idle radio never answers and a wall clock would blame the radio for our own ordering. `MetisClient::requestRegister` refuses before the stream is up for the same reason. Note that **command response slots open on alternate frames** (`resp_cnt`, *"Only every other resp_rqst"*), so 32 frames is sixteen response opportunities — still ample, and the constant is sized against that.

### The requestable addresses are an ALLOW-LIST

`ccRegister()` leaves `C0[0]` clear, the RQST flag is `C0[7]` and `withRespRqst()` touches nothing else, so **this path cannot key a transmitter** whatever the address. Everything beyond that narrow guarantee is the allow-list's job, and it is an allow-list rather than a deny-list on purpose: a deny-list fails *open* when someone later adds an address nobody thought about, an allow-list fails *closed*.

Today it is **`0x0a`** (AD9866 RX LNA gain), **`0x0e`** (ADC assign / TX LNA gain) and **`0x3b`** (AD9866 SPI, the subsystem read path). The first two are re-asserted by the round robin, so a wrong value self-corrects within a rotation. Deliberately off the list, each with its reason at the site: `0x01` (TX NCO — a one-shot, so a bad write persists until the next tune), `0x09` (TX drive/PA/ATU), `0x39` (sync/reset), and `0x3c`/`0x3d` (the two I2C buses; `0x3d` reaches the companion board that switches amplifiers, antenna relays and transverters).

### No radio has answered this code yet

Every test here is synthetic against a hand-built `Ep6Response`, which by construction cannot distinguish "the radio answers" from "we believe it would". The RTL says a correctly flagged request will be answered; nothing here is evidence that one was. Recorded in §4 with the first hardware check to run.

### Also in this PR, and not item 13

A `clip_cnt` paragraph in §4 — **`§13 item 14` material**, doc-only. `clip_cnt` is a 2-bit saturating counter cleared on every `resp_rqst` and the ADC-overload bit is `(&clip_cnt)`, so that bit means **at least three clips in the frame**, not "a sample clipped". It bears on #5626, which is in flight, which is why it is here rather than waiting for item 14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TtnKQu6QGrSeBirGeAsAs
