### PR TITLE
Fix PMS atomic persistence and truthful save responses

### DIFF
--- a/src/core/pms/PmsMailbox.cpp
+++ b/src/core/pms/PmsMailbox.cpp
@@ -1,6 +1,7 @@
 #include "core/pms/PmsMailbox.h"
 
 #include "core/AppSettings.h"
+#include "core/LogManager.h"
 #include "core/tnc/Ax25Connection.h"
 
 #include <QDir>
@@ -9,10 +10,12 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QSaveFile>
 #include <QStorageInfo>
 #include <QTimer>
 
 #include <algorithm>
+#include <utility>
 
 namespace AetherSDR {
 
@@ -27,6 +30,30 @@ QString lineEnding() { return QStringLiteral("\r"); }
 bool sameCall(const QString& a, const QString& b)
 {
     return a.compare(b, Qt::CaseInsensitive) == 0;
+}
+
+bool writeJsonAtomically(const QString& path, const QJsonObject& root, QString* error)
+{
+    QSaveFile file(path);
+    // Never fall back to writing the target directly: a failed replacement must
+    // leave the last complete mailbox snapshot available to the next startup.
+    file.setDirectWriteFallback(false);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        *error = file.errorString();
+        return false;
+    }
+
+    const QByteArray bytes = QJsonDocument(root).toJson();
+    if (file.write(bytes) != bytes.size()) {
+        *error = file.errorString();
+        file.cancelWriting();
+        return false;
+    }
+    if (!file.commit()) {
+        *error = file.errorString();
+        return false;
+    }
+    return true;
 }
 
 } // namespace
@@ -73,7 +100,7 @@ PmsMailbox::PmsMailbox(QObject* parent)
 PmsMailbox::~PmsMailbox()
 {
     if (m_loaded)
-        saveHeard();
+        saveHeard(m_heard);
 }
 
 // ---------------------------------------------------------------------------
@@ -108,7 +135,7 @@ void PmsMailbox::setEnabled(bool on)
     } else {
         m_link->reset();
         m_beaconTimer->stop();
-        saveHeard();
+        saveHeard(m_heard);
         emit activity(QStringLiteral("PMS disabled."));
     }
     emit stateChanged();
@@ -369,7 +396,7 @@ void PmsMailbox::recordHeard(const Frame& frame)
                       [](const Heard& a, const Heard& b) { return a.utc > b.utc; });
             m_heard.resize(200);
         }
-        saveHeard();
+        saveHeard(m_heard);
         emit stateChanged();
     }
 }
@@ -380,9 +407,10 @@ void PmsMailbox::recordCaller(const Address& peer)
     c.call = peer.toString();
     c.utc = QDateTime::currentDateTimeUtc();
     m_callers.append(c);
-    if (m_callers.size() > 500)
+    if (m_callers.size() > 500) {
         m_callers.remove(0, m_callers.size() - 500);
-    saveCallers();
+    }
+    saveCallers(m_callers);
 }
 
 // ---------------------------------------------------------------------------
@@ -416,7 +444,7 @@ void PmsMailbox::onLinkDisconnected(const Address& peer, bool byPeer)
     m_draftLines.clear();
     if (m_sessionIdleTimer)
         m_sessionIdleTimer->stop();
-    saveHeard();
+    saveHeard(m_heard);
     emit stateChanged();
 }
 
@@ -635,7 +663,8 @@ void PmsMailbox::cmdRead(const QString& args)
         reply(QStringLiteral("USAGE: R <message-number>"));
         return;
     }
-    for (Message& m : m_messages) {
+    for (int i = 0; i < m_messages.size(); ++i) {
+        const Message& m = m_messages.at(i);
         if (m.id != n)
             continue;
         if (!callerMayAccess(m)) {
@@ -650,8 +679,13 @@ void PmsMailbox::cmdRead(const QString& args)
         reply(m.body.isEmpty() ? QStringLiteral("(no text)") : m.body);
         reply(QStringLiteral("---"));
         if (!m.read && (sameCall(m.to, m_caller.toString()) || sameCall(m.to, m_caller.call))) {
-            m.read = true;
-            saveMessages();
+            QVector<Message> updated = m_messages;
+            updated[i].read = true;
+            if (saveMessages(updated, m_nextId)) {
+                m_messages = std::move(updated);
+            } else {
+                reply(QStringLiteral("*** Read state was not saved; message remains unread."));
+            }
         }
         return;
     }
@@ -679,8 +713,13 @@ void PmsMailbox::cmdKill(const QString& args)
             reply(QStringLiteral("Not authorized to kill message %1.").arg(n));
             return;
         }
-        m_messages.remove(i);
-        saveMessages();
+        QVector<Message> updated = m_messages;
+        updated.remove(i);
+        if (!saveMessages(updated, m_nextId)) {
+            reply(QStringLiteral("*** Message %1 was not killed; storage error.").arg(n));
+            return;
+        }
+        m_messages = std::move(updated);
         reply(QStringLiteral("Message %1 killed.").arg(n));
         emit stateChanged();
         return;
@@ -721,13 +760,21 @@ void PmsMailbox::cmdSendBegin(const QString& args, QChar type)
 void PmsMailbox::finishCompose(bool save)
 {
     if (save) {
-        m_draft.id = m_nextId++;
-        m_draft.utc = QDateTime::currentDateTimeUtc();
-        m_draft.body = m_draftLines.join(QStringLiteral("\n"));
-        m_draft.read = false;
-        m_messages.append(m_draft);
-        saveMessages();
-        reply(QStringLiteral("MESSAGE %1 SAVED.").arg(m_draft.id));
+        Message candidate = m_draft;
+        candidate.id = m_nextId;
+        candidate.utc = QDateTime::currentDateTimeUtc();
+        candidate.body = m_draftLines.join(QStringLiteral("\n"));
+        candidate.read = false;
+        QVector<Message> updated = m_messages;
+        updated.append(candidate);
+        if (!saveMessages(updated, m_nextId + 1)) {
+            reply(QStringLiteral("*** MESSAGE NOT SAVED; storage error. Draft retained: send /EX to retry."));
+            return;
+        }
+        m_messages = std::move(updated);
+        m_nextId += 1;
+        m_draft = candidate;
+        reply(QStringLiteral("MESSAGE %1 SAVED.").arg(candidate.id));
         emit stateChanged();
     } else {
         reply(QStringLiteral("Message aborted."));
@@ -805,9 +852,9 @@ QString PmsMailbox::messagesPath() const { return storageDir() + QStringLiteral(
 QString PmsMailbox::callersPath() const { return storageDir() + QStringLiteral("/callers.json"); }
 QString PmsMailbox::heardPath() const { return storageDir() + QStringLiteral("/heard.json"); }
 
-void PmsMailbox::ensureStorageDir() const
+bool PmsMailbox::ensureStorageDir() const
 {
-    QDir().mkpath(storageDir());
+    return QDir().mkpath(storageDir());
 }
 
 void PmsMailbox::loadAll()
@@ -869,11 +916,23 @@ void PmsMailbox::loadAll()
     }
 }
 
-void PmsMailbox::saveMessages() const
+void PmsMailbox::reportPersistenceFailure(const QString& store, const QString& detail)
 {
-    ensureStorageDir();
+    const QString message = QStringLiteral("PMS could not save %1: %2")
+                                .arg(store, detail);
+    qCWarning(lcAx25).noquote() << message;
+    emit activity(message);
+}
+
+bool PmsMailbox::saveMessages(const QVector<Message>& messages, int nextId)
+{
+    if (!ensureStorageDir()) {
+        reportPersistenceFailure(QStringLiteral("messages"), QStringLiteral("could not create %1")
+            .arg(storageDir()));
+        return false;
+    }
     QJsonArray arr;
-    for (const Message& m : m_messages) {
+    for (const Message& m : messages) {
         QJsonObject o;
         o.insert(QStringLiteral("id"), m.id);
         o.insert(QStringLiteral("type"), QString(m.type));
@@ -886,18 +945,25 @@ void PmsMailbox::saveMessages() const
         arr.append(o);
     }
     QJsonObject root;
-    root.insert(QStringLiteral("nextId"), m_nextId);
+    root.insert(QStringLiteral("nextId"), nextId);
     root.insert(QStringLiteral("messages"), arr);
-    QFile f(messagesPath());
-    if (f.open(QIODevice::WriteOnly | QIODevice::Truncate))
-        f.write(QJsonDocument(root).toJson());
+    QString error;
+    if (!writeJsonAtomically(messagesPath(), root, &error)) {
+        reportPersistenceFailure(QStringLiteral("messages"), error);
+        return false;
+    }
+    return true;
 }
 
-void PmsMailbox::saveCallers() const
+bool PmsMailbox::saveCallers(const QVector<Caller>& callers)
 {
-    ensureStorageDir();
+    if (!ensureStorageDir()) {
+        reportPersistenceFailure(QStringLiteral("callers"), QStringLiteral("could not create %1")
+            .arg(storageDir()));
+        return false;
+    }
     QJsonArray arr;
-    for (const Caller& c : m_callers) {
+    for (const Caller& c : callers) {
         QJsonObject o;
         o.insert(QStringLiteral("call"), c.call);
         o.insert(QStringLiteral("utc"), c.utc.toString(Qt::ISODate));
@@ -905,16 +971,23 @@ void PmsMailbox::saveCallers() const
     }
     QJsonObject root;
     root.insert(QStringLiteral("callers"), arr);
-    QFile f(callersPath());
-    if (f.open(QIODevice::WriteOnly | QIODevice::Truncate))
-        f.write(QJsonDocument(root).toJson());
+    QString error;
+    if (!writeJsonAtomically(callersPath(), root, &error)) {
+        reportPersistenceFailure(QStringLiteral("callers"), error);
+        return false;
+    }
+    return true;
 }
 
-void PmsMailbox::saveHeard() const
+bool PmsMailbox::saveHeard(const QVector<Heard>& heard)
 {
-    ensureStorageDir();
+    if (!ensureStorageDir()) {
+        reportPersistenceFailure(QStringLiteral("heard stations"), QStringLiteral("could not create %1")
+            .arg(storageDir()));
+        return false;
+    }
     QJsonArray arr;
-    for (const Heard& h : m_heard) {
+    for (const Heard& h : heard) {
         QJsonObject o;
         o.insert(QStringLiteral("call"), h.call);
         o.insert(QStringLiteral("dest"), h.dest);
@@ -925,9 +998,12 @@ void PmsMailbox::saveHeard() const
     }
     QJsonObject root;
     root.insert(QStringLiteral("heard"), arr);
-    QFile f(heardPath());
-    if (f.open(QIODevice::WriteOnly | QIODevice::Truncate))
-        f.write(QJsonDocument(root).toJson());
+    QString error;
+    if (!writeJsonAtomically(heardPath(), root, &error)) {
+        reportPersistenceFailure(QStringLiteral("heard stations"), error);
+        return false;
+    }
+    return true;
 }
 
 } // namespace AetherSDR

--- a/src/core/pms/PmsMailbox.h
+++ b/src/core/pms/PmsMailbox.h
@@ -181,11 +181,12 @@ private:
     QString messagesPath() const;
     QString callersPath() const;
     QString heardPath() const;
-    void ensureStorageDir() const;
+    bool ensureStorageDir() const;
     void loadAll();
-    void saveMessages() const;
-    void saveCallers() const;
-    void saveHeard() const;
+    bool saveMessages(const QVector<Message>& messages, int nextId);
+    bool saveCallers(const QVector<Caller>& callers);
+    bool saveHeard(const QVector<Heard>& heard);
+    void reportPersistenceFailure(const QString& store, const QString& detail);
 
     // Cap on unterminated inbound text. paclen tops out at 256 bytes and a
     // mailbox command is a few dozen characters, so anything approaching this

--- a/tests/pms_mailbox_test.cpp
+++ b/tests/pms_mailbox_test.cpp
@@ -12,10 +12,16 @@
 #include <QCoreApplication>
 #include <QDeadlineTimer>
 #include <QDir>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QVector>
 #include <QtGlobal>
 
 #include <cstdio>
+#include <filesystem>
+#include <system_error>
 
 using namespace AetherSDR;
 using AetherSDR::ax25::Address;
@@ -441,6 +447,225 @@ static void testOverlongInputIsDiscarded()
           "the mailbox still answers commands after discarding a runaway line");
 }
 
+static QJsonObject readJsonObject(const QString& path)
+{
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly)) {
+        return {};
+    }
+    return QJsonDocument::fromJson(file.readAll()).object();
+}
+
+static QByteArray readFile(const QString& path)
+{
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly)) {
+        return {};
+    }
+    return file.readAll();
+}
+
+static bool makeHardLink(const QString& source, const QString& destination)
+{
+#ifdef Q_OS_WIN
+    const std::filesystem::path sourcePath(source.toStdWString());
+    const std::filesystem::path destinationPath(destination.toStdWString());
+#else
+    const QByteArray sourceUtf8 = source.toUtf8();
+    const QByteArray destinationUtf8 = destination.toUtf8();
+    const std::filesystem::path sourcePath(sourceUtf8.constData());
+    const std::filesystem::path destinationPath(destinationUtf8.constData());
+#endif
+    std::error_code error;
+    std::filesystem::create_hard_link(sourcePath, destinationPath, error);
+    return !error;
+}
+
+// PMS JSON must be a whole-file replacement: a retained hard link observes the
+// old valid snapshot while the active path moves to the new one. The failure
+// portion temporarily makes the messages path a directory, so QSaveFile cannot
+// replace it, then proves compose/read/kill leave the in-memory and on-disk
+// message state recoverable.
+static void testPersistenceIsAtomicAndTransactional(const QString& baseDir)
+{
+    const QString store = baseDir + QStringLiteral("/pms-persistence");
+    QDir(store).removeRecursively();
+    QDir().mkpath(store);
+    qputenv("AETHER_PMS_DIR", store.toUtf8());
+
+    const Address local{QStringLiteral("N0PMS"), 1, false, false};
+    const Address peer{QStringLiteral("K7ABC"), 0, false, false};
+    const Address newHeard{QStringLiteral("W1NEW"), 0, false, false};
+
+    QStringList callerActivity;
+    QStringList heardActivity;
+    QStringList activity;
+    PmsMailbox pms;
+    pms.setListenCallsign(QStringLiteral("N0PMS-1"));
+    pms.setEnabled(true);
+    QVector<QByteArray> tx;
+    QObject::connect(&pms, &PmsMailbox::transmitFrame,
+                     [&](const QByteArray& frame) { tx.append(frame); });
+    Peer session{&pms, local, peer, &tx, 0, 0};
+    pms.onAirFrame(Frame::makeU(local, peer, FrameType::SABM, true, true).encode());
+    session.drainText();
+
+    session.send(QByteArrayLiteral("SP K7ABC\r"));
+    session.drainText();
+    session.send(QByteArrayLiteral("first\r"));
+    session.drainText();
+    session.send(QByteArrayLiteral("body\r"));
+    session.send(QByteArrayLiteral("/EX\r"));
+    CHECK(session.drainText().contains(QLatin1String("SAVED")), "baseline message saved");
+
+    const QString messages = store + QStringLiteral("/messages.json");
+    const QString callers = store + QStringLiteral("/callers.json");
+    const QString heard = store + QStringLiteral("/heard.json");
+    const QString oldMessages = store + QStringLiteral("/messages-before.json");
+    const QString oldCallers = store + QStringLiteral("/callers-before.json");
+    const QString oldHeard = store + QStringLiteral("/heard-before.json");
+    CHECK(makeHardLink(messages, oldMessages), "hard-link baseline messages snapshot");
+    CHECK(makeHardLink(callers, oldCallers), "hard-link baseline callers snapshot");
+    CHECK(makeHardLink(heard, oldHeard), "hard-link baseline heard snapshot");
+
+    session.send(QByteArrayLiteral("R 1\r"));
+    session.drainText();
+    CHECK(readJsonObject(messages).value(QStringLiteral("messages")).toArray().at(0).toObject()
+              .value(QStringLiteral("read")).toBool(),
+          "active messages file records the read flag");
+    CHECK(!readJsonObject(oldMessages).value(QStringLiteral("messages")).toArray().at(0).toObject()
+               .value(QStringLiteral("read")).toBool(),
+          "message hard link retains the complete pre-replacement snapshot");
+
+    pms.onAirFrame(Frame::makeUI(local, newHeard, {}, QByteArrayLiteral("heard")).encode());
+    CHECK(readJsonObject(heard).value(QStringLiteral("heard")).toArray().size() == 2,
+          "active heard file contains the new station");
+    CHECK(readJsonObject(oldHeard).value(QStringLiteral("heard")).toArray().size() == 1,
+          "heard hard link retains the complete pre-replacement snapshot");
+
+    {
+        PmsMailbox callerWriter;
+        callerWriter.setListenCallsign(QStringLiteral("N0PMS-1"));
+        callerWriter.setEnabled(true);
+        callerWriter.onAirFrame(
+            Frame::makeU(local, Address{QStringLiteral("W1NEW"), 0, false, false},
+                         FrameType::SABM, true, true).encode());
+    }
+    CHECK(readJsonObject(callers).value(QStringLiteral("callers")).toArray().size() == 2,
+          "active callers file contains the new caller");
+    CHECK(readJsonObject(oldCallers).value(QStringLiteral("callers")).toArray().size() == 1,
+          "callers hard link retains the complete pre-replacement snapshot");
+
+    auto blockFile = [](const QString& path, const QString& backup) {
+        CHECK(QFile::rename(path, backup), "move durable file aside for failure fixture");
+        CHECK(QDir().mkdir(path), "make file path a directory so atomic open fails");
+    };
+    auto restoreFile = [](const QString& path, const QString& backup) {
+        CHECK(QDir().rmdir(path), "remove file failure fixture");
+        CHECK(QFile::rename(backup, path), "restore durable file after failure fixture");
+    };
+
+    const QByteArray durableCallers = readFile(callers);
+    const QString callersBackup = store + QStringLiteral("/callers-failure-backup.json");
+    blockFile(callers, callersBackup);
+    {
+        PmsMailbox callerFailure;
+        QObject::connect(&callerFailure, &PmsMailbox::activity,
+                         [&](const QString& message) { callerActivity.append(message); });
+        callerFailure.setListenCallsign(QStringLiteral("N0PMS-1"));
+        callerFailure.setEnabled(true);
+        callerFailure.onAirFrame(
+            Frame::makeU(local, Address{QStringLiteral("W2FAIL"), 0, false, false},
+                         FrameType::SABM, true, true).encode());
+    }
+    CHECK(callerActivity.join(QLatin1Char('\n')).contains(QLatin1String("could not save callers")),
+          "caller persistence failure is surfaced through mailbox activity");
+    CHECK(readFile(callersBackup) == durableCallers,
+          "caller persistence failure leaves the prior snapshot intact");
+    restoreFile(callers, callersBackup);
+
+    const QByteArray durableHeard = readFile(heard);
+    const QString heardBackup = store + QStringLiteral("/heard-failure-backup.json");
+    blockFile(heard, heardBackup);
+    QObject::connect(&pms, &PmsMailbox::activity,
+                     [&](const QString& message) { heardActivity.append(message); });
+    pms.onAirFrame(Frame::makeUI(local, Address{QStringLiteral("W3FAIL"), 0, false, false}, {},
+                                 QByteArrayLiteral("heard failure")).encode());
+    CHECK(heardActivity.join(QLatin1Char('\n')).contains(QLatin1String("could not save heard stations")),
+          "heard persistence failure is surfaced through mailbox activity");
+    CHECK(readFile(heardBackup) == durableHeard,
+          "heard persistence failure leaves the prior snapshot intact");
+    restoreFile(heard, heardBackup);
+
+    const QByteArray durableMessages = readFile(messages);
+    const QString composeBackup = store + QStringLiteral("/messages-compose-backup.json");
+    blockFile(messages, composeBackup);
+
+    QObject::connect(&pms, &PmsMailbox::activity,
+                     [&](const QString& message) { activity.append(message); });
+    session.send(QByteArrayLiteral("SP K7ABC\r"));
+    session.drainText();
+    session.send(QByteArrayLiteral("retry\r"));
+    session.drainText();
+    session.send(QByteArrayLiteral("body\r"));
+    session.send(QByteArrayLiteral("/EX\r"));
+    CHECK(session.drainText().contains(QLatin1String("NOT SAVED")),
+          "compose reports a failed persistence attempt");
+    CHECK(pms.messageCount() == 1, "failed compose does not change in-memory messages");
+
+    CHECK(activity.join(QLatin1Char('\n')).contains(QLatin1String("could not save messages")),
+          "failed persistence is surfaced through mailbox activity");
+
+    CHECK(readFile(composeBackup) == durableMessages,
+          "failed write did not truncate or replace the durable message snapshot");
+    restoreFile(messages, composeBackup);
+
+    session.send(QByteArrayLiteral("/EX\r"));
+    CHECK(session.drainText().contains(QLatin1String("SAVED")),
+          "retained draft can be saved after storage recovers");
+    CHECK(pms.messageCount() == 2, "recovered compose commits exactly once");
+    CHECK(readJsonObject(messages).value(QStringLiteral("nextId")).toInt() == 3,
+          "failed compose does not consume a message ID");
+
+    const QString readBackup = store + QStringLiteral("/messages-read-backup.json");
+    blockFile(messages, readBackup);
+    session.send(QByteArrayLiteral("R 2\r"));
+    CHECK(session.drainText().contains(QLatin1String("not saved")),
+          "read reports a failed persistence attempt");
+    session.send(QByteArrayLiteral("L\r"));
+    CHECK(session.drainText().contains(QLatin1String("PN")),
+          "failed read leaves the in-memory read flag unchanged");
+    CHECK(!readJsonObject(readBackup).value(QStringLiteral("messages")).toArray().at(1).toObject()
+               .value(QStringLiteral("read")).toBool(),
+          "failed read leaves the durable read flag unchanged");
+    restoreFile(messages, readBackup);
+
+    session.send(QByteArrayLiteral("R 2\r"));
+    session.drainText();
+    CHECK(readJsonObject(messages).value(QStringLiteral("messages")).toArray().at(1).toObject()
+              .value(QStringLiteral("read")).toBool(),
+          "read state saves after the messages path recovers");
+
+    const QString killBackup = store + QStringLiteral("/messages-kill-backup.json");
+    blockFile(messages, killBackup);
+    session.send(QByteArrayLiteral("K 1\r"));
+    CHECK(session.drainText().contains(QLatin1String("not killed")),
+          "kill reports a failed persistence attempt");
+    CHECK(pms.messageCount() == 2, "failed kill preserves in-memory messages");
+    CHECK(readJsonObject(killBackup).value(QStringLiteral("messages")).toArray().size() == 2,
+          "failed kill leaves the durable message snapshot intact");
+    restoreFile(messages, killBackup);
+
+    session.send(QByteArrayLiteral("K 1\r"));
+    CHECK(session.drainText().contains(QLatin1String("killed")), "recovered kill succeeds");
+    CHECK(pms.messageCount() == 1, "recovered kill updates the mailbox once");
+
+    PmsMailbox restarted;
+    restarted.setListenCallsign(QStringLiteral("N0PMS-1"));
+    restarted.setEnabled(true);
+    CHECK(restarted.messageCount() == 1, "restart recovers the last committed mailbox snapshot");
+}
+
 int main(int argc, char** argv)
 {
     // Isolate AppSettings / PMS storage from the real user config so the test is
@@ -466,6 +691,7 @@ int main(int argc, char** argv)
     testAliasDial();
     testSessionIdleTimeoutFreesMailbox();
     testOverlongInputIsDiscarded();
+    testPersistenceIsAtomicAndTransactional(settingsProfile.path());
 
     if (g_failures == 0) {
         std::printf("All PMS mailbox tests passed.\n");


### PR DESCRIPTION
PMS previously replied `MESSAGE n SAVED.` and `Message n killed.` even when `messages.json` could not be written. Its messages, callers, and heard stores also used unchecked truncating writes, risking loss of the previous complete document.

This change writes each JSON document with `QSaveFile`, disables direct-write fallback, and checks the complete write and commit. Message additions, deletions, read flags, and the next ID enter the live mailbox only after persistence succeeds. Failed compose retains the draft for `/EX` retry; failed delete/read-state updates return an error. All three stores report failures through mailbox activity and `lcAx25`. The JSON format and heard/caller save cadence are unchanged.

Fixes #5664.

## Validation

- Extended the existing socket-free `pms_mailbox_test` with injected AX.25 commands: save/read/delete failures, draft retry, ID stability, read recovery, restart, and failure reporting for all three stores.
- Real hard links retain the previous inode's JSON while successful updates replace the active pathname. This distinguishes atomic replacement from truncating writes for messages, callers, and heard.
- Ran the new tests against original `upstream/main` PMS sources (`87b80c65d`): 16 assertions failed, including old-snapshot preservation and false success. Restored the fix and passed.
- Mutation check: bypassing the compose persistence guard caused six assertions to fail; restored and passed. An additional direct-writer mutation was rejected by automatic approval review and was not run.
- Test registration, engine boundary, frozen CI gate, touchpoint manifest, and diff checks passed. Engine boundary output contains only its tracked legacy warnings.
- Full native macOS application target built with the prescribed ARM64 toolchain and RADE enabled. CMake host/system and executable are ARM64; no RNNoise x86 sources. macOS icon packaging required normal host access after failing inside the sandbox.
- Agent automation bridge: retained the actual JSON produced by the passing regression test (ID 2, read=true, nextId=3), launched the fresh app with isolated settings/PMS storage, and observed `link status` → `pms.messages=1`, `callerConnected=false`; `get radio` → `connected=false`; `get transmit` → `transmitting=false`. PMS sent zero I-frames. Bridge `close MainWindow` succeeded and the launched process exited 0. No live radio was connected.

The agent automation bridge has no PMS frame-injection or persistence-failure verb. Failure semantics are demonstrated by the injected-frame regression test; native reload/status evidence is reported separately. No live radio or RF transmission is used.

Generated with OpenAI Codex.
