### PR TITLE
Guard DVK callbacks across canceled transfer replacements

### DIFF
--- a/src/core/DvkWavTransfer.cpp
+++ b/src/core/DvkWavTransfer.cpp
@@ -9,6 +9,8 @@
 #include <QHostAddress>
 #include <QtEndian>
 
+#include <limits>
+
 namespace AetherSDR {
 
 DvkWavTransfer::DvkWavTransfer(RadioModel* model, QObject* parent)
@@ -16,21 +18,12 @@ DvkWavTransfer::DvkWavTransfer(RadioModel* model, QObject* parent)
 {
     m_timeout = new QTimer(this);
     m_timeout->setSingleShot(true);
-    connect(m_timeout, &QTimer::timeout, this, [this]() {
-        if (!m_transferring) return;
-        if (m_direction == Download && !m_client) {
-            finish(false, "Timed out waiting for radio connection", true);
-        } else if (m_direction == Upload && m_client &&
-                   m_client->state() != QAbstractSocket::ConnectedState) {
-            finish(false, "Timed out connecting to radio upload port", false);
-        }
-    });
 }
 
 DvkWavTransfer::~DvkWavTransfer()
 {
     if (m_transferring) {
-        cleanup(m_direction == Download);
+        cleanup(m_direction == Direction::Download);
     }
 }
 
@@ -38,7 +31,7 @@ DvkWavTransfer::~DvkWavTransfer()
 
 void DvkWavTransfer::download(int slotId, const QString& savePath)
 {
-    if (m_transferring) {
+    if (m_transferring || m_cleaningUp) {
         emit finished(false, "Transfer already in progress");
         return;
     }
@@ -46,26 +39,27 @@ void DvkWavTransfer::download(int slotId, const QString& savePath)
     m_slotId = slotId;
     m_filePath = savePath;
     m_bytesReceived = 0;
-    m_direction = Download;
-    m_transferring = true;
-    m_cancelled = false;
-    m_finished = false;
+    const Generation generation = beginOperation(Direction::Download);
+    const QPointer<DvkWavTransfer> self(this);
 
     emit statusChanged(QString("Requesting export of slot %1…").arg(slotId));
+    if (!self || !self->isCurrent(generation, Phase::WaitingForDownloadPort)) {
+        return;
+    }
 
-    m_model->sendCmdPublic(
+    self->m_model->sendCmdPublic(
         QString("dvk download id=%1").arg(slotId),
-        [this](int code, const QString& body) {
-            onDownloadPortReceived(code, body);
-        });
+        self->makePortResponseCallback(generation, Direction::Download));
 }
 
-void DvkWavTransfer::onDownloadPortReceived(int code, const QString& body)
+void DvkWavTransfer::onDownloadPortReceived(Generation generation, int code, const QString& body)
 {
-    if (m_cancelled) return;
+    if (!isCurrent(generation, Phase::WaitingForDownloadPort)) {
+        return;
+    }
 
     if (code != 0) {
-        finish(false, QString("Radio rejected download — %1")
+        finish(generation, false, QString("Radio rejected download — %1")
                    .arg(DvkModel::dvkErrorString(static_cast<uint>(code))),
                false);
         return;
@@ -74,7 +68,7 @@ void DvkWavTransfer::onDownloadPortReceived(int code, const QString& body)
     bool ok = false;
     int port = body.trimmed().toInt(&ok);
     if (!ok || port <= 0 || port > 65535) {
-        finish(false, QString("Invalid port in response: %1").arg(body.trimmed()), false);
+        finish(generation, false, QString("Invalid port in response: %1").arg(body.trimmed()), false);
         return;
     }
 
@@ -82,53 +76,98 @@ void DvkWavTransfer::onDownloadPortReceived(int code, const QString& body)
 
     m_file = new QFile(m_filePath, this);
     if (!m_file->open(QIODevice::WriteOnly)) {
-        finish(false, "Cannot create file: " + m_file->errorString(), false);
+        finish(generation, false, "Cannot create file: " + m_file->errorString(), false);
         return;
     }
 
     m_server = new QTcpServer(this);
-    connect(m_server, &QTcpServer::newConnection, this, &DvkWavTransfer::onNewConnection);
+    const QPointer<DvkWavTransfer> self(this);
+    const QPointer<QTcpServer> server = m_server;
+    connect(m_server, &QTcpServer::newConnection, this, [self, generation, server]() {
+        if (self && server) {
+            self->onNewConnection(generation, server);
+        }
+    });
 
     if (!m_server->listen(QHostAddress::Any, static_cast<quint16>(port))) {
-        finish(false, QString("Cannot listen on port %1: %2")
+        finish(generation, false, QString("Cannot listen on port %1: %2")
                    .arg(port).arg(m_server->errorString()), true);
         return;
     }
 
+    m_phase = Phase::WaitingForDownloadConnection;
     qDebug() << "DvkWavTransfer: listening on port" << port << "for slot" << m_slotId;
+    armTimeout(generation);
     emit statusChanged(QString("Waiting for radio on port %1…").arg(port));
-    m_timeout->start(CONNECT_TIMEOUT_MS);
 }
 
-void DvkWavTransfer::onNewConnection()
+DvkWavTransfer::PortResponseCallback DvkWavTransfer::makePortResponseCallback(
+    Generation generation, Direction direction)
 {
-    if (m_cancelled || m_finished || !m_server) return;
-    m_timeout->stop();
+    const QPointer<DvkWavTransfer> self(this);
+    return [self, generation, direction](int code, const QString& body) {
+        if (!self) {
+            return;
+        }
+        if (direction == Direction::Download) {
+            self->onDownloadPortReceived(generation, code, body);
+        } else {
+            self->onUploadPortReceived(generation, code, body);
+        }
+    };
+}
 
-    m_client = m_server->nextPendingConnection();
+void DvkWavTransfer::onNewConnection(Generation generation, QTcpServer* server)
+{
+    if (!server || !isCurrent(generation, Phase::WaitingForDownloadConnection)
+        || server != m_server) {
+        return;
+    }
+    clearTimeout();
+
+    m_client = server->nextPendingConnection();
     if (!m_client) return;
 
-    m_server->close();
+    server->close();
+    m_phase = Phase::ReceivingDownload;
 
-    connect(m_client, &QTcpSocket::readyRead, this, &DvkWavTransfer::onReadyRead);
-    connect(m_client, &QTcpSocket::disconnected, this, &DvkWavTransfer::onDownloadFinished);
-    connect(m_client, &QTcpSocket::errorOccurred, this, [this]() { onDownloadError(); });
+    const QPointer<DvkWavTransfer> self(this);
+    const QPointer<QTcpSocket> client = m_client;
+    connect(m_client, &QTcpSocket::readyRead, this, [self, generation, client]() {
+        if (self && client) {
+            self->onReadyRead(generation, client);
+        }
+    });
+    connect(m_client, &QTcpSocket::disconnected, this, [self, generation, client]() {
+        if (self && client) {
+            self->onDownloadFinished(generation, client);
+        }
+    });
+    connect(m_client, &QTcpSocket::errorOccurred, this,
+            [self, generation, client](QAbstractSocket::SocketError) {
+                if (self && client) {
+                    self->onDownloadError(generation, client);
+                }
+            });
 
     qDebug() << "DvkWavTransfer: radio connected, receiving WAV data";
     emit statusChanged(QString("Exporting slot %1…").arg(m_slotId));
 }
 
-void DvkWavTransfer::onReadyRead()
+void DvkWavTransfer::onReadyRead(Generation generation, QTcpSocket* socket)
 {
-    if (m_cancelled || m_finished || !m_file || !m_client) return;
+    if (!socket || !isCurrent(generation, Phase::ReceivingDownload) || socket != m_client
+        || !m_file) {
+        return;
+    }
 
-    const QByteArray data = m_client->readAll();
+    const QByteArray data = socket->readAll();
     m_bytesReceived += data.size();
 
     if (m_bytesReceived > MAX_FILE_SIZE) {
         qWarning() << "DvkWavTransfer: file exceeds" << MAX_FILE_SIZE << "bytes, truncating";
         m_file->write(data.constData(), data.size() - (m_bytesReceived - MAX_FILE_SIZE));
-        finish(true, QString("Export complete (truncated at %1 KB)")
+        finish(generation, true, QString("Export complete (truncated at %1 KB)")
                    .arg(MAX_FILE_SIZE / 1024), false);
         return;
     }
@@ -136,41 +175,44 @@ void DvkWavTransfer::onReadyRead()
     m_file->write(data);
 }
 
-void DvkWavTransfer::onDownloadFinished()
+void DvkWavTransfer::onDownloadFinished(Generation generation, QTcpSocket* socket)
 {
-    if (m_cancelled || m_finished) return;
+    if (!socket || !isCurrent(generation, Phase::ReceivingDownload) || socket != m_client) {
+        return;
+    }
 
     if (m_bytesReceived == 0) {
-        finish(false, "Radio sent no data", true);
+        finish(generation, false, "Radio sent no data", true);
         return;
     }
 
     qDebug() << "DvkWavTransfer: export complete," << m_bytesReceived << "bytes";
-    finish(true, QString("Exported slot %1 (%2 KB)")
+    finish(generation, true, QString("Exported slot %1 (%2 KB)")
                .arg(m_slotId).arg(m_bytesReceived / 1024), false);
 }
 
-void DvkWavTransfer::onDownloadError()
+void DvkWavTransfer::onDownloadError(Generation generation, QTcpSocket* socket)
 {
-    if (m_cancelled || m_finished) return;
+    if (!socket || !isCurrent(generation, Phase::ReceivingDownload) || socket != m_client) {
+        return;
+    }
 
     // A clean close after we've already received data is a successful end of
     // transfer, not an error. The radio fires errorOccurred(RemoteHostClosed)
     // and disconnected() together; route both through the same idempotent path.
-    if (m_client && m_client->error() == QAbstractSocket::RemoteHostClosedError && m_bytesReceived > 0) {
-        onDownloadFinished();
+    if (socket->error() == QAbstractSocket::RemoteHostClosedError && m_bytesReceived > 0) {
+        onDownloadFinished(generation, socket);
         return;
     }
 
-    const QString err = m_client ? m_client->errorString() : "Unknown error";
-    finish(false, "Transfer error: " + err, true);
+    finish(generation, false, "Transfer error: " + socket->errorString(), true);
 }
 
 // ── Upload (client → radio) ────────────────────────────────────────────────
 
 void DvkWavTransfer::upload(int slotId, const QString& filePath)
 {
-    if (m_transferring) {
+    if (m_transferring || m_cleaningUp) {
         emit finished(false, "Transfer already in progress");
         return;
     }
@@ -199,26 +241,27 @@ void DvkWavTransfer::upload(int slotId, const QString& filePath)
     m_slotId = slotId;
     m_filePath = filePath;
     m_bytesSent = 0;
-    m_direction = Upload;
-    m_transferring = true;
-    m_cancelled = false;
-    m_finished = false;
+    const Generation generation = beginOperation(Direction::Upload);
+    const QPointer<DvkWavTransfer> self(this);
 
     emit statusChanged(QString("Requesting upload to slot %1…").arg(slotId));
+    if (!self || !self->isCurrent(generation, Phase::WaitingForUploadPort)) {
+        return;
+    }
 
-    m_model->sendCmdPublic(
+    self->m_model->sendCmdPublic(
         QString("dvk upload id=%1").arg(slotId),
-        [this](int code, const QString& body) {
-            onUploadPortReceived(code, body);
-        });
+        self->makePortResponseCallback(generation, Direction::Upload));
 }
 
-void DvkWavTransfer::onUploadPortReceived(int code, const QString& body)
+void DvkWavTransfer::onUploadPortReceived(Generation generation, int code, const QString& body)
 {
-    if (m_cancelled) return;
+    if (!isCurrent(generation, Phase::WaitingForUploadPort)) {
+        return;
+    }
 
     if (code != 0) {
-        finish(false, QString("Radio rejected upload — %1")
+        finish(generation, false, QString("Radio rejected upload — %1")
                    .arg(DvkModel::dvkErrorString(static_cast<uint>(code))),
                false);
         return;
@@ -227,75 +270,142 @@ void DvkWavTransfer::onUploadPortReceived(int code, const QString& body)
     bool ok = false;
     int port = body.trimmed().toInt(&ok);
     if (!ok || port <= 0 || port > 65535) {
-        finish(false, QString("Invalid port in response: %1").arg(body.trimmed()), false);
+        finish(generation, false, QString("Invalid port in response: %1").arg(body.trimmed()), false);
         return;
     }
 
     qDebug() << "DvkWavTransfer: connecting to upload port" << port << "for slot" << m_slotId;
-    emit statusChanged(QString("Connecting to port %1…").arg(port));
-
     m_client = new QTcpSocket(this);
-    connect(m_client, &QTcpSocket::connected, this, &DvkWavTransfer::onUploadConnected);
-    connect(m_client, &QTcpSocket::bytesWritten, this, &DvkWavTransfer::onUploadBytesWritten);
-    connect(m_client, &QTcpSocket::errorOccurred, this, [this]() { onUploadError(); });
-
-    // Small delay to let the radio set up its server (matches FirmwareUploader)
-    QTimer::singleShot(200, this, [this, port]() {
-        if (m_cancelled) return;
-        m_client->connectToHost(m_model->radioAddress(), static_cast<quint16>(port));
+    m_phase = Phase::WaitingForUploadConnection;
+    const QPointer<DvkWavTransfer> self(this);
+    const QPointer<QTcpSocket> client = m_client;
+    connect(m_client, &QTcpSocket::connected, this, [self, generation, client]() {
+        if (self && client) {
+            self->onUploadConnected(generation, client);
+        }
+    });
+    connect(m_client, &QTcpSocket::bytesWritten, this, [self, generation, client](qint64 bytes) {
+        if (self && client) {
+            self->onUploadBytesWritten(generation, client, bytes);
+        }
+    });
+    connect(m_client, &QTcpSocket::errorOccurred, this,
+            [self, generation, client](QAbstractSocket::SocketError) {
+                if (self && client) {
+                    self->onUploadError(generation, client);
+                }
     });
 
-    m_timeout->start(CONNECT_TIMEOUT_MS);
+    // Small delay to let the radio set up its server (matches FirmwareUploader)
+    const QPointer<RadioModel> model = m_model;
+    QTimer::singleShot(200, this,
+                       makeUploadConnectTimerCallback(
+                           generation, client, static_cast<quint16>(port),
+                           [model](QTcpSocket* socket, quint16 connectPort) {
+                               if (model) {
+                                   socket->connectToHost(model->radioAddress(), connectPort);
+                               }
+                           }));
+
+    armTimeout(generation);
+    emit statusChanged(QString("Connecting to port %1…").arg(port));
 }
 
-void DvkWavTransfer::onUploadConnected()
+DvkWavTransfer::DeferredConnectCallback DvkWavTransfer::makeUploadConnectTimerCallback(
+    Generation generation, QPointer<QTcpSocket> socket, quint16 port, UploadConnectFunction connect)
 {
-    if (m_cancelled || m_finished) return;
-    m_timeout->stop();
+    const QPointer<DvkWavTransfer> self(this);
+    return [self, generation, socket, port, connect = std::move(connect)]() {
+        if (self && socket) {
+            self->runUploadConnect(generation, socket, port, connect);
+        }
+    };
+}
+
+bool DvkWavTransfer::runUploadConnect(Generation generation, QTcpSocket* socket, quint16 port,
+                                       const UploadConnectFunction& connect)
+{
+    if (!socket || !isCurrent(generation, Phase::WaitingForUploadConnection)
+        || socket != m_client) {
+        return false;
+    }
+    const QPointer<DvkWavTransfer> self(this);
+    connect(socket, port);
+    return self && self->isCurrent(generation, Phase::WaitingForUploadConnection)
+        && socket == self->m_client;
+}
+
+void DvkWavTransfer::onUploadConnected(Generation generation, QTcpSocket* socket)
+{
+    if (!socket || !isCurrent(generation, Phase::WaitingForUploadConnection) || socket != m_client) {
+        return;
+    }
+    clearTimeout();
+    m_phase = Phase::SendingUpload;
 
     qDebug() << "DvkWavTransfer: connected, sending" << m_uploadData.size() << "bytes";
+    const QPointer<DvkWavTransfer> self(this);
     emit statusChanged(QString("Uploading to slot %1…").arg(m_slotId));
+    if (!self || !self->isCurrent(generation, Phase::SendingUpload) || socket != self->m_client) {
+        return;
+    }
 
-    sendNextChunk();
+    sendNextChunk(generation, socket);
 }
 
-void DvkWavTransfer::sendNextChunk()
+void DvkWavTransfer::sendNextChunk(Generation generation, QTcpSocket* socket)
 {
-    if (m_cancelled || !m_client) return;
+    if (!socket || !isCurrent(generation, Phase::SendingUpload) || socket != m_client) {
+        return;
+    }
 
     const qint64 remaining = m_uploadData.size() - m_bytesSent;
-    if (remaining <= 0) return;
+    if (remaining <= 0) {
+        return;
+    }
 
     const qint64 toSend = qMin(static_cast<qint64>(UPLOAD_CHUNK_SIZE), remaining);
-    m_client->write(m_uploadData.constData() + m_bytesSent, toSend);
+    socket->write(m_uploadData.constData() + m_bytesSent, toSend);
 }
 
-void DvkWavTransfer::onUploadBytesWritten(qint64 bytes)
+void DvkWavTransfer::onUploadBytesWritten(Generation generation, QTcpSocket* socket, qint64 bytes)
 {
-    if (m_cancelled || m_finished) return;
+    if (!socket || !isCurrent(generation, Phase::SendingUpload) || socket != m_client) {
+        return;
+    }
 
     m_bytesSent += bytes;
     const int percent = static_cast<int>(m_bytesSent * 100 / m_uploadData.size());
+    const QPointer<DvkWavTransfer> self(this);
     emit statusChanged(QString("Uploading to slot %1… %2%").arg(m_slotId).arg(percent));
+    if (!self || !self->isCurrent(generation, Phase::SendingUpload) || socket != self->m_client) {
+        return;
+    }
 
     if (m_bytesSent >= m_uploadData.size()) {
         qDebug() << "DvkWavTransfer: upload complete," << m_bytesSent << "bytes";
-        m_client->flush();
-        m_client->disconnectFromHost();
-        finish(true, QString("Uploaded to slot %1 (%2 KB)")
+        socket->flush();
+        socket->disconnectFromHost();
+        if (!self || !self->isCurrent(generation, Phase::SendingUpload) || socket != self->m_client) {
+            return;
+        }
+        finish(generation, true, QString("Uploaded to slot %1 (%2 KB)")
                    .arg(m_slotId).arg(m_bytesSent / 1024), false);
         return;
     }
 
-    sendNextChunk();
+    sendNextChunk(generation, socket);
 }
 
-void DvkWavTransfer::onUploadError()
+void DvkWavTransfer::onUploadError(Generation generation, QTcpSocket* socket)
 {
-    if (m_cancelled || m_finished) return;
+    if (!socket || (!isCurrent(generation, Phase::WaitingForUploadConnection)
+         && !isCurrent(generation, Phase::SendingUpload))
+        || socket != m_client) {
+        return;
+    }
 
-    const QString err = m_client ? m_client->errorString() : "Unknown error";
-    finish(false, "Upload error: " + err, false);
+    finish(generation, false, "Upload error: " + socket->errorString(), false);
 }
 
 // ── WAV validation ─────────────────────────────────────────────────────────
@@ -361,25 +471,28 @@ bool DvkWavTransfer::validateWavFile(const QString& filePath, QString& error)
 
 void DvkWavTransfer::cancel()
 {
-    if (!m_transferring || m_finished) {
+    if (!m_transferring) {
         return;
     }
-    m_cancelled = true;
-    finish(false, "Transfer cancelled", m_direction == Download);
+    finish(m_generation, false, "Transfer cancelled", m_direction == Direction::Download);
 }
 
-void DvkWavTransfer::finish(bool success, const QString& message, bool removeFile)
+void DvkWavTransfer::finish(Generation generation, bool success, const QString& message,
+                            bool removeFile)
 {
-    // Idempotent: the radio fires both errorOccurred() and disconnected() on a
-    // clean close, and abort()/disconnectFromHost() during teardown can emit
-    // further signals. Only the first call through here does anything.
-    if (m_finished) {
+    if (!m_transferring || generation != m_generation) {
         return;
     }
-    m_finished = true;
 
-    emit finished(success, message);
+    // Invalidate every retained callback before socket teardown. This also
+    // permits a finished() handler to begin a replacement operation without an
+    // old callback being accepted into the new one.
+    m_transferring = false;
+    m_direction = Direction::None;
+    m_phase = Phase::Idle;
+    m_generation = nextGeneration();
     cleanup(removeFile);
+    emit finished(success, message);
 }
 
 void DvkWavTransfer::cleanup(bool removeFile)
@@ -391,11 +504,7 @@ void DvkWavTransfer::cleanup(bool removeFile)
     }
     m_cleaningUp = true;
 
-    if (m_timeout) {
-        m_timeout->stop();
-    }
-    m_transferring = false;
-    m_direction = None;
+    clearTimeout();
 
     // Disconnect every socket/server signal BEFORE tearing down so abort() and
     // deleteLater() cannot re-enter our slots and touch freed objects.
@@ -427,6 +536,61 @@ void DvkWavTransfer::cleanup(bool removeFile)
     m_bytesSent = 0;
 
     m_cleaningUp = false;
+}
+
+void DvkWavTransfer::onTimeout(Generation generation)
+{
+    if (isCurrent(generation, Phase::WaitingForDownloadConnection) && !m_client) {
+        finish(generation, false, "Timed out waiting for radio connection", true);
+        return;
+    }
+    if (isCurrent(generation, Phase::WaitingForUploadConnection) && m_client
+        && m_client->state() != QAbstractSocket::ConnectedState) {
+        finish(generation, false, "Timed out connecting to radio upload port", false);
+    }
+}
+
+void DvkWavTransfer::armTimeout(Generation generation)
+{
+    clearTimeout();
+    const QPointer<DvkWavTransfer> self(this);
+    m_timeoutConnection = connect(m_timeout, &QTimer::timeout, this, [self, generation] {
+        if (self) {
+            self->onTimeout(generation);
+        }
+    });
+    m_timeout->start(CONNECT_TIMEOUT_MS);
+}
+
+void DvkWavTransfer::clearTimeout()
+{
+    if (m_timeout) {
+        m_timeout->stop();
+    }
+    if (m_timeoutConnection) {
+        disconnect(m_timeoutConnection);
+        m_timeoutConnection = {};
+    }
+}
+
+DvkWavTransfer::Generation DvkWavTransfer::beginOperation(Direction direction)
+{
+    m_generation = nextGeneration();
+    m_direction = direction;
+    m_phase = direction == Direction::Download ? Phase::WaitingForDownloadPort
+                                                : Phase::WaitingForUploadPort;
+    m_transferring = true;
+    return m_generation;
+}
+
+bool DvkWavTransfer::isCurrent(Generation generation, Phase phase) const
+{
+    return m_transferring && m_generation == generation && m_phase == phase;
+}
+
+DvkWavTransfer::Generation DvkWavTransfer::nextGeneration()
+{
+    return m_generation == std::numeric_limits<Generation>::max() ? 1 : m_generation + 1;
 }
 
 } // namespace AetherSDR

--- a/src/core/DvkWavTransfer.h
+++ b/src/core/DvkWavTransfer.h
@@ -4,11 +4,16 @@
 #include <QTcpServer>
 #include <QTcpSocket>
 #include <QFile>
+#include <QMetaObject>
+#include <QPointer>
 #include <QTimer>
+
+#include <functional>
 
 namespace AetherSDR {
 
 class RadioModel;
+class DvkWavTransferTestAccess;
 
 // Transfers DVK recordings between the radio and local WAV files.
 //
@@ -44,42 +49,72 @@ signals:
     void finished(bool success, const QString& message);
 
 private:
+    friend class DvkWavTransferTestAccess;
+
+    using Generation = quint64;
+    using UploadConnectFunction = std::function<void(QTcpSocket*, quint16)>;
+    using PortResponseCallback = std::function<void(int, const QString&)>;
+    using DeferredConnectCallback = std::function<void()>;
+
+    enum class Direction { None, Download, Upload };
+    enum class Phase {
+        Idle,
+        WaitingForDownloadPort,
+        WaitingForDownloadConnection,
+        ReceivingDownload,
+        WaitingForUploadPort,
+        WaitingForUploadConnection,
+        SendingUpload,
+    };
+
     // Download (radio → client)
-    void onDownloadPortReceived(int code, const QString& body);
-    void onNewConnection();
-    void onReadyRead();
-    void onDownloadFinished();
-    void onDownloadError();
+    void onDownloadPortReceived(Generation generation, int code, const QString& body);
+    void onNewConnection(Generation generation, QTcpServer* server);
+    void onReadyRead(Generation generation, QTcpSocket* socket);
+    void onDownloadFinished(Generation generation, QTcpSocket* socket);
+    void onDownloadError(Generation generation, QTcpSocket* socket);
 
     // Upload (client → radio)
-    void onUploadPortReceived(int code, const QString& body);
-    void onUploadConnected();
-    void onUploadBytesWritten(qint64 bytes);
-    void onUploadError();
-    void sendNextChunk();
+    void onUploadPortReceived(Generation generation, int code, const QString& body);
+    DeferredConnectCallback makeUploadConnectTimerCallback(Generation generation,
+                                                            QPointer<QTcpSocket> socket,
+                                                            quint16 port,
+                                                            UploadConnectFunction connect);
+    bool runUploadConnect(Generation generation, QTcpSocket* socket, quint16 port,
+                          const UploadConnectFunction& connect);
+    void onUploadConnected(Generation generation, QTcpSocket* socket);
+    void onUploadBytesWritten(Generation generation, QTcpSocket* socket, qint64 bytes);
+    void onUploadError(Generation generation, QTcpSocket* socket);
+    void sendNextChunk(Generation generation, QTcpSocket* socket);
 
     void cleanup(bool removeFile);
+    void armTimeout(Generation generation);
+    void clearTimeout();
+    void onTimeout(Generation generation);
+    Generation beginOperation(Direction direction);
+    PortResponseCallback makePortResponseCallback(Generation generation, Direction direction);
+    bool isCurrent(Generation generation, Phase phase) const;
+    Generation nextGeneration();
 
     // Single idempotent funnel: emits finished() once and tears down.
     // Re-entrant calls (e.g. a second socket signal during teardown) are no-ops.
-    void finish(bool success, const QString& message, bool removeFile);
-
-    enum Direction { None, Download, Upload };
+    void finish(Generation generation, bool success, const QString& message, bool removeFile);
 
     RadioModel*  m_model{nullptr};
-    QTcpServer*  m_server{nullptr};    // download: we listen
-    QTcpSocket*  m_client{nullptr};    // download: accepted socket / upload: our socket
+    QPointer<QTcpServer> m_server;     // download: we listen
+    QPointer<QTcpSocket> m_client;     // download: accepted socket / upload: our socket
     QFile*       m_file{nullptr};      // download: output file
     QTimer*      m_timeout{nullptr};
+    QMetaObject::Connection m_timeoutConnection;
     int          m_slotId{-1};
     QString      m_filePath;           // download: save path / upload: source path
     qint64       m_bytesReceived{0};
     QByteArray   m_uploadData;
     qint64       m_bytesSent{0};
-    Direction    m_direction{None};
+    Direction    m_direction{Direction::None};
+    Phase        m_phase{Phase::Idle};
+    Generation   m_generation{0};
     bool         m_transferring{false};
-    bool         m_cancelled{false};
-    bool         m_finished{false};   // guards against re-entrant finish/cleanup
     bool         m_cleaningUp{false}; // guards against re-entrant cleanup()
 
     static constexpr qint64 MAX_FILE_SIZE = 5'000'000;  // 5MB per FlexLib

--- a/tests/dvk_wav_transfer_generation_test.cpp
+++ b/tests/dvk_wav_transfer_generation_test.cpp
@@ -1,0 +1,385 @@
+#include "core/DvkWavTransfer.h"
+
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QPointer>
+#include <QTcpSocket>
+#include <QTimer>
+
+#include <functional>
+#include <iostream>
+
+namespace AetherSDR {
+
+// The seam invokes production terminal and deferred-connect handlers with
+// inert QTcpSocket instances. No socket is connected or made to listen.
+class DvkWavTransferTestAccess {
+public:
+    using Generation = DvkWavTransfer::Generation;
+    using Direction = DvkWavTransfer::Direction;
+    using Phase = DvkWavTransfer::Phase;
+
+    static Generation beginDownload(DvkWavTransfer& transfer)
+    {
+        transfer.m_slotId = 1;
+        transfer.m_bytesReceived = 0;
+        return transfer.beginOperation(Direction::Download);
+    }
+
+    static Generation beginUpload(DvkWavTransfer& transfer, QByteArray data = QByteArray("test"))
+    {
+        transfer.m_slotId = 2;
+        transfer.m_uploadData = std::move(data);
+        transfer.m_bytesSent = 0;
+        return transfer.beginOperation(Direction::Upload);
+    }
+
+    static QTcpSocket* installSocket(DvkWavTransfer& transfer, Phase phase)
+    {
+        auto* socket = new QTcpSocket(&transfer);
+        transfer.m_client = socket;
+        transfer.m_phase = phase;
+        return socket;
+    }
+
+    static void replaceSocket(DvkWavTransfer& transfer, QTcpSocket* socket)
+    {
+        transfer.m_client = socket;
+    }
+
+    static void setPhase(DvkWavTransfer& transfer, Phase phase)
+    {
+        transfer.m_phase = phase;
+    }
+
+    static void setBytesReceived(DvkWavTransfer& transfer, qint64 bytes)
+    {
+        transfer.m_bytesReceived = bytes;
+    }
+
+    static void setBytesSent(DvkWavTransfer& transfer, qint64 bytes)
+    {
+        transfer.m_bytesSent = bytes;
+    }
+
+    static void downloadFinished(DvkWavTransfer& transfer, Generation generation, QTcpSocket* socket)
+    {
+        transfer.onDownloadFinished(generation, socket);
+    }
+
+    static void downloadError(DvkWavTransfer& transfer, Generation generation, QTcpSocket* socket)
+    {
+        transfer.onDownloadError(generation, socket);
+    }
+
+    static void uploadError(DvkWavTransfer& transfer, Generation generation, QTcpSocket* socket)
+    {
+        transfer.onUploadError(generation, socket);
+    }
+
+    static void uploadBytesWritten(DvkWavTransfer& transfer, Generation generation,
+                                   QTcpSocket* socket, qint64 bytes)
+    {
+        transfer.onUploadBytesWritten(generation, socket, bytes);
+    }
+
+    static void uploadPort(DvkWavTransfer& transfer, Generation generation, int code)
+    {
+        transfer.onUploadPortReceived(generation, code, QStringLiteral("4995"));
+    }
+
+    static DvkWavTransfer::PortResponseCallback portCallback(DvkWavTransfer& transfer,
+                                                              Generation generation,
+                                                              Direction direction)
+    {
+        return transfer.makePortResponseCallback(generation, direction);
+    }
+
+    static DvkWavTransfer::DeferredConnectCallback deferredConnect(DvkWavTransfer& transfer,
+                                                                     Generation generation,
+                                                                     QTcpSocket* socket,
+                                                                     quint16 port, int& calls,
+                                                                     QTcpSocket*& observedSocket,
+                                                                     quint16& observedPort)
+    {
+        return transfer.makeUploadConnectTimerCallback(
+            generation, socket, port,
+            [&calls, &observedSocket, &observedPort](QTcpSocket* candidate, quint16 candidatePort) {
+                ++calls;
+                observedSocket = candidate;
+                observedPort = candidatePort;
+            });
+    }
+
+    static Phase phase(const DvkWavTransfer& transfer) { return transfer.m_phase; }
+    static qint64 bytesSent(const DvkWavTransfer& transfer) { return transfer.m_bytesSent; }
+    static QFile* file(const DvkWavTransfer& transfer) { return transfer.m_file; }
+};
+
+} // namespace AetherSDR
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* message)
+{
+    if (!condition) {
+        ++g_failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+void checkStaleDownloadCallbacksCannotSettleReplacement(bool replaceWithUpload)
+{
+    AetherSDR::DvkWavTransfer transfer(nullptr);
+    int completions = 0;
+    QObject::connect(&transfer, &AetherSDR::DvkWavTransfer::finished,
+                     [&completions](bool, const QString&) { ++completions; });
+
+    const auto oldGeneration = AetherSDR::DvkWavTransferTestAccess::beginDownload(transfer);
+    const auto oldPortResponse = AetherSDR::DvkWavTransferTestAccess::portCallback(
+        transfer, oldGeneration, AetherSDR::DvkWavTransferTestAccess::Direction::Download);
+    QTcpSocket* oldSocket = AetherSDR::DvkWavTransferTestAccess::installSocket(
+        transfer, AetherSDR::DvkWavTransferTestAccess::Phase::ReceivingDownload);
+    AetherSDR::DvkWavTransferTestAccess::setBytesReceived(transfer, 16);
+    transfer.cancel();
+    const auto replacement = replaceWithUpload
+        ? AetherSDR::DvkWavTransferTestAccess::beginUpload(transfer)
+        : AetherSDR::DvkWavTransferTestAccess::beginDownload(transfer);
+
+    oldPortResponse(1, QStringLiteral("old rejection"));
+    oldPortResponse(0, QStringLiteral("4995"));
+    AetherSDR::DvkWavTransferTestAccess::downloadFinished(transfer, oldGeneration, oldSocket);
+    AetherSDR::DvkWavTransferTestAccess::downloadError(transfer, oldGeneration, oldSocket);
+
+    check(completions == 1, "old download port, success, and error callbacks cannot finish the replacement");
+    check(transfer.isTransferring()
+              && AetherSDR::DvkWavTransferTestAccess::phase(transfer)
+                     == (replaceWithUpload
+                             ? AetherSDR::DvkWavTransferTestAccess::Phase::WaitingForUploadPort
+                             : AetherSDR::DvkWavTransferTestAccess::Phase::WaitingForDownloadPort),
+          "stale download callbacks leave the replacement waiting for its own port");
+    check(AetherSDR::DvkWavTransferTestAccess::file(transfer) == nullptr,
+          "a stale download port reply cannot allocate a replacement output file");
+    check(replacement != oldGeneration, "cancel advances the download operation generation");
+}
+
+void checkStaleUploadCallbacksCannotSettleReplacement(bool replaceWithUpload)
+{
+    AetherSDR::DvkWavTransfer transfer(nullptr);
+    int completions = 0;
+    QObject::connect(&transfer, &AetherSDR::DvkWavTransfer::finished,
+                     [&completions](bool, const QString&) { ++completions; });
+
+    const auto oldGeneration = AetherSDR::DvkWavTransferTestAccess::beginUpload(transfer);
+    const auto oldPortResponse = AetherSDR::DvkWavTransferTestAccess::portCallback(
+        transfer, oldGeneration, AetherSDR::DvkWavTransferTestAccess::Direction::Upload);
+    QTcpSocket* oldSocket = AetherSDR::DvkWavTransferTestAccess::installSocket(
+        transfer, AetherSDR::DvkWavTransferTestAccess::Phase::SendingUpload);
+    transfer.cancel();
+    const auto replacement = replaceWithUpload
+        ? AetherSDR::DvkWavTransferTestAccess::beginUpload(transfer)
+        : AetherSDR::DvkWavTransferTestAccess::beginDownload(transfer);
+
+    oldPortResponse(1, QStringLiteral("old rejection"));
+    oldPortResponse(0, QStringLiteral("4995"));
+    AetherSDR::DvkWavTransferTestAccess::uploadError(transfer, oldGeneration, oldSocket);
+    AetherSDR::DvkWavTransferTestAccess::uploadBytesWritten(transfer, oldGeneration, oldSocket, 4);
+
+    check(completions == 1, "old upload port, error, and success callbacks cannot finish the replacement");
+    check(transfer.isTransferring()
+              && AetherSDR::DvkWavTransferTestAccess::phase(transfer)
+                     == (replaceWithUpload
+                             ? AetherSDR::DvkWavTransferTestAccess::Phase::WaitingForUploadPort
+                             : AetherSDR::DvkWavTransferTestAccess::Phase::WaitingForDownloadPort),
+          "stale upload callbacks leave the replacement waiting for its own port");
+    check(replacement != oldGeneration, "cancel advances the upload operation generation");
+}
+
+void checkCurrentCallbacksPreserveTerminalBehavior()
+{
+    {
+        AetherSDR::DvkWavTransfer transfer(nullptr);
+        int success = 0;
+        QObject::connect(&transfer, &AetherSDR::DvkWavTransfer::finished,
+                         [&success](bool completed, const QString&) { success += completed ? 1 : 0; });
+        const auto generation = AetherSDR::DvkWavTransferTestAccess::beginDownload(transfer);
+        QTcpSocket* socket = AetherSDR::DvkWavTransferTestAccess::installSocket(
+            transfer, AetherSDR::DvkWavTransferTestAccess::Phase::ReceivingDownload);
+        AetherSDR::DvkWavTransferTestAccess::setBytesReceived(transfer, 8);
+        AetherSDR::DvkWavTransferTestAccess::downloadFinished(transfer, generation, socket);
+        check(success == 1 && !transfer.isTransferring(),
+              "the current download completion remains successful");
+    }
+
+    {
+        AetherSDR::DvkWavTransfer transfer(nullptr);
+        int success = 0;
+        QObject::connect(&transfer, &AetherSDR::DvkWavTransfer::finished,
+                         [&success](bool completed, const QString&) { success += completed ? 1 : 0; });
+        const auto generation = AetherSDR::DvkWavTransferTestAccess::beginUpload(
+            transfer, QByteArray("data"));
+        QTcpSocket* socket = AetherSDR::DvkWavTransferTestAccess::installSocket(
+            transfer, AetherSDR::DvkWavTransferTestAccess::Phase::SendingUpload);
+        AetherSDR::DvkWavTransferTestAccess::uploadBytesWritten(transfer, generation, socket, 4);
+        check(success == 1 && !transfer.isTransferring(),
+              "the current upload completion remains successful");
+    }
+}
+
+void checkPhaseAndSocketIdentityRejectDuplicates()
+{
+    AetherSDR::DvkWavTransfer transfer(nullptr);
+    int completions = 0;
+    QObject::connect(&transfer, &AetherSDR::DvkWavTransfer::finished,
+                     [&completions](bool, const QString&) { ++completions; });
+
+    const auto generation = AetherSDR::DvkWavTransferTestAccess::beginUpload(transfer);
+    QTcpSocket* socket = AetherSDR::DvkWavTransferTestAccess::installSocket(
+        transfer, AetherSDR::DvkWavTransferTestAccess::Phase::WaitingForUploadConnection);
+    AetherSDR::DvkWavTransferTestAccess::uploadPort(transfer, generation, 1);
+    AetherSDR::DvkWavTransferTestAccess::setPhase(
+        transfer, AetherSDR::DvkWavTransferTestAccess::Phase::WaitingForUploadPort);
+    AetherSDR::DvkWavTransferTestAccess::uploadError(transfer, generation, socket);
+
+    check(completions == 0 && transfer.isTransferring(),
+          "a duplicate port reply and wrong-phase error do not settle an active upload");
+
+    AetherSDR::DvkWavTransferTestAccess::setPhase(
+        transfer, AetherSDR::DvkWavTransferTestAccess::Phase::WaitingForUploadConnection);
+    int calls = 0;
+    QTcpSocket* observedSocket = nullptr;
+    quint16 observedPort = 0;
+    auto* replacementSocket = new QTcpSocket(&transfer);
+    AetherSDR::DvkWavTransferTestAccess::replaceSocket(transfer, replacementSocket);
+    const auto oldConnect = AetherSDR::DvkWavTransferTestAccess::deferredConnect(
+        transfer, generation, socket, 4995, calls, observedSocket, observedPort);
+    const auto replacementConnect = AetherSDR::DvkWavTransferTestAccess::deferredConnect(
+        transfer, generation, replacementSocket, 4996, calls, observedSocket, observedPort);
+    oldConnect();
+    replacementConnect();
+
+    check(calls == 1,
+          "the deferred timer rejects an old socket even when generation and phase match");
+    check(observedSocket == replacementSocket && observedPort == 4996,
+          "the deferred timer acts only on the current socket and its port");
+}
+
+void checkDelayedTimerCannotConnectReplacement()
+{
+    AetherSDR::DvkWavTransfer transfer(nullptr);
+    int calls = 0;
+    QTcpSocket* observedSocket = nullptr;
+    quint16 observedPort = 0;
+    const auto oldGeneration = AetherSDR::DvkWavTransferTestAccess::beginUpload(transfer);
+    QTcpSocket* oldSocket = AetherSDR::DvkWavTransferTestAccess::installSocket(
+        transfer, AetherSDR::DvkWavTransferTestAccess::Phase::WaitingForUploadConnection);
+    const auto delayedConnect = AetherSDR::DvkWavTransferTestAccess::deferredConnect(
+        transfer, oldGeneration, oldSocket, 4995, calls, observedSocket, observedPort);
+
+    // This schedules the same 200 ms callback shape production uses, with the
+    // injected connector preventing any network activity.
+    QEventLoop wait;
+    bool timerDelivered = false;
+    QTimer::singleShot(200, &transfer, [&wait, &timerDelivered, delayedConnect] {
+        timerDelivered = true;
+        delayedConnect();
+        wait.quit();
+    });
+    transfer.cancel();
+    AetherSDR::DvkWavTransferTestAccess::beginDownload(transfer);
+    QTimer::singleShot(1000, &wait, &QEventLoop::quit);
+    wait.exec();
+
+    check(timerDelivered && calls == 0 && observedSocket == nullptr && observedPort == 0,
+          "a cancelled 200 ms upload timer cannot connect a replacement operation");
+}
+
+void checkOldUploadTimerRejectsSameSocketReplacement()
+{
+    AetherSDR::DvkWavTransfer transfer(nullptr);
+    int calls = 0;
+    QTcpSocket* observedSocket = nullptr;
+    quint16 observedPort = 0;
+    const auto oldGeneration = AetherSDR::DvkWavTransferTestAccess::beginUpload(transfer);
+    QTcpSocket* socket = AetherSDR::DvkWavTransferTestAccess::installSocket(
+        transfer, AetherSDR::DvkWavTransferTestAccess::Phase::WaitingForUploadConnection);
+    const auto oldTimer = AetherSDR::DvkWavTransferTestAccess::deferredConnect(
+        transfer, oldGeneration, socket, 4995, calls, observedSocket, observedPort);
+
+    transfer.cancel();
+    const auto replacement = AetherSDR::DvkWavTransferTestAccess::beginUpload(transfer);
+    // deleteLater() has not run yet, so reusing this inert socket makes the
+    // generation guard independently observable from the socket-identity guard.
+    AetherSDR::DvkWavTransferTestAccess::replaceSocket(transfer, socket);
+    AetherSDR::DvkWavTransferTestAccess::setPhase(
+        transfer, AetherSDR::DvkWavTransferTestAccess::Phase::WaitingForUploadConnection);
+    oldTimer();
+
+    const auto currentTimer = AetherSDR::DvkWavTransferTestAccess::deferredConnect(
+        transfer, replacement, socket, 4996, calls, observedSocket, observedPort);
+    currentTimer();
+
+    check(calls == 1 && observedSocket == socket && observedPort == 4996,
+          "an old upload timer rejects the same socket while the current timer still connects it");
+}
+
+void checkStatusReentrancyCannotMutateReplacement()
+{
+    AetherSDR::DvkWavTransfer transfer(nullptr);
+    bool restarted = false;
+    AetherSDR::DvkWavTransferTestAccess::Generation replacement = 0;
+    QObject::connect(&transfer, &AetherSDR::DvkWavTransfer::statusChanged,
+                     [&transfer, &restarted, &replacement](const QString& status) {
+                         if (restarted || !status.startsWith(QStringLiteral("Uploading to slot"))) {
+                             return;
+                         }
+                         restarted = true;
+                         transfer.cancel();
+                         replacement = AetherSDR::DvkWavTransferTestAccess::beginUpload(
+                             transfer, QByteArray("replacement"));
+                     });
+
+    const auto oldGeneration = AetherSDR::DvkWavTransferTestAccess::beginUpload(
+        transfer, QByteArray("old"));
+    QTcpSocket* socket = AetherSDR::DvkWavTransferTestAccess::installSocket(
+        transfer, AetherSDR::DvkWavTransferTestAccess::Phase::SendingUpload);
+    AetherSDR::DvkWavTransferTestAccess::uploadBytesWritten(transfer, oldGeneration, socket, 1);
+
+    check(restarted && transfer.isTransferring() && replacement != oldGeneration,
+          "statusChanged cancellation can begin an independent replacement");
+    check(AetherSDR::DvkWavTransferTestAccess::phase(transfer)
+              == AetherSDR::DvkWavTransferTestAccess::Phase::WaitingForUploadPort
+              && AetherSDR::DvkWavTransferTestAccess::bytesSent(transfer) == 0,
+          "the old bytes-written continuation cannot mutate the replacement");
+}
+
+void checkQPointerOwnerGuardSurvivesDestruction()
+{
+    auto* transfer = new AetherSDR::DvkWavTransfer(nullptr);
+    const auto callback = AetherSDR::DvkWavTransferTestAccess::portCallback(
+        *transfer, 1, AetherSDR::DvkWavTransferTestAccess::Direction::Upload);
+    QPointer<AetherSDR::DvkWavTransfer> owner = transfer;
+    delete owner;
+    callback(0, QStringLiteral("4995"));
+    check(owner.isNull(), "a retained production command callback is harmless after transfer destruction");
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    checkStaleDownloadCallbacksCannotSettleReplacement(false);
+    checkStaleDownloadCallbacksCannotSettleReplacement(true);
+    checkStaleUploadCallbacksCannotSettleReplacement(false);
+    checkStaleUploadCallbacksCannotSettleReplacement(true);
+    checkCurrentCallbacksPreserveTerminalBehavior();
+    checkPhaseAndSocketIdentityRejectDuplicates();
+    checkDelayedTimerCannotConnectReplacement();
+    checkOldUploadTimerRejectsSameSocketReplacement();
+    checkStatusReentrancyCannotMutateReplacement();
+    checkQPointerOwnerGuardSurvivesDestruction();
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1976,6 +1976,16 @@ target_include_directories(firmware_uploader_test PRIVATE src)
 target_link_libraries(firmware_uploader_test PRIVATE aethercore Qt6::Core Qt6::Network)
 add_test(NAME firmware_uploader_test COMMAND firmware_uploader_test)
 
+# #5665 — stale DVK command/socket/timer callbacks must not settle a restart.
+# Inert QTcpSocket objects inject the production handlers; no listener or radio
+# peer is used.
+add_executable(dvk_wav_transfer_generation_test
+    tests/dvk_wav_transfer_generation_test.cpp
+)
+target_include_directories(dvk_wav_transfer_generation_test PRIVATE src)
+target_link_libraries(dvk_wav_transfer_generation_test PRIVATE aethercore Qt6::Core Qt6::Network)
+add_test(NAME dvk_wav_transfer_generation_test COMMAND dvk_wav_transfer_generation_test)
+
 # Local Qt dialog + injected uploader callbacks; no radio connection or peer.
 add_executable(firmware_close_dialog_test
     tests/firmware_close_dialog_test.cpp


### PR DESCRIPTION
## Summary

Fixes #5665. Canceling a DVK WAV upload or download and starting another transfer could admit the canceled operation's command reply. An old upload's 200 ms timer could dereference a cleared client or connect a replacement client to the old port.

Bind deferred replies, connection timers, and socket callbacks to an operation generation, expected phase, and captured object identity. Retire the operation before cleanup, use weak QObject references for retained work, and recheck identity across synchronous status signals. The existing DVK commands, WAV validation, upload byte accounting, and export storage behavior are unchanged.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. An ARM64 probe compiled the original transfer handlers and injected cancel/restart state without a radio. A stale rejection in either direction produced `replacement_finished=1 replacement_busy=0`. The production-linked regression now preserves the replacement through all four direction combinations.

## Validation

- Socket-free regression covers old success/rejection replies, terminal callbacks, actual 200 ms callback delivery after cancel/restart, same-phase and same-socket replacements, phase/socket identity, status reentry, owner destruction, and normal completion.
- Removing generation, phase, and socket-identity guards individually makes the regression fail; the restored fix passes.
- No listener or synthetic firmware peer is used. Current connect actions are injected into the same deferred callback used by production.
- Independent read-only review completed; its intermediate test findings were corrected.

- Complete default macOS build passed with the required ARM64 toolchain and RADE enabled. CMake host/system and the Mach-O executable are ARM64; no RNNoise x86 sources in the graph. Optional DFNR and sherpa-onnx libraries were unavailable locally.
- `dvk_wav_transfer_generation_test` and existing `dvk_availability_gate_test` both pass after restoration and the full build.
- Whitespace, test registration, frozen CI gate, generated manifest, command-plane, engine-boundary, and network-timeout checks pass.
- Refreshed upstream before publication: latest `d9e8b986a` adds unrelated HL2 work and separate test registrations; it does not change the DVK production files.

## Agent automation bridge

Native Cocoa smoke check with isolated settings: authenticated `whoami` matched the owned process and reported `txAllowed=false`; connected only to `DEMO-0001`, waited for one slice and one panadapter, captured `dumpTree` (including the constructed DVK panel), and verified `transmitting=false`. `close MainWindow` completed with process exit 0.

Coverage limitation: the bridge cannot inject DVK command replies/timers or read operation identity, and the demo's DVK control is unavailable. This smoke check establishes native integration, not the stale-callback fix; the production-linked socket-free tests and mutations prove the latter. No live radio transfer or transmit was performed.

The new test is registered in the default suite and therefore participates in the main/full-suite and sanitizer lanes; the frozen per-PR test allow-list is unchanged. Separate DVK upload-accounting and atomic-export defects from the audit remain outside this change.

Generated with OpenAI Codex.
