### PR TITLE
Fix CW decoder parameter races. Principle XI.

### DIFF
--- a/src/core/CwDecoder.cpp
+++ b/src/core/CwDecoder.cpp
@@ -18,21 +18,10 @@ void CwDecoder::start()
 {
     if (m_running) return;
 
-    // Create ggmorse instance for 24kHz mono int16 input
-    GGMorse::Parameters params;
-    params.sampleRateInp = 24000.0f;
-    params.sampleRateOut = 24000.0f;
-    params.samplesPerFrame = GGMorse::kDefaultSamplesPerFrame;
-    params.sampleFormatInp = GGMORSE_SAMPLE_FORMAT_I16;
-    params.sampleFormatOut = GGMORSE_SAMPLE_FORMAT_I16;
-
-    m_ggmorse = std::make_unique<GGMorse>(params);
-
-    // Auto-detect pitch and speed
-    GGMorse::ParametersDecode dp = GGMorse::getDefaultParametersDecode();
-    dp.frequency_hz = -1;  // auto
-    dp.speed_wpm = -1;     // auto
-    m_ggmorse->setParametersDecode(dp);
+    {
+        std::lock_guard lock(m_parametersMutex);
+        m_parametersDirty = true;
+    }
 
     m_running = true;
 
@@ -44,8 +33,7 @@ void CwDecoder::start()
     // Run decode loop on worker thread (CwDecoder stays on main thread)
     auto* worker = QThread::create([this]() { decodeLoop(); });
     worker->setObjectName("CwDecoder");
-    connect(worker, &QThread::finished, worker, &QThread::deleteLater);
-    m_workerThread = worker;
+    m_workerThread.reset(worker);
     worker->start();
 
     qCDebug(lcDsp) << "CwDecoder: started";
@@ -57,16 +45,16 @@ void CwDecoder::stop()
     m_running = false;
 
     if (m_workerThread) {
-        m_workerThread->wait(2000);
-        m_workerThread = nullptr;
+        // The callback checks m_running and each decode call is frame-bounded.
+        // Never destroy the buffer/owner while a slow frame is still running.
+        m_workerThread->wait();
+        m_workerThread.reset();
     }
-
-    m_ggmorse.reset();
 
     // The estimates died with the ggmorse instance — clear them so a later
     // Zero Beat can't retune the slice on a pitch from a previous run
     // (#5213).  Locked values are operator-set state, not estimates: keep
-    // them, or applyDecodeParameters() would feed 0 into a still-pressed
+    // them, or a restart would feed 0 into a still-pressed
     // lock button on the next start.
     if (!m_pitchLocked) m_pitch = 0;
     if (!m_speedLocked) m_speed = 0;
@@ -84,32 +72,26 @@ void CwDecoder::stop()
     qCDebug(lcDsp) << "CwDecoder: stopped";
 }
 
-// Build and apply current ggmorse decode parameters from all stored state.
-void CwDecoder::applyDecodeParameters()
-{
-    if (!m_ggmorse) return;
-    GGMorse::ParametersDecode dp = GGMorse::getDefaultParametersDecode();
-    dp.frequency_hz          = m_pitchLocked ? m_pitch.load() : -1.0f;
-    dp.speed_wpm             = m_speedLocked ? m_speed.load() : -1.0f;
-    dp.frequencyRangeMin_hz  = m_pitchRangeMin;
-    dp.frequencyRangeMax_hz  = m_pitchRangeMax;
-    dp.speedRangeMin_wpm     = m_speedRangeMin;
-    dp.speedRangeMax_wpm     = m_speedRangeMax;
-    m_ggmorse->setParametersDecode(dp);
-}
-
 void CwDecoder::lockPitch(bool lock)
 {
-    m_pitchLocked = lock;
-    applyDecodeParameters();
+    {
+        std::lock_guard guard(m_parametersMutex);
+        m_pitchLocked = lock;
+        m_pendingParameters.pitchHz = lock ? m_pitch.load() : -1.0f;
+        m_parametersDirty = true;
+    }
     qCDebug(lcDsp) << "CwDecoder: pitch" << (lock ? "locked at" : "unlocked from")
                    << m_pitch.load() << "Hz";
 }
 
 void CwDecoder::lockSpeed(bool lock)
 {
-    m_speedLocked = lock;
-    applyDecodeParameters();
+    {
+        std::lock_guard guard(m_parametersMutex);
+        m_speedLocked = lock;
+        m_pendingParameters.speedWpm = lock ? m_speed.load() : -1.0f;
+        m_parametersDirty = true;
+    }
     qCDebug(lcDsp) << "CwDecoder: speed" << (lock ? "locked at" : "unlocked from")
                    << m_speed.load() << "WPM";
 }
@@ -118,8 +100,9 @@ void CwDecoder::setKnownParameters(float pitchHz, float speedWpm)
 {
     if (pitchHz <= 0.0f || speedWpm <= 0.0f) return;
 
-    const bool unchanged = qFuzzyCompare(m_pitch.load(), pitchHz)
-        && qFuzzyCompare(m_speed.load(), speedWpm)
+    std::lock_guard lock(m_parametersMutex);
+    const bool unchanged = qFuzzyCompare(m_pendingParameters.pitchHz, pitchHz)
+        && qFuzzyCompare(m_pendingParameters.speedWpm, speedWpm)
         && m_pitchLocked && m_speedLocked;
     if (unchanged) return;
 
@@ -128,6 +111,8 @@ void CwDecoder::setKnownParameters(float pitchHz, float speedWpm)
     // sidetone is generated at exactly that rate — ggmorse with both
     // values locked gets a reliable unit length and correctly classifies
     // 1u / 3u / 7u gaps so inter-word boundaries become " " separators.
+    m_pendingParameters.pitchHz = pitchHz;
+    m_pendingParameters.speedWpm = speedWpm;
     m_pitch = pitchHz;
     m_speed = speedWpm;
     m_pitchLocked = true;
@@ -137,27 +122,29 @@ void CwDecoder::setKnownParameters(float pitchHz, float speedWpm)
     // is 500–700 Hz but operators commonly use 700 / 750 / 800).  Also
     // drives ggmorse's internal HPF cutoff.
     constexpr float kPitchRangePad = 150.0f;
-    m_pitchRangeMin = std::max(100.0f, pitchHz - kPitchRangePad);
-    m_pitchRangeMax = pitchHz + kPitchRangePad;
+    m_pendingParameters.pitchRangeMin = std::max(100.0f, pitchHz - kPitchRangePad);
+    m_pendingParameters.pitchRangeMax = pitchHz + kPitchRangePad;
 
-    applyDecodeParameters();
+    m_parametersDirty = true;
     qCDebug(lcDsp) << "CwDecoder: known params pitch=" << pitchHz
                    << "Hz speed=" << speedWpm << "WPM";
 }
 
 void CwDecoder::setPitchRange(int minHz, int maxHz)
 {
-    m_pitchRangeMin = static_cast<float>(minHz);
-    m_pitchRangeMax = static_cast<float>(maxHz);
-    applyDecodeParameters();
+    std::lock_guard lock(m_parametersMutex);
+    m_pendingParameters.pitchRangeMin = static_cast<float>(minHz);
+    m_pendingParameters.pitchRangeMax = static_cast<float>(maxHz);
+    m_parametersDirty = true;
     qCDebug(lcDsp) << "CwDecoder: pitch range" << minHz << "-" << maxHz << "Hz";
 }
 
 void CwDecoder::setSpeedRange(int minWpm, int maxWpm)
 {
-    m_speedRangeMin = static_cast<float>(minWpm);
-    m_speedRangeMax = static_cast<float>(maxWpm);
-    applyDecodeParameters();
+    std::lock_guard lock(m_parametersMutex);
+    m_pendingParameters.speedRangeMin = static_cast<float>(minWpm);
+    m_pendingParameters.speedRangeMax = static_cast<float>(maxWpm);
+    m_parametersDirty = true;
     qCDebug(lcDsp) << "CwDecoder: speed range" << minWpm << "-" << maxWpm << "WPM";
 }
 
@@ -186,10 +173,20 @@ void CwDecoder::feedAudio(const QByteArray& pcm24kStereo)
 
 void CwDecoder::decodeLoop()
 {
+    // Create ggmorse instance for 24kHz mono int16 input
+    GGMorse::Parameters params;
+    params.sampleRateInp = 24000.0f;
+    params.sampleRateOut = 24000.0f;
+    params.samplesPerFrame = GGMorse::kDefaultSamplesPerFrame;
+    params.sampleFormatInp = GGMORSE_SAMPLE_FORMAT_I16;
+    params.sampleFormatOut = GGMORSE_SAMPLE_FORMAT_I16;
+
+    GGMorse ggmorse(params);
+
     // ggmorse requests samplesPerFrame * resampleFactor * sampleSize bytes per callback.
     // At 24kHz int16, factor=6 (24000/4000), frame=128: 128*6*2 = 1536 bytes.
-    const int resampleFactor = static_cast<int>(m_ggmorse->getSampleRateInp() / GGMorse::kBaseSampleRate);
-    const int bytesPerFrame = m_ggmorse->getSamplesPerFrame() * resampleFactor * m_ggmorse->getSampleSizeBytesInp();
+    const int resampleFactor = static_cast<int>(ggmorse.getSampleRateInp() / GGMorse::kBaseSampleRate);
+    const int bytesPerFrame = ggmorse.getSamplesPerFrame() * resampleFactor * ggmorse.getSampleSizeBytesInp();
     int feedCount = 0;
 
     qCDebug(lcDsp) << "CwDecoder: decode loop running, bytesPerFrame:" << bytesPerFrame;
@@ -205,10 +202,35 @@ void CwDecoder::decodeLoop()
             }
         }
 
+        DecodeParameters pending;
+        bool applyParameters = false;
+        {
+            std::lock_guard lock(m_parametersMutex);
+            if (m_parametersDirty) {
+                pending = m_pendingParameters;
+                m_parametersDirty = false;
+                applyParameters = true;
+            }
+        }
+        if (applyParameters) {
+            GGMorse::ParametersDecode dp = GGMorse::getDefaultParametersDecode();
+            dp.frequency_hz = pending.pitchHz;
+            dp.speed_wpm = pending.speedWpm;
+            dp.frequencyRangeMin_hz = pending.pitchRangeMin;
+            dp.frequencyRangeMax_hz = pending.pitchRangeMax;
+            dp.speedRangeMin_wpm = pending.speedRangeMin;
+            dp.speedRangeMax_wpm = pending.speedRangeMax;
+            ggmorse.setParametersDecode(dp);
+        }
+
         int framesThisCall = 0;
 
-        bool gotData = m_ggmorse->decode([this, &framesThisCall](void* data, uint32_t nMaxBytes) -> uint32_t {
-            if (!m_running) return 0;
+        bool gotData = ggmorse.decode([this, &framesThisCall](void* data, uint32_t nMaxBytes) -> uint32_t {
+            // Return after one frame so continuously arriving audio cannot
+            // postpone pending parameter changes or stop indefinitely.
+            if (!m_running || framesThisCall > 0) {
+                return 0;
+            }
 
             QMutexLocker lock(&m_bufMutex);
             // ggmorse requires exactly nMaxBytes — partial returns cause it to abort
@@ -224,20 +246,20 @@ void CwDecoder::decodeLoop()
 
         // Log periodically
         if (feedCount % 200 == 0 && feedCount > 0) {
-            const auto& stats = m_ggmorse->getStatistics();
-            const auto& rxData = m_ggmorse->getRxData();
+            const auto& stats = ggmorse.getStatistics();
+            const auto& rxData = ggmorse.getRxData();
             qCDebug(lcDsp) << "CwDecoder:" << feedCount << "frames fed, pitch:"
                      << stats.estimatedPitch_Hz << "Hz, speed:"
                      << stats.estimatedSpeed_wpm << "WPM, decode:" << gotData
                      << "rxLen:" << rxData.size()
-                     << "lastResult:" << m_ggmorse->lastDecodeResult();
+                     << "lastResult:" << ggmorse.lastDecodeResult();
         }
 
-        const auto& stats = m_ggmorse->getStatistics();
+        const auto& stats = ggmorse.getStatistics();
 
         // Accept all decodes — color-coded by confidence in the UI
         GGMorse::TxRx rxData;
-        if (m_ggmorse->takeRxData(rxData) > 0 && stats.costFunction < 1.0f) {
+        if (ggmorse.takeRxData(rxData) > 0 && stats.costFunction < 1.0f) {
             QString text = QString::fromLatin1(
                 reinterpret_cast<const char*>(rxData.data()),
                 static_cast<int>(rxData.size()));
@@ -245,9 +267,23 @@ void CwDecoder::decodeLoop()
         }
 
         if (stats.estimatedPitch_Hz > 0) {
-            m_pitch = stats.estimatedPitch_Hz;
-            m_speed = stats.estimatedSpeed_wpm;
-            emit statsUpdated(m_pitch, m_speed);
+            float pitch;
+            float speed;
+            {
+                std::lock_guard lock(m_parametersMutex);
+                // A just-completed old frame must not overwrite a newer lock
+                // request. Locked setpoints live in the pending snapshot.
+                // Nonpositive locks still mean automatic detection to GGMorse.
+                if (!m_pitchLocked || m_pendingParameters.pitchHz <= 0.0f) {
+                    m_pitch = stats.estimatedPitch_Hz;
+                }
+                if (!m_speedLocked || m_pendingParameters.speedWpm <= 0.0f) {
+                    m_speed = stats.estimatedSpeed_wpm;
+                }
+                pitch = m_pitch;
+                speed = m_speed;
+            }
+            emit statsUpdated(pitch, speed);
         }
     }
 

--- a/src/core/CwDecoder.h
+++ b/src/core/CwDecoder.h
@@ -7,13 +7,12 @@
 
 #include <atomic>
 #include <memory>
-
-class GGMorse;
+#include <mutex>
 
 namespace AetherSDR {
 
 // Client-side CW (Morse code) decoder using ggmorse.
-// Runs decoding on a worker thread. Feed it 24kHz stereo int16 PCM
+// Runs decoding on a worker thread. Feed it 24kHz stereo float32 PCM
 // and it emits decoded text character by character.
 //
 // Usage:
@@ -28,6 +27,8 @@ public:
     explicit CwDecoder(QObject* parent = nullptr);
     ~CwDecoder() override;
 
+    // Lifecycle and parameter setters run on this QObject's owning thread.
+    // feedAudio() may run on the audio producer thread.
     void start();
     void stop();
     bool isRunning() const { return m_running; }
@@ -44,14 +45,14 @@ public:
     // Force pitch + speed to specific values and lock both — used by the
     // TX-side decoder (#2417) where the operator's keying parameters are
     // known from PhoneCwApplet rather than detected from the audio.
-    // Calling this while a decode is in progress reconfigures ggmorse
-    // immediately; subsequent calls are no-ops if the values are unchanged.
+    // Changes are applied by the worker before the next frame; subsequent
+    // calls are no-ops if the requested values are unchanged.
     void setKnownParameters(float pitchHz, float speedWpm);
     bool isPitchLocked() const { return m_pitchLocked; }
     bool isSpeedLocked() const { return m_speedLocked; }
 
 public slots:
-    // Feed 24kHz stereo int16 PCM (same format as AudioEngine receives).
+    // Feed 24kHz stereo float32 PCM (same format as AudioEngine receives).
     void feedAudio(const QByteArray& pcm24kStereo);
 
 signals:
@@ -60,10 +61,21 @@ signals:
 
 private:
     void decodeLoop();
-    void applyDecodeParameters();
+    std::unique_ptr<QThread> m_workerThread;
 
-    QThread*      m_workerThread{nullptr};
-    std::unique_ptr<GGMorse> m_ggmorse;
+    // One coherent pending configuration. Only setters and the decoder worker
+    // take this mutex; feedAudio() never does. GGMorse itself is worker-local.
+    struct DecodeParameters {
+        float pitchHz{-1.0f};
+        float speedWpm{-1.0f};
+        float pitchRangeMin{500.0f};
+        float pitchRangeMax{700.0f};
+        float speedRangeMin{-1.0f};
+        float speedRangeMax{-1.0f};
+    };
+    std::mutex m_parametersMutex;
+    DecodeParameters m_pendingParameters;
+    bool m_parametersDirty{true};
 
     // Ring buffer for audio samples (mono int16 at 24kHz)
     QMutex        m_bufMutex;
@@ -75,10 +87,6 @@ private:
     std::atomic<float> m_speed{0};
     std::atomic<bool> m_pitchLocked{false};
     std::atomic<bool> m_speedLocked{false};
-    std::atomic<float> m_pitchRangeMin{500.0f};
-    std::atomic<float> m_pitchRangeMax{700.0f};
-    std::atomic<float> m_speedRangeMin{-1.0f};   // -1 = full range
-    std::atomic<float> m_speedRangeMax{-1.0f};
 };
 
 } // namespace AetherSDR

--- a/tests/cw_decoder_parameters_test.cpp
+++ b/tests/cw_decoder_parameters_test.cpp
@@ -1,0 +1,238 @@
+#include "core/CwDecoder.h"
+#include "ggmorse/ggmorse.h"
+
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QLoggingCategory>
+#include <QThread>
+#include <QVector>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <iostream>
+
+namespace {
+
+int g_failures = 0;
+
+void expect(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++g_failures;
+    }
+}
+
+bool near(float actual, float expected)
+{
+    return std::abs(actual - expected) < 0.01f;
+}
+
+void pumpEvents(int milliseconds)
+{
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < milliseconds) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 5);
+        QThread::msleep(1);
+    }
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 5);
+}
+
+QByteArray makeCwPcm(float frequencyHz)
+{
+    GGMorse::Parameters parameters = GGMorse::getDefaultParameters();
+    parameters.sampleRateOut = 24000.0f;
+    parameters.sampleFormatOut = GGMORSE_SAMPLE_FORMAT_F32;
+    GGMorse encoder(parameters);
+
+    GGMorse::ParametersEncode encodeParameters = GGMorse::getDefaultParametersEncode();
+    encodeParameters.volume = 0.60f;
+    encodeParameters.frequency_hz = frequencyHz;
+    encodeParameters.speedCharacters_wpm = 20.0f;
+    encodeParameters.speedFarnsworth_wpm = 20.0f;
+    if (!encoder.setParametersEncode(encodeParameters)) {
+        return {};
+    }
+
+    constexpr char kMessage[] = "VVV VVV VVV VVV VVV";
+    if (!encoder.init(static_cast<int>(sizeof(kMessage) - 1), kMessage)) {
+        return {};
+    }
+
+    QByteArray mono;
+    if (!encoder.encode([&mono](const void* data, uint32_t byteCount) {
+            mono.append(static_cast<const char*>(data), static_cast<int>(byteCount));
+        })) {
+        return {};
+    }
+
+    const int sampleCount = mono.size() / static_cast<int>(sizeof(float));
+    QByteArray stereo(sampleCount * 2 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
+    const auto* source = reinterpret_cast<const float*>(mono.constData());
+    auto* destination = reinterpret_cast<float*>(stereo.data());
+    for (int sample = 0; sample < sampleCount; ++sample) {
+        destination[2 * sample] = source[sample];
+        destination[2 * sample + 1] = source[sample];
+    }
+    return stereo;
+}
+
+void feedChunk(AetherSDR::CwDecoder& decoder, const QByteArray& pcm, int chunkIndex)
+{
+    constexpr int kChunkSamples = 2400; // 100 ms at the public 24 kHz stereo float format.
+    const int bytesPerSample = 2 * static_cast<int>(sizeof(float));
+    const int offset = (chunkIndex * kChunkSamples * bytesPerSample) % pcm.size();
+    const int byteCount = std::min(kChunkSamples * bytesPerSample,
+                                   static_cast<int>(pcm.size()) - offset);
+    decoder.feedAudio(pcm.mid(offset, byteCount));
+}
+
+void churnParameters(AetherSDR::CwDecoder& decoder, const QByteArray& pcm, int iterations = 200)
+{
+    for (int iteration = 0; iteration < iterations; ++iteration) {
+        feedChunk(decoder, pcm, iteration);
+
+        // Every owning-thread setter runs while the decoder worker has queued
+        // audio. The duplicate known-value calls exercise the documented no-op.
+        decoder.setKnownParameters(650.0f, 25.0f);
+        decoder.setKnownParameters(650.0f, 25.0f);
+        decoder.lockPitch(false);
+        decoder.lockSpeed(false);
+        decoder.setPitchRange(450 + (iteration % 3) * 25, 850);
+        decoder.setSpeedRange(10 + (iteration % 3), 40);
+        decoder.lockPitch(true);
+        decoder.lockSpeed(true);
+        decoder.setKnownParameters(600.0f, 20.0f);
+        decoder.setKnownParameters(600.0f, 20.0f);
+        pumpEvents(5);
+    }
+}
+
+void feedKnownSignal(AetherSDR::CwDecoder& decoder, const QByteArray& pcm)
+{
+    const int bytesPerChunk = 2400 * 2 * static_cast<int>(sizeof(float));
+    for (int offset = 0; offset < pcm.size(); offset += bytesPerChunk) {
+        decoder.feedAudio(pcm.mid(offset, bytesPerChunk));
+        pumpEvents(5);
+    }
+}
+
+} // namespace
+
+namespace AetherSDR {
+Q_LOGGING_CATEGORY(lcDsp, "tests.cwdecoder", QtWarningMsg)
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    const QByteArray pcm = makeCwPcm(600.0f);
+    expect(!pcm.isEmpty(), "fixture generates 24 kHz stereo float CW PCM");
+    if (pcm.isEmpty()) {
+        return 1;
+    }
+
+    // Locking before the first estimate captures zero, which GGMorse treats
+    // as auto-detection. The public estimate must still become live.
+    {
+        AetherSDR::CwDecoder initiallyLocked;
+        initiallyLocked.lockPitch(true);
+        initiallyLocked.lockSpeed(true);
+        initiallyLocked.start();
+        feedKnownSignal(initiallyLocked, pcm);
+        pumpEvents(1000);
+        expect(initiallyLocked.estimatedPitch() > 0.0f,
+               "locking an unknown pitch still publishes automatic estimates");
+        expect(initiallyLocked.estimatedSpeed() > 0.0f,
+               "locking an unknown speed still publishes automatic estimates");
+        initiallyLocked.stop();
+    }
+
+    AetherSDR::CwDecoder decoder;
+    int statsUpdates = 0;
+    QString decodedText;
+    QVector<float> observedPitches;
+    QObject::connect(&decoder, &AetherSDR::CwDecoder::statsUpdated, &app,
+                     [&statsUpdates, &observedPitches](float pitchHz, float) {
+                         ++statsUpdates;
+                         observedPitches.append(pitchHz);
+                     });
+    QObject::connect(&decoder, &AetherSDR::CwDecoder::textDecoded, &app,
+                     [&decodedText](const QString& text, float) { decodedText += text; });
+
+    // Store known parameters before start and retain their public lock state.
+    decoder.setPitchRange(450, 850);
+    decoder.setSpeedRange(10, 40);
+    decoder.setKnownParameters(600.0f, 20.0f);
+    decoder.setKnownParameters(600.0f, 20.0f);
+    expect(decoder.isPitchLocked() && decoder.isSpeedLocked(),
+           "pre-start known parameters lock both dimensions");
+    expect(near(decoder.estimatedPitch(), 600.0f) && near(decoder.estimatedSpeed(), 20.0f),
+           "pre-start known parameters retain their requested values");
+
+    decoder.start();
+    expect(decoder.isRunning(), "decoder starts after pre-start configuration");
+    churnParameters(decoder, pcm);
+
+    // Hold the transmitted parameters steady for an independently generated,
+    // valid CW signal. A V (rather than GGMorse's pitch-change newline) proves
+    // the production worker completed Morse-symbol recognition after churn.
+    decoder.setKnownParameters(600.0f, 20.0f);
+    decodedText.clear();
+    feedKnownSignal(decoder, pcm);
+    pumpEvents(3000);
+    expect(statsUpdates > 0, "worker consumes PCM and publishes decoder statistics");
+    expect(decodedText.contains(QLatin1Char('V')),
+           "worker recognizes generated V characters after parameter churn");
+
+    decoder.stop();
+    pumpEvents(20);
+    expect(!decoder.isRunning(), "decoder stops after active parameter churn");
+    expect(decoder.isPitchLocked() && decoder.isSpeedLocked(),
+           "locked known parameters survive stop for restart");
+    expect(near(decoder.estimatedPitch(), 600.0f) && near(decoder.estimatedSpeed(), 20.0f),
+           "stop retains locked known parameter values");
+
+    // Set an auto-pitch range while stopped. The subsequent worker must start
+    // from this snapshot; no live setter may republish it after start.
+    decoder.lockPitch(false);
+    decoder.lockSpeed(false);
+    decoder.setPitchRange(800, 900);
+    decoder.setSpeedRange(18, 22);
+    pumpEvents(20);
+    observedPitches.clear();
+    decoder.start();
+    feedKnownSignal(decoder, pcm);
+    pumpEvents(1000);
+    expect(!observedPitches.isEmpty(),
+           "restart consumes PCM and publishes fresh auto-pitch observations");
+    if (!observedPitches.isEmpty()) {
+        expect(observedPitches.constLast() >= 795.0f && observedPitches.constLast() <= 905.0f,
+               "restart applies the stopped 800--900 Hz auto-pitch range");
+    }
+    decoder.stop();
+    pumpEvents(20);
+    expect(!decoder.isPitchLocked() && !decoder.isSpeedLocked(),
+           "explicit unlock survives stop");
+    expect(near(decoder.estimatedPitch(), 0.0f) && near(decoder.estimatedSpeed(), 0.0f),
+           "stop clears only unlocked estimates");
+
+    decoder.stop();
+
+    // Destruction while the worker owns queued audio must join the bounded
+    // decode loop before its buffers and pending configuration are destroyed.
+    {
+        AetherSDR::CwDecoder decoderDestroyedWhileRunning;
+        decoderDestroyedWhileRunning.setKnownParameters(600.0f, 20.0f);
+        decoderDestroyedWhileRunning.start();
+        churnParameters(decoderDestroyedWhileRunning, pcm, 24);
+        expect(decoderDestroyedWhileRunning.isRunning(),
+               "active decoder reaches its destructor with a running worker");
+    }
+
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -79,6 +79,20 @@ target_link_libraries(pcm_compatibility_test PRIVATE aethercore Qt6::Core)
 add_test(NAME pcm_compatibility_test COMMAND pcm_compatibility_test)
 set_tests_properties(pcm_compatibility_test PROPERTIES TIMEOUT 60)
 
+# CwDecoder public lifecycle/configuration race regression. Generated 24 kHz
+# stereo float CW drives the real worker/GGMorse path; no sockets or radio.
+add_executable(cw_decoder_parameters_test
+    tests/cw_decoder_parameters_test.cpp
+    src/core/CwDecoder.cpp
+    third_party/ggmorse/src/ggmorse.cpp
+    third_party/ggmorse/src/resampler.cpp
+)
+target_include_directories(cw_decoder_parameters_test PRIVATE
+    src src/core third_party/ggmorse/include third_party/ggmorse/src)
+target_link_libraries(cw_decoder_parameters_test PRIVATE Qt6::Core)
+add_test(NAME cw_decoder_parameters_test COMMAND cw_decoder_parameters_test)
+set_tests_properties(cw_decoder_parameters_test PROPERTIES TIMEOUT 60 LABELS sanitizer)
+
 # Socket/device-free production RX queue, processing-domain and output checks.
 add_executable(audio_engine_rates_test tests/audio_engine_rates_test.cpp)
 target_link_libraries(audio_engine_rates_test PRIVATE aethercore Qt6::Core)


### PR DESCRIPTION
Changing CW pitch, speed, locks, or search ranges could write GGMorse parameters and reinitialize its filters on the main thread while its worker was decoding. Scalar atomics in CwDecoder did not protect that state. Native ARM64 ThreadSanitizer reproduces the concurrent access; this report does not claim an unsanitized crash.

GGMorse now lives entirely on the existing decoder worker. Setters publish one coherent pending configuration, which the worker consumes between frame-bounded decode calls. Stop joins the worker before teardown; stopped settings survive restart, locked setpoints are retained, and unlocked estimates still clear. The parameter mutex is never taken by feedAudio(). Decoder algorithms, default values, and the audio feed path are unchanged.

Fixes #5641.

Validation:
- The exact new production-code regression test, compiled against preserved unfixed CwDecoder source from afce2e980, fails under native ARM64 TSan with a GGMorse::decode read versus GGMorse::setParametersDecode write.
- The same test against the fix passes normally and under native ARM64 TSan (about 15 seconds), with no TSan report. It exercises all public setters under 200 churn iterations, recognizes generated Morse V characters, observes a stopped-state search range after restart, destroys an active decoder, and preserves automatic estimates when a lock is pressed before any estimate exists.
- The original audit reproducer independently fails on the baseline and passes against the fix.
- cw_decoder_parameters_test is registered by default in tests/tests.cmake and therefore runs in the existing unfiltered full-suite and sanitizer workflows. It binds no sockets and uses no radio/firmware peer. The frozen per-PR test gate is unchanged.
- Full native macOS ARM64 app build passes with RADE enabled; host/system/binary are ARM64 and RNNoise x86 sources are absent. The final repository CTest passes in 11.89 seconds.
- The agent automation bridge exercised the native app with isolated settings, DEMO-0001, and TX disabled: CW mode, pitch/speed lock checked then unchecked (round-trip confirmed), USB then CW restart, and transmitting=false. Bridge close completed with process exit 0. This is UI/lifecycle smoke coverage; the production-code TSan baseline/fix comparison proves the race correction. The bridge cannot itself detect an internal data race.
- Independent concurrency and test review found no remaining actionable finding. Strict test registration, frozen CI gate, touchpoint manifest, engine-boundary and diff checks pass.

---

## Review round (`8a876b1`)

Four review passes (Copilot, aethersdr-agent, @K5PTB, @NF0T) plus a Linux pass. Everything actionable is applied here.

**Default search band restored.** `start()` re-publishing the snapshot on every start made `DecodeParameters`' struct initializers the effective default for the first time, and those read 500–700 Hz where `GGMorse::getDefaultParametersDecode()` reads 200–1200. Measured on an unconfigured decoder, 5 runs per cell: a 400 Hz CW note decoded `"VVV VVV VVV VVV VV"` on `main` and `""` here, with the speed estimate dragged from 20 to 40 WPM by the clamped pitch. The reachable path is the **RX** decoder on a default install — `routeCwDecoderOutput()`'s `setPitchRange()` was discarded while the decoder was stopped, so `start()` fell back to library defaults. (Not the TX decoder: `cwPitch()`/`cwSpeed()` are `qBound`-clamped away from 0, so `setKnownParameters()` unconditionally follows `m_cwDecoderTx.start()` twelve lines later.) The range fields now seed from ggmorse's own band, so the sentence above — algorithms, default values and the audio feed path unchanged — holds again.

**`start()`'s re-publish is now pinned.** That line is what stops the TX decoder reverting to auto-detect after a MOX cycle, and deleting it left the suite green. The test now restarts a second time with no setter in between, so the previous worker has already consumed the setters' own dirty flag and only `start()` can carry the band across. The mutant fails that assertion 3/3 and nothing else.

**Stale `statsUpdated`** (Copilot): the emission is posted through the event queue and reads `m_pitch`/`m_speed` at delivery, the shape `stop()` already used, so a setter landing mid-frame can no longer leave the panel on a dead reading.

**Housekeeping:** `${GGMORSE_SOURCES}` replaces the literal vendored paths; `LABELS sanitizer` is gone — no workflow runs `ctest -L`, so it routed nothing.

**Deferred, deliberately:** the upstream `GGMorse::setParametersDecode()` filter-cutoff lag (`ggmorse.cpp:259`/`:262` re-init the filters from the *pre-update* range). Considered and left alone — this PR does not change the number or ordering of `setParametersDecode()` calls relative to range edits, so the one-call lag behaves exactly as before. Tracked with the other adjacent pre-existing items in #5745.

**Linux verification** (GCC 16 / clang 22 / Qt 6.11), a platform none of the earlier passes covered, and through the **real CMake target** rather than a hand-rolled compile:

- `ctest -R cw_decoder_parameters_test` → passes in 9.95 s (`TIMEOUT 60`).
- 5/5 clean runs; 2 assertions fail 3/3 against the pre-fix `CwDecoder`.
- ASan: clean on head, no report on either tree.
- The test is wall-clock-bound, not CPU-bound — plain 8.2 s vs ASan 8.26 s — so a sanitizer multiplier mostly does not apply to the `TIMEOUT 60` margin.
- TSan on Linux could not be used as a signal either way: both trees abort in `sanitizer_thread_registry.cpp:186` inside `pthread_create` ← `QThread::start()`, and a twelve-line program that only does `QThread::create` → `start()` → `wait()` reproduces it with no AetherSDR code. That is clang 22 + an uninstrumented local Qt; the TSan demonstration remains the macOS ARM64 runs plus the weekly `sanitizers.yml` container.

