### PR TITLE
fix(recorder): report incomplete WAV writes and stop safely

### DIFF
--- a/src/core/QsoRecorder.cpp
+++ b/src/core/QsoRecorder.cpp
@@ -60,7 +60,7 @@ QsoRecorder::~QsoRecorder()
     // stay SILENT: this runs during teardown, and the zero-capture diagnostic
     // below is wired to a modal dialog. Popping one while the window is being
     // destroyed is both useless and a good way to hang a quit.
-    if (m_recording)
+    if (m_recording || m_writeFailurePending)
         finalizeFile(FinalizeReport::Silent);
 }
 
@@ -123,7 +123,13 @@ void QsoRecorder::startRecording()
 
 void QsoRecorder::beginRecording(StartTrigger trigger)
 {
-    if (m_recording) return;
+    // A feed-side failure stops accepting audio immediately, but its owner-
+    // thread finalization is deliberately queued so the audio thread never
+    // seeks, flushes, closes, or emits. Do not let a new run reuse m_file
+    // before that finalization has retired it.
+    if (m_recording || m_writeFailurePending) {
+        return;
+    }
 
     // Refuse before touching the filesystem (#4629). Creating the file first
     // and discovering the silence later is precisely the failure being fixed:
@@ -163,7 +169,9 @@ void QsoRecorder::beginRecording(StartTrigger trigger)
 
 void QsoRecorder::stopRecording()
 {
-    if (!m_recording) return;
+    if (!m_recording && !m_writeFailurePending) {
+        return;
+    }
     m_idleTimer->stop();
     finalizeFile();
 }
@@ -202,8 +210,18 @@ void QsoRecorder::feedRxAudio(const QByteArray& pcm)
         || m_transmitting.load(std::memory_order_acquire)
         || m_cwOverActive.load(std::memory_order_acquire)) return;
     QByteArray converted = float32ToInt16(pcm);
-    m_file->write(converted);
-    m_dataBytes += static_cast<quint32>(converted.size());
+    if (converted.isEmpty()) {
+        return;
+    }
+    const qint64 requested = converted.size();
+    const qint64 written = writeFile(converted.constData(), requested);
+    const qint64 accepted = std::clamp(written, qint64{0}, requested);
+    m_dataBytes += static_cast<quint32>(accepted);
+    if (accepted != requested) {
+        const QString deviceError = m_file->errorString();
+        queueWriteFailure(QStringLiteral("RX audio write failed")
+                          + (deviceError.isEmpty() ? QString{} : QStringLiteral(": ") + deviceError));
+    }
 }
 
 void QsoRecorder::feedTxAudio(const QByteArray& int16Stereo)
@@ -227,8 +245,18 @@ void QsoRecorder::feedTxAudio(const QByteArray& int16Stereo)
              || m_cwOverActive.load(std::memory_order_acquire))) return;
     // The post-limiter TX monitor is already 24 kHz stereo int16 — the WAV's
     // native format — so write it directly, no float32 conversion (#3556).
-    m_file->write(int16Stereo);
-    m_dataBytes += static_cast<quint32>(int16Stereo.size());
+    if (int16Stereo.isEmpty()) {
+        return;
+    }
+    const qint64 requested = int16Stereo.size();
+    const qint64 written = writeFile(int16Stereo.constData(), requested);
+    const qint64 accepted = std::clamp(written, qint64{0}, requested);
+    m_dataBytes += static_cast<quint32>(accepted);
+    if (accepted != requested) {
+        const QString deviceError = m_file->errorString();
+        queueWriteFailure(QStringLiteral("TX audio write failed")
+                          + (deviceError.isEmpty() ? QString{} : QStringLiteral(": ") + deviceError));
+    }
 }
 
 // ── TX state tracking ───────────────────────────────────────────────────────
@@ -323,7 +351,21 @@ void QsoRecorder::startFile()
         return;
     }
 
-    writeWavHeader();
+    if (!writeWavHeader()) {
+        const QString error = QStringLiteral("Cannot initialize recording file: ")
+                              + m_file->errorString();
+        {
+            std::lock_guard<std::mutex> lock(m_writeMutex);
+            m_file->close();
+            m_file->deleteLater();
+            m_file = nullptr;
+            m_lastRecordingPath.clear();
+        }
+        emit recordingError(error);
+        return;
+    }
+
+    m_recordingGeneration.fetch_add(1, std::memory_order_acq_rel);
     m_recording = true;
 
     qCInfo(lcAudio) << "QsoRecorder: started recording to" << filePath;
@@ -332,27 +374,57 @@ void QsoRecorder::startFile()
 
 void QsoRecorder::finalizeFile(FinalizeReport report)
 {
+    bool writeFailed = false;
+    bool finalized = false;
+    QString writeFailure;
+    QString finalizeError;
+    QString filePath;
+    int durationSecs = 0;
+    quint32 dataBytes = 0;
     {
         std::lock_guard<std::mutex> lock(m_writeMutex);
         m_recording = false;
+        writeFailed = m_writeFailurePending.exchange(false, std::memory_order_acq_rel);
+        writeFailure = m_pendingWriteError;
+        m_pendingWriteError.clear();
+        if (!m_file) {
+            return;
+        }
+
+        finalized = patchWavHeader();
+        finalizeError = m_file->errorString();
+        filePath = m_file->fileName();
+        durationSecs = static_cast<int>(m_startTime.secsTo(QDateTime::currentDateTimeUtc()));
+        dataBytes = m_dataBytes;
+
+        m_file->close();
+        m_file->deleteLater();
+        m_file = nullptr;
+
+        if (finalized && !writeFailed) {
+            m_lastRecordingPath = filePath;
+        } else {
+            // Do not leave a prior successful path advertised after a failed
+            // run. Filename reuse can otherwise make it name this very file.
+            m_lastRecordingPath.clear();
+        }
     }
 
-    if (!m_file) return;
-
-    patchWavHeader();
-    QString filePath = m_file->fileName();
-    m_lastRecordingPath = filePath;
-    int durationSecs = static_cast<int>(m_startTime.secsTo(QDateTime::currentDateTimeUtc()));
-
-    const quint32 dataBytes = m_dataBytes;
-
-    m_file->close();
-    m_file->deleteLater();
-    m_file = nullptr;
-
     qCInfo(lcAudio) << "QsoRecorder: stopped recording," << durationSecs << "seconds,"
-                     << dataBytes << "bytes";
+                     << dataBytes << "bytes" << (finalized && !writeFailed ? "" : "(write failed)");
     emit recordingStopped(filePath, durationSecs);
+
+    if (!finalized || writeFailed) {
+        if (report == FinalizeReport::Diagnose) {
+            const QString detail = writeFailed ? writeFailure
+                : QStringLiteral("Could not finalize WAV header")
+                      + (finalizeError.isEmpty() ? QString{} : QStringLiteral(": ") + finalizeError);
+            qCWarning(lcAudio) << "QsoRecorder:" << detail << filePath;
+            emit recordingError(QStringLiteral("Recording write failed: %1\n\n%2")
+                                    .arg(detail, filePath));
+        }
+        return;
+    }
 
     // A recording that captured NOTHING is the #4629 symptom, and until now it
     // was reported to the operator exactly like a good one — the file exists,
@@ -419,7 +491,61 @@ QString QsoRecorder::sanitizeForPath(const QString& s)
     return out;
 }
 
-void QsoRecorder::writeWavHeader()
+void QsoRecorder::finalizeWriteFailure(quint64 generation)
+{
+    // Explicit stop/destruction may have already finalized the failed file.
+    // A stale queued callback must never touch a newer recording.
+    if (generation != m_recordingGeneration.load(std::memory_order_acquire)
+        || !m_writeFailurePending.load(std::memory_order_acquire)) {
+        return;
+    }
+    m_idleTimer->stop();
+    finalizeFile();
+}
+
+qint64 QsoRecorder::writeFile(const char* data, qint64 size)
+{
+    if (m_writeForTest) {
+        return m_writeForTest(*m_file, data, size);
+    }
+    return m_file->write(data, size);
+}
+
+bool QsoRecorder::seekFile(qint64 position)
+{
+    if (m_seekForTest) {
+        return m_seekForTest(*m_file, position);
+    }
+    return m_file->seek(position);
+}
+
+bool QsoRecorder::flushFile()
+{
+    if (m_flushForTest) {
+        return m_flushForTest(*m_file);
+    }
+    return m_file->flush();
+}
+
+void QsoRecorder::queueWriteFailure(const QString& detail)
+{
+    // Called under m_writeMutex from the audio feed. Stop this and every
+    // later feed before scheduling any owner-thread work; do not emit here.
+    // Publish the pending finalization first: beginRecording() observes that
+    // flag after it sees m_recording false, so it cannot replace m_file while
+    // this feed still owns it.
+    if (m_writeFailurePending.exchange(true, std::memory_order_acq_rel)) {
+        return;
+    }
+    m_pendingWriteError = detail;
+    m_recording.store(false, std::memory_order_release);
+    const quint64 generation = m_recordingGeneration.load(std::memory_order_acquire);
+    QMetaObject::invokeMethod(this, [this, generation]() {
+        finalizeWriteFailure(generation);
+    }, Qt::QueuedConnection);
+}
+
+bool QsoRecorder::writeWavHeader()
 {
     // Write a placeholder WAV header (44 bytes). The data size fields
     // will be patched in finalizeFile() once we know the total size.
@@ -447,23 +573,37 @@ void QsoRecorder::writeWavHeader()
     memcpy(header + 36, "data", 4);
     // header[40..43] = data size (patched later)
 
-    m_file->write(header, WAV_HEADER_SIZE);
+    if (writeFile(header, WAV_HEADER_SIZE) != WAV_HEADER_SIZE) {
+        return false;
+    }
+    return flushFile();
 }
 
-void QsoRecorder::patchWavHeader()
+bool QsoRecorder::patchWavHeader()
 {
-    if (!m_file || !m_file->isOpen()) return;
+    if (!m_file || !m_file->isOpen()) {
+        return false;
+    }
 
     // Seek back and patch the two size fields in the WAV header
-    m_file->seek(4);
+    if (!seekFile(4)) {
+        return false;
+    }
     quint32 riffSize = m_dataBytes + WAV_HEADER_SIZE - 8;
     char buf[4];
     qToLittleEndian<quint32>(riffSize, buf);
-    m_file->write(buf, 4);
+    if (writeFile(buf, 4) != 4) {
+        return false;
+    }
 
-    m_file->seek(40);
+    if (!seekFile(40)) {
+        return false;
+    }
     qToLittleEndian<quint32>(m_dataBytes, buf);
-    m_file->write(buf, 4);
+    if (writeFile(buf, 4) != 4) {
+        return false;
+    }
+    return flushFile();
 }
 
 // ── Playback ───────────────────────────────────────────────────────────────

--- a/src/core/QsoRecorder.h
+++ b/src/core/QsoRecorder.h
@@ -23,6 +23,7 @@ namespace AetherSDR {
 
 class SliceModel;
 class TransmitModel;
+class QsoRecorderWriteErrorTestAccess;
 
 // Records QSO audio (both RX and TX sides) to WAV files.
 //
@@ -52,6 +53,8 @@ class TransmitModel;
 
 class QsoRecorder : public QObject {
     Q_OBJECT
+
+    friend class QsoRecorderWriteErrorTestAccess;
 
 public:
     explicit QsoRecorder(QObject* parent = nullptr);
@@ -189,10 +192,15 @@ private:
 
     void startFile();
     void finalizeFile(FinalizeReport report = FinalizeReport::Diagnose);
+    void finalizeWriteFailure(quint64 generation);
     QString buildFilename() const;
     static QString sanitizeForPath(const QString& s);
-    void writeWavHeader();
-    void patchWavHeader();
+    bool writeWavHeader();
+    bool patchWavHeader();
+    qint64 writeFile(const char* data, qint64 size);
+    bool seekFile(qint64 position);
+    bool flushFile();
+    void queueWriteFailure(const QString& detail);
     bool preparePlaybackPcm(int sinkRateHz);
 
     // Recording state
@@ -205,6 +213,9 @@ private:
     QFile*      m_file{nullptr};
     QDateTime   m_startTime;
     quint32     m_dataBytes{0};    // PCM data bytes written (for WAV header patching)
+    std::atomic<bool> m_writeFailurePending{false};
+    std::atomic<quint64> m_recordingGeneration{0};
+    QString m_pendingWriteError;
 
     // Configuration
     QString     m_recordingDir;
@@ -236,6 +247,14 @@ private:
 
     // Thread safety for audio feed paths
     mutable std::mutex  m_writeMutex;
+
+    // Narrow deterministic seam for the recorder's real QFile operations.
+    // The test uses it to make a post-open write, seek, or flush fail without
+    // changing filename allocation or relying on a full filesystem. Production
+    // paths leave all three unset and call QFile directly.
+    std::function<qint64(QFile&, const char*, qint64)> m_writeForTest;
+    std::function<bool(QFile&, qint64)> m_seekForTest;
+    std::function<bool(QFile&)> m_flushForTest;
 
     // See setBackendOwnsRxAudioProvider(). Null until MainWindow installs it,
     // and null reads as false — the Flex answer, and the safe one.

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -5777,10 +5777,16 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
                 sl->setRecordOn(on);
         }
     });
-    // Client-side recording stopped by idle timeout → update VFO button
-    connect(m_qsoRecorder, &QsoRecorder::recordingStopped, w, [w]() {
+    // A stopped recording may have failed to write/finalize; only enable
+    // playback when the recorder has a successfully finalized file.
+    connect(m_qsoRecorder, &QsoRecorder::recordingStopped, w, [this, w]() {
         w->setRecordOn(false);
-        w->setPlayEnabled(true);
+        w->setPlayEnabled(m_qsoRecorder->hasLastRecording());
+    });
+    connect(m_qsoRecorder, &QsoRecorder::recordingError, w, [this, w]() {
+        // Initial-header failures never emit recordingStopped.
+        w->setRecordOn(m_qsoRecorder->isRecording());
+        w->setPlayEnabled(m_qsoRecorder->hasLastRecording());
     });
     // Client-side playback
     connect(w, &VfoWidget::playToggled, this, [this, sliceId](bool on) {

--- a/tests/qso_recorder_write_error_test.cpp
+++ b/tests/qso_recorder_write_error_test.cpp
@@ -1,0 +1,554 @@
+// Regression test for #5648 — recorder write failures must stop the audio
+// feed, account only accepted bytes, and finalize/report on the owner thread.
+//
+// The seam below is deliberately post-open: filename allocation is covered by
+// #5644, while these cases exercise QsoRecorder's production header, feed and
+// finalization methods with deterministic QFile write/seek/flush outcomes.
+
+#include "TestSettingsProfile.h"
+#include "core/AppSettings.h"
+#include "core/QsoRecorder.h"
+
+#include <QCoreApplication>
+#include <QEvent>
+#include <QFile>
+#include <QTemporaryDir>
+#include <QThread>
+#include <QtEndian>
+
+#include <algorithm>
+#include <cstdio>
+#include <functional>
+#include <memory>
+#include <thread>
+
+using namespace AetherSDR;
+
+namespace AetherSDR {
+
+class QsoRecorderWriteErrorTestAccess {
+public:
+    static void setWriteHook(
+        QsoRecorder& recorder,
+        std::function<qint64(QFile&, const char*, qint64)> hook)
+    {
+        recorder.m_writeForTest = std::move(hook);
+    }
+
+    static void setSeekHook(QsoRecorder& recorder,
+                            std::function<bool(QFile&, qint64)> hook)
+    {
+        recorder.m_seekForTest = std::move(hook);
+    }
+
+    static void setFlushHook(QsoRecorder& recorder, std::function<bool(QFile&)> hook)
+    {
+        recorder.m_flushForTest = std::move(hook);
+    }
+
+    static QFile* openFile(QsoRecorder& recorder)
+    {
+        return recorder.m_file;
+    }
+};
+
+} // namespace AetherSDR
+
+namespace {
+
+int g_failures = 0;
+
+#define EXPECT_TRUE(condition) do { \
+    if (!(condition)) { \
+        std::fprintf(stderr, "FAIL %s:%d expected true: %s\n", \
+                     __FILE__, __LINE__, #condition); \
+        ++g_failures; \
+    } \
+} while (0)
+
+#define EXPECT_EQ(actual, expected) do { \
+    const auto actual_ = (actual); const auto expected_ = (expected); \
+    if (actual_ != expected_) { \
+        std::fprintf(stderr, "FAIL %s:%d expected %lld, got %lld\n", \
+                     __FILE__, __LINE__, static_cast<long long>(expected_), \
+                     static_cast<long long>(actual_)); \
+        ++g_failures; \
+    } \
+} while (0)
+
+struct Events {
+    int started{0};
+    int stopped{0};
+    int errors{0};
+    QString stoppedPath;
+};
+
+void connectEvents(QsoRecorder& recorder, Events& events)
+{
+    QObject::connect(&recorder, &QsoRecorder::recordingStarted, &recorder,
+                     [&events](const QString&) { ++events.started; });
+    QObject::connect(&recorder, &QsoRecorder::recordingStopped, &recorder,
+                     [&events](const QString& path, int) {
+                         ++events.stopped;
+                         events.stoppedPath = path;
+                     });
+    QObject::connect(&recorder, &QsoRecorder::recordingError, &recorder,
+                     [&events](const QString&) { ++events.errors; });
+}
+
+void allowClientRecording()
+{
+    auto& settings = AppSettings::instance();
+    settings.setValue(QStringLiteral("RecordingMode"), QStringLiteral("Client"));
+    settings.setValue(QStringLiteral("PcAudioEnabled"), QStringLiteral("True"));
+    settings.save();
+}
+
+void configure(QsoRecorder& recorder, const QString& directory)
+{
+    recorder.setRecordingDir(directory);
+    recorder.setIncludeDate(false);
+    recorder.setIncludeTime(false);
+    recorder.setIncludeFrequency(false);
+    recorder.setIncludeMode(false);
+}
+
+QByteArray rxFrame()
+{
+    QByteArray pcm(2 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
+    float* samples = reinterpret_cast<float*>(pcm.data());
+    samples[0] = 0.5f;
+    samples[1] = -0.5f;
+    return pcm;
+}
+
+QByteArray txFrame()
+{
+    return QByteArray::fromHex("0100020003000400");
+}
+
+quint32 wavDataSize(const QString& path)
+{
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly) || file.size() < 44) {
+        return 0;
+    }
+    const QByteArray header = file.read(44);
+    return qFromLittleEndian<quint32>(header.constData() + 40);
+}
+
+quint32 wavRiffSize(const QString& path)
+{
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly) || file.size() < 44) {
+        return 0;
+    }
+    const QByteArray header = file.read(44);
+    return qFromLittleEndian<quint32>(header.constData() + 4);
+}
+
+void feedFromAudioThread(QsoRecorder& recorder, bool tx)
+{
+    std::thread feeder([&recorder, tx]() {
+        if (tx) {
+            recorder.feedTxAudio(txFrame());
+        } else {
+            recorder.feedRxAudio(rxFrame());
+        }
+    });
+    feeder.join();
+}
+
+void deliverQueuedCalls()
+{
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::MetaCall);
+    QCoreApplication::processEvents();
+}
+
+void testInitialHeaderFailures()
+{
+    QTemporaryDir tmp;
+    EXPECT_TRUE(tmp.isValid());
+
+    {
+        Events events;
+        QsoRecorder recorder;
+        configure(recorder, tmp.path());
+        connectEvents(recorder, events);
+        QsoRecorderWriteErrorTestAccess::setWriteHook(
+            recorder, [](QFile& file, const char* data, qint64 size) {
+                return file.write(data, size - 1);
+            });
+
+        recorder.startRecording();
+        EXPECT_TRUE(!recorder.isRecording());
+        EXPECT_EQ(events.started, 0);
+        EXPECT_EQ(events.stopped, 0);
+        EXPECT_EQ(events.errors, 1);
+    }
+
+    {
+        Events events;
+        QsoRecorder recorder;
+        configure(recorder, tmp.path());
+        connectEvents(recorder, events);
+        QsoRecorderWriteErrorTestAccess::setFlushHook(
+            recorder, [](QFile&) { return false; });
+
+        recorder.startRecording();
+        EXPECT_TRUE(!recorder.isRecording());
+        EXPECT_EQ(events.started, 0);
+        EXPECT_EQ(events.stopped, 0);
+        EXPECT_EQ(events.errors, 1);
+    }
+}
+
+void testFeedFailure(bool tx, qint64 result)
+{
+    QTemporaryDir tmp;
+    EXPECT_TRUE(tmp.isValid());
+    Events events;
+    QThread* stoppedThread = nullptr;
+    QThread* errorThread = nullptr;
+    int writes = 0;
+    qint64 actualAccepted = -1;
+    QsoRecorder recorder;
+    configure(recorder, tmp.path());
+    connectEvents(recorder, events);
+    QObject::connect(&recorder, &QsoRecorder::recordingStopped, &recorder,
+                     [&stoppedThread](const QString&, int) {
+                         stoppedThread = QThread::currentThread();
+                     }, Qt::DirectConnection);
+    QObject::connect(&recorder, &QsoRecorder::recordingError, &recorder,
+                     [&errorThread](const QString&) {
+                         errorThread = QThread::currentThread();
+                     }, Qt::DirectConnection);
+
+    QsoRecorderWriteErrorTestAccess::setWriteHook(
+        recorder, [&writes, &actualAccepted, result](QFile& file, const char* data, qint64 size) {
+            ++writes;
+            if (writes != 2) {
+                return file.write(data, size);
+            }
+            const qint64 accepted = std::clamp(result, qint64{0}, size);
+            if (accepted > 0) {
+                actualAccepted = file.write(data, accepted);
+                return actualAccepted;
+            }
+            return result;
+        });
+
+    recorder.startRecording();
+    EXPECT_TRUE(recorder.isRecording());
+    if (tx) {
+        recorder.onMoxChanged(true);
+    }
+    feedFromAudioThread(recorder, tx);
+
+    // Incomplete writes stop the producer synchronously, while the error and
+    // close remain queued to the recorder's owning thread.
+    EXPECT_TRUE(!recorder.isRecording());
+    EXPECT_EQ(events.errors, 0);
+    EXPECT_EQ(events.stopped, 0);
+    const qint64 requested = tx ? txFrame().size() : rxFrame().size() / 2;
+    if (result > 0) {
+        EXPECT_EQ(actualAccepted, result);
+    }
+    const int writesAfterFailure = writes;
+    if (tx) {
+        recorder.feedTxAudio(txFrame());
+    } else {
+        recorder.feedRxAudio(rxFrame());
+    }
+    EXPECT_EQ(writes, writesAfterFailure);
+
+    // A pending failure owns the old handle; a restart before finalization is
+    // ignored rather than replacing it under the feed thread.
+    recorder.startRecording();
+    EXPECT_TRUE(!recorder.isRecording());
+
+    deliverQueuedCalls();
+    EXPECT_EQ(events.stopped, 1);
+    EXPECT_EQ(events.errors, 1);
+    EXPECT_TRUE(stoppedThread == recorder.thread());
+    EXPECT_TRUE(errorThread == recorder.thread());
+    EXPECT_TRUE(recorder.recordingFilePath().isEmpty());
+    EXPECT_TRUE(!recorder.hasLastRecording());
+    EXPECT_EQ(wavDataSize(events.stoppedPath), std::clamp(result, qint64{0}, requested));
+
+    // recordingStopped still clears active consumers, but the failed file is
+    // not published as the last playable recording. Do not open a platform
+    // audio sink in this storage-only regression test.
+    recorder.stopRecording();
+    EXPECT_EQ(events.stopped, 1);
+    EXPECT_EQ(events.errors, 1);  // no duplicate zero-audio diagnostic
+    if (recorder.isRecording()) {
+        recorder.stopRecording();
+    }
+}
+
+void testSuccessfulRecording(bool tx)
+{
+    QTemporaryDir tmp;
+    EXPECT_TRUE(tmp.isValid());
+    Events events;
+    QsoRecorder recorder;
+    configure(recorder, tmp.path());
+    connectEvents(recorder, events);
+
+    recorder.startRecording();
+    EXPECT_TRUE(recorder.isRecording());
+    if (tx) {
+        recorder.onMoxChanged(true);
+    }
+    feedFromAudioThread(recorder, tx);
+    recorder.stopRecording();
+
+    const quint32 expectedData = tx ? txFrame().size() : rxFrame().size() / 2;
+    EXPECT_EQ(events.started, 1);
+    EXPECT_EQ(events.stopped, 1);
+    EXPECT_EQ(events.errors, 0);
+    EXPECT_EQ(wavDataSize(events.stoppedPath), expectedData);
+    EXPECT_EQ(wavRiffSize(events.stoppedPath), expectedData + 36);
+    EXPECT_EQ(QFile(events.stoppedPath).size(), expectedData + 44);
+    EXPECT_TRUE(recorder.recordingFilePath() == events.stoppedPath);
+}
+
+void testActualReadOnlyFileFailure()
+{
+    QTemporaryDir tmp;
+    EXPECT_TRUE(tmp.isValid());
+    Events events;
+    QsoRecorder recorder;
+    configure(recorder, tmp.path());
+    connectEvents(recorder, events);
+
+    recorder.startRecording();
+    QFile* const file = QsoRecorderWriteErrorTestAccess::openFile(recorder);
+    if (!file) {
+        EXPECT_TRUE(false);
+        return;
+    }
+    file->close();
+    if (!file->open(QIODevice::ReadOnly)) {
+        EXPECT_TRUE(false);
+        return;
+    }
+    feedFromAudioThread(recorder, false);
+    EXPECT_TRUE(!recorder.isRecording());
+    EXPECT_EQ(events.errors, 0);
+    deliverQueuedCalls();
+    EXPECT_EQ(events.stopped, 1);
+    EXPECT_EQ(events.errors, 1);
+    EXPECT_TRUE(recorder.recordingFilePath().isEmpty());
+    if (recorder.isRecording()) {
+        recorder.stopRecording();
+    }
+}
+
+void testFailedRunClearsPriorPlaybackPath()
+{
+    QTemporaryDir tmp;
+    EXPECT_TRUE(tmp.isValid());
+    Events events;
+    int writes = 0;
+    QsoRecorder recorder;
+    configure(recorder, tmp.path());
+    connectEvents(recorder, events);
+
+    recorder.startRecording();
+    feedFromAudioThread(recorder, false);
+    recorder.stopRecording();
+    EXPECT_TRUE(recorder.hasLastRecording());
+
+    QsoRecorderWriteErrorTestAccess::setWriteHook(
+        recorder, [&writes](QFile& file, const char* data, qint64 size) {
+            ++writes;
+            return writes == 2 ? qint64{-1} : file.write(data, size);
+        });
+    recorder.startRecording();
+    feedFromAudioThread(recorder, false);
+    deliverQueuedCalls();
+
+    EXPECT_TRUE(!recorder.hasLastRecording());
+    EXPECT_TRUE(recorder.recordingFilePath().isEmpty());
+    if (recorder.isRecording()) {
+        recorder.stopRecording();
+    }
+}
+
+void testFinalizationFailures()
+{
+    for (const qint64 failedSeek : {qint64{4}, qint64{40}}) {
+        QTemporaryDir tmp;
+        EXPECT_TRUE(tmp.isValid());
+        Events events;
+        QsoRecorder recorder;
+        configure(recorder, tmp.path());
+        connectEvents(recorder, events);
+        recorder.startRecording();
+        recorder.feedRxAudio(rxFrame());
+        QsoRecorderWriteErrorTestAccess::setSeekHook(
+            recorder, [failedSeek](QFile& file, qint64 position) {
+                return position == failedSeek ? false : file.seek(position);
+            });
+        recorder.stopRecording();
+        EXPECT_EQ(events.stopped, 1);
+        EXPECT_EQ(events.errors, 1);
+        EXPECT_TRUE(recorder.recordingFilePath().isEmpty());
+    }
+
+    {
+        QTemporaryDir tmp;
+        EXPECT_TRUE(tmp.isValid());
+        Events events;
+        QsoRecorder recorder;
+        configure(recorder, tmp.path());
+        connectEvents(recorder, events);
+        recorder.startRecording();
+        recorder.feedRxAudio(rxFrame());
+        QsoRecorderWriteErrorTestAccess::setWriteHook(
+            recorder, [](QFile& file, const char* data, qint64 size) {
+                return size == 4 ? qint64{-1} : file.write(data, size);
+            });
+        recorder.stopRecording();
+        EXPECT_EQ(events.stopped, 1);
+        EXPECT_EQ(events.errors, 1);
+        EXPECT_TRUE(recorder.recordingFilePath().isEmpty());
+    }
+
+    // The first size-field patch can succeed while the second fails. Keep the
+    // first real write so this is not merely the earlier-patch case repeated.
+    {
+        QTemporaryDir tmp;
+        EXPECT_TRUE(tmp.isValid());
+        Events events;
+        int patchWrites = 0;
+        QsoRecorder recorder;
+        configure(recorder, tmp.path());
+        connectEvents(recorder, events);
+        recorder.startRecording();
+        recorder.feedRxAudio(rxFrame());
+        QsoRecorderWriteErrorTestAccess::setWriteHook(
+            recorder, [&patchWrites](QFile& file, const char* data, qint64 size) {
+                if (size == 4 && ++patchWrites == 2) {
+                    return qint64{-1};
+                }
+                return file.write(data, size);
+            });
+        recorder.stopRecording();
+        EXPECT_EQ(events.stopped, 1);
+        EXPECT_EQ(events.errors, 1);
+        EXPECT_TRUE(recorder.recordingFilePath().isEmpty());
+    }
+
+    {
+        QTemporaryDir tmp;
+        EXPECT_TRUE(tmp.isValid());
+        Events events;
+        int flushes = 0;
+        QsoRecorder recorder;
+        configure(recorder, tmp.path());
+        connectEvents(recorder, events);
+        QsoRecorderWriteErrorTestAccess::setFlushHook(
+            recorder, [&flushes](QFile& file) {
+                ++flushes;
+                return flushes == 1 ? file.flush() : false;
+            });
+        recorder.startRecording();
+        recorder.feedRxAudio(rxFrame());
+        recorder.stopRecording();
+        EXPECT_EQ(events.stopped, 1);
+        EXPECT_EQ(events.errors, 1);
+        EXPECT_TRUE(recorder.recordingFilePath().isEmpty());
+    }
+}
+
+void testStaleQueuedFailureCannotTouchRestart()
+{
+    QTemporaryDir tmp;
+    EXPECT_TRUE(tmp.isValid());
+    Events events;
+    int writes = 0;
+    QsoRecorder recorder;
+    configure(recorder, tmp.path());
+    connectEvents(recorder, events);
+    QsoRecorderWriteErrorTestAccess::setWriteHook(
+        recorder, [&writes](QFile& file, const char* data, qint64 size) {
+            ++writes;
+            return writes == 2 ? qint64{-1} : file.write(data, size);
+        });
+    recorder.startRecording();
+    recorder.feedRxAudio(rxFrame());
+    EXPECT_TRUE(!recorder.isRecording());
+
+    // An explicit stop owns finalization before the queued audio-thread error
+    // callback runs. The callback must then be harmless after a new start.
+    recorder.stopRecording();
+    EXPECT_EQ(events.stopped, 1);
+    EXPECT_EQ(events.errors, 1);
+    QsoRecorderWriteErrorTestAccess::setWriteHook(recorder, {});
+    recorder.startRecording();
+    EXPECT_TRUE(recorder.isRecording());
+    deliverQueuedCalls();
+    EXPECT_TRUE(recorder.isRecording());
+    EXPECT_EQ(events.stopped, 1);
+    EXPECT_EQ(events.errors, 1);
+    recorder.stopRecording();
+    EXPECT_EQ(events.stopped, 2);
+}
+
+void testDestructionCancelsQueuedFailure()
+{
+    QTemporaryDir tmp;
+    EXPECT_TRUE(tmp.isValid());
+    Events events;
+    int writes = 0;
+    auto recorder = std::make_unique<QsoRecorder>();
+    configure(*recorder, tmp.path());
+    connectEvents(*recorder, events);
+    QsoRecorderWriteErrorTestAccess::setWriteHook(
+        *recorder, [&writes](QFile& file, const char* data, qint64 size) {
+            ++writes;
+            return writes == 2 ? qint64{0} : file.write(data, size);
+        });
+    recorder->startRecording();
+    recorder->feedRxAudio(rxFrame());
+    recorder.reset();
+    deliverQueuedCalls();
+    EXPECT_EQ(events.stopped, 1);
+    EXPECT_EQ(events.errors, 0);  // teardown remains silent
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile settingsProfile(QStringLiteral("aether-qso-recorder-write-errors"));
+    if (!settingsProfile.isValid()) {
+        return 1;
+    }
+    QCoreApplication app(argc, argv);
+    AppSettings::instance().load();
+    allowClientRecording();
+
+    testInitialHeaderFailures();
+    for (const bool tx : {false, true}) {
+        testSuccessfulRecording(tx);
+        for (const qint64 result : {qint64{2}, qint64{0}, qint64{-1}}) {
+            testFeedFailure(tx, result);
+        }
+    }
+    testActualReadOnlyFileFailure();
+    testFailedRunClearsPriorPlaybackPath();
+    testFinalizationFailures();
+    testStaleQueuedFailureCannotTouchRestart();
+    testDestructionCancelsQueuedFailure();
+
+    if (g_failures == 0) {
+        std::printf("qso_recorder_write_error_test: all checks passed\n");
+        return 0;
+    }
+    std::printf("qso_recorder_write_error_test: %d failure(s)\n", g_failures);
+    return 1;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1932,6 +1932,27 @@ target_include_directories(qso_recorder_pc_audio_guard_test PRIVATE
 target_link_libraries(qso_recorder_pc_audio_guard_test PRIVATE Qt6::Core Qt6::Multimedia)
 add_test(NAME qso_recorder_pc_audio_guard_test COMMAND qso_recorder_pc_audio_guard_test)
 
+# #5648 — post-open QFile failures are finalized on the recorder owner thread;
+# no socket, device, or radio is involved.
+add_executable(qso_recorder_write_error_test
+    tests/qso_recorder_write_error_test.cpp
+    src/core/QsoRecorder.cpp
+    ${AETHER_SETTINGS_SOURCES}
+    src/core/AudioDeviceNegotiator.cpp
+    src/core/AudioFormatNegotiator.cpp
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+    src/core/Resampler.cpp
+    src/models/SliceModel.cpp
+    src/core/DigitalVoiceModeRegistry.cpp
+)
+target_include_directories(qso_recorder_write_error_test PRIVATE
+    src
+    ${CMAKE_SOURCE_DIR}/third_party/r8brain
+)
+target_link_libraries(qso_recorder_write_error_test PRIVATE Qt6::Core Qt6::Multimedia)
+add_test(NAME qso_recorder_write_error_test COMMAND qso_recorder_write_error_test)
+
 add_executable(profile_transfer_test
     tests/profile_transfer_test.cpp
 )
@@ -5146,6 +5167,7 @@ set(AETHER_SETTINGS_CONSUMERS
     panadapter_model_rx_antenna_test
     qso_recorder_slice_lifetime_test
     qso_recorder_pc_audio_guard_test
+    qso_recorder_write_error_test
     band_plan_license_filter_test
     kiwisdr_dx_spots_test
     passive_spots_policy_test

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1880,6 +1880,27 @@ target_include_directories(tx_capture_health_test PRIVATE src)
 target_link_libraries(tx_capture_health_test PRIVATE Qt6::Core)
 add_test(NAME tx_capture_health_test COMMAND tx_capture_health_test)
 
+# #5648 — post-open QFile failures are finalized on the recorder owner thread;
+# no socket, device, or radio is involved.
+add_executable(qso_recorder_write_error_test
+    tests/qso_recorder_write_error_test.cpp
+    src/core/QsoRecorder.cpp
+    ${AETHER_SETTINGS_SOURCES}
+    src/core/AudioDeviceNegotiator.cpp
+    src/core/AudioFormatNegotiator.cpp
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+    src/core/Resampler.cpp
+    src/models/SliceModel.cpp
+    src/core/DigitalVoiceModeRegistry.cpp
+)
+target_include_directories(qso_recorder_write_error_test PRIVATE
+    src
+    ${CMAKE_SOURCE_DIR}/third_party/r8brain
+)
+target_link_libraries(qso_recorder_write_error_test PRIVATE Qt6::Core Qt6::Multimedia)
+add_test(NAME qso_recorder_write_error_test COMMAND qso_recorder_write_error_test)
+
 # Regression test for #4003 — QsoRecorder must not dereference a SliceModel that
 # was freed (reconnect prune) before recording starts. QPointer auto-nulls the
 # reference; the test deletes the slice and asserts the metadata is cleared.
@@ -1931,27 +1952,6 @@ target_include_directories(qso_recorder_pc_audio_guard_test PRIVATE
 )
 target_link_libraries(qso_recorder_pc_audio_guard_test PRIVATE Qt6::Core Qt6::Multimedia)
 add_test(NAME qso_recorder_pc_audio_guard_test COMMAND qso_recorder_pc_audio_guard_test)
-
-# #5648 — post-open QFile failures are finalized on the recorder owner thread;
-# no socket, device, or radio is involved.
-add_executable(qso_recorder_write_error_test
-    tests/qso_recorder_write_error_test.cpp
-    src/core/QsoRecorder.cpp
-    ${AETHER_SETTINGS_SOURCES}
-    src/core/AudioDeviceNegotiator.cpp
-    src/core/AudioFormatNegotiator.cpp
-    src/core/LogManager.cpp
-    src/core/AsyncLogWriter.cpp
-    src/core/Resampler.cpp
-    src/models/SliceModel.cpp
-    src/core/DigitalVoiceModeRegistry.cpp
-)
-target_include_directories(qso_recorder_write_error_test PRIVATE
-    src
-    ${CMAKE_SOURCE_DIR}/third_party/r8brain
-)
-target_link_libraries(qso_recorder_write_error_test PRIVATE Qt6::Core Qt6::Multimedia)
-add_test(NAME qso_recorder_write_error_test COMMAND qso_recorder_write_error_test)
 
 add_executable(profile_transfer_test
     tests/profile_transfer_test.cpp
@@ -5165,9 +5165,9 @@ set(AETHER_SETTINGS_CONSUMERS
     nr2_settings_model_test
     rn2_settings_model_test
     panadapter_model_rx_antenna_test
+    qso_recorder_write_error_test
     qso_recorder_slice_lifetime_test
     qso_recorder_pc_audio_guard_test
-    qso_recorder_write_error_test
     band_plan_license_filter_test
     kiwisdr_dx_spots_test
     passive_spots_policy_test


### PR DESCRIPTION
Failed or short QSO recording writes previously left recording active, counted bytes that were not accepted and could advertise an incomplete WAV without an error.

The recorder now counts accepted RX/TX bytes, stops accepting feeds immediately on incomplete writes and finalizes once on its owning thread. Initial header creation/flush and final seeks, header patches, flush and close must succeed. Failed runs emit recordingStopped and one error; their files remain on disk for recovery but are not offered for playback. Record/Play controls follow the actual recorder state, including start failures. Pending cleanup blocks restart and old queued callbacks cannot affect a replacement recording.

Fixes #5648. Filename allocation and collision policy remain in #5644. No radio protocol, TX admission, settings schema or UI design change.

Validation:
- Production-code regressions exercise short/zero/negative RX/TX writes, real read-only QFile errors, initial header failures, final seek/write/flush failures, accepted payload lengths, owner-thread signals, pending restart, explicit stop, stale callbacks and destruction.
- Added a close-failure regression using only the temporary file's owned native handle after a successful real flush. Before the fix, four assertions fail: no error is reported and the failed path remains playable. With post-close inspection, it passes. The Windows native-handle injection is source-checked against Qt; native Windows execution was not performed locally.
- Accepted-byte accounting mutation fails six size assertions; restored code passes. Native macOS ARM64 production CMake build passes all three focused recorder tests. The complete ARM64 application builds with RADE enabled.
- Fresh authenticated demo-only application smoke passes on the updated head: an invalid scratch recording directory produces an error with Record unchecked and Play disabled; a successful start/stop checks then clears Record and enables Play. The resulting 681,004-byte WAV contains nonzero 24 kHz stereo PCM16 with exact RIFF/data lengths. Private settings and scratch recordings were used; the owned proof app exited afterward.
- No radio hardware, RF/TX, native Windows audio-device behavior, physical storage fault or fresh sanitizer run is claimed. Storage-failure behavior is verified in the socket-free production-recorder regression; the bridge has no storage fault-injection verb. Frozen per-PR test allow-list is unchanged.
