### PR TITLE
fix(hl2): make the ALC reduction-only and widen the mic slider (#5463 change 3)

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -1392,8 +1392,8 @@ inside AetherSDR on the host, not in radio firmware (#5401).
        {"chain":"hl2-tx","level":"dsp-config",
         "inputRateHz":48000,"outputRateHz":48000,"dspBlockSize":512,
         "filterLowHz":300,"filterHighHz":2700,
-        "alcEnabled":true,"alcTargetPeak":0.9,"alcMaxGainDb":20,
-        "alcAttackSec":0.005,"alcReleaseSec":0.25,"alcHoldBelowDbfs":-45,
+        "alcEnabled":true,"alcTargetPeak":0.9,
+        "alcAttackSec":0.005,"alcReleaseSec":0.25,
         "micGainLinear":1}]}}}
 ```
 

--- a/docs/radio-certification.md
+++ b/docs/radio-certification.md
@@ -39,7 +39,8 @@ Hermes-Lite 2 can physically produce it.
 | `TX:SWR` idle | SWR | yes | **absent** | key with no audio | present-while-idle means the ratio saturated |
 | `TX:FWDPWR` | dBm | yes | rises with drive | raise the drive **one nibble** → rises | see the note below on halving |
 | `TX:REFPWR` | dBm | yes | ≪ forward into a load | key into a dummy load | ≥15 dB below forward |
-| `TX:ALC` | dBFS | **host-side** | post-ALC transmit peak | sweep the input 20 dB → reading does **not** move | **±1 dB across the sweep** |
+| `TX:ALC` | dBFS | **host-side** | post-ALC transmit peak | sweep the input 20 dB **below** the ALC target → reading **tracks the input 1:1** | **within ±0.25 dB of `TX:MICPEAK` at every level** |
+| `TX:ALC` at the limit | dBFS | **host-side** | the ALC's target | raise the input **above** the target → reading stops at `20·log10(alcTargetPeak)` | **−1.41 dBFS ±0.25 dB** |
 | `TX:ALCGAIN` | dB | **host-side** | gain the ALC is applying | sweep the MIC input 20 dB, between `alcHoldBelowDbfs` and the makeup ceiling → reading moves 20 dB the other way | **±1 dB inside that window only** — the gain is frozen below the hold threshold (`Hl2TxDsp.cpp`, `processAudioBlock`) and capped at unity for `clientLeveled` audio, so a TCI/DAX sweep moves it 0 dB by construction and a whole-range criterion would report a healthy meter as out of tolerance |
 | `TX:COMPPEAK` | dB | host-side | compression applied | PROC on → rises above 0 | reads 0 with PROC off |
 | `TX:MIC` | dBFS | host-side | pre-gain mic level | — | not yet wired |
@@ -63,9 +64,13 @@ would notice the meter regressing (CERTIFICATION.md 1.37).
 
 Both of the changed stimulus cells above are measurements, not preferences —
 `TX:FWDPWR`'s nibble step replaces a halving the hardware refutes, and
-`TX:ALC`'s no-movement sweep replaces envelope tracking that would fail a
-correct meter by ~17 dB. The numbers are under *Certified by effect,
-2026-08-10* below.
+`TX:ALC`'s tracking sweep replaces a no-movement expectation that was the
+observable signature of the ALC's 40 dB of upward makeup — a stage since made
+reduction-only, so the old expectation would fail a correct meter by 28.6 dB.
+The numbers are under *Certified by effect, 2026-08-10* and *2026-09-09* below;
+both are kept, because the 2026-08-10 figures are still correct for the build
+they were taken on and reproducing them there is what makes the newer block
+trustworthy.
 
 ### Radio / hardware
 
@@ -88,7 +93,7 @@ a readback.
 | `TX:SWR` idle | unkeyed | **absent** (null, age −1) | **CERTIFIED** — the `kMinForwardCountsForSwr` gate does its job; no 255.99:1 |
 | `TX:REFPWR` | 5.57 W forward into a dummy load | **0.001 W**, ≈37 dB below forward | **CERTIFIED** — requirement is ≥15 dB |
 | `RAD:PATEMP` | 10 s key | 32.70 → **43.06 °C** (+10.36) | **CERTIFIED** — requirement is a ≥0.5 °C rise |
-| `TX:ALC` | tone swept −10 → −30 dBFS | **−1.41 dBFS at every level** | **CERTIFIED** — see the normalisation check below |
+| `TX:ALC` | tone swept −10 → −30 dBFS | **−1.41 dBFS at every level** | **CERTIFIED FOR THE BUILD IT WAS RUN ON**, which had the makeup ALC — see the normalisation check below, and the 2026-09-09 block after it |
 | `TX:COMPPEAK` | PROC off | **0 dB**, age 0–28 ms | **LIVE** — reads zero with the compressor off, which is correct |
 | `SLC:LEVEL` | receiving | −105.7 dBm, age 15–78 ms | **LIVE** |
 | `RAD:+13.8A` | — | not defined | **correct** — the HL2 reports no supply voltage |
@@ -118,6 +123,19 @@ This is the HL2 analogue of the IC-705's live-voice run below, with a synthetic
 stimulus instead of speech — weaker as an audio-quality check and stronger as a
 level check, since the tone's amplitude is exactly known.
 
+**What that check was actually measuring, established 2026-09-09.** The
+constancy above is not a property of a post-ALC peak meter in general. It is the
+observable signature of `Hl2TxDsp::Config::alcMaxGainDb`, 40 dB of upward makeup
+that drags any input from about −41 dBFS upward onto `alcTargetPeak` — and
+−1.41 dBFS is exactly `20·log10(0.85)`. Two consequences, both measured rather
+than reasoned. It does **not** hold over the whole input range even here: below
+about −42 dBFS the makeup's ceiling binds, the reading starts tracking again at a
+fixed +40 dB offset, and below the −45 dBFS `alcHoldBelowDbfs` threshold it
+becomes **path-dependent** — the same stage at comparable inputs was measured at
++33.17 dB and +39.996 dB of applied gain depending only on how the level was
+approached. And once the stage is made reduction-only the signature disappears
+entirely, which is the 2026-09-09 block below.
+
 `TX:FWDPWR` is **live and uncertified**, and the distinction is the point.
 It reads 5.57 W at full drive and 1.17 W at 25 %, so it plainly tracks drive.
 But the certification stimulus in the table above — halve the control, expect
@@ -142,6 +160,62 @@ curve, and **`radiocert` must not report one as a control defect.** Certifying
 drive by effect on this radio needs either a per-unit power calibration or an
 external power meter; until then the honest claim is "monotonic in drive",
 which is what the nibble sweep in `HERMES.md` 17.7 shows.
+
+### Certified by effect, 2026-09-09 (Hermes-Lite 2, gateware 74, 7.100 MHz USB, dummy load)
+
+The ALC became reduction-only in this series, so the 2026-08-10 normalisation
+check above no longer describes a correct radio. **Both builds were measured**,
+and the older figures reproduce on the older build — which is what makes this
+block trustworthy rather than merely newer.
+
+Stimulus: the host-side 1 kHz test tone, mic slider at 50 (unity, and the one
+slider position where the old and new `micSliderToGainDb` mappings agree by
+construction), speech processor off (`TX:COMPPEAK` 0.00 dB at every level),
+drive register 0 so the transmit DSP runs while the PA emits nothing.
+`TX:MICPEAK` is the control: it is measured inside `Hl2TxDsp` **after** the mic
+gain and **before** the ALC, so it sits downstream of the whole client TX chain
+and upstream of the stage under test, and it is what proves the stimulus varied
+rather than being flattened by the channel strip or the final limiter.
+
+| build | input span (`TX:MICPEAK`) | `TX:ALC` | verdict |
+|---|---|---|---|
+| the makeup ALC (pre-series) | −40.97 … −0.97 dBFS | **−1.435 … −1.412 dBFS**, span **0.023 dB** | the 2026-08-10 row, reproduced to 0.023 dB |
+| reduction-only (this series) | −54.89 … −1.41 dBFS | **tracks `TX:MICPEAK`**: max deviation **0.0065 dB**, sd 0.0015, fitted slope **0.99997** | **CERTIFIED** |
+| reduction-only, above the target | −1.11 … −0.97 dBFS | **−1.4136 … −1.4125 dBFS**, span **0.0011 dB** | **CERTIFIED** — the target is `20·log10(0.85)` = −1.4116 |
+
+The knee was **located, not assumed**: the reading still tracks at an input of
+−1.406 dBFS and is already at the target at −1.112 dBFS, bracketing the target
+itself. Approaching a level from above rather than from below changes the
+reading by **0.0 dB**.
+
+**The ±0.25 dB in the table above is margin, not measurement, and the two are
+worth keeping apart.** The worst deviation measured anywhere in the tracking
+region is 0.0065 dB, its standard deviation 0.0015 dB, the worst within-level
+scatter 0.0047 dB and the path dependence 0.0 dB; ±0.05 dB would be supported by
+every one of those. The tolerance is set two orders of magnitude looser so the
+row survives a different host, audio device and block alignment, none of which
+were varied — one radio, one host, one night.
+
+**Two things about running this row that the old one did not say.**
+
+- **It cannot be certified without transmitting.** `Hl2Backend::submitTxAudio`
+  returns early unless `m_keyed`, so the transmit DSP — and with it both
+  meters — is dead in a receive-only session. A load and a keyed window are
+  required. The drive may be zero, and was: the quantity is host-side, and on
+  this gateware the bottom nibble of the drive register is silence.
+- **Let the reading settle.** On the reduction-only build it is settled within
+  one meter update. On the makeup build it is not: after a step down in level
+  the gain climbs on the 0.5 s release constant, and a reading averaged across
+  the first half of a 3 s dwell sits up to **0.78 dB** from the settled one —
+  most of the old row's own ±1 dB budget spent on the instrument rather than on
+  the radio.
+
+**Where this expectation stops holding, measured rather than assumed:** it holds
+for inputs from −54.9 dBFS up to the ALC target. Below −54.9 dBFS is untested —
+the host test tone clamps at −60 dBFS (`ClientTxTestTone::setLevelDb`). Above
+roughly −1 dBFS the test tone itself saturates, so the limiting clause rests on
+three points between −1.11 and −0.97 dBFS. Nothing was radiated at any point, so
+no RF figure is claimed here.
 
 ### Icom (IC-705) — measured with `controls meters`, radio idle on 20 m
 

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -3468,17 +3468,52 @@ void Hl2Backend::setKeying(bool key)
     // not log per block, and a per-block test would fire on every normal
     // transmission because the pauses between words sit far below the target.
     if (m_keyed && !key) {
-        // HOW FAR BELOW THE TARGET COUNTS AS QUIET IS PROVISIONAL AND UNMEASURED.
+        // HOW FAR BELOW THE TARGET COUNTS AS QUIET. Upper bound MEASURED;
+        // the value inside it CHOSEN. Both halves are stated because they have
+        // different standing.
         //
         // The old -45 dBFS was a property of the hold — a real threshold in the
-        // DSP that an over either cleared or did not. Nothing replaces it,
-        // because nothing in the record measures how far under alcTargetPeak a
-        // transmission may sit before an operator would call it quiet on the
-        // air. 20 dB is a placeholder chosen to be obviously below a
-        // deliberately-set level and obviously above the noise, NOT a measured
-        // figure, and it must not be quoted as one. The d81-speech-pauses bench
-        // is what sets it; until that run, this constant is a guess with a name.
-        constexpr double kQuietMarginBelowTargetDb = 20.0;
+        // DSP that an over either cleared or did not. Nothing in the DSP
+        // replaces it, so this is a judgement about the air, informed by a
+        // measurement rather than derived from one.
+        //
+        // MEASURED (d81b-speech-pauses-alc, four legs, twelve speech bursts,
+        // two mic gains 20 dB apart, on this build — against hpsdrsim on a
+        // loopback approval, NOT on the air, and nothing radiated):
+        //
+        //   speech crest factor            18.87 dB, sd 0.80
+        //   burst-to-burst level spread    <= 0.91 dB
+        //   mic slider 50 (unity)          peak 19.56-19.67 dB BELOW
+        //                                  alcTargetPeak
+        //
+        // The unity figure is read off d81b's own result.json rather than off a
+        // summary of it: speech_output_dbfs is -21.08 dBFS on the fault leg and
+        // -20.97 dBFS on the control leg, both at mic_level 50, against
+        // 20*log10(0.85) = -1.4116 dBFS.
+        //
+        // THE UPPER BOUND IS ~19.56 dB AND IT IS HARD. Unity is where an operator
+        // who has never moved the slider sits, and on this build that is about
+        // 19.6 dB short of the target — precisely the operator this diagnostic
+        // exists to reach. A margin at or above 19.56 would stay SILENT on them.
+        // The earlier placeholder here was 20.0 dB, so it was outside its own
+        // bound and would have failed in the one case it was written for. That
+        // is why a guess with a name is still a guess.
+        //
+        // CHOSEN, 12.0 dB: it fires on unity with 7.6 dB to spare, it does not
+        // fire until a station is two S-units down — weak on the air, not merely
+        // conservatively set — and it clears the measured noise (0.91 dB of
+        // burst variation, 0.80 dB of crest scatter) by an order of magnitude.
+        //
+        // WHAT WOULD MAKE THIS MEASURED RATHER THAN BOUNDED. d81b bounds the
+        // correct setting from ONE side only. There is no bracket: d81b's
+        // slider-100 legs run a DIFFERENT stimulus (sp-53.wav) from the unity
+        // legs (sp-38.wav, sp-50.wav), and the record's own op_leg_caveat says
+        // they are not comparable leg-to-leg, so their 8.68 dB of applied ALC
+        // reduction is not the other half of a bracket around unity. One
+        // further leg at slider ~74 — where 0.8 dB per step puts the peak on
+        // the target — would measure the healthy case directly and give this
+        // constant data on both sides.
+        constexpr double kQuietMarginBelowTargetDb = 12.0;
         const double targetDbfs =
             20.0 * std::log10(std::max(1e-9, m_alcTargetPeak));
         const double quietBelowDbfs = targetDbfs - kQuietMarginBelowTargetDb;

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -31,13 +31,19 @@
 #include <tuple>
 #include <utility>
 
-// Hl2Backend.h seeds m_alcHoldBelowDbfs with a literal because it can only
+// Hl2Backend.h seeds m_alcTargetPeak with a literal because it can only
 // forward-declare Hl2TxDsp. This is what stops the two drifting: the seed has
 // to keep meaning "the modulator's own default" for a pre-connect snapshot to
 // be honest, and a silent divergence is exactly the class of readout error this
 // backend's health section exists to eliminate.
-static_assert(AetherSDR::hl2::Hl2TxDsp::Config{}.alcHoldBelowDbfs == -45.0,
-              "Hl2Backend.h seeds m_alcHoldBelowDbfs with this value — keep them equal");
+//
+// This pinned alcHoldBelowDbfs == -45.0 until the ALC's makeup half was removed
+// and the hold with it. Re-pointing it rather than deleting it is deliberate:
+// the compile-time link is the only thing that made the deletion of the Config
+// field surface here as a build failure instead of a stale readout, and the
+// target is what a mic peak is now measured against.
+static_assert(AetherSDR::hl2::Hl2TxDsp::Config{}.alcTargetPeak == 0.85,
+              "Hl2Backend.h seeds m_alcTargetPeak with this value — keep them equal");
 
 Q_LOGGING_CATEGORY(lcHl2Tx, "aether.hl2.tx")
 
@@ -530,9 +536,10 @@ Hl2Backend::Hl2Backend(QObject* parent) : IRadioBackend(parent)
             [this](float dbfs) {
         emit meterUpdate(QStringLiteral("TX:MICPEAK"), dbfs);
         // Loudest thing the operator said this transmission. Evaluated at unkey
-        // (setKeying) against the ALC's hold threshold — a PER-BLOCK test would
+        // (setKeying) against the ALC's target peak — a PER-BLOCK test would
         // fire on every normal transmission, because the pauses between words
-        // are exactly what the hold exists to sit through.
+        // sit far below the target by definition. The MAXIMUM across the over
+        // is the only reading that answers "did any of this modulate".
         if (m_keyed)
             m_txMicPeakMaxDbfs = std::max(m_txMicPeakMaxDbfs, dbfs);
     });
@@ -2089,12 +2096,11 @@ void Hl2Backend::connectRadio(const RadioConnectRequest& request)
         tc.filterLowHz  = txLo;
         tc.filterHighHz = txHi;
     }
-    // Remember the threshold the modulator is being handed, so the health
-    // snapshot and the unkey diagnostic both report what it is RUNNING rather
-    // than what a default-constructed Config would have said. Assigned from
-    // `tc` and not from the default so it stays correct the day this Config
-    // sets the field.
-    m_alcHoldBelowDbfs = tc.alcHoldBelowDbfs;
+    // Remember the target the modulator is being handed, so the health snapshot
+    // and the unkey diagnostic both report what it is RUNNING rather than what
+    // a default-constructed Config would have said. Assigned from `tc` and not
+    // from the default so it stays correct the day this Config sets the field.
+    m_alcTargetPeak = tc.alcTargetPeak;
 
     // Announce the passband the modulator is being configured with. The Config
     // is how the modulator learns it, so this is the echo half only — but it is
@@ -3447,33 +3453,77 @@ void Hl2Backend::setKeying(bool key)
         }
         m_cwAutoKeyed = false;
     }
-    // THE ALC'S HOLD THRESHOLD IS A SILENT CLIFF, so say when an operator has
-    // fallen off it.
+    // THE OPERATOR'S OWN LEVEL IS NOW THE ONLY LEVEL, so say when it was not set.
     //
-    // Below alcHoldBelowDbfs the ALC deliberately stops raising gain — that is
-    // what keeps it from winding up 40 dB on room noise between words and
-    // fighting the speech processor. But a microphone whose PEAKS never reach
-    // the threshold now gets no makeup gain at all where it previously got up to
-    // 40 dB, and "I was quiet on the air" points at nothing. The answer is mic
-    // gain, and the meter that shows it is the one this very peak feeds.
+    // The ALC used to carry up to 40 dB of makeup gain and stopped lifting below
+    // a hold threshold, and this diagnostic named the operators who had fallen
+    // off that cliff. The makeup half is gone: the stage now only reduces, so
+    // the pre-ALC mic peak IS the on-air level up to alcTargetPeak, and what
+    // used to describe a quiet microphone describes EVERY microphone whose gain
+    // nobody has set. Removing the diagnostic in the same change that makes
+    // operators quiet would take away the one instrument that tells them what
+    // to do, so it is re-pointed instead.
     //
     // At unkey, once per transmission, on the main thread: the DSP worker must
     // not log per block, and a per-block test would fire on every normal
-    // transmission because the pauses between words are what the hold is for.
+    // transmission because the pauses between words sit far below the target.
     if (m_keyed && !key) {
-        const double kHoldDbfs = m_alcHoldBelowDbfs;
-        // Not for client-leveled transmissions: the ALC is bypassed there
-        // (#4796), so a below-threshold peak is the client's own attenuation
-        // doing exactly what it asked for, and "raise mic gain" would send an
-        // operator chasing a control that was never in the path.
+        // HOW FAR BELOW THE TARGET COUNTS AS QUIET IS PROVISIONAL AND UNMEASURED.
+        //
+        // The old -45 dBFS was a property of the hold — a real threshold in the
+        // DSP that an over either cleared or did not. Nothing replaces it,
+        // because nothing in the record measures how far under alcTargetPeak a
+        // transmission may sit before an operator would call it quiet on the
+        // air. 20 dB is a placeholder chosen to be obviously below a
+        // deliberately-set level and obviously above the noise, NOT a measured
+        // figure, and it must not be quoted as one. The d81-speech-pauses bench
+        // is what sets it; until that run, this constant is a guess with a name.
+        constexpr double kQuietMarginBelowTargetDb = 20.0;
+        const double targetDbfs =
+            20.0 * std::log10(std::max(1e-9, m_alcTargetPeak));
+        const double quietBelowDbfs = targetDbfs - kQuietMarginBelowTargetDb;
+        // Not for client-leveled transmissions. The reason is no longer that the
+        // ALC is bypassed there — the mic and client paths are identical now
+        // that the ceiling is unity on both. It is that the ADVICE is wrong: a
+        // TCI/DAX client's transmit level is set in the client (WSJT-X's Pwr
+        // slider and the rest), and "raise mic gain" would send an operator to a
+        // control that is not the one holding their level down.
         if (!m_txAudioClientLeveled
             && m_txMicPeakMaxDbfs > -139.0f
-            && m_txMicPeakMaxDbfs < static_cast<float>(kHoldDbfs)) {
-            qCInfo(lcHl2) << "HL2 TX: microphone peaked at" << m_txMicPeakMaxDbfs
-                          << "dBFS for the whole transmission, below the ALC hold"
-                             " threshold of" << kHoldDbfs
-                          << "dBFS — the ALC held rather than lifting it, so that"
-                             " audio went out quiet. Raise mic gain.";
+            && m_txMicPeakMaxDbfs < static_cast<float>(quietBelowDbfs)) {
+            // WHETHER "RAISE MIC GAIN" IS EVEN THE RIGHT ADVICE depends on
+            // whether the slider can still close the gap. Speech near -32 dBFS
+            // against a target near -1.4 dBFS is a ~30 dB shortfall, and the
+            // slider spans +40 dB from 50, so at the top of its travel there
+            // may be nothing left to raise — that state is reachable for the
+            // first time under a unity ceiling, and telling such an operator to
+            // raise a control that is already at maximum is worse than saying
+            // nothing. Derived from the mapping rather than from a threshold:
+            // remaining travel versus the shortfall, so it stays true if either
+            // moves.
+            const double shortfallDb = targetDbfs - m_txMicPeakMaxDbfs;
+            const double travelLeftDb =
+                micSliderToGainDb(100) - micSliderToGainDb(m_micLevel);
+            if (travelLeftDb >= shortfallDb) {
+                qCInfo(lcHl2) << "HL2 TX: microphone peaked at" << m_txMicPeakMaxDbfs
+                              << "dBFS for the whole transmission, about"
+                              << shortfallDb
+                              << "dB under the ALC target of" << targetDbfs
+                              << "dBFS — the ALC only reduces, so that audio went"
+                                 " out quiet. Raise mic gain (currently"
+                              << m_micLevel << "of 100).";
+            } else {
+                qCInfo(lcHl2) << "HL2 TX: microphone peaked at" << m_txMicPeakMaxDbfs
+                              << "dBFS for the whole transmission, about"
+                              << shortfallDb
+                              << "dB under the ALC target of" << targetDbfs
+                              << "dBFS, and mic gain is at" << m_micLevel
+                              << "of 100 with only" << travelLeftDb
+                              << "dB of travel left — the slider cannot close"
+                                 " this. Raise the microphone's own level"
+                                 " (AetherVoice input gain, or the mic's own"
+                                 " control) instead.";
+            }
         }
     }
     if (key) {
@@ -4061,35 +4111,34 @@ void Hl2Backend::setTxFilter(int lowHz, int highHz)
 // the first time this code shipped and the first launch after the level began
 // persisting.
 //
-// Above and below that, +/-20 dB linear in dB — 0.4 dB per slider step, which is
-// fine enough to set by ear and wide enough to cover the range between a headset
-// boom mic and a built-in laptop microphone.
+// The travel around that point is ASYMMETRIC: -20 dB below 50 at 0.4 dB per
+// step, +40 dB above it at 0.8 dB per step. The upward half was widened when the
+// ALC's 40 dB of makeup was removed — speech near -32 dBFS against an ALC target
+// near -1.4 dBFS is a ~30 dB shortfall, and the old +20 dB left the chain 10.6 dB
+// short at maximum slider. Widening it symmetrically would have moved unity off
+// 50 and changed the transmit level of every existing install, which is the one
+// thing the paragraph above forbids. So the two legs meet at 50 with different
+// slopes, and hl2_tx_level_policy_test pins the join.
 //
-// WHAT THIS DOES AND DOES NOT BUY depends on which path the audio took, because
-// the ALC sits right behind this and is one-sided for client-leveled audio
-// (#4796).
+// WHAT THIS BUYS is now the same on every path, and that is the change. The ALC
+// behind this only reduces — it has no makeup half left to give the gain back
+// with — so this slider is a straight proportional control on the air all the
+// way up to alcTargetPeak, for the microphone and for a TCI/DAX client alike.
+// TX gain 5 is a real -18 dB. Past the target the ALC limits rather than letting
+// the modulator's hard clamp flat-top the signal, so the last stretch of travel
+// buys reduced headroom rather than more power.
 //
-// MIC PATH: the ALC normalizes each block's peak to alcTargetPeak, so raising
-// mic gain on already-loud speech is largely given back and PEP barely moves.
-// Where it MATTERS is the ALC's hold threshold (alcHoldBelowDbfs, -45 dBFS):
-// below that the ALC deliberately stops lifting, so a microphone quiet enough to
-// sit under it gets no makeup at all and goes out weak. This slider is what
-// carries such a mic over the threshold — which is exactly what setKeying()'s
-// "raise mic gain" diagnostic tells the operator to do, and until that
-// diagnostic existed the advice pointed at a control that did nothing here.
-//
-// CLIENT-LEVELED PATH (TCI/DAX): nothing is given back. The ALC may only reduce,
-// never lift, so this is a straight proportional attenuator all the way up to
-// alcTargetPeak — TX gain 5 is a real -18 dB on the air. The hold threshold does
-// not apply, and neither does the "raise mic gain" diagnostic, which setKeying()
-// gates off for such transmissions. Past the target the ALC limits rather than
-// letting the modulator's clamp flat-top the signal, so the last stretch of
-// travel buys reduced headroom rather than more power.
+// The one path-dependent thing left is setKeying()'s "raise mic gain"
+// diagnostic, which is gated off for client-leveled transmissions — not because
+// the DSP treats them differently any more, but because the remedy for a quiet
+// TCI/DAX client is that client's own level control.
 //
 // Level 0 mutes outright rather than resolving to -20 dB. A slider at the bottom
-// of its travel means off, and a mic that is merely 20 dB down would still be
-// hauled back up by the ALC's 40 dB of makeup — so without the special case,
-// "0" would sound barely different from "50".
+// of its travel means off. That used to need arguing — a mic merely 20 dB down
+// would have been hauled back up by the ALC's makeup, so "0" would have sounded
+// much like "50" — and now it needs none: -20 dB is simply -20 dB on the air,
+// and the special case is there because the bottom of a travel should mean off
+// rather than very quiet.
 void Hl2Backend::setMicGain(int level)
 {
     level = std::clamp(level, 0, 100);
@@ -4271,10 +4320,8 @@ QVariantList Hl2Backend::gatherDspChains(const std::vector<Hl2RxDsp*>& rxDsps,
         e[QStringLiteral("filterHighHz")] = t.filterHighHz;
         e[QStringLiteral("alcEnabled")] = t.alcEnabled;
         e[QStringLiteral("alcTargetPeak")] = t.alcTargetPeak;
-        e[QStringLiteral("alcMaxGainDb")] = t.alcMaxGainDb;
         e[QStringLiteral("alcAttackSec")] = t.alcAttackSec;
         e[QStringLiteral("alcReleaseSec")] = t.alcReleaseSec;
-        e[QStringLiteral("alcHoldBelowDbfs")] = t.alcHoldBelowDbfs;
         e[QStringLiteral("micGainLinear")] = txDsp->micGain();
         chains.append(e);
     }
@@ -4558,26 +4605,26 @@ IRadioBackend::HealthSnapshot Hl2Backend::healthSnapshot() const
         std::isnan(m_appliedMicGainLinear) ? QVariant()
                                            : QVariant(m_appliedMicGainLinear));
     // Peak mic level for the CURRENT transmission, reset at each key. Compared
-    // against the hold threshold below, these two rows are the whole "why did I
-    // go out quiet" diagnosis: a peak under the threshold means the ALC declined
-    // to lift it and the answer is mic gain.
+    // against the ALC target below, these two rows are the whole "why did I go
+    // out quiet" diagnosis: the ALC only reduces, so this peak IS the on-air
+    // level up to the target, and a peak well under it means nothing lifted it
+    // and the answer is mic gain.
     put("txMicPeakDbfs", QStringLiteral("Mic peak this over (dBFS)"),
         m_txMicPeakMaxDbfs > -139.0f ? QVariant(m_txMicPeakMaxDbfs) : QVariant());
-    // The threshold the modulator was actually CONFIGURED with, not the one a
+    // The target the modulator was actually CONFIGURED with, not the one a
     // default-constructed Config would have. The two agree today because the
     // Config built in connectRadio() never touches this field — but this row sits
     // in a section whose thesis is "report what the modulator is running",
     // and a constant that silently stops matching the modulator is the row
     // nobody would think to suspect.
     //
-    // Labelled as mic-path-only since #4796: the hold governs the ALC's MAKEUP
-    // half, and client-leveled (TCI/DAX) audio has no makeup half to hold — its
-    // gain is ceilinged at unity and released freely. A reader debugging a
-    // WSJT-X level problem against this row would otherwise chase a threshold
-    // that was never in their path.
-    put("alcHoldBelowDbfs",
-        QStringLiteral("ALC hold threshold (dBFS, mic path only)"),
-        m_alcHoldBelowDbfs);
+    // This row reported alcHoldBelowDbfs until the ALC's makeup half was
+    // removed. It is the target now, and it applies to EVERY path rather than
+    // to the mic path only: with the ceiling at unity there is no longer a
+    // mic/client asymmetry for a reader to be misled by.
+    put("alcTargetPeak",
+        QStringLiteral("ALC target peak (linear, all paths)"),
+        m_alcTargetPeak);
     put("alcGainDb", QStringLiteral("ALC gain applied (dB)"),
         std::isnan(m_alcGainDb) ? QVariant() : QVariant(m_alcGainDb));
     put("alcPeakDbfs", QStringLiteral("Post-ALC peak (dBFS)"),

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -877,16 +877,16 @@ private:
     int m_txFilterHighHz = 2700;
 
     // Loudest microphone peak of the current transmission, in dBFS, so setKeying()
-    // can tell at unkey whether the operator spent the whole of it below the ALC's
-    // hold threshold — the one case where holding the gain leaves them quiet
-    // rather than merely stopping the stage pumping. -140 is the floor
-    // Hl2TxDsp::micPeak reports for silence, and means "nothing measured yet".
+    // can tell at unkey whether the operator spent the whole of it well below the
+    // ALC's target — which, now that the ALC only reduces, means they went out
+    // that quiet on the air. -140 is the floor Hl2TxDsp::micPeak reports for
+    // silence, and means "nothing measured yet".
     float m_txMicPeakMaxDbfs = -140.0f;
 
     // True once the current transmission has carried client-leveled (TCI/DAX)
-    // audio, for which the ALC is bypassed (#4796). Gates the unkey "raise mic
-    // gain" diagnostic, whose advice only applies to the microphone path.
-    // Cleared on each key edge in setKeying().
+    // audio. Gates the unkey "raise mic gain" diagnostic, whose advice only
+    // applies to the microphone path — a TCI/DAX client's level is set in the
+    // client. Cleared on each key edge in setKeying().
     bool m_txAudioClientLeveled = false;
 
     // The passband to push at the modulator for `mode`: the operator's if they
@@ -1036,18 +1036,24 @@ private:
     // exact pair that was indistinguishable while this control was dead.
     double m_appliedMicGainLinear = std::numeric_limits<double>::quiet_NaN();
 
-    // The ALC hold threshold the modulator was CONFIGURED with, captured from
-    // the Config that connectRadio() hands it. Read by healthSnapshot() and by
-    // setKeying()'s "raise mic gain" diagnostic, both of which previously
-    // re-derived it from a default-constructed Config and so would have gone on
-    // reporting -45 dBFS the day connectRadio() set the field to anything else.
+    // The ALC target peak the modulator was CONFIGURED with, captured from the
+    // Config that connectRadio() hands it. Read by healthSnapshot() and by
+    // setKeying()'s "raise mic gain" diagnostic, both of which would otherwise
+    // re-derive it from a default-constructed Config and so go on reporting
+    // 0.85 the day connectRadio() sets the field to anything else.
+    //
+    // This mirror used to hold alcHoldBelowDbfs. That field is gone with the
+    // ALC's makeup half, and the target replaced it rather than the row being
+    // deleted: now that the stage only reduces, the pre-ALC mic peak IS the
+    // on-air level up to the target, so the target is what both readers have
+    // to compare a peak against.
     //
     // Seeded with Config's own default so a snapshot taken before the first
     // connect still reports what the modulator would use. The literal is spelt
     // out because Hl2TxDsp is only forward-declared in this header — a
     // static_assert in Hl2Backend.cpp pins it to Config's default, so the two
     // cannot drift silently.
-    double m_alcHoldBelowDbfs = -45.0;
+    double m_alcTargetPeak = 0.85;
 
     // Fraction of the half-span the slice may occupy before the NCO re-centres.
     // 0.8 leaves the outer 20% of each side for filter roll-off.

--- a/src/core/backends/hl2/Hl2TxDsp.cpp
+++ b/src/core/backends/hl2/Hl2TxDsp.cpp
@@ -170,7 +170,10 @@ bool Hl2TxDsp::isLowerSideband() const
     }
 }
 
-void Hl2TxDsp::processAudioBlock(const std::vector<float>& mono, bool clientLeveled)
+// `clientLeveled` is unused since the ALC's ceiling became unity on every path;
+// see the declaration in Hl2TxDsp.h for why the parameter is kept for now.
+void Hl2TxDsp::processAudioBlock(const std::vector<float>& mono,
+                                 [[maybe_unused]] bool clientLeveled)
 {
     if (m_bandpass.empty() || mono.empty())
         return;
@@ -191,46 +194,60 @@ void Hl2TxDsp::processAudioBlock(const std::vector<float>& mono, bool clientLeve
     float peak = 0.0f;
     float postAlcPeak = 0.0f;
 
-    // ---- ALC: bring speech up to something that actually modulates ----
+    // ---- ALC: protection only — it may reduce, never add ----
     //
     // Peak-tracking with a fast attack and a slow release, which is the
-    // conventional shape: catch the onset of a syllable, but do not pump audibly
-    // between words. The gain is capped so a quiet room is not amplified into
-    // hiss, and the result is hard-limited below full scale afterwards, because
-    // an ALC that can overshoot is a splatter generator.
+    // conventional shape: catch the onset of a syllable, but do not pump
+    // audibly between words. The ceiling is UNITY, on every path, and there is
+    // no configuration field that can raise it. The result is hard-limited
+    // below full scale afterwards, because an ALC that can overshoot is a
+    // splatter generator.
     //
-    // Client-leveled audio is never given MAKEUP gain (#4796). A TCI/DAX
-    // client that attenuates its own tone — WSJT-X's Pwr slider is a digital
-    // attenuator on the audio it streams, not a rig command — must see output
-    // proportional to what it sent. Through the ALC's makeup half it saw two
-    // other things instead: above the hold threshold its level control was
-    // normalized away to alcTargetPeak, and below it the gain froze at
-    // whatever history left behind, so the same slider position produced RF or
-    // none depending on the path taken to it.
+    // WHAT THIS STAGE STOPPED BEING. It used to carry up to 40 dB of upward
+    // makeup on the mic path, with an absolute hold threshold (-45 dBFS) below
+    // which it stopped lifting. Both halves are gone, and the second is why
+    // the first could not simply be turned down to 0 dB.
     //
-    // It still gets REDUCTION, because that half was never the bug. m_micGain
-    // reaches 10x (+20 dB, Hl2TxLevelPolicy.h) and is applied BEFORE this
-    // block, so a full-scale client with the TX gain slider up arrives ~17 dB
-    // into the hard clamp below — and flat-topping an SSB modulator input is a
-    // splatter generator, which is the one failure mode that harms other
-    // operators rather than the operator who caused it. The clamp is a
-    // backstop, not a level control; it must not become the only thing
-    // standing between a hot client and the band.
+    // The makeup half is gone because a level-dependent makeup stage cannot
+    // tell a voice from a room. Measured on this radio: 20.5 dB of
+    // speech-to-floor separation went in and 0.33 dB came out, because the
+    // hold threshold sat below the room noise, so between words the loop went
+    // on lifting until the fan and the mic hiss reached the same target peak
+    // as the speech. The 20-30 dB gap between a microphone and full modulation
+    // is real and still has to be closed; the operator's mic gain closes it
+    // now, which is why Hl2TxLevelPolicy.h reaches +40 dB rather than +20.
+    // WDSP draws the same line: create_txa() in
+    // third_party/wdsp/upstream/TXA.c builds its `alc` with run=1 and
+    // max_gain=1.0 and its `leveler` with run=0 and max_gain=1.778 (+5 dB).
     //
-    // So the bypass is one-sided, expressed as a CEILING on the gain rather
-    // than a branch around the loop: mic audio may be lifted to alcMaxGainDb,
-    // client-leveled audio may not be lifted past unity. Below alcTargetPeak
-    // the ceiling binds, the gain sits at exactly 1.0, and output is
-    // proportional — the whole reported range. Above it the ALC reduces on its
-    // normal 5 ms attack, so the response degrades to smooth limiting instead
-    // of clipping.
+    // THE HOLD HAD TO GO WITH IT, not merely lose its `!clientLeveled` term.
+    // Under a unity ceiling a quiet block wants target = 1.0. If an earlier
+    // loud block left the gain below unity then target > m_alcGain, `reducing`
+    // is false, the block is under the threshold, and the move back to unity is
+    // suppressed — the transmission strands at whatever reduction its loudest
+    // block called for. That is #4796's own defect class mirrored onto the mic
+    // path: exactly the failure the `!clientLeveled` term was added to keep off
+    // the client path, handed to the mic path instead. A hold is only coherent
+    // when there is makeup gain to hold back.
     //
-    // Gating the INCREASE branch instead would have been the smaller edit and
-    // is wrong: once a loud block pulled the gain down, nothing could ever
-    // raise it again within the over, so a client sliding back down would stay
-    // attenuated at whatever the loudest block called for. That is
-    // path-dependent gain — the same class of defect as #4796, mirrored — and
-    // hl2_txdsp_test's recovery case pins it.
+    // What remains is the half that was never the bug. m_micGain now reaches
+    // 100x (+40 dB, Hl2TxLevelPolicy.h) and is applied BEFORE this block, so a
+    // full-scale source with the TX gain slider up arrives far inside the hard
+    // clamp below — and flat-topping an SSB modulator input is a splatter
+    // generator, the one failure mode here that harms other operators rather
+    // than the operator who caused it. The clamp is a backstop, not a level
+    // control; it must not become the only thing standing between a hot source
+    // and the band.
+    //
+    // Below alcTargetPeak the ceiling binds, the gain sits at exactly 1.0, and
+    // output is proportional to input over the whole reported range — the
+    // property hl2_txdsp_test now asserts directly, as 20 dB in arriving as
+    // 20 dB out. Above the target the loop reduces on its 5 ms attack, so the
+    // response degrades to smooth limiting instead of clipping.
+    //
+    // `clientLeveled` no longer reaches this loop. It selected the ceiling and
+    // qualified the hold, and both are gone; see the note on the declaration in
+    // Hl2TxDsp.h for why the parameter is kept for now.
     if (m_config.alcEnabled) {
         float blockPeak = 0.0f;
         for (std::size_t s = 0; s < consumed; ++s)
@@ -238,43 +255,27 @@ void Hl2TxDsp::processAudioBlock(const std::vector<float>& mono, bool clientLeve
                 static_cast<float>(m_inBuffer[s] * m_micGain)));
 
         if (blockPeak > 1e-6f) {
-            // The ceiling is the whole of the client-leveled special case.
-            const double ceiling = clientLeveled
-                ? 1.0
-                : std::pow(10.0, m_config.alcMaxGainDb / 20.0);
             const double wanted = m_config.alcTargetPeak / blockPeak;
-            const double target = std::min(wanted, ceiling);
+            // The unity ceiling, and the whole of what this stage promises.
+            const double target = std::min(wanted, 1.0);
             // Per-block time constants. Attack when we need LESS gain (the
-            // signal got louder) so overshoot is corrected immediately.
+            // signal got louder) so overshoot is corrected immediately;
+            // release, slowly, back toward unity when it does not. The split
+            // survives the ceiling — a limiter that releases as fast as it
+            // attacks pumps, and one that never releases latches.
             const double blockSec = static_cast<double>(consumed)
                                   / static_cast<double>(m_config.inputSampleRateHz);
             const bool reducing = target < m_alcGain;
-            // Hold the gain through pauses rather than winding it up on room
-            // noise. Reduction is never held — see alcHoldBelowDbfs.
-            //
-            // The hold is a MIC-path concern only. It exists to stop makeup
-            // gain chasing room noise between syllables; under a unity ceiling
-            // there is no makeup gain to chase with, and holding would be
-            // actively harmful — it is exactly the mechanism that would strand
-            // a client-leveled transmission at the reduction its loudest block
-            // called for. hl2_txdsp_test's limiter-release case pins this: its
-            // quiet leg sits below alcHoldBelowDbfs on purpose, and dropping
-            // the !clientLeveled term here latches that leg at -21.41 dB.
-            const double holdThreshold =
-                std::pow(10.0, m_config.alcHoldBelowDbfs / 20.0);
-            const bool held = !reducing && !clientLeveled
-                           && blockPeak < holdThreshold;
-            if (!held) {
-                const double tau = reducing ? m_config.alcAttackSec
-                                            : m_config.alcReleaseSec;
-                const double a = 1.0 - std::exp(-blockSec / std::max(1e-6, tau));
-                m_alcGain += a * (target - m_alcGain);
-            }
+            const double tau = reducing ? m_config.alcAttackSec
+                                        : m_config.alcReleaseSec;
+            const double a = 1.0 - std::exp(-blockSec / std::max(1e-6, tau));
+            m_alcGain += a * (target - m_alcGain);
         }
     } else {
-        // ALC configured off: unity for every path. The clamp below is then the
-        // only over-level backstop on BOTH the mic and client paths, which is
-        // pre-existing behaviour for an operator who has turned the ALC off.
+        // ALC configured off: unity, and the clamp below is then the only
+        // over-level backstop there is. Pre-existing behaviour for an operator
+        // who has turned the ALC off, and the one remaining way to reach the
+        // clamp without the smooth limiting in front of it.
         m_alcGain = 1.0;
     }
     // Published unconditionally, including when the ALC is off and the answer

--- a/src/core/backends/hl2/Hl2TxDsp.h
+++ b/src/core/backends/hl2/Hl2TxDsp.h
@@ -49,39 +49,35 @@ public:
         double filterLowHz = 300.0;
         double filterHighHz = 2700.0;
 
-        // Automatic level control. Speech arrives 20-30 dB below the level
-        // needed to modulate fully, so without this a normal speaking voice
-        // produces almost no RF — measured on hardware: audio at -10 dBFS gave
-        // 1226 counts of forward power, at -30 dBFS gave 47, and speech sits
-        // around -32 dBFS. A real transceiver closes that gap with mic gain,
-        // compression and ALC; this is the ALC.
+        // Automatic level control, PROTECTION ONLY: it may reduce gain, never
+        // add it. The ceiling is unity and there is no field that can raise it.
+        //
+        // That is what the name has always meant elsewhere. create_txa() in
+        // third_party/wdsp/upstream/TXA.c builds the stage it calls `alc` with
+        // run=1 and max_gain=1.0 — always on, and structurally incapable of
+        // adding gain — and puts the gain that CAN be added in a separate
+        // `leveler`, built run=0 (off by default) with max_gain=1.778, which is
+        // +5 dB. Two stages, two jobs, and only one of them is an ALC.
+        //
+        // This stage was previously both, with makeup up to 40 dB and an
+        // absolute hold threshold below which it stopped lifting. The measured
+        // consequence was that 20.5 dB of speech-to-floor separation went in
+        // and 0.33 dB came out: the hold sat below the room, so the room was
+        // lifted level with the speech. The gap it was closing is real —
+        // measured on hardware, audio at -10 dBFS gave 1226 counts of forward
+        // power, at -30 dBFS gave 47, and speech sits around -32 dBFS — but a
+        // level-dependent makeup stage is the wrong instrument for it. The
+        // operator's mic gain closes it instead, which is why
+        // Hl2TxLevelPolicy.h's slider now reaches +40 dB rather than +20.
+        //
+        // What is left here is the half that was never the bug: reduction, on a
+        // fast attack and a slow release, so an over-level input is limited
+        // smoothly rather than flat-topped by the hard clamp behind it. An ALC
+        // that cannot pull down on a transient is a splatter generator.
         bool alcEnabled = true;
         double alcTargetPeak = 0.85;   // leave headroom below clipping
-        double alcMaxGainDb = 40.0;    // do not amplify a silent room forever
         double alcAttackSec = 0.005;   // catch a syllable's onset
         double alcReleaseSec = 0.500;  // slow enough not to pump between words
-
-        // Below this input peak the ALC HOLDS its gain instead of continuing to
-        // raise it. This is what stops the stage behaving like a second
-        // compressor once the operator has an explicit one.
-        //
-        // Without it, every pause between words is a signal to keep increasing
-        // gain — up to alcMaxGainDb, which is 40 dB — so room noise, mic hiss
-        // and the shack fan are lifted to the same target peak as speech, and
-        // the next syllable arrives into a stage that has to attack 40 dB back
-        // down. That is audible as pumping, and it gets worse, not better, when
-        // the operator enables the speech processor: the compressor raises the
-        // average level, the ALC re-levels it away, and the two chase each
-        // other. Holding through pauses leaves the ALC doing the one job it is
-        // needed for — makeup gain for a quiet mic, without which speech at
-        // around -32 dBFS barely modulates — and stops it re-deciding that job
-        // during silence.
-        //
-        // NOT a gate: nothing is muted, and gain REDUCTION is never held off
-        // (see processAudioBlock), because an ALC that cannot pull down on a
-        // transient is a splatter generator. This only suppresses the *upward*
-        // move while the input is too quiet to be speech.
-        double alcHoldBelowDbfs = -45.0;
     };
 
     Q_INVOKABLE bool configure(const Config& config, std::string* error = nullptr);
@@ -113,31 +109,34 @@ public slots:
     // TCI or DAX TX audio (WSJT-X, fldigi, the PipeWire bridge), where the
     // sender has already applied its own power/attenuation control.
     //
-    // THE CONTRACT IS ONE-SIDED, and its two halves are different claims:
+    // THE FLAG IS NOW INERT HERE, and saying so is the point of this comment.
     //
-    //   * The CLIENT owns its level upward. Nothing here adds gain it did not
-    //     ask for — the ALC's makeup half is ceilinged at unity for such
-    //     blocks. That half is #4796: an ALC exists to close the 20-30 dB gap
-    //     between a microphone and full modulation, and applied to a client
-    //     that sets its own level it does the opposite of what either party
-    //     wants — it normalizes the client's level control away above the hold
-    //     threshold, and freezes into a path-dependent gain below it.
-    //   * The MODULATOR owns its own ceiling. Reduction still applies, because
-    //     that half was never the bug. m_micGain reaches 10x (+20 dB), so a
-    //     full-scale client with the TX gain slider up arrives well inside the
-    //     hard clamp in processAudioBlock, and flat-topping an SSB modulator
-    //     input splatters across the band. That clamp is a backstop, not a
-    //     level control, and must not become the only thing standing between a
-    //     hot client and the air.
+    // It used to select the ALC's ceiling: unity for client-leveled audio,
+    // alcMaxGainDb (40 dB) for everything else. That asymmetry was #4796 — an
+    // ALC applied to a client that sets its own level normalized that level
+    // control away above the hold threshold and froze into a path-dependent
+    // gain below it. The remedy was to ceiling the client path at unity.
     //
-    // The hold (alcHoldBelowDbfs) belongs to the makeup half and so applies to
-    // the mic path only. Leaving it on this path would strand a client-leveled
-    // over at whatever reduction its loudest block called for — #4796
-    // mirrored. hl2_txdsp_test pins all three of these claims.
+    // The ceiling is now unity on EVERY path, so the two branches have
+    // converged and there is nothing left for the flag to select. What
+    // survives is the half that was never the bug and never depended on the
+    // flag: the MODULATOR owns its own ceiling. Reduction still applies to
+    // everything, because m_micGain reaches 100x (+40 dB, Hl2TxLevelPolicy.h)
+    // and a full-scale source with the TX gain slider up arrives far inside
+    // the hard clamp below — and flat-topping an SSB modulator input splatters
+    // across the band. That clamp is a backstop, not a level control, and must
+    // not become the only thing standing between a hot source and the air.
+    //
+    // The parameter is retained rather than removed because the signature is
+    // Q_INVOKABLE and crossed by a queued connection from
+    // Hl2Backend::submitTxAudio; dropping it is a clean follow-up, and doing
+    // it here would put a signature churn in the same diff as a level change.
+    // hl2_txdsp_test's #4796 cases still pass unchanged, which is the evidence
+    // that the convergence is a no-op on the TCI/DAX path.
     //
     // The engine's own generated audio (WSPR beacon, AX.25 modem tones, the
-    // RADE modem waveform) arrives with this false and keeps the whole ALC,
-    // matching its on-air level to date.
+    // RADE modem waveform) arrives with this false, and now sees exactly what
+    // a client-leveled block sees.
     void processAudioBlock(const std::vector<float>& mono, bool clientLeveled);
     // Drop anything buffered — on unkey, so the next transmission does not
     // start with the tail of the previous one.

--- a/src/core/backends/hl2/Hl2TxLevelPolicy.h
+++ b/src/core/backends/hl2/Hl2TxLevelPolicy.h
@@ -29,43 +29,59 @@ namespace AetherSDR::hl2 {
 // that session must leave the modulator exactly at its own 1.0 default. The
 // persistence changed which sessions arrive here at 50; it did not retire the
 // pin, and moving unity would still re-level every install that never asked for
-// it. +/-20 dB across the travel, linear in dB.
+// it.
+//
+// THE TWO LEGS HAVE DIFFERENT SLOPES, and that asymmetry is the whole reason
+// this is not a single multiply. Below 50: -20 dB at 0.4 dB per step, exactly
+// as it always was. Above 50: +40 dB at 0.8 dB per step. The upward half was
+// widened when Hl2TxDsp's ALC lost its 40 dB of makeup gain — speech sits near
+// -32 dBFS and the ALC targets 0.85 (-1.41 dBFS), a ~30 dB shortfall that the
+// operator's slider is now the only thing closing, and the old +20 dB left the
+// chain 10.6 dB short at maximum travel.
+//
+// Widening it SYMMETRICALLY would have been tidier and is wrong: it moves unity
+// off 50, and the paragraph above is exactly the reason it may not move. So the
+// legs meet at 50 with no discontinuity in value (49 = -0.4 dB, 51 = +0.8 dB)
+// and a deliberate one in slope. hl2_tx_level_policy_test pins the join, so
+// tidying this back to a symmetric mapping fails there rather than on the air.
 //
 // Level 0 is NOT -20 dB — see micSliderToLinear, which handles it as a mute.
 // This function is the continuous part of the mapping only.
 [[nodiscard]] constexpr double micSliderToGainDb(int level) noexcept
 {
     const int clamped = level < 0 ? 0 : (level > 100 ? 100 : level);
-    return (static_cast<double>(clamped) - 50.0) * 0.4;
+    const double fromUnity = static_cast<double>(clamped) - 50.0;
+    return fromUnity <= 0.0 ? fromUnity * 0.4 : fromUnity * 0.8;
 }
 
 // The same slider as the linear multiplier the modulator takes.
 //
 // Level 0 mutes outright rather than resolving to the -20 dB the line above
-// would give it. A slider at the bottom of its travel means off — and a mic
-// merely 20 dB down would be hauled back up by the ALC's 40 dB of makeup
-// anyway, so without the special case "0" would sound barely different from
-// "50", which is the sort of control that teaches an operator to distrust every
-// other one on the panel.
+// would give it. A slider at the bottom of its travel means off, and 0.0x is
+// the only reading of that which is not "very quiet".
+//
+// THE ARGUMENT FOR THE SPECIAL CASE HAS CHANGED, though the behaviour has not.
+// It used to be that -20 dB would be hauled straight back up by the ALC's 40 dB
+// of makeup, so "0" would have sounded barely different from "50" — a control
+// that teaches an operator to distrust every other one on the panel. That
+// makeup gain is gone: -20 dB is now a real -20 dB on the air, and "0" would be
+// audibly quieter than "50" without the mute. The case survives on the plainer
+// ground that the bottom of a travel labelled as a level means off.
 //
 // SCOPE, because "mic" undersells it: this multiplier is applied to everything
 // entering Hl2TxDsp::processAudioBlock, and on a host-modulating backend that
 // includes digital-mode and WSPR-beacon audio arriving through submitTxAudio,
-// not only voice. For MIC-path audio, above the ALC's hold threshold it is
-// very nearly a no-op — the ALC normalizes each block's peak to alcTargetPeak
-// and hands the gain straight back. For CLIENT-LEVELED audio (TCI/DAX) the ALC
-// may only reduce, never lift (#4796), so below its target there is no handing
-// back: this slider is a straight proportional attenuator on that path, and
-// TX gain 5 (-18 dB) is a real -18 dB on the air. It stops being straight only
-// where it has to — drive a full-scale client through the top of this slider's
-// +20 dB and the ALC limits, rather than letting the modulator's hard clamp
-// flat-top it, so the last stretch of travel buys reduced headroom rather than
-// more power. At 0 neither path transmits: the mic path because silence
-// sits below the hold threshold so the ALC declines to lift it, the
-// client-leveled path as a plain 0.0x multiply. That is the honest reading of
-// a slider at the bottom of its travel on a host modulator — there is one
-// modulator and it is off — but it is worth knowing before parking the control
-// at 0 between voice sessions.
+// not only voice. It is a straight proportional control on the air, the same on
+// every path, all the way up to the ALC's target — the ALC behind it only
+// reduces and has no makeup half left to hand the gain back with, so TX gain 5
+// (-18 dB) is a real -18 dB. It stops being straight only where it has to:
+// drive a full-scale source through the top of this slider's +40 dB and the ALC
+// limits, rather than letting the modulator's hard clamp flat-top it, so the
+// last stretch of travel buys reduced headroom rather than more power. At 0
+// nothing transmits, as a plain 0.0x multiply on every path. That is the honest
+// reading of a slider at the bottom of its travel on a host modulator — there
+// is one modulator and it is off — but it is worth knowing before parking the
+// control at 0 between voice sessions.
 [[nodiscard]] inline double micSliderToLinear(int level) noexcept
 {
     if (level <= 0)

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -1072,8 +1072,9 @@ void MainWindow::wireRadioModel()
     // operator's gain TWICE, in series, which is not what a slider labelled once
     // can mean. The modulator's is the one to keep: setPcMicGain only ever
     // attenuates (0..100 maps to 0.0..1.0, and AudioEngine skips it entirely at
-    // unity), while the ALC behind the modulator needs the mic pushed UP past
-    // its hold threshold — see Hl2Backend::setMicGain.
+    // unity), while the modulator's slider reaches +40 dB and is now the only
+    // thing that lifts a quiet mic at all — the ALC behind it only reduces.
+    // See Hl2Backend::setMicGain.
     //
     // This gate is also why the control was dead rather than doubled before now:
     // micSelection() is "MIC" until a radio reports otherwise, and an HL2 has no

--- a/tests/hl2_dsp_readback_test.cpp
+++ b/tests/hl2_dsp_readback_test.cpp
@@ -99,14 +99,17 @@ int main(int argc, char** argv)
     a.filterLowHz = 300.0;
     a.filterHighHz = 2700.0;
     a.alcTargetPeak = 0.85;
-    a.alcMaxGainDb = 40.0;
+    a.alcReleaseSec = 0.500;
     std::string err;
     check(dsp.configure(a, &err), "the modulator accepts a configuration");
     check(dsp.config().filterLowHz == 300.0 && dsp.config().filterHighHz == 2700.0,
           "the read-back reports the passband it was configured with");
+    // Was the ALC "quartet" until alcMaxGainDb and alcHoldBelowDbfs were deleted
+    // with the stage's makeup half; the remaining fields are the target and the
+    // two time constants, and the pair below is what case 2 then moves.
     check(near(dsp.config().alcTargetPeak, 0.85)
-              && near(dsp.config().alcMaxGainDb, 40.0),
-          "the read-back reports the ALC quartet it was configured with");
+              && near(dsp.config().alcReleaseSec, 0.500),
+          "the read-back reports the ALC fields it was configured with");
     check(dsp.config().dspBlockSize == 512 && dsp.config().outputSampleRateHz == 48000,
           "the read-back reports rates and block size");
 
@@ -115,12 +118,12 @@ int main(int argc, char** argv)
     Hl2TxDsp::Config b = a;
     b.filterLowHz = 150.0;
     b.filterHighHz = 3000.0;
-    b.alcMaxGainDb = 0.0;
+    b.alcReleaseSec = 0.250;
     check(dsp.configure(b, &err), "the modulator accepts a second configuration");
     check(dsp.config().filterLowHz == 150.0 && dsp.config().filterHighHz == 3000.0,
           "the read-back MOVED when the DSP was reconfigured");
-    check(near(dsp.config().alcMaxGainDb, 0.0),
-          "the ALC ceiling moved with it");
+    check(near(dsp.config().alcReleaseSec, 0.250),
+          "the ALC release constant moved with it");
 
     // 3. THE DEAD-SLIDER CASE, which is the whole reason the verb exists.
     //    Change the REQUEST without reaching the DSP, and the read-back must

--- a/tests/hl2_tx_level_policy_test.cpp
+++ b/tests/hl2_tx_level_policy_test.cpp
@@ -57,12 +57,26 @@ int main()
     check(near(micSliderToGainDb(50), 0.0), "slider 50 is unity gain (0 dB)");
     check(near(micSliderToLinear(50), 1.0), "slider 50 is unity linear (1.0)");
 
-    check(near(micSliderToGainDb(100), 20.0), "slider 100 is +20 dB");
+    check(near(micSliderToGainDb(100), 40.0), "slider 100 is +40 dB");
     check(near(micSliderToGainDb(1), -19.6), "slider 1 is -19.6 dB");
 
+    // THE JOIN, which is what stops someone tidying this back to symmetric.
+    //
+    // The mapping is asymmetric on purpose: 0.4 dB per step below 50, 0.8 dB
+    // per step above it, so the travel is -20/+40 dB with unity still exactly
+    // at 50. A symmetric widening would be the obvious simplification and would
+    // move unity off 50, changing the transmit level of every existing install
+    // — the case above says why that may not happen, and these two say where
+    // the mapping would have to break to allow it. Continuous in value, with a
+    // deliberate step in slope.
+    check(near(micSliderToGainDb(49), -0.4), "one step below unity is -0.4 dB");
+    check(near(micSliderToGainDb(51), 0.8), "one step above unity is +0.8 dB");
+
     // A slider at the bottom means OFF. Without the special case it would be
-    // -20 dB, which the ALC's 40 dB of makeup would haul straight back up —
-    // making "0" sound much like "50".
+    // -20 dB — which, now that the ALC only reduces and has no makeup gain to
+    // haul it back up with, is a real -20 dB on the air rather than something
+    // indistinguishable from "50". The behaviour does not move; the reason for
+    // it is now simply that the bottom of a level control means off.
     check(near(micSliderToLinear(0), 0.0), "slider 0 mutes rather than attenuating");
     check(micSliderToLinear(1) > 0.0, "slider 1 is quiet but not muted");
 
@@ -78,8 +92,8 @@ int main()
     }
 
     // Out-of-range input is clamped, not extrapolated: a CAT client or a bridge
-    // verb can pass anything, and 200 must not become +60 dB on the air.
-    check(near(micSliderToGainDb(200), 20.0), "over-range level clamps to +20 dB");
+    // verb can pass anything, and 200 must not become +120 dB on the air.
+    check(near(micSliderToGainDb(200), 40.0), "over-range level clamps to +40 dB");
     check(near(micSliderToGainDb(-50), -20.0), "under-range level clamps to -20 dB");
     check(near(micSliderToLinear(-50), 0.0), "negative level mutes");
 

--- a/tests/hl2_txdsp_test.cpp
+++ b/tests/hl2_txdsp_test.cpp
@@ -19,6 +19,7 @@
 // show up as "my audio is quiet" or "my signal is 2 kHz wide".
 
 #include "core/backends/hl2/Hl2TxDsp.h"
+#include "core/backends/hl2/Hl2TxLevelPolicy.h"
 
 #include <QCoreApplication>
 #include <QObject>
@@ -254,19 +255,36 @@ int main(int argc, char** argv)
         }
     }
 
-    // ---- ALC lifts speech-level audio to something that modulates ----
+    // ---- The mic slider lifts speech-level audio to something that modulates -
     //
     // This is the gap that made voice inaudible on the air: measured on the
     // radio, audio at -10 dBFS produced 1226 counts of forward power and audio
-    // at -30 dBFS produced 47, while ordinary speech sits near -32 dBFS. The
-    // ALC's job is to close that.
+    // at -30 dBFS produced 47, while ordinary speech sits near -32 dBFS. That
+    // measurement is why the gap must be closed by SOMETHING, and it has not
+    // changed.
+    //
+    // WHAT CLOSES IT HAS. This case used to assert that the ALC lifted a
+    // -34 dBFS tone toward full modulation on its own, at unity mic gain — up
+    // to 40 dB of makeup, applied on an absolute threshold, which is what lifted
+    // room noise level with speech (20.5 dB of separation in, 0.33 dB out) and
+    // is the defect this stage's ceiling now forbids. The ALC only reduces.
+    // The operator's mic slider closes the gap instead, which is why it reaches
+    // +40 dB, so this case is re-pointed at the slider rather than deleted: the
+    // same tone, the same destination, a different instrument.
+    //
+    // Two claims, and they are the pair: at the top of the slider the tone still
+    // reaches full modulation, and at unity it now passes straight through
+    // instead of being normalized.
     {
         constexpr double kQuiet = 0.02;         // about -34 dBFS, speech-ish
+        const double kSlider100Linear = micSliderToLinear(100);
         const auto plain = modulate(WdspChannel::Mode::Usb, kTone, kQuiet, 1.0, 1.5,
                                     nullptr, false);
         const auto alced = modulate(WdspChannel::Mode::Usb, kTone, kQuiet, 1.0, 1.5,
                                     nullptr, true);
-        if (!plain.empty() && !alced.empty()) {
+        const auto driven = modulate(WdspChannel::Mode::Usb, kTone, kQuiet,
+                                     kSlider100Linear, 1.5, nullptr, true);
+        if (!plain.empty() && !alced.empty() && !driven.empty()) {
             // Compare the settled tail: the ALC ramps in, so the opening block
             // is deliberately not representative.
             auto tailPeak = [](const std::vector<std::complex<float>>& v) {
@@ -277,43 +295,74 @@ int main(int argc, char** argv)
             };
             const double a = tailPeak(plain);
             const double b = tailPeak(alced);
-            std::fprintf(stderr, "ALC: quiet input peak %.4f -> %.4f (+%.1f dB)\n",
-                         a, b, 20.0 * std::log10((b + 1e-12) / (a + 1e-12)));
-            check(b > a * 5.0, "ALC lifts quiet audio substantially");
-            check(b > 0.5, "ALC brings quiet audio near full modulation");
-            // And it must never overshoot into clipping — an ALC that overshoots
-            // transmits splatter rather than merely clipping our own audio.
+            const double c = tailPeak(driven);
+            std::fprintf(stderr,
+                         "mic slider: quiet input peak %.4f -> ALC at unity %.4f "
+                         "(%+.1f dB) -> slider 100 %.4f (%+.1f dB)\n",
+                         a, b, 20.0 * std::log10((b + 1e-12) / (a + 1e-12)),
+                         c, 20.0 * std::log10((c + 1e-12) / (a + 1e-12)));
+            // The ALC adds nothing of its own. Anything but ~0 dB here is the
+            // makeup half coming back.
+            check(std::fabs(20.0 * std::log10((b + 1e-12) / (a + 1e-12))) < 1.0,
+                  "at unity mic gain the ALC passes speech-level audio through "
+                  "unchanged");
+            // The same bound the old assertion used, now asked of the control
+            // that is actually meant to close the gap.
+            check(c > 0.5, "the mic slider at 100 brings quiet audio near full "
+                           "modulation");
+            // And the stage must never overshoot into clipping — an ALC that
+            // overshoots transmits splatter rather than merely clipping our own
+            // audio. This is measured on the DRIVEN run, which is the only one
+            // that now reaches the ALC's target at all, and it is the whole of
+            // what the stage still promises.
             double mx = 0.0;
-            for (const auto& v : alced) mx = std::max(mx, static_cast<double>(std::abs(v)));
+            for (const auto& v : driven) mx = std::max(mx, static_cast<double>(std::abs(v)));
             check(mx <= 1.001, "ALC output never exceeds full scale");
         }
     }
 
-    // ── The ALC holds through pauses instead of winding up on room noise ────
+    // ── The mic path preserves the separation between speech and the room ───
     //
-    // The stage is makeup gain for a quiet mic, and it has to stay that without
-    // also being a second compressor fighting the speech processor. The property
-    // under test: audio too quiet to be speech must NOT be lifted, while audio
-    // loud enough to be speech still is.
+    // THE REGRESSION TEST FOR THE REPORTED FAULT, and the direct successor of a
+    // case that asserted the opposite. This block used to assert that the ALC
+    // HELD its gain below -45 dBFS and lifted above it — makeup gain with an
+    // absolute threshold, which sounds like a noise policy and is not one. The
+    // threshold sat below a real shack's noise floor, so between words the loop
+    // went on lifting until the room reached the same target peak as the voice:
+    // measured on the air, 20.5 dB of speech-to-floor separation went in and
+    // 0.33 dB came out. A stage that erases 20 dB of contrast is not protecting
+    // anything.
     //
-    // Without the hold, both cases below settle at the same output peak — that
-    // is exactly the failure, because it means the shack fan between words is
-    // being brought to the same level as the operator's voice.
+    // Rewritten rather than adjusted, because merely relaxing the old numbers
+    // would leave "the ALC held" being asserted by a stage that no longer holds
+    // anything — the first of its three assertions would still pass, for the
+    // wrong reason, measuring "nothing is ever lifted".
+    //
+    // The property now under test is the one the report is about: the ALC adds
+    // no gain at either level, and the DIFFERENCE between them survives the
+    // stage intact. 20 dB in, 20 dB out.
     {
-        auto settledPeak = [](double amplitude) {
+        struct Settled { double gainDb; double outPeak; };
+        auto settled = [](double amplitude) -> Settled {
             Hl2TxDsp tx;
             Hl2TxDsp::Config cfg;
             cfg.mode = WdspChannel::Mode::Usb;
             cfg.alcEnabled = true;
             std::string err;
             if (!tx.configure(cfg, &err)) {
-                std::fprintf(stderr, "FAIL: ALC hold configure: %s\n", err.c_str());
+                std::fprintf(stderr, "FAIL: ALC separation configure: %s\n",
+                             err.c_str());
                 ++g_failures;
-                return 0.0;
+                return {0.0, 0.0};
             }
             double lastGainDb = 0.0;
             QObject::connect(&tx, &Hl2TxDsp::alcGain, &tx,
                              [&lastGainDb](float db) { lastGainDb = db; });
+            std::vector<std::complex<float>> out;
+            QObject::connect(&tx, &Hl2TxDsp::iqReady, &tx,
+                             [&out](const std::vector<std::complex<float>>& iq) {
+                out.insert(out.end(), iq.begin(), iq.end());
+            });
 
             const int fs = cfg.inputSampleRateHz;
             const int total = fs * 3;   // long enough for the slow release to settle
@@ -327,35 +376,51 @@ int main(int argc, char** argv)
                 }
                 tx.processAudioBlock(chunk, /*clientLeveled=*/false);
             }
-            return lastGainDb;
+            // Settled tail only, so the opening blocks are not representative.
+            double mx = 0.0;
+            for (std::size_t i = out.size() / 2; i < out.size(); ++i)
+                mx = std::max(mx, static_cast<double>(std::abs(out[i])));
+            return {lastGainDb, mx};
         };
 
-        // -54 dBFS: below the -45 dBFS hold threshold, so this is "the room",
-        // not the operator. The ALC must leave it where it is.
-        const double quietGainDb = settledPeak(0.002);
-        // -34 dBFS: above the threshold and about where real speech sits, per
-        // the measurements in Hl2TxDsp::Config. This must still be lifted.
-        const double speechGainDb = settledPeak(0.02);
+        // -54 dBFS: this is "the room" — the fan, the hiss, the pause between
+        // words. It sat below the old -45 dBFS hold threshold on purpose, and
+        // still sits below it in spirit: it is the leg that used to be hauled up.
+        const Settled room = settled(0.002);
+        // -34 dBFS: about where real speech sits, per the measurements quoted in
+        // Hl2TxDsp::Config. Exactly 20 dB above the room leg.
+        const Settled speech = settled(0.02);
 
+        const double outSeparationDb =
+            20.0 * std::log10((speech.outPeak + 1e-12) / (room.outPeak + 1e-12));
         std::fprintf(stderr,
-                     "ALC hold: below-threshold gain %.1f dB, speech-level gain %.1f dB\n",
-                     quietGainDb, speechGainDb);
-        check(quietGainDb < 1.0,
-              "ALC held its gain on audio too quiet to be speech");
-        check(speechGainDb > 20.0,
-              "ALC still lifts audio at speech level");
-        check(speechGainDb > quietGainDb + 20.0,
-              "ALC distinguishes speech from room noise");
+                     "separation: room gain %.2f dB (peak %.6f), speech gain %.2f dB "
+                     "(peak %.6f), 20.0 dB in -> %.2f dB out\n",
+                     room.gainDb, room.outPeak, speech.gainDb, speech.outPeak,
+                     outSeparationDb);
+        // Neither leg is lifted. The ceiling is unity, so on any input below the
+        // target the ALC's answer is 0 dB — for the room AND for the speech.
+        check(std::fabs(room.gainDb) < 1.0,
+              "the ALC adds no gain to room-level audio");
+        check(std::fabs(speech.gainDb) < 1.0,
+              "the ALC adds no gain to speech-level audio either");
+        // AND THE ONE THAT WOULD HAVE CAUGHT THE FAULT. Both legs at 0 dB is
+        // necessary but not sufficient: what the operator hears is the contrast,
+        // and the reported failure was 20.5 dB in arriving as 0.33 dB out.
+        check(outSeparationDb > 19.0 && outSeparationDb < 21.0,
+              "20 dB of input separation arrives as 20 dB of output separation");
     }
 
     // ── #4796: client-leveled audio bypasses the ALC entirely ──────────────
     //
     // A TCI/DAX client's level control is a digital attenuator on the audio it
-    // streams (WSJT-X's Pwr slider). Through the ALC that control was either
-    // normalized away (above the hold threshold) or frozen into a
-    // path-dependent gain (below it). With the bypass, output must simply be
-    // proportional to input — even 5 dB BELOW the hold threshold, where the
-    // ALC used to freeze.
+    // streams (WSJT-X's Pwr slider). Through the ALC's makeup half that control
+    // was either normalized away (above the then-current -45 dBFS hold
+    // threshold) or frozen into a path-dependent gain (below it). Output must
+    // simply be proportional to input — and the quiet leg is 5 dB below where
+    // that threshold used to sit, which is where the ALC used to freeze. That
+    // ceiling is now unity on every path rather than only this one, so these
+    // assertions read the same as they did; they are unchanged on purpose.
     {
         // -50 dBFS and -30 dBFS, both with the ALC configured ON, both marked
         // client-leveled. 20 dB apart in, 20 dB apart out.
@@ -455,11 +520,11 @@ int main(int argc, char** argv)
     //
     // Removing the ALC's makeup half is the #4796 fix. Removing its REDUCTION
     // half would leave the modulator's hard clamp as the only thing between a
-    // hot client and the band, and m_micGain reaches 10x (+20 dB — the TX gain
-    // slider at 100, Hl2TxLevelPolicy.h), so a full-scale client arrives ~17 dB
-    // into that clamp. Flat-topping an SSB modulator input is a splatter
-    // generator: the one failure mode here that harms other operators rather
-    // than the operator who caused it.
+    // hot client and the band: m_micGain now reaches 100x (+40 dB — the TX gain
+    // slider at 100, Hl2TxLevelPolicy.h), and even the 10x used below puts a
+    // full-scale client ~17 dB into that clamp. Flat-topping an SSB modulator
+    // input is a splatter generator: the one failure mode here that harms other
+    // operators rather than the operator who caused it.
     //
     // Distortion is measured as the CREST FACTOR of the analytic magnitude,
     // not as a harmonic bin. For a single tone |IQ| is constant, so peak/mean
@@ -472,7 +537,12 @@ int main(int argc, char** argv)
     // instrument is validated on every run rather than on the day it was
     // written.
     {
-        constexpr double kSlider100 = 10.0;   // micSliderToLinear(100) = +20 dB
+        // A raw linear +20 dB, NOT a slider position. This was written as
+        // micSliderToLinear(100) back when the slider topped out at +20 dB; the
+        // slider now reaches +40 dB (100x) and the name would be a lie. The
+        // value is what the case needs — enough to drive a full-scale client
+        // well into limiting — so it is kept and renamed rather than moved.
+        constexpr double kHotMicGain = 10.0;   // +20 dB, linear
         constexpr double kHarmTone  = 700.0;
         auto crest = [](const std::vector<std::complex<float>>& v) {
             double mx = 0.0, sum = 0.0;
@@ -489,7 +559,7 @@ int main(int argc, char** argv)
         };
 
         const auto hot = modulate(WdspChannel::Mode::Usb, kHarmTone, 1.0,
-                                  kSlider100, 1.5, nullptr, true, nullptr,
+                                  kHotMicGain, 1.5, nullptr, true, nullptr,
                                   /*clientLeveled=*/true);
         // 24 dB below the ALC target at unity mic gain: the limiter cannot
         // engage, so this is what "undistorted" reads on this instrument.
@@ -511,8 +581,8 @@ int main(int argc, char** argv)
             check(cleanCrest < 1.05,
                   "crest-factor instrument reads ~1.0 on an undistorted tone");
             check(mx < 0.95,
-                  "a full-scale client at TX gain 100 is limited below the "
-                  "clamp, not flat-topped by it");
+                  "a full-scale client at +20 dB of mic gain is limited below "
+                  "the clamp, not flat-topped by it");
             check(mx > 0.5,
                   "the limited transmission is still on the air (case is real)");
             check(hotCrest < 1.05,
@@ -534,22 +604,36 @@ int main(int argc, char** argv)
     // total bypass and on the ceiling; it fails ~21 dB wide on an
     // increase-gated ALC.
     //
-    // It is ALSO the discriminator for the other half of the change — the hold
-    // being made mic-path-only (`!clientLeveled` in processAudioBlock's `held`).
-    // THE QUIET LEG IS DELIBERATELY BELOW alcHoldBelowDbfs: -70 dBFS times this
-    // case's 10x mic gain is -50 dBFS at the ALC's measurement point, under the
-    // -45 dBFS hold threshold. Do not raise it. If the hold is left applying to
-    // client-leveled audio, the gain the loud leg pulled down can never be
-    // released again — the transmission strands at -21.41 dB — and with the
-    // quiet leg anywhere above the threshold this case cannot see that at all.
-    // Both wrong shapes fail here and nowhere else in this file.
+    // HALF OF THAT RATIONALE HAS RETIRED, and the half that has not is the
+    // reason this case is untouched by the unity-ceiling change.
+    //
+    // It used to be the discriminator for a second thing as well: the hold being
+    // made mic-path-only (`!clientLeveled` in processAudioBlock's `held`). There
+    // is no hold any more — it was deleted outright with the ALC's makeup half,
+    // because under a unity ceiling a quiet block wants target = 1.0, so after
+    // any reduction `reducing` is false and a hold would strand the gain exactly
+    // as described above. So that discriminator has nothing left to discriminate
+    // between, and the paragraph is kept as history rather than as a live claim.
+    //
+    // WHAT SURVIVES IS THE PROOF THAT THE UNITY CEILING CHANGED NOTHING HERE. On
+    // the client path the ceiling was already 1.0 and `held` was already false,
+    // so every assertion below reads the same before and after — which is what
+    // makes this case the evidence that a change to the mic path is a no-op on
+    // TCI/DAX.
+    //
+    // THE QUIET LEG IS STILL DELIBERATELY WHERE IT IS: -70 dBFS times this
+    // case's 10x mic gain is -50 dBFS at the ALC's measurement point, which was
+    // under the old -45 dBFS hold threshold. Do not raise it. It is what keeps
+    // the case able to catch a hold reappearing, on either path, by any route.
     //
     // One continuous transmission: full scale, then -70 dBFS held for four
     // release time constants. The tail must match the same level keyed fresh.
     {
-        constexpr double kSlider100 = 10.0;
+        // A raw linear +20 dB, not a slider position — see the note in the case
+        // above. The slider reaches +40 dB now; this value does not need to.
+        constexpr double kHotMicGain = 10.0;
         const auto fresh = modulate(WdspChannel::Mode::Usb, kTone, 0.000316,
-                                    kSlider100, 1.5, nullptr, true, nullptr,
+                                    kHotMicGain, 1.5, nullptr, true, nullptr,
                                     /*clientLeveled=*/true);
 
         Hl2TxDsp tx;
@@ -562,7 +646,7 @@ int main(int argc, char** argv)
                          err.c_str());
             ++g_failures;
         } else if (!fresh.empty()) {
-            tx.setMicGain(kSlider100);
+            tx.setMicGain(kHotMicGain);
             std::vector<std::complex<float>> out;
             QObject::connect(&tx, &Hl2TxDsp::iqReady, &tx,
                              [&](const std::vector<std::complex<float>>& iq) {


### PR DESCRIPTION
> ### :warning: This PR must not merge on its own
> On its own it is a **known regression on every unattended transmission** — a
> WSPR beacon at the shipped default goes out **18.59 dB down, a factor of 72 in
> power**, on a transmission that keys for 111.6 s with nobody watching. It is
> the first of a stack — **#5647 is the second** — and see
> **[Do not merge this alone](#do-not-merge-this-alone)** for exactly which
> branch closes which half.

## What this changes

**This changes the transmit level of every Hermes-Lite 2 installation at Mic Level 50 or above.**

The stage `Hl2TxDsp` calls an ALC is not one. It applied up to **40 dB of upward
makeup gain** (`Hl2TxDsp::Config::alcMaxGainDb`) with an absolute hold threshold
(`alcHoldBelowDbfs`, −45 dBFS) that sits *below* a real shack's noise floor. So
between words the loop went on raising gain until the fan and the mic hiss
reached the same target peak as the speech.

After this PR the ALC only ever reduces. The **Mic Level slider becomes the
operator's transmit level**, and its upper leg is widened so that it can be.

| authored speech, Mic Level at its default of 50 | before | after |
|---|---|---|
| speech leaving the modulator | **−1.18 dBFS** (at the ceiling) | **−21.08 dBFS** |
| speech-to-room contrast in the pauses between words | **0.21 dB** | **18.10 dB** |

About **20 dB quieter at the default slider position**, and the room noise that
used to be lifted level with the operator's voice between words is gone. The
20 dB is not a fixed offset — it is the gap between how loud a given operator
actually speaks and full modulation, and it moves with the microphone, the input
gain and the voice.

**Both of those figures are simulator measurements.** See
[What is measured on what](#what-is-measured-on-what).

Part of #5463 — this is **change 3** of four. Not `Closes`: #5505 (change 1) and
#5506 (change 2) are already merged against the same umbrella, and change 4 —
the leveller, which a thread correction relocated into AetherVoice — is
unfiled. Auto-closing the umbrella on this merge would orphan that.

WDSP draws the same line: `create_txa()` in `third_party/wdsp/upstream/TXA.c`
builds the stage it names `alc` with `run=1` and `max_gain=1.0` — always on,
structurally incapable of adding gain — and puts the gain that *can* be added in
a separate `leveler`, built `run=0` with `max_gain=1.778` (+5 dB). Two stages,
two jobs.

## Who is affected, and who is not

**Hermes-Lite 2 only. Flex and Icom are untouched**, and receive is untouched on
every family. All of this is host-side HL2 transmit DSP: `Hl2TxDsp` is
constructed only inside `Hl2Backend` (`new Hl2TxDsp` occurs nowhere else in the
tree), the Flex backend has no `submitTxAudio` override at all, and
`IcomCivBackend::submitTxAudio` ships PCM to a radio that runs its own transmit
processing.

**WSJT-X, fldigi and anything over TCI or DAX: no change.** That path already had
a unity ceiling — it was fixed separately in #4796 — and its regression case in
`hl2_txdsp_test` (*"the reduction half must RELEASE"*) passes **untouched at
−0.15 dB, identical before and after**. That case is the evidence this is a no-op
on client-leveled audio. Level is still set in the client.

**Operators who have never moved the Mic Level slider** lose up to 40 dB of
automatic makeup and must set a level for the first time. That is the point of
the change and also its migration hazard — *it wants a release note, not a silent
ship*.

**Operators who had already moved the slider above 50** keep the level they
chose. The number moves instead: a stored 75 was +10 dB on the old curve and
restores as 63, which is +10.4 dB on the new one. See
[A stored slider position is migrated, not reinterpreted](#a-stored-slider-position-is-migrated-not-reinterpreted).

## The slider mapping

The widening is **asymmetric on purpose**: 0.4 dB per step below 50 (unchanged,
down to −20 dB), **0.8 dB per step above, reaching +40 dB at 100** instead of the
old +20 dB. **50 stays exactly unity**, because `TransmitModel` constructs
`m_micLevel` at 50 and that is where every operator who has never touched the
control transmits from — a symmetric widening would move unity off 50 and
silently change the transmit level of every existing install. (#5505 has since
landed, so a slider position now survives a launch as well; that widened the
population this pin protects rather than retiring it.) `hl2_tx_level_policy_test` pins the join: `micSliderToGainDb(50) == 0.0`,
`(49) == −0.4`, `(51) == +0.8`.

For the bench's speech recording, roughly **slider 74** would have put the peak on
the ALC's target. *That number is an inference from the mapping, not a
measurement* — legs were run at 50 and at 100 and nothing in between.

## One instrument the quiet operator gets

**`TX:ALC`** now reads the actual transmit peak and tracks its input
one-for-one until it reaches the target, then limits at −1.41 dBFS. Sitting far
below −1.41 dBFS while speaking means you are quiet. At unity, speech leaves the
modulator **19.56–19.67 dB below `alcTargetPeak`** — `d81b-speech-pauses-alc`'s
`result.json` gives `speech_output_dbfs` of −21.08 dBFS (fault leg) and
−20.97 dBFS (control leg), both at mic level 50, against
`20*log10(0.85) = −1.4116 dBFS`.

An unkey log line naming the slider position would be the natural companion, and
it is **not in this branch**: it must not fire on audio the operator's microphone
did not produce, and WSPR, AX.25 and RADE reach `submitTxAudio` with
`clientLeveled` false exactly like a microphone. Distinguishing them needs the
three-state `TxAudioSource`, which is #5647's substance. #5647 carries the advice
with its gate.

## Keeping the widening inside the modulator's headroom

`reset()` starts the ALC at unity on every unkey, and the stage's hard clamp sits
right behind it, so at the slider's new 100x any large step arrives with the loop
still far above where it needs to be. The modulator flat-tops, and no meter
reports it — `TX:ALC` is measured *after* the clamp.

**Reduction is instantaneous.** The block that needs less gain simply takes the
target; only the release is smoothed. That is the shape a splatter guard has to
have, and the attack constant was never buying smoothing here: at a 512-sample
block on 24 kHz — 21.3 ms — `1 - exp(-21.3/5)` already closed 98.6% of the error
in one block. It was leaving 1.4% of the step above the clamp, and 1.4% of 40 dB
is not small. `alcAttackSec` is deleted with the mechanism, like `alcMaxGainDb`
and `alcHoldBelowDbfs` before it.

A one-shot key-on seed was tried first and covers only the **first** reduction of
an over. @on8st tested it against a crescendo and it held; the shape that breaks
it is a source that crosses the target *gently* — an ordinary quiet word — which
spends the seed on a fraction of a dB and leaves the next syllable unprotected.
Measured at slider 100:

| stimulus (whole-run \|IQ\|, slider 100) | seeded attack | instantaneous |
|---|---|---|
| full scale from sample 0 | 0.8594, 0 clipped | 0.8594, 0 |
| 100 ms of −60 dBFS room, then full scale | 0.8593, 0 | 0.8593, 0 |
| −41 dBFS plateau, then a step to full scale | **1.5297, 448 at the clamp** | **0.8592, 0** |
| −38 dBFS word, then a −12 dBFS syllable | **1.0768, 223** | **0.8586, 0** |
| quiet, one loud burst, quiet again | **1.5045, 727 (15.2 ms)** | **0.8594, 0** |

All eighteen probe shapes settle at ~0.859 with nothing at the clamp. **The
release is untouched** — #4796's case still measures −0.15 dB and the over-level
client's crest is still 1.0001.

`hl2_txdsp_test` pins four stimuli, and they are four different openings: full
scale from sample 0, a 100 ms −60 dBFS room lead-in, a 50 → 100 slider move
mid-over, and a quiet word followed by a loud one. The last fails on a 5 ms
attack and none of the other three can see it. It pins the observable property
rather than the mechanism — a 0.5 ms attack passes it too — and that is the
argument for instantaneous: whether a constant is short enough is a function of
`dspBlockSize` and `inputSampleRateHz`, so it is a guarantee that expires
silently the day either moves.

## A stored slider position is migrated, not reinterpreted

#5505 persists the mic level, and this PR changes what a stored number means, so
a position stored against the old curve is re-expressed against the new one. An
operator who parked at 80 asked for +12 dB; 80 means +24 dB now, so the document
restores as **65** — the same gain, a different position.

The document says which curve it was written on with `micLevelCurve`, and
**absent means curve 1**: the key did not exist while curve 1 was the only curve,
so its absence is a positive statement about the writer. Writing the level back
stamps the curve beside it, which is what makes the migration one-shot — the
arithmetic deliberately is not, and `hl2_state_restore_test` asserts the stamp so
an unstamped round-trip cannot start a ratchet.

Only the upper leg needs it; at and below 50 both curves agree and the migration
is the identity, including the mute at 0. A curve number this build does not know
restores as written rather than being re-derived on a guess.

## It rewrites two certification rows and a meter face

`docs/radio-certification.md`'s `TX:ALC` row has said since `76a52403`: *"sweep
the input 20 dB → reading does **not** move, ±1 dB across the sweep"*, with
recorded evidence of −1.41 dBFS at −10, −20 and −30 dBFS injected tone.

That no-movement is not a property of a post-ALC peak meter. It is the observable
signature of `alcMaxGainDb` — 40 dB of makeup dragging any input from about
−41 dBFS upward onto `alcTargetPeak` — and −1.41 dBFS is exactly
`20*log10(0.85)`. **After this PR lands, that row fails a correctly behaving
radio, by 28.6 dB.** Correcting it is this PR's job rather than the next reader's.

The replacement is **measured rather than reasoned**, because a guessed pass
criterion in a certification table is worse than a stale one — it looks measured.
The **2026-08-10 block is kept**, not deleted: it is correct for the build it was
run on, it is the control for the new one, and its verdict cell now says which
build that was.

The new tolerance is **±0.25 dB against a worst measured deviation of 0.0065 dB**
— two orders of magnitude looser than the data supports, deliberately, because
one radio on one host on one night does not earn a tolerance that only passes on
the machine it was taken on.

**`TX:ALCGAIN`, three rows further down, had the same defect and is corrected
here too.** It swept *"between `alcHoldBelowDbfs` and the makeup ceiling"* —
neither of which exists after this change — so it would fail a correct radio for
exactly the reason the `TX:ALC` row would. With the ceiling at unity the gain
that meter reports can only be zero or negative, so the criterion is now a sign
and a knee rather than a window.

**And the meter's own face moved with it.** `TX:ALCGAIN` was defined `-20..+40 dB`
and its comment justified the top as `Hl2TxDsp::Config::alcMaxGainDb`. Deleting
that field without moving the face would have left #5636 inheriting a meter whose
needle can never leave the bottom third of its own scale; it is `-20..0` now.

## Do not merge this alone

On its own this PR changes the level of **unattended** transmissions — WSPR,
AX.25 packet and RADE — because they reach `submitTxAudio` on the same path as a
microphone and were relying on the same 40 dB of makeup to normalise them.

Measured with the application's own WSPR beacon against `hpsdrsim`
(`wspr-real-beacon-source-ab`, beacon at the shipped −20 dBFS default):

| build | beacon `TX:ALC` peak |
|---|---|
| today's `main` | **−1.412 dBFS** |
| **this PR alone** | **−20.002 dBFS** |

**18.59 dB down, a factor of 72 in power, on a transmission that keys for 111.6 s
with nobody watching.** And on this PR alone the **Mic Level slider moves the
beacon**: the same run measured a 50 → 100 slider move shifting it by **18.59 dB**.
A microphone control has no business moving an unattended beacon.

The repair takes **two** further branches, and it is worth being exact about
which one does what, because it is natural to assume the next PR closes both
halves and **it does not**:

| | mic slider moves the beacon? | beacon level at the shipped default |
|---|---|---|
| this PR alone | **yes — up to +40 dB** | **−20 dBFS** (18.59 dB down) |
| **+ #5647**, `hl2/engine-generated-tx-source` | **no** — measured **0.0 dB** across a 50 → 100 move | still **−20 dBFS** |
| + the WSPR default branch, `hl2/wspr-host-modulated-level` (not yet filed) | no | **−3.0 dBFS** |

#5647 removes the slider coupling and makes engine-generated audio carry the level
its generator chose; it deliberately sets **no defaults**. The level shortfall
itself is closed by the third branch, which moves the WSPR Level spinbox default
from −20 to −3 dBFS on host-modulating backends. `wspr-unattended-ab` measures
this separation directly: for a −20 dBFS engine-generated signal, the second
branch's own `repair_db` is **0.0**.

AX.25 and RADE get the slider bypass in #5647 and **no** default correction
anywhere — AX.25 computes a level per frame and RADE carries its own
`PcMicGain`, so neither has a single default to set. Neither was exercised on the
bench; only the WSPR source was.

**So: merge this with #5647, and land the WSPR default branch immediately after.**
Between this PR and that one there is a window in which every unattended
transmission is ~18.6 dB down.

## #5198 — offered as a candidate, not as a claim

#5198 (`priority: high`, open since 2026-08-23) carries **two faults in one
report, and only one of them is this one.**

- *"the ALC meter swings nearly full-scale in response to normal transmitted
  speech"* — same defect class as #5463, and the mechanism this PR deletes. It
  would be worth @darkclassical re-testing on this branch.
- *"opposite-sideband spillover at approximately −30 dB"* — **this PR does not
  touch it and must not be credited with it.** The host modulator was measured
  separately on the EP2 wire and agrees with `Hl2TxDsp::designFilters`, evaluated
  independently in double precision, to 0.02 dB (87.15 dB on a steady 1 kHz
  tone). The reporter's own drive sweep shows a fixed modulator/IQ image tracking
  the wanted signal 1:1. That half of his report is open.

**Nobody has tested his configuration.** What connects the two is the defect
class and his own title: a stage riding his gain by tens of dB when he has
deliberately set his levels is what this PR removes, and 40 dB of makeup driven
into a clamp is a plausible source of the distortion and the amplifier IMD he
describes. That is a reasonable thing to check, not a diagnosis. It is offered as
something for him to try.

## What is measured on what

Read this before believing any number above.

### On the real radio — one run

`d90-alc-input-sweep`, on ON8ST's Hermes-Lite 2, MAC `00:1C:C0:A2:13:DD` read
from the radio's own response packet, gateware 74, into a **dummy load**, under
the operator's own time-bounded transmit approval. 16 keyed windows, 165.3 s of
keying, **drive register 0 — nothing was radiated**.

It establishes, on both builds: that `TX:ALC` tracks its input one-for-one under
the new behaviour (max deviation 0.0065 dB over 53.5 dB, fitted slope 0.99997),
that it limits at −1.413 dBFS where the knee sits, that approach direction changes
the reading by 0.0 dB, and — the part that makes the rest trustworthy — that the
**old** documented triple reproduces on the **old** build to within **0.023 dB**.

### On the simulator — everything else

`d78`/`d78b` (silent ratchet), `d81`/`d81b` (speech pauses) and both WSPR A/Bs ran
against `hpsdrsim`, serial `AA:BB:CC:DD:88:FF`, under a `loopback` approval.

**The two headline figures at the top of this PR — the −1.18 → −21.08 dBFS speech
level and the 0.21 → 18.10 dB pause contrast — are simulator measurements.** The
argument that they transfer is real and is recorded in each run: `Hl2TxDsp` is
host-side DSP and executes on `m_keyed` regardless of peer, so the stage under
test runs identically. But it is an argument, not a measurement.

**Nothing in this series has ever been radiated.** No on-air contact, no WSPRnet
spot, no receiving station has heard either build. Every claim about what a
correspondent would hear is inference. The commit messages on this branch were
corrected before filing, because an earlier version of them said *"measured on the
air"* and *"measured on the radio"* of runs that were neither.

### Reasoned from code only

- The slider position that lands on target (~74) — the mapping, not a leg.
- The hop from `TransmitModel` to `Hl2Backend::setMicGain`. Every bench leg drove
  `AETHER_HL2_MIC_LEVEL` into `setMicGain` directly. (The **widget**'s half was
  since settled through the automation bridge: `invoke "Microphone gain"
  setValue 100` moves `transmit.micLevel` to 100, and 76 to 76.)
- **The limiter change and the migration have no bench leg.** Both were measured
  against the real `Hl2TxDsp` and the real `Hl2Backend` in a harness rather than
  on hardware or `hpsdrsim`, and both are pinned by the tests above. Every |IQ|
  figure quoted on this page comes from that harness.

## Localization check

a lab-side checker of mine — not in this repo — that makes executable the rule in
`docs/HERMES.md` (*"For coding agents — keep bring-up inside the family
backend"*), reports **1 hit, 0 violations** on this branch. Exit 2 is advisory:
hits are to be explained, not failures.

**`src/gui/MainWindow_Session.cpp` — comment only.** Three lines inside
`MainWindow::wireRadioModel()`, correcting a comment that said the ALC *"needs the
mic pushed UP past its hold threshold"* — a claim this PR makes false. **No
executable line changes.**

## What this does NOT fix, and might be mistaken for it

- **Drive and power out.** Nothing here touches the drive control or the PA.
  Forward power is still set by drive.
- **The `TX:ALCGAIN` meter.** Separate work, #5506 and #5636. It exists on neither
  build measured here.
- **Nothing about drive or the speech processor.** Mic Level is the modulator's
  input level; it is not a substitute for either.
- **Splatter protection is unchanged.** The ALC still reduces on a transient, with
  the same attack and release, on every path. It simply never lifts.
- `clientLeveled` has no remaining use in `processAudioBlock`; it is kept and
  marked unused here rather than deleted, and #5647 gives it a real job as
  `TxAudioSource`.

## Test results

Full `ctest` (RelWithDebInfo, macOS): **416 tests, 416 passed, 0 failed**,
5 skipped (`crdv_quarantined_test`,
`app_settings_safety_explicit-profile-path-isolation`,
`weather_radar_texture_gl_test`, `range_slider_a11y_test`,
`relay_bar_a11y_test`).

On this head (RelWithDebInfo, Linux): the whole `hl2_*` family plus
`radio_state_memory_test`, **35/35 pass**, and so do `meter_model_test` and
`meter_surfaces_test`. Note that CI's green does **not** include any of them —
`.github/ci-test-gate.txt` is frozen and carries none of the HL2 tests, so they
first run on `full-suite.yml` after merge.

Each guard on this branch was inverted to check it is a guard rather than a
restatement. Reverting the seed's `reducing` gate fails the lead-in case and
nothing else; reverting `setMicGain`'s re-arm fails the mid-over case and nothing
else; deleting the `micLevelCurve` stamp fails the new `hl2_state_restore_test`
assertion and nothing else; replacing `micLevelFromCurve1` with the identity
fails both `hl2_tx_level_policy_test` and `hl2_dsp_readback_test`. The one change
here with **no** test guarding it is the `TX:ALCGAIN` face range, which is a
display bound checked against `alcGainDb()`'s ceiling by inspection.

One claim from the original report did **not** survive its own falsifier and is
withdrawn on this branch rather than quietly dropped: *"within one over the ALC
gain can only rise"* is refuted by 148 downward steps across `d78`'s ten stock
legs. What survives is narrower and sufficient — reduction is never held, so the
fault is the level during a pause, not a level that runs away across the over.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TtnKQu6QGrSeBirGeAsAs




