### PR TITLE
Preserve healthy settings databases after initialization failures

### DIFF
--- a/docs/settings-store-sqlite-design.md
+++ b/docs/settings-store-sqlite-design.md
@@ -133,10 +133,15 @@ document value is redacted, not just secret-named rows.
   verified before it counts: after the import (`*-postmigration.db`), at most
   weekly (`*-auto.db`, bounded to 5), and before Reset Settings deletes
   anything (`*-prereset.db`, bounded to 3, kept through the purge).
-- Confirmed corruption (open failure or failed integrity check — never mere
-  locks): the DB/WAL/SHM set moves to `settings-quarantine/` timestamped, the
+- Confirmed corruption (SQLite reports corruption/not-a-database, or an
+  integrity check reports damage): the DB/WAL/SHM set moves to
+  `settings-quarantine/` timestamped, the
   newest verified backup is restored, and the user sees a notice naming the
   backup and its age. With no usable backup, the frozen XML re-imports.
+- Ordinary initialization failures (permissions, read-only storage, locks,
+  filesystem/I/O errors, or an integrity check that could not execute) do not
+  authorize recovery. The database stays in place; the session reports the
+  failure and refuses saves so a later launch can retry without rollback.
 - `Reset Settings` checkpoints and closes the connection first (Windows file
   locks), writes the pre-reset backup, then removes the DB, sidecars, frozen
   XML + its artifacts, rolling backups, and quarantine.

--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -207,11 +207,49 @@ void AppSettings::load()
         m_loadNotice.clear();
     }
 
-    // ── Open the database, with corruption quarantine + backup restore ──────
+    // ── Open the database, with evidence-gated corruption recovery ─────────
+    // An unavailable check is not a corruption report. In particular, a
+    // healthy owner-read-only database can open and read successfully before
+    // createSchema() is refused at PRAGMA user_version. Quarantining it would
+    // discard the user's current store and roll back to an older backup/XML.
+    const auto validateIntegrity = [this](bool& confirmedCorrupt) {
+        if (m_db->isNewerSchema()) {
+            return true;
+        }
+        const SettingsDatabase::IntegrityCheckResult quick = m_db->quickCheck();
+        if (quick == SettingsDatabase::IntegrityCheckResult::Ok) {
+            return true;
+        }
+
+        // Keep the full check as the second source of evidence after the cheap
+        // probe fails. Its result governs recovery: a successful full check
+        // accepts the store, while only its demonstrated corruption result can
+        // authorize moving the original store aside.
+        const SettingsDatabase::IntegrityCheckResult full = m_db->integrityCheck();
+        if (full == SettingsDatabase::IntegrityCheckResult::Ok) {
+            confirmedCorrupt = false;
+            return true;
+        }
+        confirmedCorrupt = full == SettingsDatabase::IntegrityCheckResult::Corrupt;
+        return false;
+    };
+    const auto failClosed = [this](const QString& summary) {
+        const QString error = m_db->lastError().isEmpty()
+                                  ? QStringLiteral("an unspecified SQLite error")
+                                  : m_db->lastError();
+        m_db->close();
+        QWriteLocker locker(&m_lock);
+        m_loadNotice = QStringLiteral(
+            "%1 The existing settings database was left in place; changes will "
+            "not be saved in this session. (%2)")
+                           .arg(summary, error);
+    };
+
     bool opened = m_db->open(m_filePath);
-    if (opened && !m_db->isNewerSchema() && !m_db->quickCheck()
-        && !m_db->integrityCheck()) {
-        qWarning() << "AppSettings: settings database failed integrity check";
+    bool confirmedCorrupt = !opened && m_db->lastOpenWasCorrupt();
+    if (opened && !validateIntegrity(confirmedCorrupt)) {
+        qWarning() << "AppSettings: settings database integrity check did not"
+                      " establish a usable store:" << m_db->lastError();
         opened = false;
     }
     if (!opened && m_db->lastOpenWasBusy()) {
@@ -223,28 +261,43 @@ void AppSettings::load()
         // session; the next launch retries.
         qWarning() << "AppSettings: settings database is locked by another"
                       " process — read-only session, retry next launch";
+        failClosed(QStringLiteral("The settings database is locked by another "
+                                  "process; retry on the next launch."));
         return;
     }
-    if (!opened && QFile::exists(m_filePath)) {
-        // Confirmed unusable (unreadable or failed integrity). Quarantine and
-        // restore are serialized under a lock file so two instances cannot
-        // both decide to "recover" — the second one fails its session instead.
+    if (!opened && QFile::exists(m_filePath) && confirmedCorrupt) {
+        // SQLite explicitly reported corruption/not-a-database, or a check
+        // returned a damage report. Only that evidence authorizes quarantine.
+        // Recovery is serialized so two instances cannot both act on it.
         QLockFile recoveryLock(m_filePath + QStringLiteral(".recovery.lock"));
         if (!recoveryLock.tryLock(0)) {
             qWarning() << "AppSettings: another instance is recovering the"
                           " settings store — read-only session";
+            failClosed(QStringLiteral("Another instance is recovering the "
+                                      "settings database."));
             return;
         }
         quarantineCorruptStore();
         const bool restored = restoreNewestVerifiedBackup();
         opened = m_db->open(m_filePath);
-        if (opened && restored && !m_db->quickCheck()) {
+        confirmedCorrupt = !opened && m_db->lastOpenWasCorrupt();
+        if (opened && !validateIntegrity(confirmedCorrupt)) {
             opened = false;
         }
         if (!opened) {
             qWarning() << "AppSettings: could not establish a usable settings database";
+            failClosed(restored
+                           ? QStringLiteral("The restored settings backup could not be "
+                                            "opened safely.")
+                           : QStringLiteral("A replacement settings database could not "
+                                            "be created safely."));
             return;  // Failed — never overwrite what's left on disk
         }
+    } else if (!opened && QFile::exists(m_filePath)) {
+        qWarning() << "AppSettings: settings database could not be opened safely:"
+                   << m_db->lastError();
+        failClosed(QStringLiteral("The settings database could not be opened safely."));
+        return;
     } else if (!opened) {
         // No file and still cannot create one (permissions, disk full).
         qWarning() << "AppSettings: cannot create settings database at" << m_filePath;
@@ -263,7 +316,17 @@ void AppSettings::load()
             m_loadNotice = QStringLiteral(
                 "Settings are running read-only from the previous settings file; "
                 "the settings database could not be created.");
+        } else {
+            const QString databaseError = m_db->lastError().isEmpty()
+                                              ? QStringLiteral("an unspecified SQLite error")
+                                              : m_db->lastError();
+            QWriteLocker locker(&m_lock);
+            m_loadNotice = QStringLiteral(
+                "The settings database could not be created; changes will not be "
+                "saved in this session. (%1)")
+                               .arg(databaseError);
         }
+        m_db->close();
         return;  // Failed state — saves refused, retry next launch
     }
 

--- a/src/core/SettingsDatabase.cpp
+++ b/src/core/SettingsDatabase.cpp
@@ -111,17 +111,25 @@ bool SettingsDatabase::exec(const char* sql)
     if (rc != SQLITE_OK) {
         m_lastError = QString::fromUtf8(errMsg ? errMsg : "unknown sqlite error");
         sqlite3_free(errMsg);
-        // Busy is contention, not corruption — open()'s callers must be able
-        // to tell them apart wherever in the open sequence the busy landed
-        // (under WAL a concurrent EXCLUSIVE first bites in createSchema's
-        // BEGIN IMMEDIATE, not the read probe).
-        if (rc == SQLITE_BUSY || rc == SQLITE_LOCKED) {
-            m_lastOpenBusy = true;
-        }
+        recordSqliteFailure(rc);
         qWarning() << "SettingsDatabase: exec failed:" << sql << "—" << m_lastError;
         return false;
     }
     return true;
+}
+
+void SettingsDatabase::recordSqliteFailure(int resultCode)
+{
+    // Extended SQLite result codes retain the primary result in the low byte.
+    // The recovery decision intentionally recognizes only demonstrated
+    // corruption, never a generic I/O, permission, or initialization error.
+    const int primaryResult = resultCode & 0xff;
+    if (primaryResult == SQLITE_BUSY || primaryResult == SQLITE_LOCKED) {
+        m_lastOpenBusy = true;
+    }
+    if (primaryResult == SQLITE_CORRUPT || primaryResult == SQLITE_NOTADB) {
+        m_lastOpenCorrupt = true;
+    }
 }
 
 bool SettingsDatabase::open(const QString& path)
@@ -129,16 +137,22 @@ bool SettingsDatabase::open(const QString& path)
     close();
     m_newerSchema = false;
     m_lastOpenBusy = false;
+    m_lastOpenCorrupt = false;
+    m_lastError.clear();
 
     sqlite3* db = nullptr;
     const QByteArray utf8Path = path.toUtf8();
-    if (sqlite3_open_v2(utf8Path.constData(), &db,
-                        SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nullptr)
-        != SQLITE_OK) {
+    const int openResult = sqlite3_open_v2(utf8Path.constData(), &db,
+                                           SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+                                           nullptr);
+    if (openResult != SQLITE_OK) {
         m_lastError = db ? QString::fromUtf8(sqlite3_errmsg(db))
                          : QStringLiteral("out of memory");
+        recordSqliteFailure(openResult);
         qWarning() << "SettingsDatabase: cannot open" << path << "—" << m_lastError;
-        sqlite3_close(db);
+        if (db != nullptr) {
+            sqlite3_close(db);
+        }
         return false;
     }
     m_db = db;
@@ -187,13 +201,11 @@ bool SettingsDatabase::open(const QString& path)
     // real query touches it — probe before trusting it.
     {
         Statement probe(m_db, "SELECT count(*) FROM sqlite_schema;");
-        const int rc = probe.valid() ? sqlite3_step(probe.get()) : SQLITE_ERROR;
+        const int rc = probe.valid() ? sqlite3_step(probe.get())
+                                     : sqlite3_errcode(m_db);
         if (rc != SQLITE_ROW) {
             m_lastError = QString::fromUtf8(sqlite3_errmsg(m_db));
-            // SQLITE_BUSY past the timeout means another process holds the
-            // store — healthy, just contended. Report it distinctly so the
-            // caller fails the session instead of quarantining a live DB.
-            m_lastOpenBusy = (rc == SQLITE_BUSY || rc == SQLITE_LOCKED);
+            recordSqliteFailure(rc);
             qWarning() << "SettingsDatabase:" << path
                        << (m_lastOpenBusy ? "is locked by another process —"
                                           : "is not a readable database —")
@@ -206,9 +218,17 @@ bool SettingsDatabase::open(const QString& path)
     int userVersion = 0;
     {
         Statement stmt(m_db, "PRAGMA user_version;");
-        if (stmt.valid() && sqlite3_step(stmt.get()) == SQLITE_ROW) {
-            userVersion = sqlite3_column_int(stmt.get(), 0);
+        const int rc = stmt.valid() ? sqlite3_step(stmt.get())
+                                    : sqlite3_errcode(m_db);
+        if (rc != SQLITE_ROW) {
+            m_lastError = QString::fromUtf8(sqlite3_errmsg(m_db));
+            recordSqliteFailure(rc);
+            qWarning() << "SettingsDatabase: could not read schema version for"
+                       << path << "—" << m_lastError;
+            close();
+            return false;
         }
+        userVersion = sqlite3_column_int(stmt.get(), 0);
     }
 
     if (userVersion > kSchemaVersion) {
@@ -224,12 +244,18 @@ bool SettingsDatabase::open(const QString& path)
         sqlite3_close(m_db);
         m_db = nullptr;
         sqlite3* readOnlyDb = nullptr;
-        if (sqlite3_open_v2(utf8Path.constData(), &readOnlyDb,
-                            SQLITE_OPEN_READONLY, nullptr) != SQLITE_OK) {
+        const int readOnlyOpenResult = sqlite3_open_v2(utf8Path.constData(),
+                                                       &readOnlyDb,
+                                                       SQLITE_OPEN_READONLY,
+                                                       nullptr);
+        if (readOnlyOpenResult != SQLITE_OK) {
             m_lastError = readOnlyDb
                               ? QString::fromUtf8(sqlite3_errmsg(readOnlyDb))
                               : QStringLiteral("out of memory");
-            sqlite3_close(readOnlyDb);
+            recordSqliteFailure(readOnlyOpenResult);
+            if (readOnlyDb != nullptr) {
+                sqlite3_close(readOnlyDb);
+            }
             m_path.clear();
             return false;
         }
@@ -284,7 +310,16 @@ bool SettingsDatabase::createSchema()
                 ") WITHOUT ROWID;")
         && exec("PRAGMA user_version = 1;");
     if (!ok) {
+        // A rollback can itself fail after the operation that made the store
+        // unusable. Keep that first error: AppSettings surfaces it and must
+        // not replace corruption/permission evidence with cleanup noise.
+        const QString originalError = m_lastError;
+        const bool originalBusy = m_lastOpenBusy;
+        const bool originalCorrupt = m_lastOpenCorrupt;
         exec("ROLLBACK;");
+        m_lastError = originalError;
+        m_lastOpenBusy = m_lastOpenBusy || originalBusy;
+        m_lastOpenCorrupt = m_lastOpenCorrupt || originalCorrupt;
         return false;
     }
     return exec("COMMIT;");
@@ -309,24 +344,48 @@ void SettingsDatabase::close()
     m_readOnly = false;
 }
 
-bool SettingsDatabase::quickCheck()
+SettingsDatabase::IntegrityCheckResult SettingsDatabase::quickCheck()
 {
-    Statement stmt(m_db, "PRAGMA quick_check;");
-    if (!stmt.valid() || sqlite3_step(stmt.get()) != SQLITE_ROW) {
-        m_lastError = QString::fromUtf8(sqlite3_errmsg(m_db));
-        return false;
-    }
-    return columnText(stmt.get(), 0) == QStringLiteral("ok");
+    return runIntegrityCheck("PRAGMA quick_check;");
 }
 
-bool SettingsDatabase::integrityCheck()
+SettingsDatabase::IntegrityCheckResult SettingsDatabase::integrityCheck()
 {
-    Statement stmt(m_db, "PRAGMA integrity_check;");
-    if (!stmt.valid() || sqlite3_step(stmt.get()) != SQLITE_ROW) {
-        m_lastError = QString::fromUtf8(sqlite3_errmsg(m_db));
-        return false;
+    return runIntegrityCheck("PRAGMA integrity_check;");
+}
+
+SettingsDatabase::IntegrityCheckResult
+SettingsDatabase::runIntegrityCheck(const char* pragma)
+{
+    if (m_db == nullptr) {
+        m_lastError = QStringLiteral("settings database is not open");
+        return IntegrityCheckResult::Failed;
     }
-    return columnText(stmt.get(), 0) == QStringLiteral("ok");
+    Statement stmt(m_db, pragma);
+    int resultCode = stmt.valid() ? SQLITE_OK : sqlite3_errcode(m_db);
+    bool sawReport = false;
+    while (stmt.valid() && (resultCode = sqlite3_step(stmt.get())) == SQLITE_ROW) {
+        sawReport = true;
+        const QString report = columnText(stmt.get(), 0);
+        if (report != QStringLiteral("ok")) {
+            // A returned report is evidence, unlike failure to run the pragma.
+            m_lastError = QStringLiteral("SQLite integrity check reported: %1")
+                              .arg(report);
+            return IntegrityCheckResult::Corrupt;
+        }
+    }
+    if (sawReport && resultCode == SQLITE_DONE) {
+        return IntegrityCheckResult::Ok;
+    }
+
+    m_lastError = resultCode == SQLITE_DONE
+                      ? QStringLiteral("SQLite integrity check returned no report")
+                      : QString::fromUtf8(sqlite3_errmsg(m_db));
+    const int primaryResult = resultCode & 0xff;
+    if (primaryResult == SQLITE_CORRUPT || primaryResult == SQLITE_NOTADB) {
+        return IntegrityCheckResult::Corrupt;
+    }
+    return IntegrityCheckResult::Failed;
 }
 
 QString SettingsDatabase::metaValue(const QString& key, const QString& defaultValue)

--- a/src/core/SettingsDatabase.h
+++ b/src/core/SettingsDatabase.h
@@ -34,6 +34,12 @@ class SettingsDatabase {
 public:
     static constexpr int kSchemaVersion = 1;
 
+    // A check that could not execute is deliberately distinct from a check
+    // that returned a corruption report. AppSettings may only move the live
+    // store aside after the latter: permissions, I/O and lock failures must
+    // leave the original database available for a later retry.
+    enum class IntegrityCheckResult { Ok, Corrupt, Failed };
+
     SettingsDatabase();
     ~SettingsDatabase();
     SettingsDatabase(const SettingsDatabase&) = delete;
@@ -54,12 +60,16 @@ public:
     // (PR #4612 review: POSIX rename() succeeds on open files, so quarantining
     // a busy store split-brains a concurrent instance's committed writes).
     bool lastOpenWasBusy() const { return m_lastOpenBusy; }
+    // True only when SQLite explicitly reported SQLITE_CORRUPT/SQLITE_NOTADB
+    // while opening this database. This is the open-path counterpart to an
+    // IntegrityCheckResult::Corrupt report.
+    bool lastOpenWasCorrupt() const { return m_lastOpenCorrupt; }
     QString path() const { return m_path; }
     QString lastError() const { return m_lastError; }
 
     // Integrity: cheap check for every startup; full check when cheap fails.
-    bool quickCheck();
-    bool integrityCheck();
+    IntegrityCheckResult quickCheck();
+    IntegrityCheckResult integrityCheck();
 
     // meta table -------------------------------------------------------------
     QString metaValue(const QString& key, const QString& defaultValue = {});
@@ -132,6 +142,8 @@ public:
 private:
     bool exec(const char* sql);
     bool createSchema();
+    void recordSqliteFailure(int resultCode);
+    IntegrityCheckResult runIntegrityCheck(const char* pragma);
 
     sqlite3* m_db = nullptr;
     QString m_path;
@@ -139,6 +151,7 @@ private:
     bool m_newerSchema = false;
     bool m_readOnly = false;
     bool m_lastOpenBusy = false;
+    bool m_lastOpenCorrupt = false;
 };
 
 } // namespace AetherSDR

--- a/tests/app_settings_safety_test.cpp
+++ b/tests/app_settings_safety_test.cpp
@@ -6,7 +6,8 @@
 //   - save() before a successful load() can never create or damage a store
 //   - the one-time XML import: parity, recovery-ladder sources, frozen
 //     snapshot, meta stamping, credential exodus, no re-import
-//   - corruption handling: quarantine + backup restore, XML re-import
+//   - corruption handling: quarantine + backup restore, XML re-import, while
+//     permission/I/O failures leave healthy databases in place
 //   - newer-schema databases open read-only
 //   - dirty-row saves persist exactly the mutated rows
 #include "TestSettingsProfile.h"
@@ -536,6 +537,123 @@ void testLockedDbFailsClosed()
            "the next launch recovers normally once the lock is gone");
 }
 
+// A read-only owner file can still be opened and queried before SQLite reaches
+// createSchema()'s user_version write. That ordinary write refusal is not a
+// corruption report: quarantining it would replace current settings with an
+// older backup or legacy XML. Exercise both no-backup and backup-present forms
+// because recovery must stay forbidden in either case.
+int testReadOnlyDbFailsClosed(bool hasOlderBackup)
+{
+#ifdef Q_OS_WIN
+    Q_UNUSED(hasOlderBackup);
+    std::printf("[SKIP] POSIX owner-read-only fixture is not available on Windows\n");
+    return 77;
+#else
+    AppSettings& settings = AppSettings::instance();
+    const QByteArray frozenXml = settingsDocument(10, QStringLiteral("legacy"));
+    expect(writeFile(xmlPath(), frozenXml), "frozen legacy XML fixture is written");
+    settings.load();
+    settings.setValue(QStringLiteral("Survivor"), QStringLiteral("current"));
+    settings.save();
+    settings.reset();
+
+    QDir backups(SettingsPaths::backupsDir());
+    if (hasOlderBackup) {
+        expect(!backups.entryList({QStringLiteral("*.db")}, QDir::Files).isEmpty(),
+               "a verified older backup exists before the read-only failure");
+    } else {
+        const QStringList backupFiles = backups.entryList({QStringLiteral("*.db")},
+                                                           QDir::Files);
+        for (const QString& name : backupFiles) {
+            expect(backups.remove(name), "fixture backup is removed");
+        }
+        expect(backups.entryList({QStringLiteral("*.db")}, QDir::Files).isEmpty(),
+               "no backup remains before the read-only failure");
+    }
+    SettingsDatabase verifier;
+    expect(verifier.open(dbPath())
+               && verifier.quickCheck()
+                      == SettingsDatabase::IntegrityCheckResult::Ok,
+           "original database is healthy before permissions are changed");
+    verifier.close();
+    expect(QFile::setPermissions(dbPath(), QFileDevice::ReadOwner),
+           "healthy database is made owner-read-only");
+    if (g_failures != 0) {
+        return 1;
+    }
+    if (QFileInfo(dbPath()).isWritable()) {
+        QFile::setPermissions(dbPath(), QFileDevice::ReadOwner | QFileDevice::WriteOwner);
+        std::printf("[SKIP] this process can bypass owner-read-only permissions\n");
+        return 77;
+    }
+
+    settings.load();
+    settings.setValue(QStringLiteral("MustNotSave"), QStringLiteral("x"));
+    settings.save();
+
+    expect(QFile::exists(dbPath()), "a read-only database remains in place");
+    expect(!settings.storeWritable(),
+           "a read-only database failure keeps the session non-writable");
+    expect(!settings.loadNotice().isEmpty(),
+           "a read-only database failure is surfaced to the operator");
+    const QDir quarantine(SettingsPaths::quarantineDir());
+    expect(quarantine.entryList(QDir::Files).isEmpty(),
+           "a read-only database is never quarantined");
+    QString survivor;
+    expect(dbRow(QStringLiteral("Survivor"), survivor)
+               && survivor == QStringLiteral("current"),
+           "the original current database remains authoritative");
+    expect(!dbHas(QStringLiteral("MustNotSave")),
+           "the failed read-only session cannot save");
+    expect(readFile(xmlPath()) == frozenXml,
+           "the frozen legacy XML is unchanged by the failed read-only session");
+
+    expect(QFile::setPermissions(dbPath(),
+                                 QFileDevice::ReadOwner | QFileDevice::WriteOwner),
+           "database permissions are restored for the retry");
+    settings.reset();
+    settings.load();
+    expect(settings.value(QStringLiteral("Survivor")).toString()
+               == QStringLiteral("current"),
+           "a later writable launch loads the original database without recovery");
+    return g_failures == 0 ? 0 : 1;
+#endif
+}
+
+void testUnavailableIntegrityCheck()
+{
+    SettingsDatabase database;
+    expect(database.quickCheck() == SettingsDatabase::IntegrityCheckResult::Failed,
+           "an unavailable quick check is an execution failure, not corruption");
+    expect(database.integrityCheck() == SettingsDatabase::IntegrityCheckResult::Failed,
+           "an unavailable full check is an execution failure, not corruption");
+    expect(!database.lastOpenWasCorrupt() && !database.lastOpenWasBusy(),
+           "integrity execution failures do not change open-path classification");
+    expect(!database.lastError().isEmpty(), "an unavailable check reports its error");
+}
+
+void testFilesystemFailureFailsClosed()
+{
+    const QString markerPath = dbPath() + QStringLiteral("/ordinary-failure-marker");
+    expect(QDir().mkpath(dbPath()), "database-path directory obstacle is created");
+    expect(writeFile(markerPath, QByteArray("leave this ordinary filesystem failure")),
+           "database-path obstacle marker is written");
+
+    AppSettings& settings = AppSettings::instance();
+    settings.load();
+    settings.setValue(QStringLiteral("MustNotSave"), QStringLiteral("x"));
+    settings.save();
+
+    expect(QDir(dbPath()).exists(),
+           "an ordinary filesystem failure leaves the existing path in place");
+    expect(readFile(markerPath) == QByteArray("leave this ordinary filesystem failure"),
+           "an ordinary filesystem failure leaves existing path contents intact");
+    expect(!settings.storeWritable(),
+           "an ordinary filesystem failure keeps the session non-writable");
+    expect(!settings.loadNotice().isEmpty(),
+           "an ordinary filesystem failure is surfaced to the operator");
+}
+
 void testNewerSchemaOpensReadOnly()
 {
     // Create a healthy store, then stamp a schema version from the future.
@@ -950,6 +1068,14 @@ int main(int argc, char** argv)
         testCorruptDbReimportsFrozenXml();
     } else if (scenario == QStringLiteral("locked-db-fails-closed")) {
         testLockedDbFailsClosed();
+    } else if (scenario == QStringLiteral("readonly-db-fails-closed")) {
+        return testReadOnlyDbFailsClosed(false);
+    } else if (scenario == QStringLiteral("readonly-db-with-backup-fails-closed")) {
+        return testReadOnlyDbFailsClosed(true);
+    } else if (scenario == QStringLiteral("unavailable-integrity-check")) {
+        testUnavailableIntegrityCheck();
+    } else if (scenario == QStringLiteral("filesystem-failure-fails-closed")) {
+        testFilesystemFailureFailsClosed();
     } else if (scenario == QStringLiteral("newer-schema-readonly")) {
         testNewerSchemaOpensReadOnly();
     } else if (scenario == QStringLiteral("dirty-row-save")) {

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1222,6 +1222,10 @@ foreach(APP_SETTINGS_SCENARIO
         corrupt-db-restore-backup
         corrupt-db-reimport-xml
         locked-db-fails-closed
+        readonly-db-fails-closed
+        readonly-db-with-backup-fails-closed
+        unavailable-integrity-check
+        filesystem-failure-fails-closed
         newer-schema-readonly
         dirty-row-save
         display-slice-depth-default
@@ -1232,6 +1236,10 @@ foreach(APP_SETTINGS_SCENARIO
         NAME app_settings_safety_${APP_SETTINGS_SCENARIO}
         COMMAND app_settings_safety_test ${APP_SETTINGS_SCENARIO})
 endforeach()
+set_tests_properties(
+    app_settings_safety_readonly-db-fails-closed
+    app_settings_safety_readonly-db-with-backup-fails-closed
+    PROPERTIES SKIP_RETURN_CODE 77)
 
 add_executable(nr2_settings_model_test
     tests/nr2_settings_model_test.cpp


### PR DESCRIPTION
A healthy settings database could be quarantined and replaced by an older backup or frozen XML when initialization hit a write-permission error. A read-only file reproduced this at `PRAGMA user_version = 1`, losing newer settings from the active profile despite the original database still passing integrity verification.

Recovery now requires explicit SQLite corruption/not-a-database evidence or an integrity check that returns a damage report. Failed check execution, permissions, filesystem errors, and contention preserve the existing store and leave the session unable to save, with the error surfaced through the existing startup/CLI notice. Genuine corruption recovery and newer-schema read-only behavior remain covered.

Two changes go slightly beyond reclassification and are called out because they change *when* `open()` fails, not only how a failure is described:

- `PRAGMA user_version` that cannot be read now fails the open instead of silently defaulting to 0 and writing a schema into a store whose version is unknown. It is classified like any other failure, so a permission or I/O error there preserves rather than quarantines.
- `open()` asks the engine whether the handle can actually write (`sqlite3_db_readonly`). `sqlite3_open_v2(READWRITE|CREATE)` silently falls back to a read-only connection when the file is unwritable — which is the root of #5635 — so without an explicit check an unwritable store opens "successfully" and only fails at the first save.

Fixes #5635. Principle XIV (persist atomically — never leave a reader with a rolled-back or partially-replaced store).

## Preservation is literal

"Left in place" means byte-for-byte and mode-for-mode. Three things contradicted that and are fixed here:

- `createSchema()` re-stamped `PRAGMA user_version = 1` on every open of an existing store. The `CREATE TABLE IF NOT EXISTS` statements are no-ops that commit nothing, but that redundant stamp commits a transaction and bumps the SQLite file change counter on every launch. It is now written only when the value differs.
- The permission hardening pass wrote a fixed `ReadOwner|WriteOwner`, which also *grants* write on a store the operator deliberately left read-only. Running before the write refusal is detected, it silently turned a 0400 database into 0600 while reporting the file had been left in place. It now only ever removes group/other access.
- Preserving the database's mode exposed a lock-out: SQLite creates `-wal`/`-shm` with the *database's* mode, so merely reading a read-only store leaves read-only sidecars. The next connection maps them before any hardening pass can widen them, so `BEGIN IMMEDIATE` fails with `SQLITE_READONLY` even after the operator restores permissions, and the store stays locked out for good. `open()` now normalizes the sidecars on the way in — the only point that works, since a later chmod rescues nothing, exactly as in #5635 itself. They are SQLite scratch files, never operator state.

`createSchema()`'s rollback handler also restored `m_lastError` by assignment but OR-ed the two classification flags, so a `ROLLBACK` that itself reported `SQLITE_CORRUPT` could escalate a permission failure to quarantine-eligible while the error string still named the permission problem. All three are restored by assignment.

## Tests

The damage-report half of the admission rule had **no** coverage: both pre-existing corruption scenarios replace the whole file, which fails at `open()` and routes through `lastOpenWasCorrupt()` without ever calling `quickCheck()`. Downgrading `runIntegrityCheck()`'s report arm from `Corrupt` to `Failed` left all 26 scenarios green.

Three scenarios added (thanks @K5PTB for the integrity-report case):

| scenario | pins |
|---|---|
| `integrity-report-restores-backup` | a damaged data page opens cleanly and passes the schema probe; only the integrity check reports it, and that report still authorizes quarantine + restore |
| `preserve-keeps-bytes-and-mode` | byte identity, mode identity, and that a later launch is not locked out |
| `reopen-does-not-write` | an up-to-date store reopens without a single byte changing, while a fresh store is still stamped |

`filesystem-failure-fails-closed` now also asserts the empty quarantine, so it pins the preserve branch instead of passing equally well in the "cannot create" branch.

Every fix above is mutation-verified to fail at least one scenario:

| mutation | result |
|---|---|
| admission reverted to `!opened && QFile::exists(...)` | 3 fail |
| damage report downgraded to `Failed` | 1 fail (was 0) |
| writability probe removed | 3 fail |
| `user_version` stamped unconditionally | 1 fail |
| hardening forces owner rw on the database | 3 fail |
| early sidecar normalization removed | 2 fail |
| none (the branch as it stands) | 29/29 pass |

## Validation

- GitHub CI passed: Linux build, macOS, Windows, static checks, and sanitizer-option configuration.
- Full native ARM64 build passed with RADE enabled; host/system processor and final Mach-O are arm64, with no RNNoise x86 sources. The macOS icon-packaging step required execution outside the command sandbox.
- Linux RelWithDebInfo: clean full build, 29/29 `app_settings_safety_*` and 42/42 settings-related scenarios pass.
- End-to-end on the real binary: healthy store + sentinel, backups removed, `chmod 0400` → the CLI prints the notice and exits 2, the database is byte-identical by sha256, the quarantine is empty, and restoring permissions returns `preserve-me`.
- Automation bridge, offscreen, isolated settings, TX disabled: the startup notice renders verbatim in a `FramelessMessageBox`, the radio stays disconnected, and a full GUI session plus a clean Quit leaves the store byte-identical.

Coverage limits: permission fixtures skip (exit 77) on Windows or when the process can bypass permissions. The unavailable-integrity test proves failure classification on a closed handle; it does not inject a post-open storage-device I/O fault. The `Other`/unknown result-code arm of the classifier is not directly exercised — it fails toward preserve. No real user settings, backups, or radio were used.
